### PR TITLE
Bugfix/closing tcp client connections on drop

### DIFF
--- a/common/healthcheck/src/path_check.rs
+++ b/common/healthcheck/src/path_check.rs
@@ -183,7 +183,7 @@ impl PathChecker {
             return;
         }
 
-        debug!("Checking path: {:?} ({})", path, iteration);
+        trace!("Checking path: {:?} ({})", path, iteration);
         let path_identifier = PathChecker::unique_path_key(path, self.check_id, iteration);
 
         // check if there is even any point in sending the packet

--- a/mixnode/src/node/listener.rs
+++ b/mixnode/src/node/listener.rs
@@ -48,6 +48,8 @@ async fn process_socket_connection(
                 return;
             }
             Ok(n) => {
+                // If I understand it correctly, this if should never be executed as if `read_exact`
+                // does not fill buffer, it will throw UnexpectedEof?
                 if n != sphinx::PACKET_SIZE {
                     warn!("read data of different length than expected sphinx packet size - {} (expected {})", n, sphinx::PACKET_SIZE);
                     continue;
@@ -63,10 +65,16 @@ async fn process_socket_connection(
                 ))
             }
             Err(e) => {
-                warn!(
-                    "failed to read from socket. Closing the connection; err = {:?}",
-                    e
-                );
+                if e.kind() == io::ErrorKind::UnexpectedEof {
+                    debug!("Read buffer was not fully filled. Most likely the client ({:?}) closed the connection.\
+                    Also closing the connection on this end.", socket.peer_addr())
+                } else {
+                    warn!(
+                        "failed to read from socket (source: {:?}). Closing the connection; err = {:?}",
+                        socket.peer_addr(),
+                        e
+                    );
+                }
                 return;
             }
         };


### PR DESCRIPTION
* Slightly better (still not perfect) handling of "early eof" errors. 
* tcp connections should now be immediately closed after [tcp] client goes out of scope 