### PR TITLE
Removed misplaced WorkingDirectory parameter

### DIFF
--- a/scripts/systemd/nym-mixnode.service
+++ b/scripts/systemd/nym-mixnode.service
@@ -41,7 +41,6 @@ After=network.target
 Type=simple
 User=nym
 Group=nym
-WorkingDirectory=/home/nym
 ExecStart=/home/nym/nym-mixnode_linux_x86_64 run --id iamboss
 Restart=on-abort
 


### PR DESCRIPTION
If a `WorkingDirectory` is specified explicitly then it would have to go to a seperate `[Exec]` section. However this parameter is unnecessary as it defaults to the `User` home directory anyway.