### PR TITLE
the port in the announce address is not optional

### DIFF
--- a/mixnode/src/config/template.rs
+++ b/mixnode/src/config/template.rs
@@ -50,9 +50,7 @@ public_sphinx_key_file = '{{ mixnode.public_sphinx_key_file }}'
 # Optional address announced to the directory server for the clients to connect to.
 # It is useful, say, in NAT scenarios or wanting to more easily update actual IP address
 # later on by using name resolvable with a DNS query, such as `nymtech.net:8080`.
-# Additionally a custom port can be provided, so both `nymtech.net:8080` and `nymtech.net`
-# are valid announce addresses, while the later will default to whatever port is used for
-# `listening_address`.
+# Additionally a custom port can be provided.
 announce_address = '{{ mixnode.announce_address }}'
 
 # Directory server to which the server will be reporting their presence data.


### PR DESCRIPTION
Remove a misleading comment about the port in the announce address
being optional and defaulting to the listening port. Testing shows
this is not the case. The dashboard shows the announce address
without the port and no packets are received by nym-mixnode.

Of course a better fix would be to make that the listening port is used in case one is omitted in the announce address.