### PR TITLE
Feature/outbound request lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ scripts/run_mix.sh
 scripts/start_local_tmux_network.sh
 /.floo
 /.flooignore
+/service-providers/simple-socks5/allowed.list

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,6 +2768,7 @@ dependencies = [
  "ordered-buffer",
  "pretty_env_logger",
  "proxy-helpers",
+ "rand 0.7.3",
  "socks5-requests",
  "tokio 0.2.22",
  "tokio-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check 0.9.1",
+]
+
+[[package]]
 name = "extend"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2291,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "publicsuffix"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
+dependencies = [
+ "error-chain",
+ "idna 0.2.0",
+ "lazy_static",
+ "native-tls",
+ "regex",
+ "url 2.1.1",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2769,6 +2792,7 @@ dependencies = [
  "ordered-buffer",
  "pretty_env_logger",
  "proxy-helpers",
+ "publicsuffix",
  "rand 0.7.3",
  "socks5-requests",
  "tokio 0.2.22",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,6 +2762,7 @@ name = "simple-socks5"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "dirs 2.0.2",
  "futures 0.3.4",
  "log 0.4.8",
  "nymsphinx",

--- a/common/socks5/ordered-buffer/src/buffer.rs
+++ b/common/socks5/ordered-buffer/src/buffer.rs
@@ -61,6 +61,7 @@ impl OrderedMessageBuffer {
 
         let high_water = index;
         self.next_index = high_water;
+        trace!("Next high water mark is: {}", high_water);
 
         // dig out the bytes from inside the struct
         let data: Vec<u8> = contiguous_messages

--- a/common/socks5/ordered-buffer/src/buffer.rs
+++ b/common/socks5/ordered-buffer/src/buffer.rs
@@ -61,7 +61,7 @@ impl OrderedMessageBuffer {
 
         let high_water = index;
         self.next_index = high_water;
-        warn!("Next high water mark is: {}", high_water);
+        info!("Next high water mark is: {}", high_water);
 
         // dig out the bytes from inside the struct
         let data: Vec<u8> = contiguous_messages

--- a/common/socks5/ordered-buffer/src/buffer.rs
+++ b/common/socks5/ordered-buffer/src/buffer.rs
@@ -61,7 +61,6 @@ impl OrderedMessageBuffer {
 
         let high_water = index;
         self.next_index = high_water;
-        info!("Next high water mark is: {}", high_water);
 
         // dig out the bytes from inside the struct
         let data: Vec<u8> = contiguous_messages

--- a/service-providers/simple-socks5/Cargo.toml
+++ b/service-providers/simple-socks5/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33.0"
+dirs = "2.0.2"
 futures = "0.3"
 log = "0.4"
 pretty_env_logger = "0.3"

--- a/service-providers/simple-socks5/Cargo.toml
+++ b/service-providers/simple-socks5/Cargo.toml
@@ -19,3 +19,6 @@ ordered-buffer = {path = "../../common/socks5/ordered-buffer"}
 socks5-requests = { path = "../../common/socks5/requests" }
 proxy-helpers = { path = "../../common/socks5/proxy-helpers" }
 websocket-requests = { path = "../../clients/native/websocket-requests" }
+
+[dev-dependencies]
+rand = "0.7"

--- a/service-providers/simple-socks5/Cargo.toml
+++ b/service-providers/simple-socks5/Cargo.toml
@@ -14,7 +14,9 @@ log = "0.4"
 pretty_env_logger = "0.3"
 tokio = { version = "0.2", features = ["stream", "tcp", "rt-threaded", "macros"] }
 tokio-tungstenite = "0.11.0"
+publicsuffix = "1.3.1"
 
+# internal
 nymsphinx = { path = "../../common/nymsphinx" }
 ordered-buffer = {path = "../../common/socks5/ordered-buffer"}
 socks5-requests = { path = "../../common/socks5/requests" }

--- a/service-providers/simple-socks5/src/allowed_hosts.rs
+++ b/service-providers/simple-socks5/src/allowed_hosts.rs
@@ -87,6 +87,11 @@ mod requests_to_unknown_hosts {
         let mut filter = setup();
         filter.check(host);
         assert_eq!(1, filter.unknown_hosts.hosts.len());
+        assert_eq!("unknown.com", filter.unknown_hosts.hosts.first().unwrap());
+
+        filter.check(host);
+        assert_eq!(1, filter.unknown_hosts.hosts.len());
+        assert_eq!("unknown.com", filter.unknown_hosts.hosts.first().unwrap());
     }
 }
 

--- a/service-providers/simple-socks5/src/allowed_hosts.rs
+++ b/service-providers/simple-socks5/src/allowed_hosts.rs
@@ -1,3 +1,6 @@
+use std::fs::{self};
+use std::path::PathBuf;
+
 struct OutboundRequestFilter {
     allowed_hosts: HostsStore,
     unknown_hosts: HostsStore,
@@ -23,96 +26,163 @@ impl OutboundRequestFilter {
         }
     }
 
-    pub(crate) fn is_unknown(&self, _host: &str) -> bool {
-        true
+    pub(crate) fn is_unknown(&self, host: &str) -> bool {
+        !self.allowed_hosts.contains(host)
     }
 }
 
 #[derive(Debug)]
 struct HostsStore {
+    storefile: String,
     hosts: Vec<String>,
 }
 
 impl HostsStore {
-    fn new(hosts: Vec<String>) -> HostsStore {
-        HostsStore { hosts }
+    fn new(filename: &str, hosts: Vec<String>) -> HostsStore {
+        let dirpath = HostsStore::setup_storage_path();
+        let filepath = dirpath.join(filename);
+        HostsStore {
+            storefile: filepath.to_str().unwrap().to_string(),
+            hosts,
+        }
     }
 
     fn contains(&self, host: &str) -> bool {
         self.hosts.contains(&host.to_string())
     }
 
+    fn ensure_directory_exists(dirpath: &PathBuf) {
+        fs::create_dir_all(dirpath);
+    }
+
     fn maybe_add(&mut self, host: &str) {
         if !self.contains(&host) {
             self.hosts.push(host.to_string());
+            self.append_to_file(host);
         }
+    }
+
+    fn append_to_file(&self, host: &str) -> std::io::Result<()> {
+        fs::write(&self.storefile, host)?;
+        Ok(())
+    }
+    fn setup_storage_path() -> PathBuf {
+        let os_home_dir = dirs::home_dir().expect("no home directory known for this OS"); // grabs the OS default home dir
+        let dirpath = os_home_dir
+            .join(".nym")
+            .join("service-providers")
+            .join("socks5");
+        HostsStore::ensure_directory_exists(&dirpath);
+        dirpath
     }
 
     /// Reloads the allowed.list and unknown.list files into memory. Used primarily for testing.
     fn reload_from_disk(&self) {}
-
-    fn append_to_file(&self, _host: String) {}
 }
 // Appender
 
 #[cfg(test)]
-mod requests_to_unknown_hosts {
+mod tests {
     use super::*;
 
-    fn setup() -> OutboundRequestFilter {
-        let allowed = HostsStore::new(vec![]);
-        let unknown = HostsStore::new(vec![]);
-        OutboundRequestFilter::new(allowed, unknown)
+    fn random_string() -> String {
+        format!("{:?}", rand::random::<u32>())
     }
 
-    #[test]
-    fn are_not_allowed() {
-        let host = "unknown.com";
-        let mut filter = setup();
-        assert_eq!(false, filter.check(&host));
+    #[cfg(test)]
+    mod requests_to_unknown_hosts {
+        use super::*;
+
+        fn setup() -> OutboundRequestFilter {
+            let allowed = HostsStore::new(&format!("allowed-{}.list", random_string()), vec![]);
+            let unknown = HostsStore::new(&format!("unknown-{}.list", random_string()), vec![]);
+            OutboundRequestFilter::new(allowed, unknown)
+        }
+
+        #[test]
+        fn are_not_allowed() {
+            let host = "unknown.com";
+            let mut filter = setup();
+            assert_eq!(false, filter.check(&host));
+        }
+
+        #[test]
+        fn get_saved_to_file() {
+            let host = "unknown.com";
+            let mut filter = setup();
+            filter.check(host);
+            assert!(true, filter.is_unknown(host));
+        }
+
+        #[test]
+        fn get_appended_once_to_the_unknown_hosts_list() {
+            let host = "unknown.com";
+            let mut filter = setup();
+            filter.check(host);
+            assert_eq!(1, filter.unknown_hosts.hosts.len());
+            assert_eq!("unknown.com", filter.unknown_hosts.hosts.first().unwrap());
+            filter.check(host);
+            assert_eq!(1, filter.unknown_hosts.hosts.len());
+            assert_eq!("unknown.com", filter.unknown_hosts.hosts.first().unwrap());
+        }
+
+        #[test]
+        fn are_written_once_to_file() {
+            let host = "unknown.com";
+            let mut filter = setup();
+            filter.check(host);
+            let lines = lines_from_file(&filter.unknown_hosts.storefile).unwrap();
+            assert_eq!(1, lines.len());
+
+            filter.check(host);
+            let lines = lines_from_file(&filter.unknown_hosts.storefile).unwrap();
+            assert_eq!(1, lines.len());
+        }
+
+        use io::BufReader;
+        use std::fs::File;
+        use std::io;
+        use std::io::BufRead;
+        use std::path::Path;
+
+        fn lines_from_file<P>(filename: P) -> io::Result<Vec<String>>
+        where
+            P: AsRef<Path>,
+        {
+            let file = File::open(filename)?;
+            let reader = BufReader::new(&file);
+            let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
+            Ok(lines)
+        }
     }
+    #[cfg(test)]
+    mod requests_to_allowed_hosts {
+        use super::*;
+        fn setup() -> OutboundRequestFilter {
+            let allowed = HostsStore::new(
+                &format!("allowed-{}.list", random_string()),
+                vec!["nymtech.net".to_string()],
+            );
+            let unknown = HostsStore::new(&format!("unknown-{}.list", random_string()), vec![]);
 
-    #[test]
-    fn get_saved_to_file() {
-        let host = "unknown.com";
-        let mut filter = setup();
-        filter.check(host);
-        assert!(true, filter.is_unknown(host));
+            OutboundRequestFilter::new(allowed, unknown)
+        }
+        #[test]
+        fn are_allowed() {
+            let host = "nymtech.net";
+            let mut filter = setup();
+            assert_eq!(true, filter.check(host));
+        }
+
+        #[test]
+        fn are_not_unknown() {
+            let host = "nymtech.net";
+            let mut filter = setup();
+            assert_eq!(false, filter.is_unknown(host));
+        }
+        // #[test]
+        // fn are_not_appended_to_file() {
+        //     todo!()
+        // }
     }
-
-    #[test]
-    fn get_appended_once_to_the_unknown_hosts_list() {
-        let host = "unknown.com";
-        let mut filter = setup();
-        filter.check(host);
-        assert_eq!(1, filter.unknown_hosts.hosts.len());
-        assert_eq!("unknown.com", filter.unknown_hosts.hosts.first().unwrap());
-
-        filter.check(host);
-        assert_eq!(1, filter.unknown_hosts.hosts.len());
-        assert_eq!("unknown.com", filter.unknown_hosts.hosts.first().unwrap());
-    }
-}
-
-#[cfg(test)]
-mod requests_to_allowed_hosts {
-    use super::*;
-
-    fn setup() -> OutboundRequestFilter {
-        let allowed = HostsStore::new(vec!["nymtech.net".to_string()]);
-        let unknown = HostsStore::new(vec![]);
-        OutboundRequestFilter::new(allowed, unknown)
-    }
-
-    #[test]
-    fn are_allowed() {
-        let host = "nymtech.net";
-        let mut filter = setup();
-        assert_eq!(true, filter.check(host));
-    }
-
-    // #[test]
-    // fn are_not_appended_to_file() {
-    //     todo!()
-    // }
 }

--- a/service-providers/simple-socks5/src/allowed_hosts.rs
+++ b/service-providers/simple-socks5/src/allowed_hosts.rs
@@ -15,11 +15,10 @@ impl OutboundRequestFilter {
     }
 
     pub(crate) fn check(&mut self, host: &str) -> bool {
-        let hostname = host.to_string().clone();
-        if self.allowed_hosts.contains(hostname.clone()) {
+        if self.allowed_hosts.contains(host) {
             true
         } else {
-            self.unknown_hosts.maybe_add(hostname);
+            self.unknown_hosts.maybe_add(host);
             false
         }
     }
@@ -39,13 +38,13 @@ impl HostsStore {
         HostsStore { hosts }
     }
 
-    fn contains(&self, host: String) -> bool {
-        self.hosts.contains(&host)
+    fn contains(&self, host: &str) -> bool {
+        self.hosts.contains(&host.to_string())
     }
 
-    fn maybe_add(&mut self, host: String) {
-        if !self.contains(host.clone()) {
-            self.hosts.push(host);
+    fn maybe_add(&mut self, host: &str) {
+        if !self.contains(&host) {
+            self.hosts.push(host.to_string());
         }
     }
 

--- a/service-providers/simple-socks5/src/allowed_hosts.rs
+++ b/service-providers/simple-socks5/src/allowed_hosts.rs
@@ -14,16 +14,17 @@ impl OutboundRequestFilter {
         }
     }
 
-    pub(crate) fn check(&self, host: &str) -> bool {
-        if self.allowed_hosts.contains(host.to_string()) {
+    pub(crate) fn check(&mut self, host: &str) -> bool {
+        let hostname = host.to_string().clone();
+        if self.allowed_hosts.contains(hostname.clone()) {
             true
         } else {
-            self.unknown_hosts.maybe_add(host.to_string());
+            self.unknown_hosts.maybe_add(hostname);
             false
         }
     }
 
-    pub(crate) fn is_unknown(&self, host: &str) -> bool {
+    pub(crate) fn is_unknown(&self, _host: &str) -> bool {
         true
     }
 }
@@ -43,7 +44,7 @@ impl Persistence {
     }
 
     fn maybe_add(&mut self, host: String) {
-        if !self.contains(host) {
+        if !self.contains(host.clone()) {
             self.hosts.push(host);
         }
     }
@@ -51,7 +52,7 @@ impl Persistence {
     /// Reloads the allowed.list and unknown.list files into memory. Used primarily for testing.
     fn reload_from_disk(&self) {}
 
-    fn append_to_file(&self, host: String) {}
+    fn append_to_file(&self, _host: String) {}
 }
 // Appender
 
@@ -68,14 +69,14 @@ mod requests_to_unknown_hosts {
     #[test]
     fn are_not_allowed() {
         let host = "unknown.com";
-        let filter = setup();
+        let mut filter = setup();
         assert_eq!(false, filter.check(&host));
     }
 
     #[test]
     fn get_saved_to_file() {
         let host = "unknown.com";
-        let filter = setup();
+        let mut filter = setup();
         filter.check(host);
         assert!(true, filter.is_unknown(host));
     }
@@ -83,7 +84,7 @@ mod requests_to_unknown_hosts {
     #[test]
     fn get_appended_once_to_the_unknown_hosts_list() {
         let host = "unknown.com";
-        let filter = setup();
+        let mut filter = setup();
         filter.check(host);
         assert_eq!(1, filter.unknown_hosts.hosts.len());
     }
@@ -102,7 +103,7 @@ mod requests_to_allowed_hosts {
     #[test]
     fn are_allowed() {
         let host = "nymtech.net";
-        let filter = setup();
+        let mut filter = setup();
         assert_eq!(true, filter.check(host));
     }
 

--- a/service-providers/simple-socks5/src/allowed_hosts.rs
+++ b/service-providers/simple-socks5/src/allowed_hosts.rs
@@ -1,0 +1,113 @@
+struct OutboundRequestFilter {
+    allowed_hosts: Persistence,
+    unknown_hosts: Persistence,
+}
+
+impl OutboundRequestFilter {
+    pub(crate) fn new(
+        allowed_hosts: Persistence,
+        unknown_hosts: Persistence,
+    ) -> OutboundRequestFilter {
+        OutboundRequestFilter {
+            allowed_hosts,
+            unknown_hosts,
+        }
+    }
+
+    pub(crate) fn check(&self, host: &str) -> bool {
+        if self.allowed_hosts.contains(host.to_string()) {
+            true
+        } else {
+            self.unknown_hosts.maybe_add(host.to_string());
+            false
+        }
+    }
+
+    pub(crate) fn is_unknown(&self, host: &str) -> bool {
+        true
+    }
+}
+
+#[derive(Debug)]
+struct Persistence {
+    hosts: Vec<String>,
+}
+
+impl Persistence {
+    fn new(hosts: Vec<String>) -> Persistence {
+        Persistence { hosts }
+    }
+
+    fn contains(&self, host: String) -> bool {
+        self.hosts.contains(&host)
+    }
+
+    fn maybe_add(&mut self, host: String) {
+        if !self.contains(host) {
+            self.hosts.push(host);
+        }
+    }
+
+    /// Reloads the allowed.list and unknown.list files into memory. Used primarily for testing.
+    fn reload_from_disk(&self) {}
+
+    fn append_to_file(&self, host: String) {}
+}
+// Appender
+
+#[cfg(test)]
+mod requests_to_unknown_hosts {
+    use super::*;
+
+    fn setup() -> OutboundRequestFilter {
+        let allowed = Persistence::new(vec![]);
+        let unknown = Persistence::new(vec![]);
+        OutboundRequestFilter::new(allowed, unknown)
+    }
+
+    #[test]
+    fn are_not_allowed() {
+        let host = "unknown.com";
+        let filter = setup();
+        assert_eq!(false, filter.check(&host));
+    }
+
+    #[test]
+    fn get_saved_to_file() {
+        let host = "unknown.com";
+        let filter = setup();
+        filter.check(host);
+        assert!(true, filter.is_unknown(host));
+    }
+
+    #[test]
+    fn get_appended_once_to_the_unknown_hosts_list() {
+        let host = "unknown.com";
+        let filter = setup();
+        filter.check(host);
+        assert_eq!(1, filter.unknown_hosts.hosts.len());
+    }
+}
+
+#[cfg(test)]
+mod requests_to_allowed_hosts {
+    use super::*;
+
+    fn setup() -> OutboundRequestFilter {
+        let allowed = Persistence::new(vec!["nymtech.net".to_string()]);
+        let unknown = Persistence::new(vec![]);
+        OutboundRequestFilter::new(allowed, unknown)
+    }
+
+    #[test]
+    fn are_allowed() {
+        let host = "nymtech.net";
+        let filter = setup();
+        assert_eq!(true, filter.check(host));
+    }
+
+    // #[test]
+    // fn are_not_appended_to_file() {
+    //     todo!()
+    // }
+}

--- a/service-providers/simple-socks5/src/allowed_hosts.rs
+++ b/service-providers/simple-socks5/src/allowed_hosts.rs
@@ -15,6 +15,11 @@ use std::path::PathBuf;
 /// This may be handy for service provider node operators who want to be able to look in the
 /// `unknown_hosts` file and allow new hosts (e.g. if a wallet has added a new outbound request
 /// which needs to be allowed).
+///
+/// We rely on the list of domains at https://publicsuffix.org/ to figure out what the root
+/// domain is for a given request. This allows us to distinguish all the rules for e.g.
+/// .com, .co.uk, .co.jp, uk.com, etc, so that we can distinguish correct root-ish
+/// domains as allowed. That list is loaded once at startup from the network.
 pub(crate) struct OutboundRequestFilter {
     allowed_hosts: HostsStore,
     unknown_hosts: HostsStore,

--- a/service-providers/simple-socks5/src/allowed_hosts.rs
+++ b/service-providers/simple-socks5/src/allowed_hosts.rs
@@ -1,12 +1,12 @@
 struct OutboundRequestFilter {
-    allowed_hosts: Persistence,
-    unknown_hosts: Persistence,
+    allowed_hosts: HostsStore,
+    unknown_hosts: HostsStore,
 }
 
 impl OutboundRequestFilter {
     pub(crate) fn new(
-        allowed_hosts: Persistence,
-        unknown_hosts: Persistence,
+        allowed_hosts: HostsStore,
+        unknown_hosts: HostsStore,
     ) -> OutboundRequestFilter {
         OutboundRequestFilter {
             allowed_hosts,
@@ -30,13 +30,13 @@ impl OutboundRequestFilter {
 }
 
 #[derive(Debug)]
-struct Persistence {
+struct HostsStore {
     hosts: Vec<String>,
 }
 
-impl Persistence {
-    fn new(hosts: Vec<String>) -> Persistence {
-        Persistence { hosts }
+impl HostsStore {
+    fn new(hosts: Vec<String>) -> HostsStore {
+        HostsStore { hosts }
     }
 
     fn contains(&self, host: String) -> bool {
@@ -61,8 +61,8 @@ mod requests_to_unknown_hosts {
     use super::*;
 
     fn setup() -> OutboundRequestFilter {
-        let allowed = Persistence::new(vec![]);
-        let unknown = Persistence::new(vec![]);
+        let allowed = HostsStore::new(vec![]);
+        let unknown = HostsStore::new(vec![]);
         OutboundRequestFilter::new(allowed, unknown)
     }
 
@@ -95,8 +95,8 @@ mod requests_to_allowed_hosts {
     use super::*;
 
     fn setup() -> OutboundRequestFilter {
-        let allowed = Persistence::new(vec!["nymtech.net".to_string()]);
-        let unknown = Persistence::new(vec![]);
+        let allowed = HostsStore::new(vec!["nymtech.net".to_string()]);
+        let unknown = HostsStore::new(vec![]);
         OutboundRequestFilter::new(allowed, unknown)
     }
 

--- a/service-providers/simple-socks5/src/core.rs
+++ b/service-providers/simple-socks5/src/core.rs
@@ -129,6 +129,7 @@ impl ServiceProvider {
                     return_address,
                 } => {
                     if !self.outbound_request_filter.check(&remote_addr) {
+                        log::info!("Domain {:?} failed filter check", remote_addr);
                         continue;
                     }
 

--- a/service-providers/simple-socks5/src/core.rs
+++ b/service-providers/simple-socks5/src/core.rs
@@ -1,3 +1,4 @@
+use crate::allowed_hosts::{HostsStore, OutboundRequestFilter};
 use crate::connection::Connection;
 use crate::websocket;
 use futures::channel::mpsc;
@@ -8,6 +9,7 @@ use nymsphinx::addressing::clients::Recipient;
 use ordered_buffer::OrderedMessageBuffer;
 use proxy_helpers::connection_controller::{Controller, ControllerCommand};
 use socks5_requests::{Request, Response};
+use std::path::PathBuf;
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::protocol::Message;
 use tokio_tungstenite::WebSocketStream;
@@ -16,11 +18,25 @@ use websocket_requests::{requests::ClientRequest, responses::ServerResponse};
 
 pub struct ServiceProvider {
     listening_address: String,
+    outbound_request_filter: OutboundRequestFilter,
 }
 
 impl ServiceProvider {
     pub fn new(listening_address: String) -> ServiceProvider {
-        ServiceProvider { listening_address }
+        let allowed_hosts = HostsStore::new(
+            HostsStore::default_base_dir(),
+            PathBuf::from("allowed.list"),
+        );
+
+        let unknown_hosts = HostsStore::new(
+            HostsStore::default_base_dir(),
+            PathBuf::from("unknown.list"),
+        );
+        let outbound_request_filter = OutboundRequestFilter::new(allowed_hosts, unknown_hosts);
+        ServiceProvider {
+            listening_address,
+            outbound_request_filter,
+        }
     }
 
     /// Listens for any messages from `mix_reader` that should be written back to the mix network
@@ -112,6 +128,10 @@ impl ServiceProvider {
                     message,
                     return_address,
                 } => {
+                    if !self.outbound_request_filter.check(&remote_addr) {
+                        continue;
+                    }
+
                     let controller_sender_clone = controller_sender.clone();
                     let mut ordered_buffer = OrderedMessageBuffer::new();
                     ordered_buffer.write(message);

--- a/service-providers/simple-socks5/src/main.rs
+++ b/service-providers/simple-socks5/src/main.rs
@@ -2,6 +2,15 @@ mod connection;
 mod core;
 mod websocket;
 
+#[tokio::main]
+async fn main() {
+    setup_logging();
+    let uri = "ws://localhost:1977";
+    println!("Starting socks5 service provider:");
+    let mut server = core::ServiceProvider::new(uri.into());
+    server.run().await;
+}
+
 fn setup_logging() {
     let mut log_builder = pretty_env_logger::formatted_timed_builder();
     if let Ok(s) = ::std::env::var("RUST_LOG") {
@@ -18,13 +27,4 @@ fn setup_logging() {
         .filter_module("mio", log::LevelFilter::Warn)
         .filter_module("want", log::LevelFilter::Warn)
         .init();
-}
-
-#[tokio::main]
-async fn main() {
-    setup_logging();
-    let uri = "ws://localhost:1977";
-    println!("Starting socks5 service provider:");
-    let mut server = core::ServiceProvider::new(uri.into());
-    server.run().await;
 }

--- a/service-providers/simple-socks5/src/main.rs
+++ b/service-providers/simple-socks5/src/main.rs
@@ -1,3 +1,4 @@
+mod allowed_hosts;
 mod connection;
 mod core;
 mod websocket;


### PR DESCRIPTION
Allows the socks5 service provider to easily limit outbound requests based on a domain list loaded from a text file. Requests to unknown domains are logged.