### PR TITLE
Fix compiler warnings for unneeded mut

### DIFF
--- a/common/wasm-utils/src/websocket/mod.rs
+++ b/common/wasm-utils/src/websocket/mod.rs
@@ -214,7 +214,7 @@ impl Drop for JSWebsocket {
 impl Stream for JSWebsocket {
     type Item = Result<WsMessage, WsError>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // if there's anything in the internal queue, keep returning that
         let ws_message = self.message_queue.borrow_mut().pop_front();
         match ws_message {
@@ -238,7 +238,7 @@ impl Stream for JSWebsocket {
 impl Sink<WsMessage> for JSWebsocket {
     type Error = WsError;
 
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match self.state() {
             State::Connecting => {
                 // clone the waker to be able to notify the executor once we get connected
@@ -280,7 +280,7 @@ impl Sink<WsMessage> for JSWebsocket {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match self.state() {
             State::Open | State::Connecting => {
                 // TODO: do we need to wait for closing event here?


### PR DESCRIPTION
When running `wasm-pack build` (or `cargo build` inside `common/wasm-utils`), I get the following compiler warnings:

```
   Compiling wasm-utils v0.1.0 (/home/ethan/IdeaProjects/nym/common/wasm-utils)
warning: variable does not need to be mutable
   --> common/wasm-utils/src/websocket/mod.rs:217:18
    |
217 |     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
    |                  ----^^^^
    |                  |
    |                  help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

warning: variable does not need to be mutable
   --> common/wasm-utils/src/websocket/mod.rs:241:19
    |
241 |     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
    |                   ----^^^^
    |                   |
    |                   help: remove this `mut`

warning: variable does not need to be mutable
   --> common/wasm-utils/src/websocket/mod.rs:283:19
    |
283 |     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
    |                   ----^^^^
    |                   |
    |                   help: remove this `mut`

warning: 3 warnings emitted
```

This patch remove the unneeded mut to remove the warnings. js-example did not work on develop, but I did cherry-pick the commit to `v0.8.1`, recompiled the wasm files, re-created node_modules for `js-example` and ensure I did not accidentally break the wasm bindings some how.