### PR TITLE
Feature/max retry

### DIFF
--- a/common/client-libs/mixnet-client/src/client.rs
+++ b/common/client-libs/mixnet-client/src/client.rs
@@ -107,7 +107,7 @@ impl Client {
                 match self.start_new_connection_manager(socket_address).await {
                     Ok(res) => res,
                     Err(err) => {
-                        warn!(
+                        debug!(
                             "failed to establish initial connection to {} - {}",
                             socket_address, err
                         );

--- a/gateway/src/config/mod.rs
+++ b/gateway/src/config/mod.rs
@@ -41,6 +41,7 @@ const DEFAULT_PACKET_FORWARDING_INITIAL_BACKOFF: Duration = Duration::from_milli
 const DEFAULT_PACKET_FORWARDING_MAXIMUM_BACKOFF: Duration = Duration::from_millis(300_000);
 const DEFAULT_INITIAL_CONNECTION_TIMEOUT: Duration = Duration::from_millis(1_500);
 const DEFAULT_CACHE_ENTRY_TTL: Duration = Duration::from_millis(30_000);
+const DEFAULT_MAXIMUM_RECONNECTION_ATTEMPTS: u32 = 20;
 
 const DEFAULT_STORED_MESSAGE_FILENAME_LENGTH: u16 = 16;
 const DEFAULT_MESSAGE_RETRIEVAL_LIMIT: u16 = 5;
@@ -444,6 +445,10 @@ impl Config {
         self.debug.initial_connection_timeout
     }
 
+    pub fn get_packet_forwarding_max_reconnections(&self) -> u32 {
+        self.debug.maximum_reconnection_attempts
+    }
+
     pub fn get_message_retrieval_limit(&self) -> u16 {
         self.debug.message_retrieval_limit
     }
@@ -651,6 +656,10 @@ pub struct Debug {
     )]
     presence_sending_delay: Duration,
 
+    /// Maximum number of retries node is going to attempt to re-establish existing connection
+    /// to another node when forwarding sphinx packets.
+    maximum_reconnection_attempts: u32,
+
     /// Length of filenames for new client messages.
     stored_messages_filename_length: u16,
 
@@ -674,6 +683,7 @@ impl Default for Debug {
             packet_forwarding_maximum_backoff: DEFAULT_PACKET_FORWARDING_MAXIMUM_BACKOFF,
             initial_connection_timeout: DEFAULT_INITIAL_CONNECTION_TIMEOUT,
             presence_sending_delay: DEFAULT_PRESENCE_SENDING_DELAY,
+            maximum_reconnection_attempts: DEFAULT_MAXIMUM_RECONNECTION_ATTEMPTS,
             stored_messages_filename_length: DEFAULT_STORED_MESSAGE_FILENAME_LENGTH,
             message_retrieval_limit: DEFAULT_MESSAGE_RETRIEVAL_LIMIT,
             cache_entry_ttl: DEFAULT_CACHE_ENTRY_TTL,

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -107,6 +107,7 @@ impl Gateway {
             self.config.get_packet_forwarding_initial_backoff(),
             self.config.get_packet_forwarding_maximum_backoff(),
             self.config.get_initial_connection_timeout(),
+            self.config.get_packet_forwarding_max_reconnections(),
         );
 
         tokio::spawn(async move { packet_forwarder.run().await });

--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -40,6 +40,7 @@ const DEFAULT_PACKET_FORWARDING_INITIAL_BACKOFF: Duration = Duration::from_milli
 const DEFAULT_PACKET_FORWARDING_MAXIMUM_BACKOFF: Duration = Duration::from_millis(300_000);
 const DEFAULT_INITIAL_CONNECTION_TIMEOUT: Duration = Duration::from_millis(1_500);
 const DEFAULT_CACHE_ENTRY_TTL: Duration = Duration::from_millis(30_000);
+const DEFAULT_MAXIMUM_RECONNECTION_ATTEMPTS: u32 = 20;
 
 #[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -330,6 +331,10 @@ impl Config {
         self.debug.initial_connection_timeout
     }
 
+    pub fn get_packet_forwarding_max_reconnections(&self) -> u32 {
+        self.debug.maximum_reconnection_attempts
+    }
+
     pub fn get_cache_entry_ttl(&self) -> Duration {
         self.debug.cache_entry_ttl
     }
@@ -490,6 +495,10 @@ pub struct Debug {
     )]
     initial_connection_timeout: Duration,
 
+    /// Maximum number of retries node is going to attempt to re-establish existing connection
+    /// to another node when forwarding sphinx packets.
+    maximum_reconnection_attempts: u32,
+
     /// Duration for which a cached vpn processing result is going to get stored for.
     #[serde(
         deserialize_with = "deserialize_duration",
@@ -505,6 +514,7 @@ impl Default for Debug {
             packet_forwarding_initial_backoff: DEFAULT_PACKET_FORWARDING_INITIAL_BACKOFF,
             packet_forwarding_maximum_backoff: DEFAULT_PACKET_FORWARDING_MAXIMUM_BACKOFF,
             initial_connection_timeout: DEFAULT_INITIAL_CONNECTION_TIMEOUT,
+            maximum_reconnection_attempts: DEFAULT_MAXIMUM_RECONNECTION_ATTEMPTS,
             cache_entry_ttl: DEFAULT_CACHE_ENTRY_TTL,
         }
     }

--- a/mixnode/src/node/mod.rs
+++ b/mixnode/src/node/mod.rs
@@ -83,6 +83,7 @@ impl MixNode {
             self.config.get_packet_forwarding_initial_backoff(),
             self.config.get_packet_forwarding_maximum_backoff(),
             self.config.get_initial_connection_timeout(),
+            self.config.get_packet_forwarding_max_reconnections(),
         );
 
         tokio::spawn(async move { packet_forwarder.run().await });


### PR DESCRIPTION
This pull request specifies maximum number of times node will try to reconnect to another node. By default I've set it to 20. (note, exponential backoff still exists). This way we will avoid situation where you will try to reconnect for all eternity. 

On top of that, I've made it so that it's required that initial internode connection succeeds - this avoids going into `reconnection` mode immediately for nodes you might never establish connection with.