### PR TITLE
More human-readable errors on mixnode/gateway startup

### DIFF
--- a/common/client-libs/validator-client/src/lib.rs
+++ b/common/client-libs/validator-client/src/lib.rs
@@ -113,7 +113,7 @@ impl Display for ValidatorClientError {
                 } else {
                     write!(
                         f,
-                        "received data was completely unexpected. got: {}",
+                        "received data was completely unexpected. got: {}...",
                         received
                             .chars()
                             .take(MAX_SANE_UNEXPECTED_PRINT)

--- a/common/client-libs/validator-client/src/rest_requests/active_topology_get.rs
+++ b/common/client-libs/validator-client/src/rest_requests/active_topology_get.rs
@@ -14,7 +14,7 @@
 
 use crate::models::topology::Topology;
 use crate::rest_requests::{PathParam, QueryParam, RESTRequest, RESTRequestError};
-use crate::ErrorResponse;
+use crate::ErrorResponses;
 use reqwest::{Method, Url};
 use serde::Deserialize;
 
@@ -26,7 +26,7 @@ pub struct Request {
 #[serde(rename_all = "camelCase", untagged)]
 pub(crate) enum Response {
     Ok(Topology),
-    Error(ErrorResponse),
+    Error(ErrorResponses),
 }
 
 impl RESTRequest for Request {

--- a/common/client-libs/validator-client/src/rest_requests/mod.rs
+++ b/common/client-libs/validator-client/src/rest_requests/mod.rs
@@ -14,6 +14,7 @@
 
 use reqwest::{Method, Url};
 use serde::{de::DeserializeOwned, Serialize};
+use std::fmt::{self, Display, Formatter};
 
 pub(crate) use active_topology_get::{
     Request as ActiveTopologyGet, Response as ActiveTopologyGetResponse,
@@ -46,8 +47,30 @@ pub enum RESTRequestError {
     MalformedUrl(String),
 }
 
+impl Display for RESTRequestError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            RESTRequestError::InvalidPathParams => write!(
+                f,
+                "invalid number of path parameters was provided or they were malformed"
+            ),
+            RESTRequestError::InvalidQueryParams => write!(
+                f,
+                "invalid number of query parameters was provided or they were malformed"
+            ),
+            RESTRequestError::NoPayloadProvided => {
+                write!(f, "no request payload was provided while it was expected")
+            }
+            RESTRequestError::MalformedUrl(url) => {
+                write!(f, "tried to make request to malformed url ({})", url)
+            }
+        }
+    }
+}
+
 pub(crate) trait RESTRequest {
-    const METHOD: Method; // 'GET', 'POST', 'DELETE', etc.
+    const METHOD: Method;
+    // 'GET', 'POST', 'DELETE', etc.
     const RELATIVE_PATH: &'static str;
 
     type JsonPayload: Serialize + Sized;

--- a/common/client-libs/validator-client/src/rest_requests/mod.rs
+++ b/common/client-libs/validator-client/src/rest_requests/mod.rs
@@ -69,8 +69,8 @@ impl Display for RESTRequestError {
 }
 
 pub(crate) trait RESTRequest {
-    const METHOD: Method;
     // 'GET', 'POST', 'DELETE', etc.
+    const METHOD: Method;
     const RELATIVE_PATH: &'static str;
 
     type JsonPayload: Serialize + Sized;

--- a/common/client-libs/validator-client/src/rest_requests/topology_get.rs
+++ b/common/client-libs/validator-client/src/rest_requests/topology_get.rs
@@ -14,7 +14,7 @@
 
 use crate::models::topology::Topology;
 use crate::rest_requests::{PathParam, QueryParam, RESTRequest, RESTRequestError};
-use crate::ErrorResponse;
+use crate::ErrorResponses;
 use reqwest::{Method, Url};
 use serde::Deserialize;
 
@@ -26,7 +26,7 @@ pub struct Request {
 #[serde(rename_all = "camelCase", untagged)]
 pub(crate) enum Response {
     Ok(Topology),
-    Error(ErrorResponse),
+    Error(ErrorResponses),
 }
 
 impl RESTRequest for Request {


### PR DESCRIPTION
When mixnode (or gateway) `init` or `run` fails, especially when trying to get topology or register the node, the error messages should now be better in explaining what happened.

~Note: as with the other pending pull requests, I absolutely expect this one to also fail nightly clippy check until the monitor change is merged.~ - no longer applies