### PR TITLE
Feature/validator client rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "miniz_oxide",
  "object",
@@ -180,6 +180,12 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -219,7 +225,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "constant_time_eq",
  "crypto-mac 0.8.0",
  "digest 0.9.0",
@@ -304,6 +310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
 name = "cc"
 version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +326,12 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha"
@@ -370,7 +388,7 @@ dependencies = [
  "serde",
  "sled 0.33.0",
  "tempfile",
- "tokio",
+ "tokio 0.2.22",
  "topology",
  "validator-client",
 ]
@@ -419,7 +437,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "wasm-bindgen",
 ]
 
@@ -431,9 +449,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -441,9 +459,32 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
+name = "cosmwasm-derive"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de70197a0fe4e402aa260da00ec62d9bf091afe87866e9f3347691d591b60f89"
+dependencies = [
+ "syn 1.0.58",
+]
+
+[[package]]
+name = "cosmwasm-std"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02173c4eb78ef76863f5190f60a45278d11e7c8b142327c149e18128b2b97f85"
+dependencies = [
+ "base64 0.13.0",
+ "cosmwasm-derive",
+ "schemars",
+ "serde",
+ "serde-json-wasm",
+ "thiserror",
+]
 
 [[package]]
 name = "cpuid-bool"
@@ -457,7 +498,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -467,7 +508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils",
  "lazy_static",
  "maybe-uninit",
@@ -482,7 +523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
 ]
 
@@ -574,11 +615,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "4.0.0-rc6"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308a6703be2d759cb5fb7b80a23547fe73a8d5ebf70d3a4ca7f0ef4c0bfc2265"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
- "once_cell",
+ "cfg-if 1.0.0",
+ "num_cpus",
 ]
 
 [[package]]
@@ -611,7 +653,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -682,7 +724,7 @@ version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -745,6 +787,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs2"
@@ -892,11 +944,11 @@ dependencies = [
  "log",
  "nymsphinx",
  "rand",
- "tokio",
+ "tokio 0.2.22",
  "tokio-tungstenite",
  "tungstenite",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.17",
+ "wasm-bindgen-futures 0.4.21",
  "wasm-timer",
  "wasm-utils",
 ]
@@ -942,7 +994,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
  "wasm-bindgen",
@@ -960,7 +1012,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -968,8 +1020,27 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
- "tokio-util",
+ "tokio 0.2.22",
+ "tokio-util 0.3.1",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.3.0",
+ "tokio-util 0.6.4",
  "tracing",
 ]
 
@@ -1048,7 +1119,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -1059,7 +1130,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
+ "http",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+dependencies = [
+ "bytes 1.0.1",
  "http",
 ]
 
@@ -1068,6 +1149,12 @@ name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
@@ -1100,19 +1187,43 @@ version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.6",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
  "itoa",
  "pin-project 0.4.23",
  "socket2",
  "time",
- "tokio",
+ "tokio 0.2.22",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.1",
+ "http",
+ "http-body 0.4.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.4",
+ "socket2",
+ "tokio 1.3.0",
  "tower-service",
  "tracing",
  "want",
@@ -1124,11 +1235,24 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes",
- "hyper",
+ "bytes 0.5.6",
+ "hyper 0.13.7",
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
  "tokio-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.1",
+ "hyper 0.14.4",
+ "native-tls",
+ "tokio 1.3.0",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1158,7 +1282,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
 ]
 
 [[package]]
@@ -1199,9 +1323,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.44"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1230,9 +1354,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.76"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+checksum = "538c092e5586f4cdd7dd8078c4a79220e3e168880218124dcbce860f0ea938c6"
 
 [[package]]
 name = "lioness"
@@ -1270,7 +1394,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1317,9 +1441,9 @@ name = "metrics-client"
 version = "0.1.0"
 dependencies = [
  "mockito",
- "reqwest",
+ "reqwest 0.10.8",
  "serde",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1353,7 +1477,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -1367,14 +1491,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2182a122f3b7f3f5329cb1972cee089ba2459a0a80a56935e6e674f096f8d839"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.6",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "mio-named-pipes"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
- "mio",
- "miow 0.3.5",
+ "mio 0.6.22",
+ "miow 0.3.6",
  "winapi 0.3.9",
 ]
 
@@ -1386,7 +1523,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.22",
 ]
 
 [[package]]
@@ -1403,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
@@ -1418,8 +1555,17 @@ dependencies = [
  "futures 0.3.9",
  "log",
  "nymsphinx",
- "tokio",
- "tokio-util",
+ "tokio 0.2.22",
+ "tokio-util 0.3.1",
+]
+
+[[package]]
+name = "mixnet-contract"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
 ]
 
 [[package]]
@@ -1436,7 +1582,7 @@ dependencies = [
  "nymsphinx-framing",
  "nymsphinx-params",
  "nymsphinx-types",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1459,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1481,7 +1627,7 @@ version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
 ]
@@ -1490,7 +1636,16 @@ dependencies = [
 name = "nonexhaustive-delayqueue"
 version = "0.1.0"
 dependencies = [
- "tokio",
+ "tokio 0.2.22",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1543,7 +1698,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sled 0.33.0",
- "tokio",
+ "tokio 0.2.22",
  "tokio-tungstenite",
  "topology",
  "url",
@@ -1567,7 +1722,7 @@ dependencies = [
  "topology",
  "validator-client",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.17",
+ "wasm-bindgen-futures 0.4.21",
  "wasm-bindgen-test",
  "wasm-utils",
  "wee_alloc",
@@ -1595,9 +1750,9 @@ dependencies = [
  "rand",
  "serde",
  "sled 0.31.0",
- "tokio",
+ "tokio 0.2.22",
  "tokio-tungstenite",
- "tokio-util",
+ "tokio-util 0.3.1",
  "tungstenite",
  "validator-client",
  "version-checker",
@@ -1626,8 +1781,8 @@ dependencies = [
  "pretty_env_logger",
  "rand",
  "serde",
- "tokio",
- "tokio-util",
+ "tokio 0.2.22",
+ "tokio-util 0.3.1",
  "topology",
  "validator-client",
  "version-checker",
@@ -1650,7 +1805,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 0.2.22",
  "topology",
  "validator-client",
  "version-checker",
@@ -1672,7 +1827,7 @@ dependencies = [
  "publicsuffix",
  "rand",
  "socks5-requests",
- "tokio",
+ "tokio 0.2.22",
  "tokio-tungstenite",
  "websocket-requests",
 ]
@@ -1700,7 +1855,7 @@ dependencies = [
  "serde",
  "snafu",
  "socks5-requests",
- "tokio",
+ "tokio 0.2.22",
  "topology",
  "validator-client",
  "version-checker",
@@ -1722,7 +1877,7 @@ dependencies = [
  "nymsphinx-types",
  "rand",
  "rand_distr",
- "tokio",
+ "tokio 0.2.22",
  "topology",
 ]
 
@@ -1802,10 +1957,10 @@ dependencies = [
 name = "nymsphinx-framing"
 version = "0.1.0"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "nymsphinx-params",
  "nymsphinx-types",
- "tokio-util",
+ "tokio-util 0.3.1",
 ]
 
 [[package]]
@@ -1831,9 +1986,9 @@ checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -1854,7 +2009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -1914,7 +2069,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
@@ -1928,7 +2083,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.1.0",
  "instant",
  "libc",
@@ -2143,12 +2298,12 @@ dependencies = [
 name = "proxy-helpers"
 version = "0.1.0"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures 0.3.9",
  "log",
  "ordered-buffer",
  "socks5-requests",
- "tokio",
+ "tokio 0.2.22",
  "tokio-test",
 ]
 
@@ -2297,14 +2452,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
 dependencies = [
  "base64 0.12.3",
- "bytes",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http",
- "http-body",
- "hyper",
- "hyper-tls",
+ "http-body 0.3.1",
+ "hyper 0.13.7",
+ "hyper-tls 0.4.3",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -2316,12 +2471,47 @@ dependencies = [
  "pin-project-lite 0.1.7",
  "serde",
  "serde_json",
- "serde_urlencoded",
- "tokio",
+ "serde_urlencoded 0.6.1",
+ "tokio 0.2.22",
  "tokio-tls",
  "url",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.17",
+ "wasm-bindgen-futures 0.4.21",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 0.4.0",
+ "hyper 0.14.4",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite 0.2.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded 0.7.0",
+ "tokio 1.3.0",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures 0.4.21",
  "web-sys",
  "winreg",
 ]
@@ -2397,9 +2587,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "0.4.4"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2410,9 +2600,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.3"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2440,6 +2630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-json-wasm"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120bad73306616e91acd7ceed522ba96032a51cffeef3cc813de7f367df71e37"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2488,6 +2687,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,7 +2717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -2531,7 +2742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -2622,13 +2833,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -2738,7 +2948,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand",
  "redox_syscall",
@@ -2762,6 +2972,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.58",
 ]
 
 [[package]]
@@ -2796,14 +3026,14 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
  "libc",
  "memchr",
- "mio",
+ "mio 0.6.22",
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
@@ -2812,6 +3042,20 @@ dependencies = [
  "slab",
  "tokio-macros",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+dependencies = [
+ "autocfg",
+ "bytes 1.0.1",
+ "libc",
+ "memchr",
+ "mio 0.7.10",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -2826,14 +3070,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.3.0",
+]
+
+[[package]]
 name = "tokio-test"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0049c119b6d505c4447f5c64873636c7af6c75ab0d45fd9f618d82acb8016d"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -2843,7 +3097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -2855,7 +3109,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project 0.4.23",
- "tokio",
+ "tokio 0.2.22",
  "tungstenite",
 ]
 
@@ -2865,12 +3119,26 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite 0.1.7",
- "tokio",
+ "tokio 0.2.22",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec31e5cc6b46e653cf57762f36f71d5e6386391d88a72fd6db4508f8f676fb29"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.4",
+ "tokio 1.3.0",
 ]
 
 [[package]]
@@ -2904,20 +3172,21 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
+ "pin-project-lite 0.2.4",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0e00789804e99b20f12bc7003ca416309d28a6f495d6af58d1e2c2842461b5"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
 ]
@@ -2936,7 +3205,7 @@ checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
  "base64 0.12.3",
  "byteorder",
- "bytes",
+ "bytes 0.5.6",
  "http",
  "httparse",
  "input_buffer",
@@ -3006,10 +3275,11 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
@@ -3028,11 +3298,22 @@ dependencies = [
  "crypto",
  "log",
  "mockito",
- "reqwest",
+ "reqwest 0.10.8",
  "schemars",
  "serde",
- "tokio",
+ "tokio 0.2.22",
  "topology",
+]
+
+[[package]]
+name = "validator-client-rest"
+version = "0.1.0"
+dependencies = [
+ "base64 0.13.0",
+ "mixnet-contract",
+ "reqwest 0.11.2",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3084,11 +3365,11 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.67"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -3096,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.67"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3115,7 +3396,7 @@ version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83420b37346c311b9ed822af41ec2e82839bfe99867ec6c54e2da43b7538771c"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "futures 0.1.29",
  "js-sys",
  "wasm-bindgen",
@@ -3124,11 +3405,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.17"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
+checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -3136,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.67"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -3146,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.67"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -3159,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.67"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -3199,7 +3480,7 @@ dependencies = [
  "parking_lot 0.11.0",
  "pin-utils",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.17",
+ "wasm-bindgen-futures 0.4.21",
  "web-sys",
 ]
 
@@ -3211,7 +3492,7 @@ dependencies = [
  "js-sys",
  "tungstenite",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.17",
+ "wasm-bindgen-futures 0.4.21",
  "web-sys",
 ]
 
@@ -3240,7 +3521,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "memory_units",
  "winapi 0.3.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "common/client-libs/validator-client",
     "common/config",
     "common/crypto",
+    "common/mixnet-contract",
     "common/mixnode-common",
     "common/nonexhaustive-delayqueue",
     "common/nymsphinx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "common/client-libs/metrics-client",
     "common/client-libs/mixnet-client",
     "common/client-libs/validator-client",
+    "common/client-libs/validator-client-rest",
     "common/config",
     "common/crypto",
     "common/mixnet-contract",

--- a/common/client-libs/validator-client-rest/Cargo.toml
+++ b/common/client-libs/validator-client-rest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "validator-client-rest"
 version = "0.1.0"
-authors = ["Jędrzej Stuczyński <jedrzej.stuczynski@gmail.com>"]
+authors = ["Jędrzej Stuczyński <andrew@nymtech.net>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -13,5 +13,3 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.11", features = ["json"] }
 
-[dev-dependencies]
-tokio = { version = "1", features = ["full"] }

--- a/common/client-libs/validator-client-rest/Cargo.toml
+++ b/common/client-libs/validator-client-rest/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "validator-client-rest"
+version = "0.1.0"
+authors = ["Jędrzej Stuczyński <jedrzej.stuczynski@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+base64 = "0.13"
+mixnet-contract = { path = "../../../common/mixnet-contract" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+reqwest = { version = "0.11", features = ["json"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }

--- a/common/client-libs/validator-client-rest/src/lib.rs
+++ b/common/client-libs/validator-client-rest/src/lib.rs
@@ -1,0 +1,157 @@
+use mixnet_contract::{HumanAddr, PagedGatewayResponse, PagedResponse};
+use reqwest::Method;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::str::FromStr;
+
+pub struct Config {
+    rpc_server_base_url: String,
+    mixnet_contract_address: String,
+    mixnode_page_limit: Option<u32>,
+    gateway_page_limit: Option<u32>,
+}
+
+impl Config {
+    pub fn new<S: Into<String>>(base_url: S, mixnet_contract_address: S) -> Self {
+        Config {
+            rpc_server_base_url: base_url.into(),
+            mixnet_contract_address: mixnet_contract_address.into(),
+            mixnode_page_limit: None,
+            gateway_page_limit: None,
+        }
+    }
+
+    pub fn with_mixnode_page_limit(mut self, limit: Option<u32>) -> Config {
+        self.mixnode_page_limit = limit;
+        self
+    }
+
+    pub fn with_gateway_page_limit(mut self, limit: Option<u32>) -> Config {
+        self.gateway_page_limit = limit;
+        self
+    }
+}
+
+pub struct Client {
+    config: Config,
+    reqwest_client: reqwest::Client,
+}
+
+impl Client {
+    pub fn new(config: Config) -> Self {
+        let reqwest_client = reqwest::Client::new();
+        Client {
+            config,
+            reqwest_client,
+        }
+    }
+
+    fn base_query_path(&self) -> String {
+        format!(
+            "{}/wasm/contract/{}/smart",
+            self.config.rpc_server_base_url, self.config.mixnet_contract_address
+        )
+    }
+
+    async fn get_mix_nodes_paged(&self, start_after: Option<HumanAddr>) {
+        let query_content_json = serde_json::to_string(&QueryRequest::GetMixNodes {
+            limit: self.config.mixnode_page_limit,
+            start_after,
+        })
+        .expect("serde was incorrectly implemented on QueryRequest::GetMixNodes!");
+
+        println!("req json: {}", query_content_json);
+
+        let query_content = base64::encode(query_content_json);
+
+        let query_url = format!(
+            "{}/{}?encoding=base64",
+            self.base_query_path(),
+            query_content
+        );
+
+        let res = self.reqwest_client.get(query_url).send().await;
+
+        println!("{:?}", res);
+        let a: SmartQueryResult = res.unwrap().json().await.unwrap();
+        // let a = res.unwrap().text().await.unwrap();
+        // let foo: SmartQueryResult = serde_json::from_str(&a).unwrap();
+        println!("got {:?}", a)
+        // let mut req_builder = self.reqwest_client.request(Method::GET)
+    }
+
+    pub async fn get_mix_nodes(&self) {}
+
+    async fn get_gateways_paged(&self) {}
+
+    pub async fn get_gateways(&self) {}
+}
+
+// TODO: this is really a duplicate code but it really does not feel
+// like it belongs in the common crate because it's TOO contract specific...
+// I'm not entirely sure what to do about it now.
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum QueryRequest {
+    GetMixNodes {
+        limit: Option<u32>,
+        start_after: Option<HumanAddr>,
+    },
+    GetGateways {
+        start_after: Option<HumanAddr>,
+        limit: Option<u32>,
+    },
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+enum QueryResponse {
+    MixNodes(PagedResponse),
+    Gateways(PagedGatewayResponse),
+}
+
+#[derive(Deserialize, Debug)]
+struct SmartResult {
+    #[serde(deserialize_with = "de_query_response_from_str")]
+    smart: QueryResponse,
+}
+
+#[derive(Deserialize, Debug)]
+struct SmartQueryResult {
+    #[serde(deserialize_with = "de_i64_from_str")]
+    height: i64,
+    result: SmartResult,
+}
+
+fn de_query_response_from_str<'de, D>(deserializer: D) -> Result<QueryResponse, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    let b64_decoded = base64::decode(&s).map_err(serde::de::Error::custom)?;
+
+    let json_string = String::from_utf8(b64_decoded).map_err(serde::de::Error::custom)?;
+    serde_json::from_str(&json_string).map_err(serde::de::Error::custom)
+}
+
+fn de_i64_from_str<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    i64::from_str(&s).map_err(serde::de::Error::custom)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn foo() {
+        let base_url = "http://localhost:1317";
+        let contract = "nym10pyejy66429refv3g35g2t7am0was7ya69su6d";
+
+        let client = Client::new(Config::new(base_url, contract));
+
+        client.get_mix_nodes_paged(None).await;
+    }
+}

--- a/common/client-libs/validator-client-rest/src/models.rs
+++ b/common/client-libs/validator-client-rest/src/models.rs
@@ -1,0 +1,90 @@
+// Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::serde_helpers::{de_i64_from_str, de_paged_query_response_from_str};
+use core::fmt::{self, Display, Formatter};
+use mixnet_contract::HumanAddr;
+use serde::{Deserialize, Serialize};
+
+// TODO: this is a duplicate code but it really does not feel
+// like it would belong in the common crate because it's TOO contract specific...
+// I'm not entirely sure what to do about it now.
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum QueryRequest {
+    GetMixNodes {
+        limit: Option<u32>,
+        start_after: Option<HumanAddr>,
+    },
+    GetGateways {
+        start_after: Option<HumanAddr>,
+        limit: Option<u32>,
+    },
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(bound = "for<'a> T: Deserialize<'a>")]
+pub(super) struct SmartQueryResult<T>
+where
+    for<'a> T: Deserialize<'a>,
+{
+    #[serde(deserialize_with = "de_paged_query_response_from_str")]
+    pub(super) smart: T,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(bound = "for<'a> T: Deserialize<'a>")]
+pub(super) struct SmartQueryResponse<T>
+where
+    for<'a> T: Deserialize<'a>,
+{
+    #[serde(deserialize_with = "de_i64_from_str")]
+    pub(super) height: i64,
+    pub(super) result: SmartQueryResult<T>,
+}
+
+#[derive(Deserialize, Debug)]
+pub(super) struct SmartQueryError {
+    pub(super) error: String,
+}
+
+// this is the case of message like
+/*
+{
+  "code": 12,
+  "message": "Not Implemented",
+  "details": [
+  ]
+}
+ */
+// I didn't manage to find where it exactly originates, nor what the correct types should be
+// so all of those are some educated guesses
+#[derive(Deserialize, Debug)]
+pub(super) struct CodedError {
+    code: u32,
+    message: String,
+    details: Vec<(String, String)>,
+}
+
+impl Display for CodedError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "code: {} - {}", self.code, self.message)?;
+        // this is under assumption that details are indeed key value pairs which is a big IF
+        for detail in &self.details {
+            write!(f, " {:?}", detail)?
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(bound = "for<'a> T: Deserialize<'a>")]
+#[serde(untagged)]
+pub(super) enum QueryResponse<T>
+where
+    for<'a> T: Deserialize<'a>,
+{
+    Ok(SmartQueryResponse<T>),
+    Error(SmartQueryError),
+    CodedError(CodedError),
+}

--- a/common/client-libs/validator-client-rest/src/serde_helpers.rs
+++ b/common/client-libs/validator-client-rest/src/serde_helpers.rs
@@ -1,0 +1,26 @@
+// Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use core::str::FromStr;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer};
+
+pub(super) fn de_paged_query_response_from_str<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: DeserializeOwned,
+{
+    let s = String::deserialize(deserializer)?;
+    let b64_decoded = base64::decode(&s).map_err(serde::de::Error::custom)?;
+
+    let json_string = String::from_utf8(b64_decoded).map_err(serde::de::Error::custom)?;
+    serde_json::from_str(&json_string).map_err(serde::de::Error::custom)
+}
+
+pub(super) fn de_i64_from_str<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    i64::from_str(&s).map_err(serde::de::Error::custom)
+}

--- a/common/mixnet-contract/Cargo.toml
+++ b/common/mixnet-contract/Cargo.toml
@@ -9,6 +9,4 @@ edition = "2018"
 [dependencies]
 cosmwasm-std = { version = "0.13.2" }
 serde = { version = "1.0", features = ["derive"] }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
 schemars = "0.7"

--- a/common/mixnet-contract/Cargo.toml
+++ b/common/mixnet-contract/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mixnet-contract"
+version = "0.1.0"
+authors = ["Jędrzej Stuczyński <jedrzej.stuczynski@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cosmwasm-std = { version = "0.13.2" }
+serde = { version = "1.0", features = ["derive"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+schemars = "0.7"

--- a/common/mixnet-contract/Cargo.toml
+++ b/common/mixnet-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mixnet-contract"
 version = "0.1.0"
-authors = ["Jędrzej Stuczyński <jedrzej.stuczynski@gmail.com>"]
+authors = ["Jędrzej Stuczyński <andrew@nymtech.net>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/common/mixnet-contract/src/lib.rs
+++ b/common/mixnet-contract/src/lib.rs
@@ -12,6 +12,24 @@ pub struct MixNode {
     pub(crate) version: String,
 }
 
+impl MixNode {
+    pub fn new(
+        host: String,
+        layer: u64,
+        location: String,
+        sphinx_key: String,
+        version: String,
+    ) -> Self {
+        MixNode {
+            host,
+            layer,
+            location,
+            sphinx_key,
+            version,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
 pub struct MixNodeBond {
     pub(crate) amount: Vec<Coin>,
@@ -60,6 +78,26 @@ pub struct Gateway {
     /// Base58 encoded ed25519 EdDSA public key of the gateway used to derive shared keys with clients
     pub(crate) identity_key: String,
     pub(crate) version: String,
+}
+
+impl Gateway {
+    pub fn new(
+        mix_host: String,
+        clients_host: String,
+        location: String,
+        sphinx_key: String,
+        identity_key: String,
+        version: String,
+    ) -> Self {
+        Gateway {
+            mix_host,
+            clients_host,
+            location,
+            sphinx_key,
+            identity_key,
+            version,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]

--- a/common/mixnet-contract/src/lib.rs
+++ b/common/mixnet-contract/src/lib.rs
@@ -1,12 +1,9 @@
 use cosmwasm_std::{Coin, HumanAddr};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
-#[cfg(target_arch = "wasm32")]
-use schemars::JsonSchema;
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[cfg_attr(target_arch = "wasm32", derive(JsonSchema))]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
 pub struct MixNode {
     pub(crate) host: String,
     pub(crate) layer: u64,
@@ -15,8 +12,7 @@ pub struct MixNode {
     pub(crate) version: String,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[cfg_attr(target_arch = "wasm32", derive(JsonSchema))]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
 pub struct MixNodeBond {
     pub(crate) amount: Vec<Coin>,
     pub(crate) owner: HumanAddr,
@@ -55,8 +51,7 @@ impl Display for MixNodeBond {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[cfg_attr(target_arch = "wasm32", derive(JsonSchema))]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
 pub struct Gateway {
     pub(crate) mix_host: String,
     pub(crate) clients_host: String,
@@ -67,8 +62,7 @@ pub struct Gateway {
     pub(crate) version: String,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[cfg_attr(target_arch = "wasm32", derive(JsonSchema))]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
 pub struct GatewayBond {
     pub(crate) amount: Vec<Coin>,
     pub(crate) owner: HumanAddr,

--- a/common/mixnet-contract/src/lib.rs
+++ b/common/mixnet-contract/src/lib.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Coin, HumanAddr};
+pub use cosmwasm_std::{Coin, HumanAddr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;

--- a/common/mixnet-contract/src/lib.rs
+++ b/common/mixnet-contract/src/lib.rs
@@ -1,0 +1,112 @@
+use cosmwasm_std::{Coin, HumanAddr};
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+
+#[cfg(target_arch = "wasm32")]
+use schemars::JsonSchema;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(target_arch = "wasm32", derive(JsonSchema))]
+pub struct MixNode {
+    pub(crate) host: String,
+    pub(crate) layer: u64,
+    pub(crate) location: String,
+    pub(crate) sphinx_key: String,
+    pub(crate) version: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(target_arch = "wasm32", derive(JsonSchema))]
+pub struct MixNodeBond {
+    pub(crate) amount: Vec<Coin>,
+    pub(crate) owner: HumanAddr,
+    pub(crate) mix_node: MixNode,
+}
+
+impl MixNodeBond {
+    pub fn new(amount: Vec<Coin>, owner: HumanAddr, mix_node: MixNode) -> Self {
+        MixNodeBond {
+            amount,
+            owner,
+            mix_node,
+        }
+    }
+
+    pub fn amount(&self) -> &[Coin] {
+        &self.amount
+    }
+
+    pub fn owner(&self) -> &HumanAddr {
+        &self.owner
+    }
+
+    pub fn mix_node(&self) -> &MixNode {
+        &self.mix_node
+    }
+}
+
+impl Display for MixNodeBond {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        // Write strictly the first element into the supplied output
+        // stream: `f`. Returns `fmt::Result` which indicates whether the
+        // operation succeeded or failed. Note that `write!` uses syntax which
+        // is very similar to `println!`.
+        write!(f, "amount: {:?}, owner: {}", self.amount, self.owner)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(target_arch = "wasm32", derive(JsonSchema))]
+pub struct Gateway {
+    pub(crate) mix_host: String,
+    pub(crate) clients_host: String,
+    pub(crate) location: String,
+    pub(crate) sphinx_key: String,
+    /// Base58 encoded ed25519 EdDSA public key of the gateway used to derive shared keys with clients
+    pub(crate) identity_key: String,
+    pub(crate) version: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(target_arch = "wasm32", derive(JsonSchema))]
+pub struct GatewayBond {
+    pub(crate) amount: Vec<Coin>,
+    pub(crate) owner: HumanAddr,
+    pub(crate) gateway: Gateway,
+}
+
+impl GatewayBond {
+    pub fn new(amount: Vec<Coin>, owner: HumanAddr, gateway: Gateway) -> Self {
+        GatewayBond {
+            amount,
+            owner,
+            gateway,
+        }
+    }
+
+    pub fn amount(&self) -> &[Coin] {
+        &self.amount
+    }
+
+    pub fn owner(&self) -> &HumanAddr {
+        &self.owner
+    }
+
+    pub fn gateway(&self) -> &Gateway {
+        &self.gateway
+    }
+}
+
+impl Display for GatewayBond {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if self.amount.len() != 1 {
+            write!(f, "amount: {:?}, owner: {}", self.amount, self.owner)
+        } else {
+            write!(
+                f,
+                "amount: {} {}, owner: {}",
+                self.amount[0].amount, self.amount[0].denom, self.owner
+            )
+        }
+    }
+}

--- a/common/mixnet-contract/src/lib.rs
+++ b/common/mixnet-contract/src/lib.rs
@@ -104,3 +104,45 @@ impl Display for GatewayBond {
         }
     }
 }
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
+pub struct PagedResponse {
+    pub nodes: Vec<MixNodeBond>,
+    pub per_page: usize,
+    pub start_next_after: Option<HumanAddr>,
+}
+
+impl PagedResponse {
+    pub fn new(
+        nodes: Vec<MixNodeBond>,
+        per_page: usize,
+        start_next_after: Option<HumanAddr>,
+    ) -> Self {
+        PagedResponse {
+            nodes,
+            per_page,
+            start_next_after,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
+pub struct PagedGatewayResponse {
+    pub nodes: Vec<GatewayBond>,
+    pub per_page: usize,
+    pub start_next_after: Option<HumanAddr>,
+}
+
+impl PagedGatewayResponse {
+    pub fn new(
+        nodes: Vec<GatewayBond>,
+        per_page: usize,
+        start_next_after: Option<HumanAddr>,
+    ) -> Self {
+        PagedGatewayResponse {
+            nodes,
+            per_page,
+            start_next_after,
+        }
+    }
+}

--- a/common/mixnode-common/Cargo.toml
+++ b/common/mixnode-common/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# using 4.0.0 release candidate as it's faster than 3.X and more importantly it resolves edge cases deadlocks
-dashmap = "4.0.0-rc6"
+dashmap = "4.0"
 futures = "0.3"
 log = "0.4"
 nonexhaustive-delayqueue = { path = "../nonexhaustive-delayqueue" }

--- a/common/mixnode-common/src/cached_packet_processor/cache.rs
+++ b/common/mixnode-common/src/cached_packet_processor/cache.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use dashmap::{DashMap, ElementGuard};
+use dashmap::mapref::one::Ref;
+use dashmap::DashMap;
 use futures::channel::mpsc;
 use log::*;
 use nonexhaustive_delayqueue::{Expired, NonExhaustiveDelayQueue};
@@ -67,7 +68,7 @@ impl KeyCache {
 
     pub(super) fn insert(&self, key: SharedSecret, cached_keys: CachedKeys) -> bool {
         trace!("inserting {:?} into the cache", key);
-        let insertion_result = self.vpn_key_cache.insert(key, cached_keys);
+        let insertion_result = self.vpn_key_cache.insert(key, cached_keys).is_some();
         if !insertion_result {
             debug!("{:?} was put into the cache", key);
             // this shouldn't really happen, but don't insert entry to invalidator if it was already
@@ -80,7 +81,7 @@ impl KeyCache {
     }
 
     // ElementGuard has Deref for CachedKeys so that's fine
-    pub(super) fn get(&self, key: &SharedSecret) -> Option<ElementGuard<SharedSecret, CachedKeys>> {
+    pub(super) fn get(&self, key: &SharedSecret) -> Option<Ref<SharedSecret, CachedKeys>> {
         self.vpn_key_cache.get(key)
     }
 
@@ -136,7 +137,11 @@ impl CacheInvalidator {
             expired_entry.get_ref()
         );
 
-        if !self.vpn_key_cache.remove(&expired_entry.into_inner()) {
+        if self
+            .vpn_key_cache
+            .remove(&expired_entry.into_inner())
+            .is_none()
+        {
             error!("Tried to remove vpn cache entry for non-existent key!")
         }
     }

--- a/contracts/mixnet/Cargo.lock
+++ b/contracts/mixnet/Cargo.lock
@@ -56,12 +56,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "mixnet-contract"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "mixnet-contracts"
 version = "0.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
+ "mixnet-contract",
  "schemars",
  "serde",
  "thiserror",

--- a/contracts/mixnet/Cargo.toml
+++ b/contracts/mixnet/Cargo.toml
@@ -33,6 +33,7 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
+mixnet-contract = { path = "../../common/mixnet-contract" }
 cosmwasm-std = { version = "0.13.2", features = ["iterator"] }
 cosmwasm-storage = { version = "0.13.2", features = ["iterator"] }
 schemars = "0.7"

--- a/contracts/mixnet/examples/schema.rs
+++ b/contracts/mixnet/examples/schema.rs
@@ -1,13 +1,9 @@
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+use mixnet_contract::MixNodeBond;
+use mixnet_contracts::msg::{HandleMsg, InitMsg, QueryMsg};
+use mixnet_contracts::state::State;
 use std::env::current_dir;
 use std::fs::create_dir_all;
-
-use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
-
-use mixnet_contracts::state::State;
-use mixnet_contracts::{
-    msg::{HandleMsg, InitMsg, QueryMsg},
-    state::MixNodeBond,
-};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -205,14 +205,12 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 
 #[cfg(test)]
 pub mod tests {
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{coins, from_binary};
-
-    use crate::queries::{PagedGatewayResponse, PagedResponse};
+    use super::*;
     use crate::support::tests::helpers;
     use crate::support::tests::helpers::*;
-
-    use super::*;
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::{coins, from_binary};
+    use mixnet_contract::{PagedGatewayResponse, PagedResponse};
 
     #[test]
     fn initialize_contract() {
@@ -293,7 +291,7 @@ pub mod tests {
         .unwrap();
         let page: PagedResponse = from_binary(&query_response).unwrap();
         assert_eq!(1, page.nodes.len());
-        assert_eq!(helpers::mix_node_fixture(), page.nodes[0].mix_node())
+        assert_eq!(&helpers::mix_node_fixture(), page.nodes[0].mix_node())
 
         // adding another node from another account, but with the same IP, should fail (or we would have a weird state). Is that right? Think about this, not sure yet.
         // if we attempt to register a second node from the same address, should we get an error? It would probably be polite.
@@ -379,7 +377,7 @@ pub mod tests {
         // only 1 node now exists, owned by bob:
         let mix_node_bonds = helpers::get_mix_nodes(&mut deps);
         assert_eq!(1, mix_node_bonds.len());
-        assert_eq!("bob", mix_node_bonds[0].owner);
+        assert_eq!("bob", mix_node_bonds[0].owner());
     }
 
     fn good_gateway_stake() -> Vec<Coin> {
@@ -481,7 +479,7 @@ pub mod tests {
         .unwrap();
         let page: PagedGatewayResponse = from_binary(&query_response).unwrap();
         assert_eq!(1, page.nodes.len());
-        assert_eq!(helpers::gateway_fixture(), page.nodes[0].gateway());
+        assert_eq!(&helpers::gateway_fixture(), page.nodes[0].gateway());
 
         // if there was already a gateway bonded by particular user
         let info = mock_info("foomper", &good_gateway_stake());
@@ -545,7 +543,7 @@ pub mod tests {
         assert_eq!(1, nodes.len());
 
         let first_node = &nodes[0];
-        assert_eq!("bob", first_node.owner);
+        assert_eq!("bob", first_node.owner());
 
         // add a node owned by fred
         let fred_bond = good_gateway_stake();
@@ -585,6 +583,6 @@ pub mod tests {
         // only 1 node now exists, owned by bob:
         let gateway_bonds = helpers::get_gateways(&mut deps);
         assert_eq!(1, gateway_bonds.len());
-        assert_eq!("bob", gateway_bonds[0].owner);
+        assert_eq!("bob", gateway_bonds[0].owner());
     }
 }

--- a/contracts/mixnet/src/msg.rs
+++ b/contracts/mixnet/src/msg.rs
@@ -1,8 +1,7 @@
 use cosmwasm_std::HumanAddr;
+use mixnet_contract::{Gateway, MixNode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-use crate::state::{Gateway, MixNode};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InitMsg {}

--- a/contracts/mixnet/src/queries.rs
+++ b/contracts/mixnet/src/queries.rs
@@ -1,10 +1,11 @@
 // settings for pagination
-use crate::state::{gateways_read, GatewayBond, MixNodeBond, PREFIX_MIXNODES};
+use crate::state::{gateways_read, PREFIX_MIXNODES};
 use cosmwasm_std::Deps;
 use cosmwasm_std::HumanAddr;
 use cosmwasm_std::Order;
 use cosmwasm_std::StdResult;
 use cosmwasm_storage::bucket_read;
+use mixnet_contract::{GatewayBond, MixNodeBond};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -66,7 +67,7 @@ pub(crate) fn query_gateways_paged(
         .map(|res| res.map(|item| item.1))
         .collect::<StdResult<Vec<GatewayBond>>>()?;
 
-    let start_next_after = nodes.last().map(|node| node.owner.clone());
+    let start_next_after = nodes.last().map(|node| node.owner().clone());
 
     Ok(PagedGatewayResponse {
         nodes,
@@ -90,7 +91,7 @@ fn calculate_start_value(
 fn last_node_owner(nodes: &[MixNodeBond]) -> Option<HumanAddr> {
     match nodes.last() {
         None => None,
-        Some(node) => Some(node.owner.clone()),
+        Some(node) => Some(node.owner().clone()),
     }
 }
 

--- a/contracts/mixnet/src/queries.rs
+++ b/contracts/mixnet/src/queries.rs
@@ -5,19 +5,10 @@ use cosmwasm_std::HumanAddr;
 use cosmwasm_std::Order;
 use cosmwasm_std::StdResult;
 use cosmwasm_storage::bucket_read;
-use mixnet_contract::{GatewayBond, MixNodeBond};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use mixnet_contract::{GatewayBond, MixNodeBond, PagedGatewayResponse, PagedResponse};
 
 const MAX_LIMIT: u32 = 30;
 const DEFAULT_LIMIT: u32 = 10;
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
-pub struct PagedResponse {
-    pub nodes: Vec<MixNodeBond>,
-    pub per_page: usize,
-    pub start_next_after: Option<HumanAddr>,
-}
 
 pub fn query_mixnodes_paged(
     deps: Deps,
@@ -38,19 +29,8 @@ pub fn query_mixnodes_paged(
         .collect::<Vec<_>>();
     let start_next_after = last_node_owner(&nodes);
 
-    let response = PagedResponse {
-        nodes,
-        per_page: limit,
-        start_next_after,
-    };
+    let response = PagedResponse::new(nodes, limit, start_next_after);
     Ok(response)
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
-pub struct PagedGatewayResponse {
-    pub(crate) nodes: Vec<GatewayBond>,
-    pub(crate) per_page: usize,
-    pub(crate) start_next_after: Option<HumanAddr>,
 }
 
 pub(crate) fn query_gateways_paged(
@@ -69,11 +49,7 @@ pub(crate) fn query_gateways_paged(
 
     let start_next_after = nodes.last().map(|node| node.owner().clone());
 
-    Ok(PagedGatewayResponse {
-        nodes,
-        per_page: limit,
-        start_next_after,
-    })
+    Ok(PagedGatewayResponse::new(nodes, limit, start_next_after))
 }
 
 /// Adds a 0 byte to terminate the `start_after` value given. This allows CosmWasm

--- a/contracts/mixnet/src/state.rs
+++ b/contracts/mixnet/src/state.rs
@@ -1,12 +1,11 @@
-use cosmwasm_std::Coin;
 use cosmwasm_std::{HumanAddr, Storage};
 use cosmwasm_storage::{
     bucket, bucket_read, singleton, singleton_read, Bucket, ReadonlyBucket, ReadonlySingleton,
     Singleton,
 };
+use mixnet_contract::{GatewayBond, MixNodeBond};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
 
 // Contract-level stuff
 
@@ -26,33 +25,7 @@ pub fn config_read(storage: &dyn Storage) -> ReadonlySingleton<State> {
 }
 
 // Mixnode-related stuff
-
 pub const PREFIX_MIXNODES: &[u8] = b"mixnodes";
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
-pub struct MixNodeBond {
-    pub(crate) amount: Vec<Coin>,
-    pub(crate) owner: HumanAddr,
-    pub(crate) mix_node: MixNode,
-}
-
-impl Display for MixNodeBond {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        // Write strictly the first element into the supplied output
-        // stream: `f`. Returns `fmt::Result` which indicates whether the
-        // operation succeeded or failed. Note that `write!` uses syntax which
-        // is very similar to `println!`.
-        write!(f, "amount: {:?}, owner: {}", self.amount, self.owner)
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
-pub struct MixNode {
-    pub(crate) host: String,
-    pub(crate) layer: u64,
-    pub(crate) location: String,
-    pub(crate) sphinx_key: String,
-    pub(crate) version: String,
-}
 
 pub fn mixnodes(storage: &mut dyn Storage) -> Bucket<MixNodeBond> {
     bucket(storage, PREFIX_MIXNODES)
@@ -65,50 +38,6 @@ pub fn mixnodes_read(storage: &dyn Storage) -> ReadonlyBucket<MixNodeBond> {
 // Gateway-related stuff
 
 pub const PREFIX_GATEWAYS: &[u8] = b"gateways";
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
-pub struct GatewayBond {
-    pub(crate) amount: Vec<Coin>,
-    pub(crate) owner: HumanAddr,
-    pub(crate) gateway: Gateway,
-}
-
-impl GatewayBond {
-    pub fn new(amount: Vec<Coin>, owner: HumanAddr, gateway: Gateway) -> Self {
-        GatewayBond {
-            amount,
-            owner,
-            gateway,
-        }
-    }
-}
-
-impl Display for GatewayBond {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if self.amount.len() != 1 {
-            write!(f, "amount: {:?}, owner: {}", self.amount, self.owner)
-        } else {
-            write!(
-                f,
-                "amount: {} {}, owner: {}",
-                self.amount[0].amount, self.amount[0].denom, self.owner
-            )
-        }
-    }
-}
-
-// TODO: I'm not entirely sure what's up with clippy::field_reassign_with_default
-// since it's not present in almost identical MixNode struct
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
-pub struct Gateway {
-    pub(crate) mix_host: String,
-    pub(crate) clients_host: String,
-    pub(crate) location: String,
-    pub(crate) sphinx_key: String,
-    /// Base58 encoded ed25519 EdDSA public key of the gateway used to derive shared keys with clients
-    pub(crate) identity_key: String,
-    pub(crate) version: String,
-}
 
 pub fn gateways(storage: &mut dyn Storage) -> Bucket<GatewayBond> {
     bucket(storage, PREFIX_GATEWAYS)

--- a/contracts/mixnet/src/support/tests.rs
+++ b/contracts/mixnet/src/support/tests.rs
@@ -6,9 +6,6 @@ pub mod helpers {
     use crate::contract::{init, try_add_gateway};
     use crate::msg::InitMsg;
     use crate::msg::QueryMsg;
-    use crate::queries::{PagedGatewayResponse, PagedResponse};
-    use crate::state::MixNodeBond;
-    use crate::state::{Gateway, GatewayBond, MixNode};
     use cosmwasm_std::coins;
     use cosmwasm_std::from_binary;
     use cosmwasm_std::testing::mock_dependencies;
@@ -21,6 +18,9 @@ pub mod helpers {
     use cosmwasm_std::HumanAddr;
     use cosmwasm_std::OwnedDeps;
     use cosmwasm_std::{Empty, MemoryStorage};
+    use mixnet_contract::{
+        Gateway, GatewayBond, MixNode, MixNodeBond, PagedGatewayResponse, PagedResponse,
+    };
 
     pub fn add_mixnode(
         pubkey: &str,
@@ -84,55 +84,47 @@ pub mod helpers {
     }
 
     pub fn mix_node_fixture() -> MixNode {
-        MixNode {
-            host: "mix.node.org".to_string(),
-            layer: 1,
-            location: "Sweden".to_string(),
-            sphinx_key: "sphinx".to_string(),
-            version: "0.10.0".to_string(),
-        }
+        MixNode::new(
+            "mix.node.org".to_string(),
+            1,
+            "Sweden".to_string(),
+            "sphinx".to_string(),
+            "0.10.0".to_string(),
+        )
     }
 
     pub fn mixnode_bond_fixture() -> MixNodeBond {
-        let mix_node = MixNode {
-            host: "1.1.1.1".to_string(),
-            layer: 1,
-            location: "London".to_string(),
-            sphinx_key: "1234".to_string(),
-            version: "0.10.0".to_string(),
-        };
-        MixNodeBond {
-            amount: coins(50, "unym"),
-            owner: HumanAddr::from("foo"),
-            mix_node,
-        }
+        let mix_node = MixNode::new(
+            "1.1.1.1".to_string(),
+            1,
+            "London".to_string(),
+            "1234".to_string(),
+            "0.10.0".to_string(),
+        );
+        MixNodeBond::new(coins(50, "unym"), HumanAddr::from("foo"), mix_node)
     }
 
     pub fn gateway_fixture() -> Gateway {
-        Gateway {
-            mix_host: "1.1.1.1:1234".to_string(),
-            clients_host: "ws://1.1.1.1:1235".to_string(),
-            location: "Sweden".to_string(),
-            sphinx_key: "sphinx".to_string(),
-            identity_key: "identity".to_string(),
-            version: "0.10.0".to_string(),
-        }
+        Gateway::new(
+            "1.1.1.1:1234".to_string(),
+            "ws://1.1.1.1:1235".to_string(),
+            "Sweden".to_string(),
+            "sphinx".to_string(),
+            "identity".to_string(),
+            "0.10.0".to_string(),
+        )
     }
 
     pub fn gateway_bond_fixture() -> GatewayBond {
-        let gateway = Gateway {
-            mix_host: "1.1.1.1:1234".to_string(),
-            clients_host: "ws://1.1.1.1:1235".to_string(),
-            location: "London".to_string(),
-            sphinx_key: "sphinx".to_string(),
-            identity_key: "identity".to_string(),
-            version: "0.10.0".to_string(),
-        };
-        GatewayBond {
-            amount: coins(50, "unym"),
-            owner: HumanAddr::from("foo"),
-            gateway,
-        }
+        let gateway = Gateway::new(
+            "1.1.1.1:1234".to_string(),
+            "ws://1.1.1.1:1235".to_string(),
+            "London".to_string(),
+            "sphinx".to_string(),
+            "identity".to_string(),
+            "0.10.0".to_string(),
+        );
+        GatewayBond::new(coins(50, "unym"), HumanAddr::from("foo"), gateway)
     }
 
     pub fn query_contract_balance(

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -12,8 +12,7 @@ edition = "2018"
 [dependencies]
 clap = "2.33.0"
 dirs = "2.0.2"
-# using 4.0.0 release candidate as it's faster than 3.X and more importantly it resolves edge cases deadlocks
-dashmap = "4.0.0-rc6"
+dashmap = "4.0"
 dotenv = "0.15.0"
 futures = "0.3"
 humantime-serde = "1.0.1"

--- a/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
+++ b/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
@@ -90,7 +90,11 @@ impl ConnectionHandler {
     }
 
     fn remove_stale_client_sender(&self, client_address: &DestinationAddressBytes) {
-        if !self.available_socket_senders_cache.remove(client_address) {
+        if self
+            .available_socket_senders_cache
+            .remove(client_address)
+            .is_none()
+        {
             warn!(
                 "Tried to remove stale entry for non-existent client sender: {}",
                 client_address
@@ -134,6 +138,7 @@ impl ConnectionHandler {
         if self
             .available_socket_senders_cache
             .insert(client_address, client_sender.clone())
+            .is_some()
         {
             // this warning is harmless, but I want to see if it's realistically for it to even occur
             warn!("Other thread already updated cache for client sender!")


### PR DESCRIPTION
Note: the only reason I touched the dashmap dependency (used by mixnodes and gateways) is that compiler complained about version of `once_cell` used in the project when I started using `reqwest` in the client.