### PR TITLE
Bugfix/unique node ownership

### DIFF
--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -115,15 +115,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
 }
 
 pub fn migrate(
-    deps: DepsMut,
+    _deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
+    _info: MessageInfo,
     _msg: MigrateMsg,
 ) -> Result<MigrateResponse, ContractError> {
-    // set the state to the default
-    let state = default_initial_state(info.sender);
-
-    config(deps.storage).save(&state)?;
     Ok(Default::default())
 }
 

--- a/contracts/mixnet/src/error.rs
+++ b/contracts/mixnet/src/error.rs
@@ -53,4 +53,10 @@ pub enum ContractError {
 
     #[error("This address has already bonded a gateway")]
     AlreadyOwnsGateway,
+
+    #[error("Mixnode with this identity already exists. Its owner is {owner:?}")]
+    DuplicateMixnode { owner: HumanAddr },
+
+    #[error("Gateway with this identity already exists. Its owner is {owner:?}")]
+    DuplicateGateway { owner: HumanAddr },
 }

--- a/contracts/mixnet/src/storage.rs
+++ b/contracts/mixnet/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::state::{State, StateParams};
-use cosmwasm_std::{Decimal, StdError, StdResult, Storage};
+use cosmwasm_std::{Decimal, HumanAddr, StdError, StdResult, Storage};
 use cosmwasm_storage::{
     bucket, bucket_read, singleton, singleton_read, Bucket, ReadonlyBucket, ReadonlySingleton,
     Singleton,
@@ -51,6 +51,16 @@ pub fn mixnodes_read(storage: &dyn Storage) -> ReadonlyBucket<MixNodeBond> {
     bucket_read(storage, PREFIX_MIXNODES)
 }
 
+const PREFIX_MIXNODES_OWNERS: &[u8] = b"mix-owners";
+
+pub fn mixnodes_owners(storage: &mut dyn Storage) -> Bucket<HumanAddr> {
+    bucket(storage, PREFIX_MIXNODES_OWNERS)
+}
+
+pub fn mixnodes_owners_read(storage: &dyn Storage) -> ReadonlyBucket<HumanAddr> {
+    bucket_read(storage, PREFIX_MIXNODES_OWNERS)
+}
+
 // helpers
 pub(crate) fn increase_mixnode_bond(
     storage: &mut dyn Storage,
@@ -96,6 +106,16 @@ pub fn gateways(storage: &mut dyn Storage) -> Bucket<GatewayBond> {
 
 pub fn gateways_read(storage: &dyn Storage) -> ReadonlyBucket<GatewayBond> {
     bucket_read(storage, PREFIX_GATEWAYS)
+}
+
+const PREFIX_GATEWAYS_OWNERS: &[u8] = b"gateway-owners";
+
+pub fn gateways_owners(storage: &mut dyn Storage) -> Bucket<HumanAddr> {
+    bucket(storage, PREFIX_GATEWAYS_OWNERS)
+}
+
+pub fn gateways_owners_read(storage: &dyn Storage) -> ReadonlyBucket<HumanAddr> {
+    bucket_read(storage, PREFIX_GATEWAYS_OWNERS)
 }
 
 // helpers

--- a/contracts/mixnet/src/support/tests.rs
+++ b/contracts/mixnet/src/support/tests.rs
@@ -29,7 +29,15 @@ pub mod helpers {
         deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
     ) {
         let info = mock_info(pubkey, &stake);
-        try_add_mixnode(deps.as_mut(), info, helpers::mix_node_fixture()).unwrap();
+        try_add_mixnode(
+            deps.as_mut(),
+            info,
+            MixNode {
+                identity_key: format!("{}mixnode", pubkey),
+                ..helpers::mix_node_fixture()
+            },
+        )
+        .unwrap();
     }
 
     pub fn get_mix_nodes(
@@ -55,7 +63,15 @@ pub mod helpers {
         deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
     ) {
         let info = mock_info(pubkey, &stake);
-        try_add_gateway(deps.as_mut(), info, helpers::gateway_fixture()).unwrap();
+        try_add_gateway(
+            deps.as_mut(),
+            info,
+            Gateway {
+                identity_key: format!("{}gateway", pubkey),
+                ..helpers::gateway_fixture()
+            },
+        )
+        .unwrap();
     }
 
     pub fn get_gateways(

--- a/contracts/mixnet/src/transactions.rs
+++ b/contracts/mixnet/src/transactions.rs
@@ -421,7 +421,10 @@ pub mod tests {
         // if we send enough funds
         let info = mock_info("anyone", &coins(1000_000000, DENOM));
         let msg = HandleMsg::BondMixnode {
-            mix_node: helpers::mix_node_fixture(),
+            mix_node: MixNode {
+                identity_key: "anyonesmixnode".into(),
+                ..helpers::mix_node_fixture()
+            },
         };
 
         // we get back a message telling us everything was OK
@@ -440,12 +443,21 @@ pub mod tests {
         .unwrap();
         let page: PagedResponse = from_binary(&query_response).unwrap();
         assert_eq!(1, page.nodes.len());
-        assert_eq!(&helpers::mix_node_fixture(), page.nodes[0].mix_node());
+        assert_eq!(
+            &MixNode {
+                identity_key: "anyonesmixnode".into(),
+                ..helpers::mix_node_fixture()
+            },
+            page.nodes[0].mix_node()
+        );
 
         // if there was already a mixnode bonded by particular user
         let info = mock_info("foomper", &good_mixnode_bond());
         let msg = HandleMsg::BondMixnode {
-            mix_node: helpers::mix_node_fixture(),
+            mix_node: MixNode {
+                identity_key: "foompermixnode".into(),
+                ..helpers::mix_node_fixture()
+            },
         };
 
         let handle_response = handle(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -453,7 +465,10 @@ pub mod tests {
 
         let info = mock_info("foomper", &good_mixnode_bond());
         let msg = HandleMsg::BondMixnode {
-            mix_node: helpers::mix_node_fixture(),
+            mix_node: MixNode {
+                identity_key: "foompermixnode".into(),
+                ..helpers::mix_node_fixture()
+            },
         };
 
         // we get a log message about it (TODO: does it get back to the user?)
@@ -488,6 +503,121 @@ pub mod tests {
 
         // adding another node from another account, but with the same IP, should fail (or we would have a weird state). Is that right? Think about this, not sure yet.
         // if we attempt to register a second node from the same address, should we get an error? It would probably be polite.
+    }
+
+    #[test]
+    fn adding_mixnode_without_existing_owner() {
+        let mut deps = helpers::init_contract();
+
+        let info = mock_info("mix-owner", &good_mixnode_bond());
+        let msg = HandleMsg::BondMixnode {
+            mix_node: MixNode {
+                identity_key: "myAwesomeMixnode".to_string(),
+                ..helpers::mix_node_fixture()
+            },
+        };
+
+        // before the execution the node had no associated owner
+        assert!(mixnodes_owners_read(deps.as_ref().storage)
+            .may_load("myAwesomeMixnode".as_bytes())
+            .unwrap()
+            .is_none());
+
+        // it's all fine, owner is saved
+        let handle_response = handle(deps.as_mut(), mock_env(), info, msg);
+        assert!(handle_response.is_ok());
+
+        assert_eq!(
+            HumanAddr::from("mix-owner"),
+            mixnodes_owners_read(deps.as_ref().storage)
+                .load("myAwesomeMixnode".as_bytes())
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn adding_mixnode_with_existing_owner() {
+        let mut deps = helpers::init_contract();
+
+        let info = mock_info("mix-owner", &good_mixnode_bond());
+        let msg = HandleMsg::BondMixnode {
+            mix_node: MixNode {
+                identity_key: "myAwesomeMixnode".to_string(),
+                ..helpers::mix_node_fixture()
+            },
+        };
+
+        handle(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+        // request fails giving the existing owner address in the message
+        let info = mock_info("mix-owner-pretender", &good_mixnode_bond());
+        let msg = HandleMsg::BondMixnode {
+            mix_node: MixNode {
+                identity_key: "myAwesomeMixnode".to_string(),
+                ..helpers::mix_node_fixture()
+            },
+        };
+
+        let handle_response = handle(deps.as_mut(), mock_env(), info, msg);
+        assert_eq!(
+            Err(ContractError::DuplicateMixnode {
+                owner: "mix-owner".into()
+            }),
+            handle_response
+        );
+
+        // owner is not changed
+        assert_eq!(
+            HumanAddr::from("mix-owner"),
+            mixnodes_owners_read(deps.as_ref().storage)
+                .load("myAwesomeMixnode".as_bytes())
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn adding_mixnode_with_existing_unchanged_owner() {
+        let mut deps = helpers::init_contract();
+
+        let info = mock_info("mix-owner", &good_mixnode_bond());
+        let msg = HandleMsg::BondMixnode {
+            mix_node: MixNode {
+                identity_key: "myAwesomeMixnode".to_string(),
+                host: "1.1.1.1:1789".into(),
+                ..helpers::mix_node_fixture()
+            },
+        };
+
+        handle(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+        let info = mock_info("mix-owner", &good_mixnode_bond());
+        let msg = HandleMsg::BondMixnode {
+            mix_node: MixNode {
+                identity_key: "myAwesomeMixnode".to_string(),
+                host: "2.2.2.2:1789".into(),
+                ..helpers::mix_node_fixture()
+            },
+        };
+
+        assert!(handle(deps.as_mut(), mock_env(), info, msg).is_ok());
+
+        // make sure the host information was updated
+        assert_eq!(
+            "2.2.2.2:1789".to_string(),
+            mixnodes_read(deps.as_ref().storage)
+                .load("mix-owner".as_bytes())
+                .unwrap()
+                .mix_node
+                .host
+        );
+
+        // and nothing was changed regarding ownership
+        assert_eq!(
+            HumanAddr::from("mix-owner"),
+            mixnodes_owners_read(deps.as_ref().storage)
+                .load("myAwesomeMixnode".as_bytes())
+                .unwrap()
+        );
     }
 
     #[test]
@@ -573,6 +703,54 @@ pub mod tests {
         assert_eq!("bob", mix_node_bonds[0].owner());
     }
 
+    #[test]
+    fn removing_mixnode_clears_ownership() {
+        let mut deps = helpers::init_contract();
+
+        let info = mock_info("mix-owner", &good_mixnode_bond());
+        let msg = HandleMsg::BondMixnode {
+            mix_node: MixNode {
+                identity_key: "myAwesomeMixnode".to_string(),
+                ..helpers::mix_node_fixture()
+            },
+        };
+
+        handle(deps.as_mut(), mock_env(), info, msg).unwrap();
+        assert_eq!(
+            HumanAddr::from("mix-owner"),
+            mixnodes_owners_read(deps.as_ref().storage)
+                .load("myAwesomeMixnode".as_bytes())
+                .unwrap()
+        );
+
+        let info = mock_info("mix-owner", &[]);
+        let msg = HandleMsg::UnbondMixnode {};
+
+        assert!(handle(deps.as_mut(), mock_env(), info, msg).is_ok());
+
+        assert!(mixnodes_owners_read(deps.as_ref().storage)
+            .may_load("myAwesomeMixnode".as_bytes())
+            .unwrap()
+            .is_none());
+
+        // and since it's removed, it can be reclaimed
+        let info = mock_info("mix-owner", &good_mixnode_bond());
+        let msg = HandleMsg::BondMixnode {
+            mix_node: MixNode {
+                identity_key: "myAwesomeMixnode".to_string(),
+                ..helpers::mix_node_fixture()
+            },
+        };
+
+        assert!(handle(deps.as_mut(), mock_env(), info, msg).is_ok());
+        assert_eq!(
+            HumanAddr::from("mix-owner"),
+            mixnodes_owners_read(deps.as_ref().storage)
+                .load("myAwesomeMixnode".as_bytes())
+                .unwrap()
+        );
+    }
+
     fn good_gateway_bond() -> Vec<Coin> {
         vec![Coin {
             denom: DENOM.to_string(),
@@ -653,7 +831,10 @@ pub mod tests {
         // if we send enough funds
         let info = mock_info("anyone", &good_gateway_bond());
         let msg = HandleMsg::BondGateway {
-            gateway: helpers::gateway_fixture(),
+            gateway: Gateway {
+                identity_key: "anyonesgateway".into(),
+                ..helpers::gateway_fixture()
+            },
         };
 
         // we get back a message telling us everything was OK
@@ -672,12 +853,21 @@ pub mod tests {
         .unwrap();
         let page: PagedGatewayResponse = from_binary(&query_response).unwrap();
         assert_eq!(1, page.nodes.len());
-        assert_eq!(&helpers::gateway_fixture(), page.nodes[0].gateway());
+        assert_eq!(
+            &Gateway {
+                identity_key: "anyonesgateway".into(),
+                ..helpers::gateway_fixture()
+            },
+            page.nodes[0].gateway()
+        );
 
         // if there was already a gateway bonded by particular user
         let info = mock_info("foomper", &good_gateway_bond());
         let msg = HandleMsg::BondGateway {
-            gateway: helpers::gateway_fixture(),
+            gateway: Gateway {
+                identity_key: "foompersgateway".into(),
+                ..helpers::gateway_fixture()
+            },
         };
 
         let handle_response = handle(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -685,7 +875,10 @@ pub mod tests {
 
         let info = mock_info("foomper", &good_gateway_bond());
         let msg = HandleMsg::BondGateway {
-            gateway: helpers::gateway_fixture(),
+            gateway: Gateway {
+                identity_key: "foompersgateway".into(),
+                ..helpers::gateway_fixture()
+            },
         };
 
         // we get a log message about it (TODO: does it get back to the user?)
@@ -699,7 +892,7 @@ pub mod tests {
         };
         handle(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-        let info = mock_info("mixnode-owner", &good_mixnode_bond());
+        let info = mock_info("mixnode-owner", &good_gateway_bond());
         let msg = HandleMsg::BondGateway {
             gateway: helpers::gateway_fixture(),
         };
@@ -711,7 +904,7 @@ pub mod tests {
         let msg = HandleMsg::UnbondMixnode {};
         handle(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-        let info = mock_info("mixnode-owner", &good_mixnode_bond());
+        let info = mock_info("mixnode-owner", &good_gateway_bond());
         let msg = HandleMsg::BondGateway {
             gateway: helpers::gateway_fixture(),
         };
@@ -720,6 +913,121 @@ pub mod tests {
 
         // adding another node from another account, but with the same IP, should fail (or we would have a weird state).
         // Is that right? Think about this, not sure yet.
+    }
+
+    #[test]
+    fn adding_gateway_without_existing_owner() {
+        let mut deps = helpers::init_contract();
+
+        let info = mock_info("gateway-owner", &good_gateway_bond());
+        let msg = HandleMsg::BondGateway {
+            gateway: Gateway {
+                identity_key: "myAwesomeGateway".to_string(),
+                ..helpers::gateway_fixture()
+            },
+        };
+
+        // before the execution the node had no associated owner
+        assert!(gateways_owners_read(deps.as_ref().storage)
+            .may_load("myAwesomeGateway".as_bytes())
+            .unwrap()
+            .is_none());
+
+        // it's all fine, owner is saved
+        let handle_response = handle(deps.as_mut(), mock_env(), info, msg);
+        assert!(handle_response.is_ok());
+
+        assert_eq!(
+            HumanAddr::from("gateway-owner"),
+            gateways_owners_read(deps.as_ref().storage)
+                .load("myAwesomeGateway".as_bytes())
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn adding_gateway_with_existing_owner() {
+        let mut deps = helpers::init_contract();
+
+        let info = mock_info("gateway-owner", &good_gateway_bond());
+        let msg = HandleMsg::BondGateway {
+            gateway: Gateway {
+                identity_key: "myAwesomeGateway".to_string(),
+                ..helpers::gateway_fixture()
+            },
+        };
+
+        handle(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+        // request fails giving the existing owner address in the message
+        let info = mock_info("gateway-owner-pretender", &good_gateway_bond());
+        let msg = HandleMsg::BondGateway {
+            gateway: Gateway {
+                identity_key: "myAwesomeGateway".to_string(),
+                ..helpers::gateway_fixture()
+            },
+        };
+
+        let handle_response = handle(deps.as_mut(), mock_env(), info, msg);
+        assert_eq!(
+            Err(ContractError::DuplicateGateway {
+                owner: "gateway-owner".into()
+            }),
+            handle_response
+        );
+
+        // owner is not changed
+        assert_eq!(
+            HumanAddr::from("gateway-owner"),
+            gateways_owners_read(deps.as_ref().storage)
+                .load("myAwesomeGateway".as_bytes())
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn adding_gateway_with_existing_unchanged_owner() {
+        let mut deps = helpers::init_contract();
+
+        let info = mock_info("gateway-owner", &good_gateway_bond());
+        let msg = HandleMsg::BondGateway {
+            gateway: Gateway {
+                identity_key: "myAwesomeGateway".to_string(),
+                mix_host: "1.1.1.1:1789".into(),
+                ..helpers::gateway_fixture()
+            },
+        };
+
+        handle(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+        let info = mock_info("gateway-owner", &good_gateway_bond());
+        let msg = HandleMsg::BondGateway {
+            gateway: Gateway {
+                identity_key: "myAwesomeGateway".to_string(),
+                mix_host: "2.2.2.2:1789".into(),
+                ..helpers::gateway_fixture()
+            },
+        };
+
+        assert!(handle(deps.as_mut(), mock_env(), info, msg).is_ok());
+
+        // make sure the host information was updated
+        assert_eq!(
+            "2.2.2.2:1789".to_string(),
+            gateways_read(deps.as_ref().storage)
+                .load("gateway-owner".as_bytes())
+                .unwrap()
+                .gateway
+                .mix_host
+        );
+
+        // and nothing was changed regarding ownership
+        assert_eq!(
+            HumanAddr::from("gateway-owner"),
+            gateways_owners_read(deps.as_ref().storage)
+                .load("myAwesomeGateway".as_bytes())
+                .unwrap()
+        );
     }
 
     #[test]
@@ -806,6 +1114,54 @@ pub mod tests {
         let gateway_bonds = helpers::get_gateways(&mut deps);
         assert_eq!(1, gateway_bonds.len());
         assert_eq!("bob", gateway_bonds[0].owner());
+    }
+
+    #[test]
+    fn removing_gateway_clears_ownership() {
+        let mut deps = helpers::init_contract();
+
+        let info = mock_info("gateway-owner", &good_mixnode_bond());
+        let msg = HandleMsg::BondGateway {
+            gateway: Gateway {
+                identity_key: "myAwesomeGateway".to_string(),
+                ..helpers::gateway_fixture()
+            },
+        };
+
+        handle(deps.as_mut(), mock_env(), info, msg).unwrap();
+        assert_eq!(
+            HumanAddr::from("gateway-owner"),
+            gateways_owners_read(deps.as_ref().storage)
+                .load("myAwesomeGateway".as_bytes())
+                .unwrap()
+        );
+
+        let info = mock_info("gateway-owner", &[]);
+        let msg = HandleMsg::UnbondGateway {};
+
+        assert!(handle(deps.as_mut(), mock_env(), info, msg).is_ok());
+
+        assert!(gateways_owners_read(deps.as_ref().storage)
+            .may_load("myAwesomeGateway".as_bytes())
+            .unwrap()
+            .is_none());
+
+        // and since it's removed, it can be reclaimed
+        let info = mock_info("gateway-owner", &good_mixnode_bond());
+        let msg = HandleMsg::BondGateway {
+            gateway: Gateway {
+                identity_key: "myAwesomeGateway".to_string(),
+                ..helpers::gateway_fixture()
+            },
+        };
+
+        assert!(handle(deps.as_mut(), mock_env(), info, msg).is_ok());
+        assert_eq!(
+            HumanAddr::from("gateway-owner"),
+            gateways_owners_read(deps.as_ref().storage)
+                .load("myAwesomeGateway".as_bytes())
+                .unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
@futurechimp Before merging it, let's have a discussion about what to do with the migration. I see two options here:
1. Don't do anything, the problem _should_ solve itself as people unbond and rebond to update. 
2. During migration iterate through all bonded mixnodes and (assuming they are in order which I'm not sure of), use the first entry as ownership and insert that data.