### PR TITLE
Bugfix/verloc fixes and adjustments

### DIFF
--- a/common/mixnode-common/src/rtt_measurement/error.rs
+++ b/common/mixnode-common/src/rtt_measurement/error.rs
@@ -32,6 +32,7 @@ pub enum RttError {
     UnexpectedConnectionFailureWrite(String, io::Error),
     UnexpectedConnectionFailureRead(String, io::Error),
     ConnectionReadTimeout(String),
+    ConnectionWriteTimeout(String),
 
     UnexpectedReplySequence,
 }
@@ -71,6 +72,9 @@ impl Display for RttError {
             }
             RttError::ConnectionReadTimeout(id) => {
                 write!(f, "Timed out while trying to read reply packet from {}", id)
+            }
+            RttError::ConnectionWriteTimeout(id) => {
+                write!(f, "Timed out while trying to write echo packet to {}", id)
             }
             RttError::UnexpectedReplySequence => write!(
                 f,

--- a/common/mixnode-common/src/rtt_measurement/measurement.rs
+++ b/common/mixnode-common/src/rtt_measurement/measurement.rs
@@ -69,11 +69,10 @@ where
 
 impl Display for Verloc {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let identity = self.identity.to_base58_string();
         if let Some(measurement) = self.latest_measurement {
-            write!(f, "{} - {}", identity, measurement)
+            write!(f, "{} - {}", self.identity, measurement)
         } else {
-            write!(f, "{} - COULD NOT MEASURE", identity)
+            write!(f, "{} - COULD NOT MEASURE", self.identity)
         }
     }
 }

--- a/common/mixnode-common/src/rtt_measurement/measurement.rs
+++ b/common/mixnode-common/src/rtt_measurement/measurement.rs
@@ -27,11 +27,11 @@ pub struct AtomicVerlocResult {
 #[derive(Debug, Clone, Serialize)]
 pub struct VerlocResult {
     total_tested: usize,
-    results: Vec<Verloc>,
     #[serde(with = "humantime_serde")]
     run_started: std::time::SystemTime,
     #[serde(with = "humantime_serde")]
     run_finished: std::time::SystemTime,
+    results: Vec<Verloc>,
 }
 
 impl AtomicVerlocResult {
@@ -40,9 +40,9 @@ impl AtomicVerlocResult {
         AtomicVerlocResult {
             inner: Arc::new(RwLock::new(VerlocResult {
                 total_tested: 0,
-                results: Vec::new(),
                 run_started: now,
                 run_finished: now,
+                results: Vec::new(),
             })),
         }
     }

--- a/common/mixnode-common/src/rtt_measurement/mod.rs
+++ b/common/mixnode-common/src/rtt_measurement/mod.rs
@@ -325,6 +325,9 @@ impl RttMeasurer {
 
             self.perform_measurement(tested_nodes).await;
 
+            // write current time to "run finished" field
+            self.results.finish_measurements().await;
+
             info!(target: "verloc", "Finished performing verloc measurements. The next one will happen in {:?}", self.config.testing_interval);
             sleep(self.config.testing_interval).await
         }

--- a/common/mixnode-common/src/rtt_measurement/mod.rs
+++ b/common/mixnode-common/src/rtt_measurement/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::rtt_measurement::listener::PacketListener;
-pub use crate::rtt_measurement::measurement::{AtomicVerlocResult, Verloc};
+pub use crate::rtt_measurement::measurement::{AtomicVerlocResult, Verloc, VerlocResult};
 use crate::rtt_measurement::sender::{PacketSender, TestedNode};
 use crypto::asymmetric::identity;
 use futures::stream::FuturesUnordered;
@@ -39,6 +39,7 @@ pub const DEFAULT_MEASUREMENT_PORT: u16 = 1790;
 // by default all of those are overwritten by config data from mixnodes directly
 const DEFAULT_PACKETS_PER_NODE: usize = 100;
 const DEFAULT_PACKET_TIMEOUT: Duration = Duration::from_millis(1500);
+const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_millis(5000);
 const DEFAULT_DELAY_BETWEEN_PACKETS: Duration = Duration::from_millis(50);
 const DEFAULT_BATCH_SIZE: usize = 50;
 const DEFAULT_TESTING_INTERVAL: Duration = Duration::from_secs(60 * 60 * 12);
@@ -60,6 +61,9 @@ pub struct Config {
 
     /// Specifies maximum amount of time to wait for the reply packet to arrive before abandoning the test.
     packet_timeout: Duration,
+
+    /// Specifies maximum amount of time to wait for the connection to get established.
+    connection_timeout: Duration,
 
     /// Specifies delay between subsequent test packets being sent (after receiving a reply).
     delay_between_packets: Duration,
@@ -114,6 +118,10 @@ impl ConfigBuilder {
         self.0.packet_timeout = packet_timeout;
         self
     }
+    pub fn connection_timeout(mut self, connection_timeout: Duration) -> Self {
+        self.0.connection_timeout = connection_timeout;
+        self
+    }
     pub fn delay_between_packets(mut self, delay_between_packets: Duration) -> Self {
         self.0.delay_between_packets = delay_between_packets;
         self
@@ -163,6 +171,7 @@ impl Default for ConfigBuilder {
                 .unwrap(),
             packets_per_node: DEFAULT_PACKETS_PER_NODE,
             packet_timeout: DEFAULT_PACKET_TIMEOUT,
+            connection_timeout: DEFAULT_CONNECTION_TIMEOUT,
             delay_between_packets: DEFAULT_DELAY_BETWEEN_PACKETS,
             tested_nodes_batch_size: DEFAULT_BATCH_SIZE,
             testing_interval: DEFAULT_TESTING_INTERVAL,
@@ -198,6 +207,7 @@ impl RttMeasurer {
                 Arc::clone(&identity),
                 config.packets_per_node,
                 config.packet_timeout,
+                config.connection_timeout,
                 config.delay_between_packets,
             )),
             packet_listener: Arc::new(PacketListener::new(
@@ -222,10 +232,10 @@ impl RttMeasurer {
         tokio::spawn(packet_listener.run())
     }
 
-    async fn perform_measurement(&self, nodes_to_test: Vec<TestedNode>) -> Vec<Verloc> {
-        let mut results = Vec::with_capacity(nodes_to_test.len());
-
+    async fn perform_measurement(&self, nodes_to_test: Vec<TestedNode>) {
         for chunk in nodes_to_test.chunks(self.config.tested_nodes_batch_size) {
+            let mut chunk_results = Vec::with_capacity(chunk.len());
+
             let mut measurement_chunk = chunk
                 .iter()
                 .map(|node| {
@@ -261,18 +271,18 @@ impl RttMeasurer {
                     }
                     Ok(result) => Some(result),
                 };
-                results.push(Verloc::new(execution_result.1, measurement_result));
+                chunk_results.push(Verloc::new(execution_result.1, measurement_result));
             }
-        }
 
-        // finally sort the results
-        results.sort();
-        results
+            // update the results vector with chunks as they become available (by default every 50 nodes)
+            self.results.append_results(chunk_results).await;
+        }
     }
 
     pub async fn run(&mut self) {
         self.start_listening();
         loop {
+            info!(target: "verloc", "Starting verloc measurements");
             // TODO: should we also measure gateways?
             let all_mixes = match self.validator_client.get_mix_nodes().await {
                 Ok(nodes) => nodes,
@@ -310,9 +320,12 @@ impl RttMeasurer {
                 })
                 .collect::<Vec<_>>();
 
-            let results = self.perform_measurement(tested_nodes).await;
-            self.results.update_results(results).await;
+            // on start of each run remove old results
+            self.results.reset_results(tested_nodes.len()).await;
 
+            self.perform_measurement(tested_nodes).await;
+
+            info!(target: "verloc", "Finished performing verloc measurements. The next one will happen in {:?}", self.config.testing_interval);
             sleep(self.config.testing_interval).await
         }
     }

--- a/common/mixnode-common/src/rtt_measurement/sender.rs
+++ b/common/mixnode-common/src/rtt_measurement/sender.rs
@@ -84,7 +84,7 @@ impl PacketSender {
             self.connection_timeout,
             TcpStream::connect(tested_node.address),
         )
-            .await
+        .await
         {
             Err(_timeout) => {
                 return Err(RttError::UnreachableNode(
@@ -127,16 +127,16 @@ impl PacketSender {
                     ));
                 }
                 Ok(Err(err)) => {
-                let identity_string = tested_node.identity.to_base58_string();
+                    let identity_string = tested_node.identity.to_base58_string();
                     debug!(
-                    "failed to write echo packet to {} - {}. Stopping the test.",
-                    identity_string, err
-                );
-                return Err(RttError::UnexpectedConnectionFailureWrite(
-                    identity_string,
-                    err,
-                ));
-            }
+                        "failed to write echo packet to {} - {}. Stopping the test.",
+                        identity_string, err
+                    );
+                    return Err(RttError::UnexpectedConnectionFailureWrite(
+                        identity_string,
+                        err,
+                    ));
+                }
                 Ok(Ok(_)) => {}
             }
 

--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -27,6 +27,7 @@ pub const DEFAULT_MIXNET_CONTRACT_ADDRESS: &str = "hal1k0jntykt7e4g3y88ltc60czgj
 
 // 'RTT MEASUREMENT'
 const DEFAULT_PACKETS_PER_NODE: usize = 100;
+const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_millis(5000);
 const DEFAULT_PACKET_TIMEOUT: Duration = Duration::from_millis(1500);
 const DEFAULT_DELAY_BETWEEN_PACKETS: Duration = Duration::from_millis(50);
 const DEFAULT_BATCH_SIZE: usize = 50;
@@ -314,6 +315,11 @@ impl Config {
     pub fn get_measurement_packet_timeout(&self) -> Duration {
         self.rtt_measurement.packet_timeout
     }
+
+    pub fn get_measurement_connection_timeout(&self) -> Duration {
+        self.rtt_measurement.connection_timeout
+    }
+
     pub fn get_measurement_delay_between_packets(&self) -> Duration {
         self.rtt_measurement.delay_between_packets
     }
@@ -450,6 +456,9 @@ pub struct RttMeasurement {
     /// Specifies number of echo packets sent to each node during a measurement run.
     packets_per_node: usize,
 
+    /// Specifies maximum amount of time to wait for the connection to get established.
+    connection_timeout: Duration,
+
     /// Specifies maximum amount of time to wait for the reply packet to arrive before abandoning the test.
     packet_timeout: Duration,
 
@@ -471,6 +480,7 @@ impl Default for RttMeasurement {
     fn default() -> Self {
         RttMeasurement {
             packets_per_node: DEFAULT_PACKETS_PER_NODE,
+            connection_timeout: DEFAULT_CONNECTION_TIMEOUT,
             packet_timeout: DEFAULT_PACKET_TIMEOUT,
             delay_between_packets: DEFAULT_DELAY_BETWEEN_PACKETS,
             tested_nodes_batch_size: DEFAULT_BATCH_SIZE,

--- a/mixnode/src/node/http/verloc.rs
+++ b/mixnode/src/node/http/verloc.rs
@@ -1,4 +1,4 @@
-use mixnode_common::rtt_measurement::{AtomicVerlocResult, Verloc};
+use mixnode_common::rtt_measurement::{AtomicVerlocResult, VerlocResult};
 use rocket::State;
 use rocket_contrib::json::Json;
 
@@ -17,7 +17,7 @@ impl VerlocState {
 /// Provides verifiable location (verloc) measurements for this mixnode - a list of the
 /// round-trip times, in milliseconds, for all other mixnodes that this node knows about.
 #[get("/verloc")]
-pub(crate) async fn verloc(state: State<'_, VerlocState>) -> Json<Vec<Verloc>> {
+pub(crate) async fn verloc(state: State<'_, VerlocState>) -> Json<VerlocResult> {
     // since it's impossible to get a mutable reference to the state, we can't cache any results outside the lock : (
     Json(state.shared.clone_data().await)
 }

--- a/mixnode/src/node/mod.rs
+++ b/mixnode/src/node/mod.rs
@@ -144,6 +144,7 @@ impl MixNode {
         let config = rtt_measurement::ConfigBuilder::new()
             .listening_address(listening_address)
             .packets_per_node(self.config.get_measurement_packets_per_node())
+            .connection_timeout(self.config.get_measurement_connection_timeout())
             .packet_timeout(self.config.get_measurement_packet_timeout())
             .delay_between_packets(self.config.get_measurement_delay_between_packets())
             .tested_nodes_batch_size(self.config.get_measurement_tested_nodes_batch_size())


### PR DESCRIPTION
This pull requests does the following:
- Introduces timeout on trying to establish connection to tested nodes
- Introduces timeout when trying to write packets to tested nodes
- Saves verloc results in tested chunks rather than everything when it's done (i.e. by default writes in increments of 50)
- Adds `tested_nodes` fields to the verloc result to give indication of how many results are expected
- Adds `run_started` and `run_finished` fields to the verloc results to give indication of how old are the results

The added timeouts significantly decrease time it takes for the measurements to complete as some misconfigured nodes will keep the connection in limbo until the OS TCP timeout kicks in (and I'm actually not entirely sure if there are some edge cases that might keep it alive indefinitely hence never allowing verloc to finish, so maybe it's a bugfix after all.)