### PR TITLE
Feature/per layer count

### DIFF
--- a/common/client-libs/validator-client/src/lib.rs
+++ b/common/client-libs/validator-client/src/lib.rs
@@ -4,7 +4,9 @@
 use crate::models::{QueryRequest, QueryResponse};
 use crate::ValidatorClientError::ValidatorError;
 use core::fmt::{self, Display, Formatter};
-use mixnet_contract::{GatewayBond, HumanAddr, MixNodeBond, PagedGatewayResponse, PagedResponse};
+use mixnet_contract::{
+    GatewayBond, HumanAddr, LayerDistribution, MixNodeBond, PagedGatewayResponse, PagedResponse,
+};
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use serde::Deserialize;
@@ -237,5 +239,18 @@ impl Client {
         }
 
         Ok(gateways)
+    }
+
+    pub async fn get_layer_distribution(
+        &mut self,
+    ) -> Result<LayerDistribution, ValidatorClientError> {
+        // serialization of an empty enum can't fail...
+        let query_content_json =
+            serde_json::to_string(&QueryRequest::LayerDistribution {}).unwrap();
+
+        // we need to encode our json request
+        let query_content = base64::encode(query_content_json);
+
+        self.query_validators(query_content).await
     }
 }

--- a/common/client-libs/validator-client/src/models.rs
+++ b/common/client-libs/validator-client/src/models.rs
@@ -20,6 +20,7 @@ pub(super) enum QueryRequest {
         start_after: Option<HumanAddr>,
         limit: Option<u32>,
     },
+    LayerDistribution {},
 }
 
 #[derive(Deserialize, Debug)]

--- a/common/mixnet-contract/src/lib.rs
+++ b/common/mixnet-contract/src/lib.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 mod gateway;
 mod mixnode;
 
@@ -5,9 +7,11 @@ pub use cosmwasm_std::{Coin, HumanAddr};
 pub use gateway::{Gateway, GatewayBond, GatewayOwnershipResponse, PagedGatewayResponse};
 pub use mixnode::{MixNode, MixNodeBond, MixOwnershipResponse, PagedResponse};
 
+#[derive(Debug, Default, Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
 pub struct LayerDistribution {
-    pub layer1: u32,
-    pub layer2: u32,
-    pub layer3: u32,
-    pub gateways: u32,
+    pub gateways: u64,
+    pub layer1: u64,
+    pub layer2: u64,
+    pub layer3: u64,
+    pub invalid: u64,
 }

--- a/common/mixnet-contract/src/lib.rs
+++ b/common/mixnet-contract/src/lib.rs
@@ -4,3 +4,10 @@ mod mixnode;
 pub use cosmwasm_std::{Coin, HumanAddr};
 pub use gateway::{Gateway, GatewayBond, GatewayOwnershipResponse, PagedGatewayResponse};
 pub use mixnode::{MixNode, MixNodeBond, MixOwnershipResponse, PagedResponse};
+
+pub struct LayerDistribution {
+    pub layer1: u32,
+    pub layer2: u32,
+    pub layer3: u32,
+    pub gateways: u32,
+}

--- a/contracts/mixnet/src/msg.rs
+++ b/contracts/mixnet/src/msg.rs
@@ -51,6 +51,7 @@ pub enum QueryMsg {
         address: HumanAddr,
     },
     StateParams {},
+    LayerDistribution {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/mixnet/src/queries.rs
+++ b/contracts/mixnet/src/queries.rs
@@ -1,12 +1,12 @@
 use crate::state::StateParams;
-use crate::storage::{gateways_read, mixnodes_read, read_state_params};
+use crate::storage::{gateways_read, mixnodes_read, read_layer_distribution, read_state_params};
 use cosmwasm_std::Deps;
 use cosmwasm_std::HumanAddr;
 use cosmwasm_std::Order;
 use cosmwasm_std::StdResult;
 use mixnet_contract::{
-    GatewayBond, GatewayOwnershipResponse, MixNodeBond, MixOwnershipResponse, PagedGatewayResponse,
-    PagedResponse,
+    GatewayBond, GatewayOwnershipResponse, LayerDistribution, MixNodeBond, MixOwnershipResponse,
+    PagedGatewayResponse, PagedResponse,
 };
 
 const MAX_LIMIT: u32 = 100;
@@ -75,6 +75,10 @@ pub(crate) fn query_owns_gateway(
 
 pub(crate) fn query_state_params(deps: Deps) -> StateParams {
     read_state_params(deps.storage)
+}
+
+pub(crate) fn query_layer_distribution(deps: Deps) -> LayerDistribution {
+    read_layer_distribution(deps.storage)
 }
 
 /// Adds a 0 byte to terminate the `start_after` value given. This allows CosmWasm

--- a/contracts/mixnet/src/transactions.rs
+++ b/contracts/mixnet/src/transactions.rs
@@ -4,9 +4,9 @@ use crate::helpers::{calculate_epoch_reward_rate, scale_reward_by_uptime};
 use crate::state::StateParams;
 use crate::storage::{
     config, config_read, decrement_layer_count, gateways, gateways_owners, gateways_owners_read,
-    gateways_read, increase_gateway_bond, increase_mixnode_bond, increment_layer_count,
-    layer_distribution, mixnodes, mixnodes_owners, mixnodes_owners_read, mixnodes_read,
-    read_gateway_epoch_reward_rate, read_mixnode_epoch_reward_rate, read_state_params, Layer,
+    gateways_read, increase_gateway_bond, increase_mixnode_bond, increment_layer_count, mixnodes,
+    mixnodes_owners, mixnodes_owners_read, mixnodes_read, read_gateway_epoch_reward_rate,
+    read_mixnode_epoch_reward_rate, read_state_params, Layer,
 };
 use cosmwasm_std::{
     attr, BankMsg, Coin, Decimal, DepsMut, Env, HandleResponse, HumanAddr, MessageInfo, Uint128,

--- a/mixnode/src/commands/init.rs
+++ b/mixnode/src/commands/init.rs
@@ -9,7 +9,6 @@ use config::NymConfig;
 use crypto::asymmetric::{encryption, identity};
 use log::debug;
 use nymsphinx::params::DEFAULT_NUM_MIX_HOPS;
-use std::collections::HashMap;
 use tokio::runtime::Runtime;
 
 pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {

--- a/mixnode/src/node/mod.rs
+++ b/mixnode/src/node/mod.rs
@@ -201,7 +201,7 @@ impl MixNode {
         runtime.block_on(async {
             if let Some(duplicate_node_key) = self.check_if_same_ip_node_exists().await {
                 if duplicate_node_key == self.identity_keypair.public_key().to_base58_string() {
-                    warn!("You seem to have bonded your mixnode before starting it - that's highly unrecommended as in the future it will result in slashing");
+                    warn!("You seem to have bonded your mixnode before starting it - that's highly unrecommended as in the future it might result in slashing");
                 } else {
                     log::error!(
                         "Our announce-host is identical to an existing node's announce-host! (its key is {:?})",


### PR DESCRIPTION
This pull request should make it easier and faster to initialise mixnode. Rather than pulling entire topology, parsing it and figuring out which layer has fewest nodes, now the contract will hold a single struct containing the layer distribution that can be easily queried by the nodes.

Note that `mixnode run` will still take the same time as the node has to query for the entire list in order to figure out if another node with the same announce address exists.

Closes https://github.com/nymtech/nym/issues/610