### PR TITLE
Feature/describe location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,6 +1830,7 @@ dependencies = [
  "rocket",
  "rocket_contrib",
  "serde",
+ "serial_test",
  "tokio",
  "tokio-util",
  "toml",
@@ -2837,6 +2838,28 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "nym-mixnode"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "bs58 0.4.0",
  "clap",

--- a/mixnode/Cargo.toml
+++ b/mixnode/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-mixnode"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Dave Hrycyszyn <futurechimp@users.noreply.github.com>", "Jędrzej Stuczyński <andrew@nymtech.net>"]
 edition = "2018"
 

--- a/mixnode/Cargo.toml
+++ b/mixnode/Cargo.toml
@@ -38,3 +38,6 @@ pemstore = { path = "../common/pemstore" }
 topology = { path = "../common/topology" }
 validator-client = { path = "../common/client-libs/validator-client" }
 version-checker = { path = "../common/version-checker" }
+
+[dev-dependencies]
+serial_test = "0.5"

--- a/mixnode/src/commands/describe.rs
+++ b/mixnode/src/commands/describe.rs
@@ -48,6 +48,7 @@ pub fn execute(matches: &ArgMatches) {
     let description = desc_buf.trim().to_string();
 
     let example_url = "https://mixnode.yourdomain.com".bright_cyan();
+    let example_location = "City: YourCity, Country: YourCountry";
 
     print!("link, e.g. {}: ", example_url);
     io::stdout().flush().unwrap();
@@ -55,10 +56,17 @@ pub fn execute(matches: &ArgMatches) {
     io::stdin().read_line(&mut link_buf).unwrap();
     let link = link_buf.trim().to_string();
 
+    print!("location, e.g. {}: ", example_location);
+    io::stdout().flush().unwrap();
+    let mut location_buf = String::new();
+    io::stdin().read_line(&mut location_buf).unwrap();
+    let location = location_buf.trim().to_string();
+
     let node_description = NodeDescription {
         name,
         description,
         link,
+        location,
     };
 
     // save the struct

--- a/mixnode/src/commands/describe.rs
+++ b/mixnode/src/commands/describe.rs
@@ -48,7 +48,7 @@ pub fn execute(matches: &ArgMatches) {
     let description = desc_buf.trim().to_string();
 
     let example_url = "https://mixnode.yourdomain.com".bright_cyan();
-    let example_location = "City: YourCity, Country: YourCountry";
+    let example_location = "City: London, Country: UK";
 
     print!("link, e.g. {}: ", example_url);
     io::stdout().flush().unwrap();

--- a/mixnode/src/commands/init.rs
+++ b/mixnode/src/commands/init.rs
@@ -133,7 +133,6 @@ fn show_bonding_info(config: &Config) {
     Address: {}
     Mix port: {}
     Layer: {}
-    Location: [physical location of your node's server]
     Version: {}
     ",
         identity_keypair.public_key().to_base58_string(),

--- a/mixnode/src/commands/run.rs
+++ b/mixnode/src/commands/run.rs
@@ -163,7 +163,6 @@ pub fn execute(matches: &ArgMatches) {
     Address: {}
     Mix port: {}
     Layer: {}
-    Location: {}
     Version: {}
     ",
         identity_keypair.public_key().to_base58_string(),
@@ -171,7 +170,6 @@ pub fn execute(matches: &ArgMatches) {
         config.get_announce_address(),
         config.get_mix_port(),
         config.get_layer(),
-        description.location,
         config.get_version(),
     );
     MixNode::new(config, description, identity_keypair, sphinx_keypair).run();

--- a/mixnode/src/commands/run.rs
+++ b/mixnode/src/commands/run.rs
@@ -140,6 +140,9 @@ pub fn execute(matches: &ArgMatches) {
         show_binding_warning(config.get_listening_address().to_string());
     }
 
+    let description =
+        NodeDescription::load_from_file(Config::default_config_directory(id)).unwrap_or_default();
+
     println!(
         "Validator servers: {:?}",
         config.get_validator_rest_endpoints()
@@ -160,7 +163,7 @@ pub fn execute(matches: &ArgMatches) {
     Address: {}
     Mix port: {}
     Layer: {}
-    Location: [physical location of your node's server]
+    Location: {}
     Version: {}
     ",
         identity_keypair.public_key().to_base58_string(),
@@ -168,10 +171,8 @@ pub fn execute(matches: &ArgMatches) {
         config.get_announce_address(),
         config.get_mix_port(),
         config.get_layer(),
+        description.location,
         config.get_version(),
     );
-
-    let description =
-        NodeDescription::load_from_file(Config::default_config_directory(id)).unwrap_or_default();
     MixNode::new(config, description, identity_keypair, sphinx_keypair).run();
 }

--- a/mixnode/src/commands/upgrade.rs
+++ b/mixnode/src/commands/upgrade.rs
@@ -361,10 +361,12 @@ fn patch_0_10_2_upgrade(
                     format!("failed to deserialize description content! - {:?}", err),
                 )
             })?;
-        let mut new_description = NodeDescription::default();
-        new_description.name = old_description.name;
-        new_description.description = old_description.description;
-        new_description.link = old_description.link;
+        let new_description = NodeDescription {
+            name: old_description.name,
+            description: old_description.description,
+            link: old_description.link,
+            ..Default::default()
+        };
         let description_toml = toml::to_string(&new_description).map_err(|err| {
             (
                 to_version.clone(),

--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -284,6 +284,10 @@ impl Config {
         &self.mixnode.version
     }
 
+    pub fn get_id(&self) -> String {
+        self.mixnode.id.clone()
+    }
+
     pub fn get_measurement_packets_per_node(&self) -> usize {
         self.verloc.packets_per_node
     }

--- a/mixnode/src/node/node_description.rs
+++ b/mixnode/src/node/node_description.rs
@@ -10,6 +10,7 @@ pub struct NodeDescription {
     pub(crate) name: String,
     pub(crate) description: String,
     pub(crate) link: String,
+    pub(crate) location: String,
 }
 
 impl Default for NodeDescription {
@@ -18,6 +19,7 @@ impl Default for NodeDescription {
             name: "This node has not yet set a name".to_string(),
             description: "This node has not yet set a description".to_string(),
             link: "https://nymtech.net".to_string(),
+            location: "This node has not yet set a location".to_string(),
         }
     }
 }


### PR DESCRIPTION
Give a mixnode operator the possibility to `describe` the location of its mixnode. Also removed the location from the `init` output.