### PR TITLE
Minimize read/write cache contention

### DIFF
--- a/validator-api/src/cache.rs
+++ b/validator-api/src/cache.rs
@@ -1,27 +1,33 @@
 use anyhow::Result;
 use mixnet_contract::{GatewayBond, MixNodeBond};
-use std::time::Instant;
+use serde::Serialize;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::RwLock;
 use validator_client::Client;
 
 pub struct ValidatorCache {
-    mixnodes: Cache<Vec<MixNodeBond>>,
-    gateways: Cache<Vec<GatewayBond>>,
+    mixnodes: RwLock<Cache<Vec<MixNodeBond>>>,
+    gateways: RwLock<Cache<Vec<GatewayBond>>>,
     validator_client: Client,
 }
 
-#[derive(Default)]
-struct Cache<T> {
+#[derive(Default, Serialize, Clone)]
+pub struct Cache<T> {
     value: T,
     #[allow(dead_code)]
-    as_at: Option<Instant>,
+    as_at: u64,
 }
 
 impl<T: Clone> Cache<T> {
     fn set(&mut self, value: T) {
         self.value = value;
-        self.as_at = Some(Instant::now())
+        self.as_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
     }
 
+    #[allow(dead_code)]
     pub fn get(&self) -> T {
         self.value.clone()
     }
@@ -32,27 +38,28 @@ impl ValidatorCache {
         let config = validator_client::Config::new(validators_rest_uris, mixnet_contract);
         let validator_client = validator_client::Client::new(config);
         ValidatorCache {
-            mixnodes: Cache::default(),
-            gateways: Cache::default(),
+            mixnodes: RwLock::new(Cache::default()),
+            gateways: RwLock::new(Cache::default()),
             validator_client,
         }
     }
 
-    pub async fn cache(&mut self) -> Result<()> {
+    pub async fn refresh_cache(&self) -> Result<()> {
         let (mixnodes, gateways) = tokio::join!(
             self.validator_client.get_mix_nodes(),
             self.validator_client.get_gateways()
         );
-        self.mixnodes.set(mixnodes?);
-        self.gateways.set(gateways?);
+        self.mixnodes.write().await.set(mixnodes?);
+        self.gateways.write().await.set(gateways?);
+
         Ok(())
     }
 
-    pub fn mixnodes(&self) -> Vec<MixNodeBond> {
-        self.mixnodes.get()
+    pub async fn mixnodes(&self) -> Cache<Vec<MixNodeBond>> {
+        self.mixnodes.read().await.clone()
     }
 
-    pub fn gateways(&self) -> Vec<GatewayBond> {
-        self.gateways.get()
+    pub async fn gateways(&self) -> Cache<Vec<GatewayBond>> {
+        self.gateways.read().await.clone()
     }
 }

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -481,7 +481,7 @@ async fn main() -> Result<()> {
     rocket::build()
         .attach(cors)
         .mount("/v1", routes![get_mixnodes, get_gateways])
-        .manage(mixnode_cache)
+        .manage(validator_cache)
         .ignite()
         .await?
         .launch()

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -443,19 +443,19 @@ async fn main() -> Result<()> {
         info!("Network monitoring is disabled.")
     }
 
-    let mixnode_cache = Arc::new(RwLock::new(ValidatorCache::init(
+    let validator_cache = Arc::new(RwLock::new(ValidatorCache::init(
         config.get_validators_urls(),
         config.get_mixnet_contract_address(),
     )));
 
-    let write_mixnode_cache = Arc::clone(&mixnode_cache);
+    let write_validator_cache = Arc::clone(&validator_cache);
 
     tokio::spawn(async move {
         let mut interval = time::interval(config.get_caching_interval());
         loop {
             interval.tick().await;
             {
-                match timeout(Duration::from_secs(10), write_mixnode_cache.write()).await {
+                match timeout(Duration::from_secs(10), write_validator_cache.write()).await {
                     Ok(mut w) => w.cache().await.unwrap(),
                     Err(e) => error!("Timeout: Could not aquire write lock on cache: {}", e),
                 }


### PR DESCRIPTION
+ Moves `RwLocks` into `ValidatorCache` struct in order to minimize locking, and avoid contention and avoid timeouts
+ Returns full `Cache` struct as `Json` in order to provide `as_at` to the caller as well