### PR TITLE
Disables nightly clippy CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
           args: --all -- --check
 
       - uses: actions-rs/cargo@v1
+        if: ${{ matrix.rust != 'nightly' }}
         with:
           command: clippy
           args: -- -D warnings 

--- a/.github/workflows/mixnet_contract.yml
+++ b/.github/workflows/mixnet_contract.yml
@@ -38,6 +38,7 @@ jobs:
           args: --manifest-path contracts/mixnet/Cargo.toml -- --check
 
       - uses: actions-rs/cargo@v1
+        if: ${{ matrix.rust != 'nightly' }}
         with:
           command: clippy
           args: --manifest-path contracts/mixnet/Cargo.toml -- -D warnings


### PR DESCRIPTION
Lets not worry about new clippy rules on nightly. Let's only care about them on stable and beta. However, we still ensure stuff builds on nightly.

Note: as of time of creating this PR, CI fails on trying to download `https://crates.io/api/v1/crates/crossbeam-utils/0.8.5/download` in one of the flows. Not entirely sure what's up with that...