### PR TITLE
Using specific commit of rocket cors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "rocket_cors"
 version = "0.5.2"
-source = "git+https://github.com/lawliet89/rocket_cors?branch=master#dfd3662c49e2f6fc37df35091cb94d82f7fb5915"
+source = "git+https://github.com/lawliet89/rocket_cors?rev=dfd3662c49e2f6fc37df35091cb94d82f7fb5915#dfd3662c49e2f6fc37df35091cb94d82f7fb5915"
 dependencies = [
  "log",
  "regex",

--- a/validator-api/Cargo.toml
+++ b/validator-api/Cargo.toml
@@ -27,7 +27,7 @@ rocket = { version="0.5.0-rc.1", features=["json"] }
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version="1.4", features=["rt-multi-thread", "macros", "signal", "time"] }
-rocket_cors = { git="https://github.com/lawliet89/rocket_cors", branch="master" }
+rocket_cors = { git="https://github.com/lawliet89/rocket_cors", rev="dfd3662c49e2f6fc37df35091cb94d82f7fb5915" }
 anyhow = "1"
 
 


### PR DESCRIPTION
Using the most recent version of `rocket_cors` was kinda stressing me out. Now at least we point to a specific commit so stuff is not going to break randomly. However, do we even need that dependency? @durch what was the reason it was introduced in the first place?