### PR TITLE
Feature/more reliable uptime calculation

### DIFF
--- a/validator-api/migrations/20210819120000_monitor_runs.sql
+++ b/validator-api/migrations/20210819120000_monitor_runs.sql
@@ -1,0 +1,7 @@
+-- keeping track of all monitor runs that have happened will help to
+-- solve an issue of mixnode being online only for a single check and yet being assigned 100% uptime
+CREATE TABLE monitor_run
+(
+    id        INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    timestamp INTEGER NOT NULL
+)

--- a/validator-api/src/network_monitor/monitor/mod.rs
+++ b/validator-api/src/network_monitor/monitor/mod.rs
@@ -77,6 +77,18 @@ impl Monitor {
             // TODO: slightly more graceful shutdown here
             process::exit(1);
         }
+
+        // indicate our run has completed successfully and should be used in any future
+        // uptime calculations
+        if let Err(err) = self.node_status_storage.insert_monitor_run().await {
+            error!(
+                "Failed to submit monitor run information to the database - {}",
+                err
+            );
+
+            // TODO: slightly more graceful shutdown here
+            process::exit(1);
+        }
     }
 
     // checking it this way with a TestReport is rather suboptimal but given the fact we're only

--- a/validator-api/src/node_status_api/models.rs
+++ b/validator-api/src/node_status_api/models.rs
@@ -7,6 +7,7 @@ use rocket::http::{ContentType, Status};
 use rocket::response::{self, Responder, Response};
 use rocket::Request;
 use serde::{Deserialize, Serialize};
+use sqlx::types::time::OffsetDateTime;
 use std::convert::TryFrom;
 use std::fmt::{self, Display, Formatter};
 use std::io::Cursor;
@@ -90,13 +91,21 @@ pub struct MixnodeStatusReport {
 
 impl MixnodeStatusReport {
     pub(crate) fn construct_from_last_day_reports(
+        report_time: OffsetDateTime,
         identity: String,
         owner: String,
         last_day_ipv4: Vec<NodeStatus>,
         last_day_ipv6: Vec<NodeStatus>,
+        last_hour_test_runs: usize,
+        last_day_test_runs: usize,
     ) -> Self {
-        let node_uptimes =
-            NodeUptimes::calculate_from_last_day_reports(last_day_ipv4, last_day_ipv6);
+        let node_uptimes = NodeUptimes::calculate_from_last_day_reports(
+            report_time,
+            last_day_ipv4,
+            last_day_ipv6,
+            last_hour_test_runs,
+            last_day_test_runs,
+        );
 
         MixnodeStatusReport {
             identity,
@@ -128,13 +137,21 @@ pub struct GatewayStatusReport {
 
 impl GatewayStatusReport {
     pub(crate) fn construct_from_last_day_reports(
+        report_time: OffsetDateTime,
         identity: String,
         owner: String,
         last_day_ipv4: Vec<NodeStatus>,
         last_day_ipv6: Vec<NodeStatus>,
+        last_hour_test_runs: usize,
+        last_day_test_runs: usize,
     ) -> Self {
-        let node_uptimes =
-            NodeUptimes::calculate_from_last_day_reports(last_day_ipv4, last_day_ipv6);
+        let node_uptimes = NodeUptimes::calculate_from_last_day_reports(
+            report_time,
+            last_day_ipv4,
+            last_day_ipv6,
+            last_hour_test_runs,
+            last_day_test_runs,
+        );
 
         GatewayStatusReport {
             identity,

--- a/validator-api/src/storage/manager.rs
+++ b/validator-api/src/storage/manager.rs
@@ -463,6 +463,43 @@ impl StorageManager {
         Ok(())
     }
 
+    /// Creates a database entry for a finished network monitor test run.
+    ///
+    /// # Arguments
+    ///
+    /// * `timestamp`: unix timestamp at which the monitor test run has occurred
+    pub(crate) async fn insert_monitor_run(
+        &self,
+        timestamp: UnixTimestamp,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query!("INSERT INTO monitor_run(timestamp) VALUES (?)", timestamp)
+            .execute(&self.connection_pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Obtains number of network monitor test runs that have occurred within the specified interval.
+    ///
+    /// # Arguments
+    ///
+    /// * `since`: unix timestamp indicating the lower bound interval of the selection.
+    /// * `until`: unix timestamp indicating the upper bound interval of the selection.
+    pub(crate) async fn get_monitor_runs_count(
+        &self,
+        since: UnixTimestamp,
+        until: UnixTimestamp,
+    ) -> Result<i32, sqlx::Error> {
+        let count = sqlx::query!(
+            "SELECT COUNT(*) as count FROM monitor_run WHERE timestamp > ? AND timestamp < ?",
+            since,
+            until,
+        )
+        .fetch_one(&self.connection_pool)
+        .await?
+        .count;
+        Ok(count)
+    }
+
     pub(crate) async fn purge_old_mixnode_ipv4_statuses(
         &self,
         timestamp: UnixTimestamp,

--- a/validator-api/src/storage/manager.rs
+++ b/validator-api/src/storage/manager.rs
@@ -4,10 +4,8 @@
 use crate::network_monitor::monitor::summary_producer::NodeResult;
 use crate::node_status_api::models::{HistoricalUptime, Uptime};
 use crate::node_status_api::utils::ActiveNodeDayStatuses;
-use crate::node_status_api::ONE_DAY;
 use crate::storage::models::{ActiveNode, NodeStatus};
 use crate::storage::UnixTimestamp;
-use sqlx::types::time::OffsetDateTime;
 use std::convert::TryFrom;
 
 #[derive(Clone)]
@@ -616,19 +614,17 @@ impl StorageManager {
     // since technically it doesn't touch any SQL directly
     pub(crate) async fn get_all_active_mixnodes_statuses(
         &self,
+        since: UnixTimestamp,
     ) -> Result<Vec<ActiveNodeDayStatuses>, sqlx::Error> {
-        let now = OffsetDateTime::now_utc();
-        let day_ago = (now - ONE_DAY).unix_timestamp();
-
-        let active_nodes = self.get_all_active_mixnodes(day_ago).await?;
+        let active_nodes = self.get_all_active_mixnodes(since).await?;
 
         let mut active_day_statuses = Vec::with_capacity(active_nodes.len());
         for active_node in active_nodes.into_iter() {
             let ipv4_statuses = self
-                .get_mixnode_ipv4_statuses_since_by_id(active_node.id, day_ago)
+                .get_mixnode_ipv4_statuses_since_by_id(active_node.id, since)
                 .await?;
             let ipv6_statuses = self
-                .get_mixnode_ipv6_statuses_since_by_id(active_node.id, day_ago)
+                .get_mixnode_ipv6_statuses_since_by_id(active_node.id, since)
                 .await?;
 
             let statuses = ActiveNodeDayStatuses {
@@ -651,19 +647,17 @@ impl StorageManager {
     // since technically it doesn't touch any SQL directly
     pub(crate) async fn get_all_active_gateways_statuses(
         &self,
+        since: UnixTimestamp,
     ) -> Result<Vec<ActiveNodeDayStatuses>, sqlx::Error> {
-        let now = OffsetDateTime::now_utc();
-        let day_ago = (now - ONE_DAY).unix_timestamp();
-
-        let active_nodes = self.get_all_active_gateways(day_ago).await?;
+        let active_nodes = self.get_all_active_gateways(since).await?;
 
         let mut active_day_statuses = Vec::with_capacity(active_nodes.len());
         for active_node in active_nodes.into_iter() {
             let ipv4_statuses = self
-                .get_gateway_ipv4_statuses_since_by_id(active_node.id, day_ago)
+                .get_gateway_ipv4_statuses_since_by_id(active_node.id, since)
                 .await?;
             let ipv6_statuses = self
-                .get_gateway_ipv6_statuses_since_by_id(active_node.id, day_ago)
+                .get_gateway_ipv6_statuses_since_by_id(active_node.id, since)
                 .await?;
 
             let statuses = ActiveNodeDayStatuses {


### PR DESCRIPTION
This pull request changes how node uptimes are calculated. Up until this point the uptime was based on the percentage of "up" test runs during which the nodes was online. So for example if a mixnode was online during 100 network monitor test runs and it passed 90 of them it'd have 90% uptime. 

However, this approach has an issue. The calculation didn't care about number of actual runs that have happened. So say somebody was offline for 99% of given day and happened to be up for a single test run. They'd get assigned 100% uptime because they happened to pass that one test run. 

This pull request changes this and takes into consideration the total number of test runs. So in the previous case the node would have gotten score of 1% as there would be no information about them passing the runs during which they were offline.