### PR TITLE
Feature/get own delegations

### DIFF
--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -243,7 +243,7 @@ impl<C> Client<C> {
         Ok(delegations)
     }
 
-    pub async fn get_all_nymd_mixnode_reverse_delegations(
+    pub async fn get_all_nymd_reverse_mixnode_delegations(
         &self,
         delegation_owner: &cosmos_sdk::AccountId,
     ) -> Result<Vec<mixnet_contract::IdentityKey>, ValidatorClientError>
@@ -255,7 +255,7 @@ impl<C> Client<C> {
         loop {
             let mut paged_response = self
                 .nymd
-                .get_mix_reverse_delegations_paged(
+                .get_reverse_mix_delegations_paged(
                     mixnet_contract::Addr::unchecked(delegation_owner.as_ref()),
                     start_after.take(),
                     self.mixnode_delegations_page_limit,
@@ -282,7 +282,7 @@ impl<C> Client<C> {
     {
         let mut delegations = Vec::new();
         for node_identity in self
-            .get_all_nymd_mixnode_reverse_delegations(delegation_owner)
+            .get_all_nymd_reverse_mixnode_delegations(delegation_owner)
             .await?
         {
             let delegation = self
@@ -325,7 +325,7 @@ impl<C> Client<C> {
         Ok(delegations)
     }
 
-    pub async fn get_all_nymd_gateway_reverse_delegations(
+    pub async fn get_all_nymd_reverse_gateway_delegations(
         &self,
         delegation_owner: &cosmos_sdk::AccountId,
     ) -> Result<Vec<mixnet_contract::IdentityKey>, ValidatorClientError>
@@ -337,7 +337,7 @@ impl<C> Client<C> {
         loop {
             let mut paged_response = self
                 .nymd
-                .get_gateway_reverse_delegations_paged(
+                .get_reverse_gateway_delegations_paged(
                     mixnet_contract::Addr::unchecked(delegation_owner.as_ref()),
                     start_after.take(),
                     self.mixnode_delegations_page_limit,
@@ -364,7 +364,7 @@ impl<C> Client<C> {
     {
         let mut delegations = Vec::new();
         for node_identity in self
-            .get_all_nymd_gateway_reverse_delegations(delegation_owner)
+            .get_all_nymd_reverse_gateway_delegations(delegation_owner)
             .await?
         {
             let delegation = self

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -243,6 +243,58 @@ impl<C> Client<C> {
         Ok(delegations)
     }
 
+    pub async fn get_all_nymd_mixnode_reverse_delegations(
+        &self,
+        delegation_owner: &cosmos_sdk::AccountId,
+    ) -> Result<Vec<mixnet_contract::IdentityKey>, ValidatorClientError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        let mut delegations = Vec::new();
+        let mut start_after = None;
+        loop {
+            let mut paged_response = self
+                .nymd
+                .get_mix_reverse_delegations_paged(
+                    mixnet_contract::Addr::unchecked(delegation_owner.as_ref()),
+                    start_after.take(),
+                    self.mixnode_delegations_page_limit,
+                )
+                .await?;
+            delegations.append(&mut paged_response.delegated_nodes);
+
+            if let Some(start_after_res) = paged_response.start_next_after {
+                start_after = Some(start_after_res)
+            } else {
+                break;
+            }
+        }
+
+        Ok(delegations)
+    }
+
+    pub async fn get_all_nymd_mixnode_delegations_of_owner(
+        &self,
+        delegation_owner: &cosmos_sdk::AccountId,
+    ) -> Result<Vec<mixnet_contract::Delegation>, ValidatorClientError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        let mut delegations = Vec::new();
+        for node_identity in self
+            .get_all_nymd_mixnode_reverse_delegations(delegation_owner)
+            .await?
+        {
+            let delegation = self
+                .nymd
+                .get_mix_delegation(node_identity, delegation_owner)
+                .await?;
+            delegations.push(delegation);
+        }
+
+        Ok(delegations)
+    }
+
     pub async fn get_all_nymd_gateway_delegations(
         &self,
         identity: mixnet_contract::IdentityKey,
@@ -268,6 +320,58 @@ impl<C> Client<C> {
             } else {
                 break;
             }
+        }
+
+        Ok(delegations)
+    }
+
+    pub async fn get_all_nymd_gateway_reverse_delegations(
+        &self,
+        delegation_owner: &cosmos_sdk::AccountId,
+    ) -> Result<Vec<mixnet_contract::IdentityKey>, ValidatorClientError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        let mut delegations = Vec::new();
+        let mut start_after = None;
+        loop {
+            let mut paged_response = self
+                .nymd
+                .get_gateway_reverse_delegations_paged(
+                    mixnet_contract::Addr::unchecked(delegation_owner.as_ref()),
+                    start_after.take(),
+                    self.mixnode_delegations_page_limit,
+                )
+                .await?;
+            delegations.append(&mut paged_response.delegated_nodes);
+
+            if let Some(start_after_res) = paged_response.start_next_after {
+                start_after = Some(start_after_res)
+            } else {
+                break;
+            }
+        }
+
+        Ok(delegations)
+    }
+
+    pub async fn get_all_nymd_gateway_delegations_of_owner(
+        &self,
+        delegation_owner: &cosmos_sdk::AccountId,
+    ) -> Result<Vec<mixnet_contract::Delegation>, ValidatorClientError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        let mut delegations = Vec::new();
+        for node_identity in self
+            .get_all_nymd_gateway_reverse_delegations(delegation_owner)
+            .await?
+        {
+            let delegation = self
+                .nymd
+                .get_gateway_delegation(node_identity, delegation_owner)
+                .await?;
+            delegations.push(delegation);
         }
 
         Ok(delegations)

--- a/common/client-libs/validator-client/src/nymd/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/mod.rs
@@ -18,8 +18,9 @@ use cosmwasm_std::Coin;
 use mixnet_contract::{
     Addr, Delegation, ExecuteMsg, Gateway, GatewayOwnershipResponse, IdentityKey,
     LayerDistribution, MixNode, MixOwnershipResponse, PagedGatewayDelegationsResponse,
-    PagedGatewayResponse, PagedGatewayReverseDelegationsResponse, PagedMixDelegationsResponse,
-    PagedMixReverseDelegationsResponse, PagedMixnodeResponse, QueryMsg, StateParams,
+    PagedGatewayResponse, PagedMixDelegationsResponse, PagedMixnodeResponse,
+    PagedReverseGatewayDelegationsResponse, PagedReverseMixDelegationsResponse, QueryMsg,
+    StateParams,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -261,16 +262,16 @@ impl<C> NymdClient<C> {
     }
 
     /// Gets list of all the mixnodes on which a particular address delegated.
-    pub async fn get_mix_reverse_delegations_paged(
+    pub async fn get_reverse_mix_delegations_paged(
         &self,
         delegation_owner: Addr,
         start_after: Option<IdentityKey>,
         page_limit: Option<u32>,
-    ) -> Result<PagedMixReverseDelegationsResponse, NymdError>
+    ) -> Result<PagedReverseMixDelegationsResponse, NymdError>
     where
         C: CosmWasmClient + Sync,
     {
-        let request = QueryMsg::GetMixReverseDelegations {
+        let request = QueryMsg::GetReverseMixDelegations {
             delegation_owner,
             start_after,
             limit: page_limit,
@@ -319,16 +320,16 @@ impl<C> NymdClient<C> {
     }
 
     /// Gets list of all the gateways on which a particular address delegated.
-    pub async fn get_gateway_reverse_delegations_paged(
+    pub async fn get_reverse_gateway_delegations_paged(
         &self,
         delegation_owner: Addr,
         start_after: Option<IdentityKey>,
         page_limit: Option<u32>,
-    ) -> Result<PagedGatewayReverseDelegationsResponse, NymdError>
+    ) -> Result<PagedReverseGatewayDelegationsResponse, NymdError>
     where
         C: CosmWasmClient + Sync,
     {
-        let request = QueryMsg::GetGatewayReverseDelegations {
+        let request = QueryMsg::GetReverseGatewayDelegations {
             delegation_owner,
             start_after,
             limit: page_limit,

--- a/common/client-libs/validator-client/src/nymd/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/mod.rs
@@ -18,7 +18,8 @@ use cosmwasm_std::Coin;
 use mixnet_contract::{
     Addr, Delegation, ExecuteMsg, Gateway, GatewayOwnershipResponse, IdentityKey,
     LayerDistribution, MixNode, MixOwnershipResponse, PagedGatewayDelegationsResponse,
-    PagedGatewayResponse, PagedMixDelegationsResponse, PagedMixnodeResponse, QueryMsg, StateParams,
+    PagedGatewayResponse, PagedGatewayReverseDelegationsResponse, PagedMixDelegationsResponse,
+    PagedMixReverseDelegationsResponse, PagedMixnodeResponse, QueryMsg, StateParams,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -259,6 +260,26 @@ impl<C> NymdClient<C> {
             .await
     }
 
+    /// Gets list of all the mixnodes on which a particular address delegated.
+    pub async fn get_mix_reverse_delegations_paged(
+        &self,
+        delegation_owner: Addr,
+        start_after: Option<IdentityKey>,
+        page_limit: Option<u32>,
+    ) -> Result<PagedMixReverseDelegationsResponse, NymdError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        let request = QueryMsg::GetMixReverseDelegations {
+            delegation_owner,
+            start_after,
+            limit: page_limit,
+        };
+        self.client
+            .query_contract_smart(self.contract_address()?, &request)
+            .await
+    }
+
     /// Checks value of delegation of given client towards particular mixnode.
     pub async fn get_mix_delegation(
         &self,
@@ -289,6 +310,26 @@ impl<C> NymdClient<C> {
     {
         let request = QueryMsg::GetGatewayDelegations {
             gateway_identity,
+            start_after,
+            limit: page_limit,
+        };
+        self.client
+            .query_contract_smart(self.contract_address()?, &request)
+            .await
+    }
+
+    /// Gets list of all the gateways on which a particular address delegated.
+    pub async fn get_gateway_reverse_delegations_paged(
+        &self,
+        delegation_owner: Addr,
+        start_after: Option<IdentityKey>,
+        page_limit: Option<u32>,
+    ) -> Result<PagedGatewayReverseDelegationsResponse, NymdError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        let request = QueryMsg::GetGatewayReverseDelegations {
+            delegation_owner,
             start_after,
             limit: page_limit,
         };

--- a/common/mixnet-contract/src/delegation.rs
+++ b/common/mixnet-contract/src/delegation.rs
@@ -59,6 +59,27 @@ impl PagedMixDelegationsResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
+pub struct PagedMixReverseDelegationsResponse {
+    pub delegation_owner: Addr,
+    pub delegated_nodes: Vec<IdentityKey>,
+    pub start_next_after: Option<IdentityKey>,
+}
+
+impl PagedMixReverseDelegationsResponse {
+    pub fn new(
+        delegation_owner: Addr,
+        delegated_nodes: Vec<IdentityKey>,
+        start_next_after: Option<IdentityKey>,
+    ) -> Self {
+        PagedMixReverseDelegationsResponse {
+            delegation_owner,
+            delegated_nodes,
+            start_next_after,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
 pub struct PagedGatewayDelegationsResponse {
     pub node_identity: IdentityKey,
     pub delegations: Vec<Delegation>,
@@ -74,6 +95,27 @@ impl PagedGatewayDelegationsResponse {
         PagedGatewayDelegationsResponse {
             node_identity,
             delegations,
+            start_next_after,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
+pub struct PagedGatewayReverseDelegationsResponse {
+    pub delegation_owner: Addr,
+    pub delegated_nodes: Vec<IdentityKey>,
+    pub start_next_after: Option<IdentityKey>,
+}
+
+impl PagedGatewayReverseDelegationsResponse {
+    pub fn new(
+        delegation_owner: Addr,
+        delegated_nodes: Vec<IdentityKey>,
+        start_next_after: Option<IdentityKey>,
+    ) -> Self {
+        PagedGatewayReverseDelegationsResponse {
+            delegation_owner,
+            delegated_nodes,
             start_next_after,
         }
     }

--- a/common/mixnet-contract/src/delegation.rs
+++ b/common/mixnet-contract/src/delegation.rs
@@ -59,19 +59,19 @@ impl PagedMixDelegationsResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
-pub struct PagedMixReverseDelegationsResponse {
+pub struct PagedReverseMixDelegationsResponse {
     pub delegation_owner: Addr,
     pub delegated_nodes: Vec<IdentityKey>,
     pub start_next_after: Option<IdentityKey>,
 }
 
-impl PagedMixReverseDelegationsResponse {
+impl PagedReverseMixDelegationsResponse {
     pub fn new(
         delegation_owner: Addr,
         delegated_nodes: Vec<IdentityKey>,
         start_next_after: Option<IdentityKey>,
     ) -> Self {
-        PagedMixReverseDelegationsResponse {
+        PagedReverseMixDelegationsResponse {
             delegation_owner,
             delegated_nodes,
             start_next_after,
@@ -101,19 +101,19 @@ impl PagedGatewayDelegationsResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
-pub struct PagedGatewayReverseDelegationsResponse {
+pub struct PagedReverseGatewayDelegationsResponse {
     pub delegation_owner: Addr,
     pub delegated_nodes: Vec<IdentityKey>,
     pub start_next_after: Option<IdentityKey>,
 }
 
-impl PagedGatewayReverseDelegationsResponse {
+impl PagedReverseGatewayDelegationsResponse {
     pub fn new(
         delegation_owner: Addr,
         delegated_nodes: Vec<IdentityKey>,
         start_next_after: Option<IdentityKey>,
     ) -> Self {
-        PagedGatewayReverseDelegationsResponse {
+        PagedReverseGatewayDelegationsResponse {
             delegation_owner,
             delegated_nodes,
             start_next_after,

--- a/common/mixnet-contract/src/lib.rs
+++ b/common/mixnet-contract/src/lib.rs
@@ -8,7 +8,10 @@ mod msg;
 mod types;
 
 pub use cosmwasm_std::{Addr, Coin};
-pub use delegation::{Delegation, PagedGatewayDelegationsResponse, PagedMixDelegationsResponse};
+pub use delegation::{
+    Delegation, PagedGatewayDelegationsResponse, PagedGatewayReverseDelegationsResponse,
+    PagedMixDelegationsResponse, PagedMixReverseDelegationsResponse,
+};
 pub use gateway::{Gateway, GatewayBond, GatewayOwnershipResponse, PagedGatewayResponse};
 pub use mixnode::{Layer, MixNode, MixNodeBond, MixOwnershipResponse, PagedMixnodeResponse};
 pub use msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};

--- a/common/mixnet-contract/src/lib.rs
+++ b/common/mixnet-contract/src/lib.rs
@@ -9,8 +9,8 @@ mod types;
 
 pub use cosmwasm_std::{Addr, Coin};
 pub use delegation::{
-    Delegation, PagedGatewayDelegationsResponse, PagedGatewayReverseDelegationsResponse,
-    PagedMixDelegationsResponse, PagedMixReverseDelegationsResponse,
+    Delegation, PagedGatewayDelegationsResponse, PagedMixDelegationsResponse,
+    PagedReverseGatewayDelegationsResponse, PagedReverseMixDelegationsResponse,
 };
 pub use gateway::{Gateway, GatewayBond, GatewayOwnershipResponse, PagedGatewayResponse};
 pub use mixnode::{Layer, MixNode, MixNodeBond, MixOwnershipResponse, PagedMixnodeResponse};

--- a/common/mixnet-contract/src/msg.rs
+++ b/common/mixnet-contract/src/msg.rs
@@ -75,6 +75,11 @@ pub enum QueryMsg {
         start_after: Option<Addr>,
         limit: Option<u32>,
     },
+    GetMixReverseDelegations {
+        delegation_owner: Addr,
+        start_after: Option<IdentityKey>,
+        limit: Option<u32>,
+    },
     GetMixDelegation {
         mix_identity: IdentityKey,
         address: Addr,
@@ -82,6 +87,11 @@ pub enum QueryMsg {
     GetGatewayDelegations {
         gateway_identity: IdentityKey,
         start_after: Option<Addr>,
+        limit: Option<u32>,
+    },
+    GetGatewayReverseDelegations {
+        delegation_owner: Addr,
+        start_after: Option<IdentityKey>,
         limit: Option<u32>,
     },
     GetGatewayDelegation {

--- a/common/mixnet-contract/src/msg.rs
+++ b/common/mixnet-contract/src/msg.rs
@@ -75,7 +75,7 @@ pub enum QueryMsg {
         start_after: Option<Addr>,
         limit: Option<u32>,
     },
-    GetMixReverseDelegations {
+    GetReverseMixDelegations {
         delegation_owner: Addr,
         start_after: Option<IdentityKey>,
         limit: Option<u32>,
@@ -89,7 +89,7 @@ pub enum QueryMsg {
         start_after: Option<Addr>,
         limit: Option<u32>,
     },
-    GetGatewayReverseDelegations {
+    GetReverseGatewayDelegations {
         delegation_owner: Addr,
         start_after: Option<IdentityKey>,
         limit: Option<u32>,

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -4,7 +4,7 @@
 use crate::helpers::calculate_epoch_reward_rate;
 use crate::state::State;
 use crate::storage::{
-    config, gateway_reverse_delegations, layer_distribution, mix_reverse_delegations,
+    config, reverse_gateway_delegations, layer_distribution, reverse_mix_delegations,
 };
 use crate::{error::ContractError, queries, transactions};
 use config::defaults::NETWORK_MONITOR_ADDRESS;
@@ -154,11 +154,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
             start_after,
             limit,
         )?),
-        QueryMsg::GetMixReverseDelegations {
+        QueryMsg::GetReverseMixDelegations {
             delegation_owner,
             start_after,
             limit,
-        } => to_binary(&queries::query_mixnode_reverse_delegations_paged(
+        } => to_binary(&queries::query_reverse_mixnode_delegations_paged(
             deps,
             delegation_owner,
             start_after,
@@ -182,11 +182,11 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
             start_after,
             limit,
         )?),
-        QueryMsg::GetGatewayReverseDelegations {
+        QueryMsg::GetReverseGatewayDelegations {
             delegation_owner,
             start_after,
             limit,
-        } => to_binary(&queries::query_gateway_reverse_delegations_paged(
+        } => to_binary(&queries::query_reverse_gateway_delegations_paged(
             deps,
             delegation_owner,
             start_after,
@@ -305,7 +305,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
     for mix_identity in mixnodes_identities {
         let delegations = get_all_mixnode_delegations(&deps, &mix_identity)?;
         for delegation in delegations {
-            mix_reverse_delegations(deps.storage, &delegation.owner())
+            reverse_mix_delegations(deps.storage, &delegation.owner())
                 .save(mix_identity.as_bytes(), &())?;
         }
     }
@@ -314,7 +314,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
     for gateway_identity in gateways_identities {
         let delegations = get_all_gateway_delegations(&deps, &gateway_identity)?;
         for delegation in delegations {
-            gateway_reverse_delegations(deps.storage, &delegation.owner())
+            reverse_gateway_delegations(deps.storage, &delegation.owner())
                 .save(gateway_identity.as_bytes(), &())?;
         }
     }

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -205,100 +205,102 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
     Ok(query_res?)
 }
 
-fn get_all_mixnodes_identities(deps: &DepsMut) -> Result<Vec<IdentityKey>, ContractError> {
-    let mut mixnode_bonds = Vec::new();
-    let mut start_after = None;
-    loop {
-        let mut paged_response = queries::query_mixnodes_paged(deps.as_ref(), start_after, None)?;
-        mixnode_bonds.append(&mut paged_response.nodes);
-
-        if let Some(start_after_res) = paged_response.start_next_after {
-            start_after = Some(start_after_res)
-        } else {
-            break;
-        }
-    }
-    let mixnodes = mixnode_bonds
-        .into_iter()
-        .map(|bond| bond.mix_node.identity_key)
-        .collect();
-
-    Ok(mixnodes)
-}
-
-fn get_all_gateways_identities(deps: &DepsMut) -> Result<Vec<IdentityKey>, ContractError> {
-    let mut gateway_bonds = Vec::new();
-    let mut start_after = None;
-    loop {
-        let mut paged_response = queries::query_gateways_paged(deps.as_ref(), start_after, None)?;
-        gateway_bonds.append(&mut paged_response.nodes);
-
-        if let Some(start_after_res) = paged_response.start_next_after {
-            start_after = Some(start_after_res)
-        } else {
-            break;
-        }
-    }
-    let gateways = gateway_bonds
-        .into_iter()
-        .map(|bond| bond.gateway.identity_key)
-        .collect();
-
-    Ok(gateways)
-}
-
-fn get_all_mixnode_delegations(
-    deps: &DepsMut,
-    mix_identity: IdentityKeyRef,
-) -> Result<Vec<Delegation>, ContractError> {
-    let mut delegations = Vec::new();
-    let mut start_after = None;
-    loop {
-        let mut paged_response = queries::query_mixnode_delegations_paged(
-            deps.as_ref(),
-            mix_identity.into(),
-            start_after,
-            None,
-        )?;
-        delegations.append(&mut paged_response.delegations);
-
-        if let Some(start_after_res) = paged_response.start_next_after {
-            start_after = Some(start_after_res)
-        } else {
-            break;
-        }
-    }
-
-    Ok(delegations)
-}
-
-fn get_all_gateway_delegations(
-    deps: &DepsMut,
-    gateway_identity: IdentityKeyRef,
-) -> Result<Vec<Delegation>, ContractError> {
-    let mut delegations = Vec::new();
-    let mut start_after = None;
-    loop {
-        let mut paged_response = queries::query_gateway_delegations_paged(
-            deps.as_ref(),
-            gateway_identity.into(),
-            start_after,
-            None,
-        )?;
-        delegations.append(&mut paged_response.delegations);
-
-        if let Some(start_after_res) = paged_response.start_next_after {
-            start_after = Some(start_after_res)
-        } else {
-            break;
-        }
-    }
-
-    Ok(delegations)
-}
-
 #[entry_point]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    fn get_all_mixnodes_identities(deps: &DepsMut) -> Result<Vec<IdentityKey>, ContractError> {
+        let mut mixnode_bonds = Vec::new();
+        let mut start_after = None;
+        loop {
+            let mut paged_response =
+                queries::query_mixnodes_paged(deps.as_ref(), start_after, None)?;
+            mixnode_bonds.append(&mut paged_response.nodes);
+
+            if let Some(start_after_res) = paged_response.start_next_after {
+                start_after = Some(start_after_res)
+            } else {
+                break;
+            }
+        }
+        let mixnodes = mixnode_bonds
+            .into_iter()
+            .map(|bond| bond.mix_node.identity_key)
+            .collect();
+
+        Ok(mixnodes)
+    }
+
+    fn get_all_gateways_identities(deps: &DepsMut) -> Result<Vec<IdentityKey>, ContractError> {
+        let mut gateway_bonds = Vec::new();
+        let mut start_after = None;
+        loop {
+            let mut paged_response =
+                queries::query_gateways_paged(deps.as_ref(), start_after, None)?;
+            gateway_bonds.append(&mut paged_response.nodes);
+
+            if let Some(start_after_res) = paged_response.start_next_after {
+                start_after = Some(start_after_res)
+            } else {
+                break;
+            }
+        }
+        let gateways = gateway_bonds
+            .into_iter()
+            .map(|bond| bond.gateway.identity_key)
+            .collect();
+
+        Ok(gateways)
+    }
+
+    fn get_all_mixnode_delegations(
+        deps: &DepsMut,
+        mix_identity: IdentityKeyRef,
+    ) -> Result<Vec<Delegation>, ContractError> {
+        let mut delegations = Vec::new();
+        let mut start_after = None;
+        loop {
+            let mut paged_response = queries::query_mixnode_delegations_paged(
+                deps.as_ref(),
+                mix_identity.into(),
+                start_after,
+                None,
+            )?;
+            delegations.append(&mut paged_response.delegations);
+
+            if let Some(start_after_res) = paged_response.start_next_after {
+                start_after = Some(start_after_res)
+            } else {
+                break;
+            }
+        }
+
+        Ok(delegations)
+    }
+
+    fn get_all_gateway_delegations(
+        deps: &DepsMut,
+        gateway_identity: IdentityKeyRef,
+    ) -> Result<Vec<Delegation>, ContractError> {
+        let mut delegations = Vec::new();
+        let mut start_after = None;
+        loop {
+            let mut paged_response = queries::query_gateway_delegations_paged(
+                deps.as_ref(),
+                gateway_identity.into(),
+                start_after,
+                None,
+            )?;
+            delegations.append(&mut paged_response.delegations);
+
+            if let Some(start_after_res) = paged_response.start_next_after {
+                start_after = Some(start_after_res)
+            } else {
+                break;
+            }
+        }
+
+        Ok(delegations)
+    }
+
     let mixnodes_identities = get_all_mixnodes_identities(&deps)?;
     for mix_identity in mixnodes_identities {
         let delegations = get_all_mixnode_delegations(&deps, &mix_identity)?;

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -4,7 +4,7 @@
 use crate::helpers::calculate_epoch_reward_rate;
 use crate::state::State;
 use crate::storage::{
-    config, reverse_gateway_delegations, layer_distribution, reverse_mix_delegations,
+    config, layer_distribution, reverse_gateway_delegations, reverse_mix_delegations,
 };
 use crate::{error::ContractError, queries, transactions};
 use config::defaults::NETWORK_MONITOR_ADDRESS;

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -3,14 +3,19 @@
 
 use crate::helpers::calculate_epoch_reward_rate;
 use crate::state::State;
-use crate::storage::{config, layer_distribution};
+use crate::storage::{
+    config, gateway_reverse_delegations, layer_distribution, mix_reverse_delegations,
+};
 use crate::{error::ContractError, queries, transactions};
 use config::defaults::NETWORK_MONITOR_ADDRESS;
 use cosmwasm_std::{
     entry_point, to_binary, Addr, Decimal, Deps, DepsMut, Env, MessageInfo, QueryResponse,
     Response, Uint128,
 };
-use mixnet_contract::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, StateParams};
+use mixnet_contract::{
+    Delegation, ExecuteMsg, IdentityKey, IdentityKeyRef, InstantiateMsg, MigrateMsg, QueryMsg,
+    StateParams,
+};
 
 pub const INITIAL_DEFAULT_EPOCH_LENGTH: u32 = 2;
 
@@ -200,8 +205,118 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
     Ok(query_res?)
 }
 
+fn get_all_mixnodes_identities(deps: &DepsMut) -> Result<Vec<IdentityKey>, ContractError> {
+    let mut mixnode_bonds = Vec::new();
+    let mut start_after = None;
+    loop {
+        let mut paged_response = queries::query_mixnodes_paged(deps.as_ref(), start_after, None)?;
+        mixnode_bonds.append(&mut paged_response.nodes);
+
+        if let Some(start_after_res) = paged_response.start_next_after {
+            start_after = Some(start_after_res)
+        } else {
+            break;
+        }
+    }
+    let mixnodes = mixnode_bonds
+        .into_iter()
+        .map(|bond| bond.mix_node.identity_key)
+        .collect();
+
+    Ok(mixnodes)
+}
+
+fn get_all_gateways_identities(deps: &DepsMut) -> Result<Vec<IdentityKey>, ContractError> {
+    let mut gateway_bonds = Vec::new();
+    let mut start_after = None;
+    loop {
+        let mut paged_response = queries::query_gateways_paged(deps.as_ref(), start_after, None)?;
+        gateway_bonds.append(&mut paged_response.nodes);
+
+        if let Some(start_after_res) = paged_response.start_next_after {
+            start_after = Some(start_after_res)
+        } else {
+            break;
+        }
+    }
+    let gateways = gateway_bonds
+        .into_iter()
+        .map(|bond| bond.gateway.identity_key)
+        .collect();
+
+    Ok(gateways)
+}
+
+fn get_all_mixnode_delegations(
+    deps: &DepsMut,
+    mix_identity: IdentityKeyRef,
+) -> Result<Vec<Delegation>, ContractError> {
+    let mut delegations = Vec::new();
+    let mut start_after = None;
+    loop {
+        let mut paged_response = queries::query_mixnode_delegations_paged(
+            deps.as_ref(),
+            mix_identity.into(),
+            start_after,
+            None,
+        )?;
+        delegations.append(&mut paged_response.delegations);
+
+        if let Some(start_after_res) = paged_response.start_next_after {
+            start_after = Some(start_after_res)
+        } else {
+            break;
+        }
+    }
+
+    Ok(delegations)
+}
+
+fn get_all_gateway_delegations(
+    deps: &DepsMut,
+    gateway_identity: IdentityKeyRef,
+) -> Result<Vec<Delegation>, ContractError> {
+    let mut delegations = Vec::new();
+    let mut start_after = None;
+    loop {
+        let mut paged_response = queries::query_gateway_delegations_paged(
+            deps.as_ref(),
+            gateway_identity.into(),
+            start_after,
+            None,
+        )?;
+        delegations.append(&mut paged_response.delegations);
+
+        if let Some(start_after_res) = paged_response.start_next_after {
+            start_after = Some(start_after_res)
+        } else {
+            break;
+        }
+    }
+
+    Ok(delegations)
+}
+
 #[entry_point]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    let mixnodes_identities = get_all_mixnodes_identities(&deps)?;
+    for mix_identity in mixnodes_identities {
+        let delegations = get_all_mixnode_delegations(&deps, &mix_identity)?;
+        for delegation in delegations {
+            mix_reverse_delegations(deps.storage, &delegation.owner())
+                .save(mix_identity.as_bytes(), &())?;
+        }
+    }
+
+    let gateways_identities = get_all_gateways_identities(&deps)?;
+    for gateway_identity in gateways_identities {
+        let delegations = get_all_gateway_delegations(&deps, &gateway_identity)?;
+        for delegation in delegations {
+            gateway_reverse_delegations(deps.storage, &delegation.owner())
+                .save(gateway_identity.as_bytes(), &())?;
+        }
+    }
+
     Ok(Default::default())
 }
 

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -149,6 +149,16 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
             start_after,
             limit,
         )?),
+        QueryMsg::GetMixReverseDelegations {
+            delegation_owner,
+            start_after,
+            limit,
+        } => to_binary(&queries::query_mixnode_reverse_delegations_paged(
+            deps,
+            delegation_owner,
+            start_after,
+            limit,
+        )?),
         QueryMsg::GetMixDelegation {
             mix_identity,
             address,
@@ -164,6 +174,16 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
         } => to_binary(&queries::query_gateway_delegations_paged(
             deps,
             gateway_identity,
+            start_after,
+            limit,
+        )?),
+        QueryMsg::GetGatewayReverseDelegations {
+            delegation_owner,
+            start_after,
+            limit,
+        } => to_binary(&queries::query_gateway_reverse_delegations_paged(
+            deps,
+            delegation_owner,
             start_after,
             limit,
         )?),

--- a/contracts/mixnet/src/queries.rs
+++ b/contracts/mixnet/src/queries.rs
@@ -158,7 +158,7 @@ pub(crate) fn query_mixnode_reverse_delegations_paged(
         .map(|res| res.map(|entry| String::from_utf8(entry.0).unwrap()))
         .collect::<StdResult<Vec<IdentityKey>>>()?;
 
-    let start_next_after = delegations.last().map(|v| v.clone());
+    let start_next_after = delegations.last().cloned();
 
     Ok(PagedMixReverseDelegationsResponse::new(
         delegation_owner,
@@ -235,7 +235,7 @@ pub(crate) fn query_gateway_reverse_delegations_paged(
         .map(|res| res.map(|entry| String::from_utf8(entry.0).unwrap()))
         .collect::<StdResult<Vec<IdentityKey>>>()?;
 
-    let start_next_after = delegations.last().map(|v| v.clone());
+    let start_next_after = delegations.last().cloned();
 
     Ok(PagedGatewayReverseDelegationsResponse::new(
         delegation_owner,

--- a/contracts/mixnet/src/queries.rs
+++ b/contracts/mixnet/src/queries.rs
@@ -125,7 +125,9 @@ pub(crate) fn query_mixnode_delegations_paged(
         .map(|res| {
             res.map(|entry| {
                 Delegation::new(
-                    Addr::unchecked(String::from_utf8(entry.0).unwrap()),
+                    Addr::unchecked(String::from_utf8(entry.0).expect(
+                        "Non-UTF8 address used as key in bucket. The storage is corrupted!",
+                    )),
                     coin(entry.1.u128(), DENOM),
                 )
             })
@@ -155,7 +157,12 @@ pub(crate) fn query_mixnode_reverse_delegations_paged(
     let delegations = mix_reverse_delegations_read(deps.storage, &delegation_owner)
         .range(start.as_deref(), None, Order::Ascending)
         .take(limit)
-        .map(|res| res.map(|entry| String::from_utf8(entry.0).unwrap()))
+        .map(|res| {
+            res.map(|entry| {
+                String::from_utf8(entry.0)
+                    .expect("Non-UTF8 address used as key in bucket. The storage is corrupted!")
+            })
+        })
         .collect::<StdResult<Vec<IdentityKey>>>()?;
 
     let start_next_after = delegations.last().cloned();
@@ -202,7 +209,9 @@ pub(crate) fn query_gateway_delegations_paged(
         .map(|res| {
             res.map(|entry| {
                 Delegation::new(
-                    Addr::unchecked(String::from_utf8(entry.0).unwrap()),
+                    Addr::unchecked(String::from_utf8(entry.0).expect(
+                        "Non-UTF8 address used as key in bucket. The storage is corrupted!",
+                    )),
                     coin(entry.1.u128(), DENOM),
                 )
             })
@@ -232,7 +241,12 @@ pub(crate) fn query_gateway_reverse_delegations_paged(
     let delegations = gateway_reverse_delegations_read(deps.storage, &delegation_owner)
         .range(start.as_deref(), None, Order::Ascending)
         .take(limit)
-        .map(|res| res.map(|entry| String::from_utf8(entry.0).unwrap()))
+        .map(|res| {
+            res.map(|entry| {
+                String::from_utf8(entry.0)
+                    .expect("Non-UTF8 address used as key in bucket. The storage is corrupted!")
+            })
+        })
         .collect::<StdResult<Vec<IdentityKey>>>()?;
 
     let start_next_after = delegations.last().cloned();

--- a/contracts/mixnet/src/queries.rs
+++ b/contracts/mixnet/src/queries.rs
@@ -859,19 +859,6 @@ mod tests {
         use super::*;
         use crate::storage::mix_reverse_delegations;
 
-        fn query_mixnode_reverse_delegation(
-            deps: Deps,
-            mix_identity: IdentityKey,
-            address: Addr,
-        ) -> Result<(), ContractError> {
-            mix_reverse_delegations_read(deps.storage, &address)
-                .may_load(mix_identity.as_bytes())?
-                .ok_or(ContractError::NoMixnodeDelegationFound {
-                    identity: mix_identity,
-                    address,
-                })
-        }
-
         fn store_n_reverse_delegations(n: u32, storage: &mut dyn Storage, delegation_owner: &Addr) {
             for i in 0..n {
                 let node_identity = format!("node{}", i);
@@ -1025,74 +1012,6 @@ mod tests {
 
             // now we have 2 pages, with 2 results on the second page
             assert_eq!(2, page2.delegated_nodes.len());
-        }
-
-        #[test]
-        fn mix_reverse_deletion_query_returns_current_delegation_value() {
-            let mut deps = helpers::init_contract();
-            let node_identity: IdentityKey = "foo".into();
-            let delegation_owner = Addr::unchecked("bar");
-
-            mix_reverse_delegations(&mut deps.storage, &delegation_owner)
-                .save(node_identity.as_bytes(), &())
-                .unwrap();
-
-            assert_eq!(
-                Ok(()),
-                query_mixnode_reverse_delegation(deps.as_ref(), node_identity, delegation_owner)
-            )
-        }
-
-        #[test]
-        fn mix_reverse_deletion_query_returns_error_if_delegation_doesnt_exist() {
-            let mut deps = helpers::init_contract();
-
-            let node_identity1: IdentityKey = "foo1".into();
-            let node_identity2: IdentityKey = "foo2".into();
-            let delegation_owner1 = Addr::unchecked("bar");
-            let delegation_owner2 = Addr::unchecked("bar2");
-
-            assert_eq!(
-                Err(ContractError::NoMixnodeDelegationFound {
-                    identity: node_identity1.clone(),
-                    address: delegation_owner1.clone(),
-                }),
-                query_mixnode_reverse_delegation(
-                    deps.as_ref(),
-                    node_identity1.clone(),
-                    delegation_owner1.clone()
-                )
-            );
-
-            // add delegation for a different node
-            mix_reverse_delegations(&mut deps.storage, &delegation_owner1)
-                .save(node_identity2.as_bytes(), &())
-                .unwrap();
-
-            assert_eq!(
-                Err(ContractError::NoMixnodeDelegationFound {
-                    identity: node_identity1.clone(),
-                    address: delegation_owner1.clone(),
-                }),
-                query_mixnode_reverse_delegation(
-                    deps.as_ref(),
-                    node_identity1.clone(),
-                    delegation_owner1.clone()
-                )
-            );
-
-            // add delegation from a different owner
-            mix_reverse_delegations(&mut deps.storage, &delegation_owner2)
-                .save(node_identity1.as_bytes(), &())
-                .unwrap();
-
-            assert_eq!(
-                Err(ContractError::NoMixnodeDelegationFound {
-                    identity: node_identity1.clone(),
-                    address: delegation_owner1.clone()
-                }),
-                query_mixnode_reverse_delegation(deps.as_ref(), node_identity1, delegation_owner1)
-            )
         }
     }
 
@@ -1326,19 +1245,6 @@ mod tests {
         use super::*;
         use crate::storage::gateway_reverse_delegations;
 
-        fn query_gateway_reverse_delegation(
-            deps: Deps,
-            mix_identity: IdentityKey,
-            address: Addr,
-        ) -> Result<(), ContractError> {
-            gateway_reverse_delegations_read(deps.storage, &address)
-                .may_load(mix_identity.as_bytes())?
-                .ok_or(ContractError::NoGatewayDelegationFound {
-                    identity: mix_identity,
-                    address,
-                })
-        }
-
         fn store_n_reverse_delegations(n: u32, storage: &mut dyn Storage, delegation_owner: &Addr) {
             for i in 0..n {
                 let node_identity = format!("node{}", i);
@@ -1492,74 +1398,6 @@ mod tests {
 
             // now we have 2 pages, with 2 results on the second page
             assert_eq!(2, page2.delegated_nodes.len());
-        }
-
-        #[test]
-        fn gateway_reverse_deletion_query_returns_current_delegation_value() {
-            let mut deps = helpers::init_contract();
-            let node_identity: IdentityKey = "foo".into();
-            let delegation_owner = Addr::unchecked("bar");
-
-            gateway_reverse_delegations(&mut deps.storage, &delegation_owner)
-                .save(node_identity.as_bytes(), &())
-                .unwrap();
-
-            assert_eq!(
-                Ok(()),
-                query_gateway_reverse_delegation(deps.as_ref(), node_identity, delegation_owner)
-            )
-        }
-
-        #[test]
-        fn gateway_reverse_deletion_query_returns_error_if_delegation_doesnt_exist() {
-            let mut deps = helpers::init_contract();
-
-            let node_identity1: IdentityKey = "foo1".into();
-            let node_identity2: IdentityKey = "foo2".into();
-            let delegation_owner1 = Addr::unchecked("bar");
-            let delegation_owner2 = Addr::unchecked("bar2");
-
-            assert_eq!(
-                Err(ContractError::NoGatewayDelegationFound {
-                    identity: node_identity1.clone(),
-                    address: delegation_owner1.clone(),
-                }),
-                query_gateway_reverse_delegation(
-                    deps.as_ref(),
-                    node_identity1.clone(),
-                    delegation_owner1.clone()
-                )
-            );
-
-            // add delegation for a different node
-            gateway_reverse_delegations(&mut deps.storage, &delegation_owner1)
-                .save(node_identity2.as_bytes(), &())
-                .unwrap();
-
-            assert_eq!(
-                Err(ContractError::NoGatewayDelegationFound {
-                    identity: node_identity1.clone(),
-                    address: delegation_owner1.clone(),
-                }),
-                query_gateway_reverse_delegation(
-                    deps.as_ref(),
-                    node_identity1.clone(),
-                    delegation_owner1.clone()
-                )
-            );
-
-            // add delegation from a different owner
-            gateway_reverse_delegations(&mut deps.storage, &delegation_owner2)
-                .save(node_identity1.as_bytes(), &())
-                .unwrap();
-
-            assert_eq!(
-                Err(ContractError::NoGatewayDelegationFound {
-                    identity: node_identity1.clone(),
-                    address: delegation_owner1.clone()
-                }),
-                query_gateway_reverse_delegation(deps.as_ref(), node_identity1, delegation_owner1)
-            )
         }
     }
 }

--- a/contracts/mixnet/src/storage.rs
+++ b/contracts/mixnet/src/storage.rs
@@ -30,8 +30,8 @@ const PREFIX_GATEWAYS_OWNERS: &[u8] = b"go";
 
 const PREFIX_MIX_DELEGATION: &[u8] = b"md";
 const PREFIX_GATEWAY_DELEGATION: &[u8] = b"gd";
-const PREFIX_MIX_REVERSE_DELEGATION: &[u8] = b"dm";
-const PREFIX_GATEWAY_REVERSE_DELEGATION: &[u8] = b"dg";
+const PREFIX_REVERSE_MIX_DELEGATION: &[u8] = b"dm";
+const PREFIX_REVERSE_GATEWAY_DELEGATION: &[u8] = b"dg";
 
 // Contract-level stuff
 
@@ -304,15 +304,15 @@ pub fn mix_delegations_read<'a>(
     ReadonlyBucket::multilevel(storage, &[PREFIX_MIX_DELEGATION, mix_identity.as_bytes()])
 }
 
-pub fn mix_reverse_delegations<'a>(storage: &'a mut dyn Storage, owner: &Addr) -> Bucket<'a, ()> {
-    Bucket::multilevel(storage, &[PREFIX_MIX_REVERSE_DELEGATION, owner.as_bytes()])
+pub fn reverse_mix_delegations<'a>(storage: &'a mut dyn Storage, owner: &Addr) -> Bucket<'a, ()> {
+    Bucket::multilevel(storage, &[PREFIX_REVERSE_MIX_DELEGATION, owner.as_bytes()])
 }
 
-pub fn mix_reverse_delegations_read<'a>(
+pub fn reverse_mix_delegations_read<'a>(
     storage: &'a dyn Storage,
     owner: &Addr,
 ) -> ReadonlyBucket<'a, ()> {
-    ReadonlyBucket::multilevel(storage, &[PREFIX_MIX_REVERSE_DELEGATION, owner.as_bytes()])
+    ReadonlyBucket::multilevel(storage, &[PREFIX_REVERSE_MIX_DELEGATION, owner.as_bytes()])
 }
 
 pub fn gateway_delegations<'a>(
@@ -335,23 +335,23 @@ pub fn gateway_delegations_read<'a>(
     )
 }
 
-pub fn gateway_reverse_delegations<'a>(
+pub fn reverse_gateway_delegations<'a>(
     storage: &'a mut dyn Storage,
     owner: &Addr,
 ) -> Bucket<'a, ()> {
     Bucket::multilevel(
         storage,
-        &[PREFIX_GATEWAY_REVERSE_DELEGATION, owner.as_bytes()],
+        &[PREFIX_REVERSE_GATEWAY_DELEGATION, owner.as_bytes()],
     )
 }
 
-pub fn gateway_reverse_delegations_read<'a>(
+pub fn reverse_gateway_delegations_read<'a>(
     storage: &'a dyn Storage,
     owner: &Addr,
 ) -> ReadonlyBucket<'a, ()> {
     ReadonlyBucket::multilevel(
         storage,
-        &[PREFIX_GATEWAY_REVERSE_DELEGATION, owner.as_bytes()],
+        &[PREFIX_REVERSE_GATEWAY_DELEGATION, owner.as_bytes()],
     )
 }
 
@@ -609,22 +609,22 @@ mod tests {
     }
 
     #[cfg(test)]
-    mod mix_reverse_delegations {
+    mod reverse_mix_delegations {
         use super::*;
         use crate::support::tests::helpers;
 
         #[test]
-        fn mix_reverse_delegation_exists() {
+        fn reverse_mix_delegation_exists() {
             let mut deps = helpers::init_contract();
             let node_identity: IdentityKey = "foo".into();
             let delegation_owner = Addr::unchecked("bar");
 
-            mix_reverse_delegations(&mut deps.storage, &delegation_owner)
+            reverse_mix_delegations(&mut deps.storage, &delegation_owner)
                 .save(node_identity.as_bytes(), &())
                 .unwrap();
 
             assert!(
-                mix_reverse_delegations_read(deps.as_ref().storage, &delegation_owner)
+                reverse_mix_delegations_read(deps.as_ref().storage, &delegation_owner)
                     .may_load(node_identity.as_bytes())
                     .unwrap()
                     .is_some(),
@@ -632,7 +632,7 @@ mod tests {
         }
 
         #[test]
-        fn mix_reverse_delegation_returns_none_if_delegation_doesnt_exist() {
+        fn reverse_mix_delegation_returns_none_if_delegation_doesnt_exist() {
             let mut deps = helpers::init_contract();
 
             let node_identity1: IdentityKey = "foo1".into();
@@ -641,31 +641,31 @@ mod tests {
             let delegation_owner2 = Addr::unchecked("bar2");
 
             assert!(
-                mix_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                reverse_mix_delegations_read(deps.as_ref().storage, &delegation_owner1)
                     .may_load(node_identity1.as_bytes())
                     .unwrap()
                     .is_none()
             );
 
             // add delegation for a different node
-            mix_reverse_delegations(&mut deps.storage, &delegation_owner1)
+            reverse_mix_delegations(&mut deps.storage, &delegation_owner1)
                 .save(node_identity2.as_bytes(), &())
                 .unwrap();
 
             assert!(
-                mix_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                reverse_mix_delegations_read(deps.as_ref().storage, &delegation_owner1)
                     .may_load(node_identity1.as_bytes())
                     .unwrap()
                     .is_none()
             );
 
             // add delegation from a different owner
-            mix_reverse_delegations(&mut deps.storage, &delegation_owner2)
+            reverse_mix_delegations(&mut deps.storage, &delegation_owner2)
                 .save(node_identity1.as_bytes(), &())
                 .unwrap();
 
             assert!(
-                mix_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                reverse_mix_delegations_read(deps.as_ref().storage, &delegation_owner1)
                     .may_load(node_identity1.as_bytes())
                     .unwrap()
                     .is_none()
@@ -811,22 +811,22 @@ mod tests {
     }
 
     #[cfg(test)]
-    mod gateway_reverse_delegations {
+    mod reverse_gateway_delegations {
         use super::*;
         use crate::support::tests::helpers;
 
         #[test]
-        fn gateway_reverse_delegation_exists() {
+        fn reverse_gateway_delegation_exists() {
             let mut deps = helpers::init_contract();
             let node_identity: IdentityKey = "foo".into();
             let delegation_owner = Addr::unchecked("bar");
 
-            mix_reverse_delegations(&mut deps.storage, &delegation_owner)
+            reverse_gateway_delegations(&mut deps.storage, &delegation_owner)
                 .save(node_identity.as_bytes(), &())
                 .unwrap();
 
             assert!(
-                mix_reverse_delegations_read(deps.as_ref().storage, &delegation_owner)
+                reverse_gateway_delegations_read(deps.as_ref().storage, &delegation_owner)
                     .may_load(node_identity.as_bytes())
                     .unwrap()
                     .is_some(),
@@ -834,7 +834,7 @@ mod tests {
         }
 
         #[test]
-        fn gateway_reverse_delegation_returns_none_if_delegation_doesnt_exist() {
+        fn reverse_gateway_delegation_returns_none_if_delegation_doesnt_exist() {
             let mut deps = helpers::init_contract();
 
             let node_identity1: IdentityKey = "foo1".into();
@@ -843,31 +843,31 @@ mod tests {
             let delegation_owner2 = Addr::unchecked("bar2");
 
             assert!(
-                gateway_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                reverse_gateway_delegations_read(deps.as_ref().storage, &delegation_owner1)
                     .may_load(node_identity1.as_bytes())
                     .unwrap()
                     .is_none()
             );
 
             // add delegation for a different node
-            gateway_reverse_delegations(&mut deps.storage, &delegation_owner1)
+            reverse_gateway_delegations(&mut deps.storage, &delegation_owner1)
                 .save(node_identity2.as_bytes(), &())
                 .unwrap();
 
             assert!(
-                gateway_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                reverse_gateway_delegations_read(deps.as_ref().storage, &delegation_owner1)
                     .may_load(node_identity1.as_bytes())
                     .unwrap()
                     .is_none()
             );
 
             // add delegation from a different owner
-            gateway_reverse_delegations(&mut deps.storage, &delegation_owner2)
+            reverse_gateway_delegations(&mut deps.storage, &delegation_owner2)
                 .save(node_identity1.as_bytes(), &())
                 .unwrap();
 
             assert!(
-                gateway_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                reverse_gateway_delegations_read(deps.as_ref().storage, &delegation_owner1)
                     .may_load(node_identity1.as_bytes())
                     .unwrap()
                     .is_none()

--- a/contracts/mixnet/src/storage.rs
+++ b/contracts/mixnet/src/storage.rs
@@ -9,7 +9,8 @@ use cosmwasm_storage::{
     Singleton,
 };
 use mixnet_contract::{
-    GatewayBond, IdentityKey, IdentityKeyRef, Layer, LayerDistribution, MixNodeBond, StateParams,
+    Addr, GatewayBond, IdentityKey, IdentityKeyRef, Layer, LayerDistribution, MixNodeBond,
+    StateParams,
 };
 
 // storage prefixes
@@ -29,6 +30,8 @@ const PREFIX_GATEWAYS_OWNERS: &[u8] = b"go";
 
 const PREFIX_MIX_DELEGATION: &[u8] = b"md";
 const PREFIX_GATEWAY_DELEGATION: &[u8] = b"gd";
+const PREFIX_MIX_REVERSE_DELEGATION: &[u8] = b"dm";
+const PREFIX_GATEWAY_REVERSE_DELEGATION: &[u8] = b"dg";
 
 // Contract-level stuff
 
@@ -301,6 +304,17 @@ pub fn mix_delegations_read<'a>(
     ReadonlyBucket::multilevel(storage, &[PREFIX_MIX_DELEGATION, mix_identity.as_bytes()])
 }
 
+pub fn mix_reverse_delegations<'a>(storage: &'a mut dyn Storage, owner: &Addr) -> Bucket<'a, ()> {
+    Bucket::multilevel(storage, &[PREFIX_MIX_REVERSE_DELEGATION, owner.as_bytes()])
+}
+
+pub fn mix_reverse_delegations_read<'a>(
+    storage: &'a dyn Storage,
+    owner: &Addr,
+) -> ReadonlyBucket<'a, ()> {
+    ReadonlyBucket::multilevel(storage, &[PREFIX_MIX_REVERSE_DELEGATION, owner.as_bytes()])
+}
+
 pub fn gateway_delegations<'a>(
     storage: &'a mut dyn Storage,
     gateway_identity: IdentityKeyRef,
@@ -318,6 +332,26 @@ pub fn gateway_delegations_read<'a>(
     ReadonlyBucket::multilevel(
         storage,
         &[PREFIX_GATEWAY_DELEGATION, gateway_identity.as_bytes()],
+    )
+}
+
+pub fn gateway_reverse_delegations<'a>(
+    storage: &'a mut dyn Storage,
+    owner: &Addr,
+) -> Bucket<'a, ()> {
+    Bucket::multilevel(
+        storage,
+        &[PREFIX_GATEWAY_REVERSE_DELEGATION, owner.as_bytes()],
+    )
+}
+
+pub fn gateway_reverse_delegations_read<'a>(
+    storage: &'a dyn Storage,
+    owner: &Addr,
+) -> ReadonlyBucket<'a, ()> {
+    ReadonlyBucket::multilevel(
+        storage,
+        &[PREFIX_GATEWAY_REVERSE_DELEGATION, owner.as_bytes()],
     )
 }
 

--- a/contracts/mixnet/src/storage.rs
+++ b/contracts/mixnet/src/storage.rs
@@ -609,6 +609,71 @@ mod tests {
     }
 
     #[cfg(test)]
+    mod mix_reverse_delegations {
+        use super::*;
+        use crate::support::tests::helpers;
+
+        #[test]
+        fn mix_reverse_delegation_exists() {
+            let mut deps = helpers::init_contract();
+            let node_identity: IdentityKey = "foo".into();
+            let delegation_owner = Addr::unchecked("bar");
+
+            mix_reverse_delegations(&mut deps.storage, &delegation_owner)
+                .save(node_identity.as_bytes(), &())
+                .unwrap();
+
+            assert!(
+                mix_reverse_delegations_read(deps.as_ref().storage, &delegation_owner)
+                    .may_load(node_identity.as_bytes())
+                    .unwrap()
+                    .is_some(),
+            );
+        }
+
+        #[test]
+        fn mix_reverse_delegation_returns_none_if_delegation_doesnt_exist() {
+            let mut deps = helpers::init_contract();
+
+            let node_identity1: IdentityKey = "foo1".into();
+            let node_identity2: IdentityKey = "foo2".into();
+            let delegation_owner1 = Addr::unchecked("bar");
+            let delegation_owner2 = Addr::unchecked("bar2");
+
+            assert!(
+                mix_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                    .may_load(node_identity1.as_bytes())
+                    .unwrap()
+                    .is_none()
+            );
+
+            // add delegation for a different node
+            mix_reverse_delegations(&mut deps.storage, &delegation_owner1)
+                .save(node_identity2.as_bytes(), &())
+                .unwrap();
+
+            assert!(
+                mix_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                    .may_load(node_identity1.as_bytes())
+                    .unwrap()
+                    .is_none()
+            );
+
+            // add delegation from a different owner
+            mix_reverse_delegations(&mut deps.storage, &delegation_owner2)
+                .save(node_identity1.as_bytes(), &())
+                .unwrap();
+
+            assert!(
+                mix_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                    .may_load(node_identity1.as_bytes())
+                    .unwrap()
+                    .is_none()
+            );
+        }
+    }
+
+    #[cfg(test)]
     mod increasing_gateway_delegated_stakes {
         use super::*;
         use crate::queries::query_gateway_delegations_paged;
@@ -742,6 +807,71 @@ mod tests {
                         .unwrap()
                 )
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod gateway_reverse_delegations {
+        use super::*;
+        use crate::support::tests::helpers;
+
+        #[test]
+        fn gateway_reverse_delegation_exists() {
+            let mut deps = helpers::init_contract();
+            let node_identity: IdentityKey = "foo".into();
+            let delegation_owner = Addr::unchecked("bar");
+
+            mix_reverse_delegations(&mut deps.storage, &delegation_owner)
+                .save(node_identity.as_bytes(), &())
+                .unwrap();
+
+            assert!(
+                mix_reverse_delegations_read(deps.as_ref().storage, &delegation_owner)
+                    .may_load(node_identity.as_bytes())
+                    .unwrap()
+                    .is_some(),
+            );
+        }
+
+        #[test]
+        fn gateway_reverse_delegation_returns_none_if_delegation_doesnt_exist() {
+            let mut deps = helpers::init_contract();
+
+            let node_identity1: IdentityKey = "foo1".into();
+            let node_identity2: IdentityKey = "foo2".into();
+            let delegation_owner1 = Addr::unchecked("bar");
+            let delegation_owner2 = Addr::unchecked("bar2");
+
+            assert!(
+                gateway_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                    .may_load(node_identity1.as_bytes())
+                    .unwrap()
+                    .is_none()
+            );
+
+            // add delegation for a different node
+            gateway_reverse_delegations(&mut deps.storage, &delegation_owner1)
+                .save(node_identity2.as_bytes(), &())
+                .unwrap();
+
+            assert!(
+                gateway_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                    .may_load(node_identity1.as_bytes())
+                    .unwrap()
+                    .is_none()
+            );
+
+            // add delegation from a different owner
+            gateway_reverse_delegations(&mut deps.storage, &delegation_owner2)
+                .save(node_identity1.as_bytes(), &())
+                .unwrap();
+
+            assert!(
+                gateway_reverse_delegations_read(deps.as_ref().storage, &delegation_owner1)
+                    .may_load(node_identity1.as_bytes())
+                    .unwrap()
+                    .is_none()
+            );
         }
     }
 }

--- a/contracts/mixnet/src/transactions.rs
+++ b/contracts/mixnet/src/transactions.rs
@@ -572,6 +572,8 @@ pub(crate) fn try_delegate_to_mixnode(
         None => delegation_bucket.save(sender_bytes, &info.funds[0].amount)?,
     }
 
+    mix_reverse_delegations(deps.storage, &info.sender).save(mix_identity.as_bytes(), &())?;
+
     Ok(Response::default())
 }
 
@@ -584,8 +586,9 @@ pub(crate) fn try_remove_delegation_from_mixnode(
     let sender_bytes = info.sender.as_bytes();
     match delegation_bucket.may_load(sender_bytes)? {
         Some(delegation) => {
-            // remove delegation from the bucket
+            // remove delegation from the buckets
             delegation_bucket.remove(sender_bytes);
+            mix_reverse_delegations(deps.storage, &info.sender).remove(mix_identity.as_bytes());
 
             // send delegated funds back to the delegation owner
             let messages = vec![BankMsg::Send {
@@ -656,6 +659,9 @@ pub(crate) fn try_delegate_to_gateway(
         None => delegation_bucket.save(sender_bytes, &info.funds[0].amount)?,
     }
 
+    gateway_reverse_delegations(deps.storage, &info.sender)
+        .save(gateway_identity.as_bytes(), &())?;
+
     Ok(Response::default())
 }
 
@@ -668,8 +674,10 @@ pub(crate) fn try_remove_delegation_from_gateway(
     let sender_bytes = info.sender.as_bytes();
     match delegation_bucket.may_load(sender_bytes)? {
         Some(delegation) => {
-            // remove delegation from the bucket
+            // remove delegation from the buckets
             delegation_bucket.remove(sender_bytes);
+            gateway_reverse_delegations(deps.storage, &info.sender)
+                .remove(gateway_identity.as_bytes());
 
             // send delegated funds back to the delegation owner
             let messages = vec![BankMsg::Send {

--- a/contracts/mixnet/src/transactions.rs
+++ b/contracts/mixnet/src/transactions.rs
@@ -2038,11 +2038,12 @@ pub mod tests {
             let mut deps = helpers::init_contract();
             let mixnode_owner = "bob";
             let identity = add_mixnode(mixnode_owner, good_mixnode_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             let delegation = coin(123, DENOM);
             assert!(try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender", &vec![delegation.clone()]),
+                mock_info(delegation_owner.as_str(), &vec![delegation.clone()]),
                 identity.clone()
             )
             .is_ok());
@@ -2050,8 +2051,13 @@ pub mod tests {
             assert_eq!(
                 delegation.amount,
                 mix_delegations_read(&deps.storage, &identity)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
+            );
+            assert!(
+                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity.as_bytes())
+                    .is_ok()
             );
 
             // node's "total_delegation" is increased
@@ -2070,6 +2076,7 @@ pub mod tests {
 
             let mixnode_owner = "bob";
             let identity = add_mixnode(mixnode_owner, good_mixnode_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             try_remove_mixnode(deps.as_mut(), mock_info(mixnode_owner, &[])).unwrap();
 
@@ -2079,7 +2086,7 @@ pub mod tests {
                 }),
                 try_delegate_to_mixnode(
                     deps.as_mut(),
-                    mock_info("sender", &coins(123, DENOM)),
+                    mock_info(delegation_owner.as_str(), &coins(123, DENOM)),
                     identity
                 )
             );
@@ -2094,10 +2101,11 @@ pub mod tests {
             try_remove_mixnode(deps.as_mut(), mock_info(mixnode_owner, &[])).unwrap();
             let identity = add_mixnode(mixnode_owner, good_mixnode_bond(), &mut deps);
             let delegation = coin(123, DENOM);
+            let delegation_owner = Addr::unchecked("sender");
 
             assert!(try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender", &vec![delegation.clone()]),
+                mock_info(delegation_owner.as_str(), &vec![delegation.clone()]),
                 identity.clone()
             )
             .is_ok());
@@ -2105,8 +2113,13 @@ pub mod tests {
             assert_eq!(
                 delegation.amount,
                 mix_delegations_read(&deps.storage, &identity)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
+            );
+            assert!(
+                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity.as_bytes())
+                    .is_ok()
             );
 
             // node's "total_delegation" is increased
@@ -2124,20 +2137,21 @@ pub mod tests {
             let mut deps = helpers::init_contract();
             let mixnode_owner = "bob";
             let identity = add_mixnode(mixnode_owner, good_mixnode_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             let delegation1 = coin(100, DENOM);
             let delegation2 = coin(50, DENOM);
 
             try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender", &vec![delegation1.clone()]),
+                mock_info(delegation_owner.as_str(), &vec![delegation1.clone()]),
                 identity.clone(),
             )
             .unwrap();
 
             try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender", &vec![delegation2.clone()]),
+                mock_info(delegation_owner.as_str(), &vec![delegation2.clone()]),
                 identity.clone(),
             )
             .unwrap();
@@ -2145,8 +2159,13 @@ pub mod tests {
             assert_eq!(
                 delegation1.amount + delegation2.amount,
                 mix_delegations_read(&deps.storage, &identity)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
+            );
+            assert!(
+                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity.as_bytes())
+                    .is_ok()
             );
 
             // node's "total_delegation" is sum of both
@@ -2166,10 +2185,11 @@ pub mod tests {
 
             let mixnode_owner = "bob";
             let identity = add_mixnode(mixnode_owner, good_mixnode_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender", &coins(100, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(100, DENOM)),
                 identity.clone(),
             )
             .unwrap();
@@ -2182,7 +2202,7 @@ pub mod tests {
                 }),
                 try_delegate_to_mixnode(
                     deps.as_mut(),
-                    mock_info("sender", &coins(50, DENOM)),
+                    mock_info(delegation_owner.as_str(), &coins(50, DENOM)),
                     identity
                 )
             );
@@ -2195,17 +2215,18 @@ pub mod tests {
             let mixnode_owner2 = "fred";
             let identity1 = add_mixnode(mixnode_owner1, good_mixnode_bond(), &mut deps);
             let identity2 = add_mixnode(mixnode_owner2, good_mixnode_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             assert!(try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender", &coins(123, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(123, DENOM)),
                 identity1.clone()
             )
             .is_ok());
 
             assert!(try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender", &coins(42, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(42, DENOM)),
                 identity2.clone()
             )
             .is_ok());
@@ -2213,17 +2234,27 @@ pub mod tests {
             assert_eq!(
                 123,
                 mix_delegations_read(&deps.storage, &identity1)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
                     .u128()
+            );
+            assert!(
+                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity1.as_bytes())
+                    .is_ok()
             );
 
             assert_eq!(
                 42,
                 mix_delegations_read(&deps.storage, &identity2)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
                     .u128()
+            );
+            assert!(
+                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity2.as_bytes())
+                    .is_ok()
             );
         }
 
@@ -2267,10 +2298,11 @@ pub mod tests {
 
             let mixnode_owner = "bob";
             let identity = add_mixnode(mixnode_owner, good_mixnode_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender", &coins(100, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(100, DENOM)),
                 identity.clone(),
             )
             .unwrap();
@@ -2280,9 +2312,14 @@ pub mod tests {
             assert_eq!(
                 100,
                 mix_delegations_read(&deps.storage, &identity)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
                     .u128()
+            );
+            assert!(
+                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity.as_bytes())
+                    .is_ok()
             );
         }
     }
@@ -2299,15 +2336,16 @@ pub mod tests {
 
             let mixnode_owner = "bob";
             let identity = add_mixnode(mixnode_owner, good_mixnode_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             assert_eq!(
                 Err(ContractError::NoMixnodeDelegationFound {
                     identity: identity.clone(),
-                    address: Addr::unchecked("sender"),
+                    address: delegation_owner.clone(),
                 }),
                 try_remove_delegation_from_mixnode(
                     deps.as_mut(),
-                    mock_info("sender", &[]),
+                    mock_info(delegation_owner.as_str(), &[]),
                     identity,
                 )
             );
@@ -2319,10 +2357,11 @@ pub mod tests {
 
             let mixnode_owner = "bob";
             let identity = add_mixnode(mixnode_owner, good_mixnode_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender", &coins(100, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(100, DENOM)),
                 identity.clone(),
             )
             .unwrap();
@@ -2331,7 +2370,7 @@ pub mod tests {
                 Ok(Response {
                     submessages: vec![],
                     messages: vec![BankMsg::Send {
-                        to_address: "sender".into(),
+                        to_address: delegation_owner.clone().into(),
                         amount: coins(100, DENOM),
                     }
                     .into()],
@@ -2340,15 +2379,21 @@ pub mod tests {
                 }),
                 try_remove_delegation_from_mixnode(
                     deps.as_mut(),
-                    mock_info("sender", &[]),
+                    mock_info(delegation_owner.as_str(), &[]),
                     identity.clone(),
                 )
             );
 
             assert!(mix_delegations_read(&deps.storage, &identity)
-                .may_load(b"sender")
+                .may_load(delegation_owner.as_bytes())
                 .unwrap()
                 .is_none());
+            assert!(
+                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .may_load(identity.as_bytes())
+                    .unwrap()
+                    .is_none()
+            );
 
             // and total delegation is cleared
             assert_eq!(
@@ -2367,10 +2412,11 @@ pub mod tests {
 
             let mixnode_owner = "bob";
             let identity = add_mixnode(mixnode_owner, good_mixnode_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender", &coins(100, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(100, DENOM)),
                 identity.clone(),
             )
             .unwrap();
@@ -2381,7 +2427,7 @@ pub mod tests {
                 Ok(Response {
                     submessages: vec![],
                     messages: vec![BankMsg::Send {
-                        to_address: "sender".into(),
+                        to_address: delegation_owner.clone().into(),
                         amount: coins(100, DENOM),
                     }
                     .into()],
@@ -2390,15 +2436,21 @@ pub mod tests {
                 }),
                 try_remove_delegation_from_mixnode(
                     deps.as_mut(),
-                    mock_info("sender", &[]),
+                    mock_info(delegation_owner.as_str(), &[]),
                     identity.clone(),
                 )
             );
 
             assert!(mix_delegations_read(&deps.storage, &identity)
-                .may_load(b"sender")
+                .may_load(delegation_owner.as_bytes())
                 .unwrap()
                 .is_none());
+            assert!(
+                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .may_load(identity.as_bytes())
+                    .unwrap()
+                    .is_none()
+            );
         }
 
         #[test]
@@ -2406,20 +2458,22 @@ pub mod tests {
             let mut deps = helpers::init_contract();
             let mixnode_owner = "bob";
             let identity = add_mixnode(mixnode_owner, good_mixnode_bond(), &mut deps);
+            let delegation_owner1 = Addr::unchecked("sender1");
+            let delegation_owner2 = Addr::unchecked("sender2");
 
             let delegation1 = coin(123, DENOM);
             let delegation2 = coin(234, DENOM);
 
             assert!(try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender1", &vec![delegation1.clone()]),
+                mock_info(delegation_owner1.as_str(), &vec![delegation1.clone()]),
                 identity.clone()
             )
             .is_ok());
 
             assert!(try_delegate_to_mixnode(
                 deps.as_mut(),
-                mock_info("sender2", &vec![delegation2.clone()]),
+                mock_info(delegation_owner2.as_str(), &vec![delegation2.clone()]),
                 identity.clone()
             )
             .is_ok());
@@ -2427,7 +2481,7 @@ pub mod tests {
             // sender1 undelegates
             try_remove_delegation_from_mixnode(
                 deps.as_mut(),
-                mock_info("sender1", &[]),
+                mock_info(delegation_owner1.as_str(), &[]),
                 identity.clone(),
             )
             .unwrap();
@@ -2646,11 +2700,12 @@ pub mod tests {
             let mut deps = helpers::init_contract();
             let gateway_owner = "bob";
             let identity = add_gateway(gateway_owner, good_gateway_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             let delegation = coin(123, DENOM);
             assert!(try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender", &vec![delegation.clone()]),
+                mock_info(delegation_owner.as_str(), &vec![delegation.clone()]),
                 identity.clone()
             )
             .is_ok());
@@ -2658,8 +2713,13 @@ pub mod tests {
             assert_eq!(
                 delegation.amount,
                 gateway_delegations_read(&deps.storage, &identity)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
+            );
+            assert!(
+                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity.as_bytes())
+                    .is_ok()
             );
 
             // node's "total_delegation" is increased
@@ -2678,6 +2738,8 @@ pub mod tests {
 
             let gateway_owner = "bob";
             let identity = add_gateway(gateway_owner, good_gateway_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
+
             try_remove_gateway(deps.as_mut(), mock_info(gateway_owner, &[])).unwrap();
 
             assert_eq!(
@@ -2686,7 +2748,7 @@ pub mod tests {
                 }),
                 try_delegate_to_gateway(
                     deps.as_mut(),
-                    mock_info("sender", &coins(123, DENOM)),
+                    mock_info(delegation_owner.as_str(), &coins(123, DENOM)),
                     identity
                 )
             );
@@ -2701,10 +2763,11 @@ pub mod tests {
             try_remove_gateway(deps.as_mut(), mock_info(gateway_owner, &[])).unwrap();
             let identity = add_gateway(gateway_owner, good_gateway_bond(), &mut deps);
             let delegation = coin(123, DENOM);
+            let delegation_owner = Addr::unchecked("sender");
 
             assert!(try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender", &vec![delegation.clone()]),
+                mock_info(delegation_owner.as_str(), &vec![delegation.clone()]),
                 identity.clone()
             )
             .is_ok());
@@ -2712,8 +2775,13 @@ pub mod tests {
             assert_eq!(
                 delegation.amount,
                 gateway_delegations_read(&deps.storage, &identity)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
+            );
+            assert!(
+                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity.as_bytes())
+                    .is_ok()
             );
 
             // node's "total_delegation" is increased
@@ -2731,20 +2799,21 @@ pub mod tests {
             let mut deps = helpers::init_contract();
             let gateway_owner = "bob";
             let identity = add_gateway(gateway_owner, good_gateway_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             let delegation1 = coin(100, DENOM);
             let delegation2 = coin(50, DENOM);
 
             try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender", &vec![delegation1.clone()]),
+                mock_info(delegation_owner.as_str(), &vec![delegation1.clone()]),
                 identity.clone(),
             )
             .unwrap();
 
             try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender", &vec![delegation2.clone()]),
+                mock_info(delegation_owner.as_str(), &vec![delegation2.clone()]),
                 identity.clone(),
             )
             .unwrap();
@@ -2752,8 +2821,13 @@ pub mod tests {
             assert_eq!(
                 delegation1.amount + delegation2.amount,
                 gateway_delegations_read(&deps.storage, &identity)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
+            );
+            assert!(
+                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity.as_bytes())
+                    .is_ok()
             );
 
             // node's "total_delegation" is sum of both
@@ -2773,10 +2847,11 @@ pub mod tests {
 
             let gateway_owner = "bob";
             let identity = add_gateway(gateway_owner, good_gateway_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender", &coins(100, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(100, DENOM)),
                 identity.clone(),
             )
             .unwrap();
@@ -2789,7 +2864,7 @@ pub mod tests {
                 }),
                 try_delegate_to_gateway(
                     deps.as_mut(),
-                    mock_info("sender", &coins(50, DENOM)),
+                    mock_info(delegation_owner.as_str(), &coins(50, DENOM)),
                     identity.clone()
                 )
             );
@@ -2802,17 +2877,18 @@ pub mod tests {
             let gateway_owner2 = "fred";
             let identity1 = add_gateway(gateway_owner1, good_gateway_bond(), &mut deps);
             let identity2 = add_gateway(gateway_owner2, good_gateway_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             assert!(try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender", &coins(123, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(123, DENOM)),
                 identity1.clone()
             )
             .is_ok());
 
             assert!(try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender", &coins(42, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(42, DENOM)),
                 identity2.clone()
             )
             .is_ok());
@@ -2820,17 +2896,27 @@ pub mod tests {
             assert_eq!(
                 123,
                 gateway_delegations_read(&deps.storage, &identity1)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
                     .u128()
+            );
+            assert!(
+                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity1.as_bytes())
+                    .is_ok()
             );
 
             assert_eq!(
                 42,
                 gateway_delegations_read(&deps.storage, &identity2)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
                     .u128()
+            );
+            assert!(
+                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity2.as_bytes())
+                    .is_ok()
             );
         }
 
@@ -2874,10 +2960,11 @@ pub mod tests {
 
             let gateway_owner = "bob";
             let identity = add_gateway(gateway_owner, good_gateway_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender", &coins(100, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(100, DENOM)),
                 identity.clone(),
             )
             .unwrap();
@@ -2887,9 +2974,14 @@ pub mod tests {
             assert_eq!(
                 100,
                 gateway_delegations_read(&deps.storage, &identity)
-                    .load(b"sender")
+                    .load(delegation_owner.as_bytes())
                     .unwrap()
                     .u128()
+            );
+            assert!(
+                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .load(identity.as_bytes())
+                    .is_ok()
             );
         }
     }
@@ -2906,14 +2998,16 @@ pub mod tests {
 
             let gateway_owner = "bob";
             let identity = add_gateway(gateway_owner, good_gateway_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
+
             assert_eq!(
                 Err(ContractError::NoGatewayDelegationFound {
                     identity: identity.clone(),
-                    address: Addr::unchecked("sender"),
+                    address: delegation_owner.clone(),
                 }),
                 try_remove_delegation_from_gateway(
                     deps.as_mut(),
-                    mock_info("sender", &[]),
+                    mock_info(delegation_owner.as_str(), &[]),
                     identity,
                 )
             );
@@ -2925,10 +3019,11 @@ pub mod tests {
 
             let gateway_owner = "bob";
             let identity = add_gateway(gateway_owner, good_gateway_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender", &coins(100, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(100, DENOM)),
                 identity.clone(),
             )
             .unwrap();
@@ -2937,7 +3032,7 @@ pub mod tests {
                 Ok(Response {
                     submessages: vec![],
                     messages: vec![BankMsg::Send {
-                        to_address: "sender".into(),
+                        to_address: delegation_owner.clone().into(),
                         amount: coins(100, DENOM),
                     }
                     .into()],
@@ -2946,15 +3041,21 @@ pub mod tests {
                 }),
                 try_remove_delegation_from_gateway(
                     deps.as_mut(),
-                    mock_info("sender", &[]),
+                    mock_info(delegation_owner.as_str(), &[]),
                     identity.clone(),
                 )
             );
 
             assert!(gateway_delegations_read(&deps.storage, &identity)
-                .may_load(b"sender")
+                .may_load(delegation_owner.as_bytes())
                 .unwrap()
                 .is_none());
+            assert!(
+                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .may_load(identity.as_bytes())
+                    .unwrap()
+                    .is_none()
+            );
 
             // and total delegation is cleared
             assert_eq!(
@@ -2973,10 +3074,11 @@ pub mod tests {
 
             let gateway_owner = "bob";
             let identity = add_gateway(gateway_owner, good_gateway_bond(), &mut deps);
+            let delegation_owner = Addr::unchecked("sender");
 
             try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender", &coins(100, DENOM)),
+                mock_info(delegation_owner.as_str(), &coins(100, DENOM)),
                 identity.clone(),
             )
             .unwrap();
@@ -2987,7 +3089,7 @@ pub mod tests {
                 Ok(Response {
                     submessages: vec![],
                     messages: vec![BankMsg::Send {
-                        to_address: "sender".into(),
+                        to_address: delegation_owner.clone().into(),
                         amount: coins(100, DENOM),
                     }
                     .into()],
@@ -2996,15 +3098,21 @@ pub mod tests {
                 }),
                 try_remove_delegation_from_gateway(
                     deps.as_mut(),
-                    mock_info("sender", &[]),
+                    mock_info(delegation_owner.as_str(), &[]),
                     identity.clone(),
                 )
             );
 
             assert!(gateway_delegations_read(&deps.storage, &identity)
-                .may_load(b"sender")
+                .may_load(delegation_owner.as_bytes())
                 .unwrap()
                 .is_none());
+            assert!(
+                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                    .may_load(identity.as_bytes())
+                    .unwrap()
+                    .is_none()
+            );
         }
 
         #[test]
@@ -3012,20 +3120,22 @@ pub mod tests {
             let mut deps = helpers::init_contract();
             let gateway_owner = "bob";
             let identity = add_gateway(gateway_owner, good_gateway_bond(), &mut deps);
+            let delegation_owner1 = Addr::unchecked("sender1");
+            let delegation_owner2 = Addr::unchecked("sender2");
 
             let delegation1 = coin(123, DENOM);
             let delegation2 = coin(234, DENOM);
 
             assert!(try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender1", &vec![delegation1.clone()]),
+                mock_info(delegation_owner1.as_str(), &vec![delegation1.clone()]),
                 identity.clone()
             )
             .is_ok());
 
             assert!(try_delegate_to_gateway(
                 deps.as_mut(),
-                mock_info("sender2", &vec![delegation2.clone()]),
+                mock_info(delegation_owner2.as_str(), &vec![delegation2.clone()]),
                 identity.clone()
             )
             .is_ok());
@@ -3033,7 +3143,7 @@ pub mod tests {
             // sender1 undelegates
             try_remove_delegation_from_gateway(
                 deps.as_mut(),
-                mock_info("sender1", &[]),
+                mock_info(delegation_owner1.as_str(), &[]),
                 identity.clone(),
             )
             .unwrap();

--- a/contracts/mixnet/src/transactions.rs
+++ b/contracts/mixnet/src/transactions.rs
@@ -572,7 +572,7 @@ pub(crate) fn try_delegate_to_mixnode(
         None => delegation_bucket.save(sender_bytes, &info.funds[0].amount)?,
     }
 
-    mix_reverse_delegations(deps.storage, &info.sender).save(mix_identity.as_bytes(), &())?;
+    reverse_mix_delegations(deps.storage, &info.sender).save(mix_identity.as_bytes(), &())?;
 
     Ok(Response::default())
 }
@@ -588,7 +588,7 @@ pub(crate) fn try_remove_delegation_from_mixnode(
         Some(delegation) => {
             // remove delegation from the buckets
             delegation_bucket.remove(sender_bytes);
-            mix_reverse_delegations(deps.storage, &info.sender).remove(mix_identity.as_bytes());
+            reverse_mix_delegations(deps.storage, &info.sender).remove(mix_identity.as_bytes());
 
             // send delegated funds back to the delegation owner
             let messages = vec![BankMsg::Send {
@@ -659,7 +659,7 @@ pub(crate) fn try_delegate_to_gateway(
         None => delegation_bucket.save(sender_bytes, &info.funds[0].amount)?,
     }
 
-    gateway_reverse_delegations(deps.storage, &info.sender)
+    reverse_gateway_delegations(deps.storage, &info.sender)
         .save(gateway_identity.as_bytes(), &())?;
 
     Ok(Response::default())
@@ -676,7 +676,7 @@ pub(crate) fn try_remove_delegation_from_gateway(
         Some(delegation) => {
             // remove delegation from the buckets
             delegation_bucket.remove(sender_bytes);
-            gateway_reverse_delegations(deps.storage, &info.sender)
+            reverse_gateway_delegations(deps.storage, &info.sender)
                 .remove(gateway_identity.as_bytes());
 
             // send delegated funds back to the delegation owner
@@ -2055,7 +2055,7 @@ pub mod tests {
                     .unwrap()
             );
             assert!(
-                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_mix_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity.as_bytes())
                     .is_ok()
             );
@@ -2117,7 +2117,7 @@ pub mod tests {
                     .unwrap()
             );
             assert!(
-                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_mix_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity.as_bytes())
                     .is_ok()
             );
@@ -2163,7 +2163,7 @@ pub mod tests {
                     .unwrap()
             );
             assert!(
-                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_mix_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity.as_bytes())
                     .is_ok()
             );
@@ -2239,7 +2239,7 @@ pub mod tests {
                     .u128()
             );
             assert!(
-                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_mix_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity1.as_bytes())
                     .is_ok()
             );
@@ -2252,7 +2252,7 @@ pub mod tests {
                     .u128()
             );
             assert!(
-                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_mix_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity2.as_bytes())
                     .is_ok()
             );
@@ -2317,7 +2317,7 @@ pub mod tests {
                     .u128()
             );
             assert!(
-                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_mix_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity.as_bytes())
                     .is_ok()
             );
@@ -2389,7 +2389,7 @@ pub mod tests {
                 .unwrap()
                 .is_none());
             assert!(
-                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_mix_delegations_read(&deps.storage, &delegation_owner)
                     .may_load(identity.as_bytes())
                     .unwrap()
                     .is_none()
@@ -2446,7 +2446,7 @@ pub mod tests {
                 .unwrap()
                 .is_none());
             assert!(
-                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_mix_delegations_read(&deps.storage, &delegation_owner)
                     .may_load(identity.as_bytes())
                     .unwrap()
                     .is_none()
@@ -2717,7 +2717,7 @@ pub mod tests {
                     .unwrap()
             );
             assert!(
-                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_gateway_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity.as_bytes())
                     .is_ok()
             );
@@ -2779,7 +2779,7 @@ pub mod tests {
                     .unwrap()
             );
             assert!(
-                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_gateway_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity.as_bytes())
                     .is_ok()
             );
@@ -2825,7 +2825,7 @@ pub mod tests {
                     .unwrap()
             );
             assert!(
-                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_gateway_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity.as_bytes())
                     .is_ok()
             );
@@ -2901,7 +2901,7 @@ pub mod tests {
                     .u128()
             );
             assert!(
-                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_gateway_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity1.as_bytes())
                     .is_ok()
             );
@@ -2914,7 +2914,7 @@ pub mod tests {
                     .u128()
             );
             assert!(
-                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_gateway_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity2.as_bytes())
                     .is_ok()
             );
@@ -2979,7 +2979,7 @@ pub mod tests {
                     .u128()
             );
             assert!(
-                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_gateway_delegations_read(&deps.storage, &delegation_owner)
                     .load(identity.as_bytes())
                     .is_ok()
             );
@@ -3051,7 +3051,7 @@ pub mod tests {
                 .unwrap()
                 .is_none());
             assert!(
-                mix_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_mix_delegations_read(&deps.storage, &delegation_owner)
                     .may_load(identity.as_bytes())
                     .unwrap()
                     .is_none()
@@ -3108,7 +3108,7 @@ pub mod tests {
                 .unwrap()
                 .is_none());
             assert!(
-                gateway_reverse_delegations_read(&deps.storage, &delegation_owner)
+                reverse_gateway_delegations_read(&deps.storage, &delegation_owner)
                     .may_load(identity.as_bytes())
                     .unwrap()
                     .is_none()


### PR DESCRIPTION
Create two new buckets with reverse delegation data: for each delegation owner address, store the list of delegated nodes (one bucket for mixnodes, one bucket for gateways)

The reason for storing only the node address and not other additional data (like the amount of stake, or other values that might be added in the future) is so that we don't store the same data in multiple places, as that would cause confusion on which data is the source of truth and also possible difficulties in keeping those two places in sync.

With that in ming, in order for one to obtain the full data (including the amount), one would have to query the list of nodes that a certain address delegated towards (query address1 -> [node1, node2, ...]) and then query independently for each node to obtain the amount that was delegated (and possibly other data in the future as well) (query (address1, node1) -> amount1; query (address1, node2) -> amount2 ...)

Although this incurs additional queries being performed, we can safely assume that an address is less likely to have a big number of nodes delegating towards (<10), so the additional number of queries should be small enough. The same cannot be said about the nodes, which could have delegations towards them in the order of hundreds or thousands.

<s> TODO list until finishing draft: </s>

- [x]  Modify existing contract tests and possibly add some new ones for these two buckets

- [x] Add contract migration code and perform a test: bind and delegate a node, check that after migration the node is present in the reversed bucket