### PR TITLE
NetworkMonitorBuilder - starting the monitor after rocket has launched

### DIFF
--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -22,7 +22,6 @@ use rocket::{Ignite, Rocket};
 use rocket_cors::{AllowedHeaders, AllowedOrigins, Cors};
 use std::process;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::Notify;
 use url::Url;
 


### PR DESCRIPTION
This pull request modifies the startup sequence of the validator api. It ensures network monitor is started after the rocket has already launched. Otherwise it will fail to obtain the verification key of the local validator since the endpoint would not yet be available.