### PR TITLE
Updated cosmos-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,8 +905,9 @@ dependencies = [
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.6.0"
-source = "git+https://github.com/cosmos/cosmos-rust/#ba012bd820240d3df2d9a0ab1deabe4ecd9a2f30"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7115eae4b8518967b8e737a3ef76025f2d007de7906d88c18f00b8bbfc70f51e"
 dependencies = [
  "prost",
  "prost-types",
@@ -914,9 +915,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmos_sdk"
-version = "0.2.0"
-source = "git+https://github.com/cosmos/cosmos-rust/#ba012bd820240d3df2d9a0ab1deabe4ecd9a2f30"
+name = "cosmrs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609eba7eee6d9929927cbdf15f9fe96d250c316c5e1b983c4a47a10f60da5ea7"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",
@@ -6325,7 +6327,7 @@ dependencies = [
  "bip39",
  "coconut-interface",
  "config",
- "cosmos_sdk",
+ "cosmrs",
  "cosmwasm-std",
  "flate2",
  "itertools 0.10.1",

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -24,8 +24,8 @@ network-defaults = { path = "../../network-defaults" }
 # perhaps after https://github.com/cosmos/cosmos-rust/pull/97 is resolved (and tendermint-rs is updated)
 async-trait = { version = "0.1.51", optional = true }
 bip39 = { version = "1", features = ["rand"], optional = true }
-config = { path = "../../config", optional = true}
-cosmos_sdk = { git = "https://github.com/cosmos/cosmos-rust/", commit="ba012bd820240d3df2d9a0ab1deabe4ecd9a2f30", features = ["rpc", "bip32", "cosmwasm"], optional = true }
+config = { path = "../../config", optional = true }
+cosmrs = { version = "0.1", features = ["rpc", "bip32", "cosmwasm"], optional = true }
 prost = { version = "0.7", default-features = false, optional = true }
 flate2 = { version = "1.0.20", optional = true }
 sha2 = { version = "0.9.5", optional = true }
@@ -33,4 +33,4 @@ itertools = { version = "0.10", optional = true }
 cosmwasm-std = { git = "https://github.com/jstuczyn/cosmwasm", branch="0.14.1-updatedk256", optional = true }
 
 [features]
-nymd-client = ["async-trait", "bip39", "config", "cosmos_sdk", "prost", "flate2", "sha2", "itertools", "cosmwasm-std"]
+nymd-client = ["async-trait", "bip39", "config", "cosmrs", "prost", "flate2", "sha2", "itertools", "cosmwasm-std"]

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -14,7 +14,7 @@ use url::Url;
 pub struct Config {
     api_url: Url,
     nymd_url: Url,
-    mixnet_contract_address: Option<cosmos_sdk::AccountId>,
+    mixnet_contract_address: Option<cosmrs::AccountId>,
 
     mixnode_page_limit: Option<u32>,
     gateway_page_limit: Option<u32>,
@@ -27,7 +27,7 @@ impl Config {
     pub fn new(
         nymd_url: Url,
         api_url: Url,
-        mixnet_contract_address: Option<cosmos_sdk::AccountId>,
+        mixnet_contract_address: Option<cosmrs::AccountId>,
     ) -> Self {
         Config {
             nymd_url,
@@ -63,7 +63,7 @@ impl Config {
 
 #[cfg(feature = "nymd-client")]
 pub struct Client<C> {
-    mixnet_contract_address: Option<cosmos_sdk::AccountId>,
+    mixnet_contract_address: Option<cosmrs::AccountId>,
     mnemonic: Option<bip39::Mnemonic>,
 
     mixnode_page_limit: Option<u32>,
@@ -154,7 +154,7 @@ impl<C> Client<C> {
 
     // use case: somebody initialised client without a contract in order to upload and initialise one
     // and now they want to actually use it without making new client
-    pub fn set_mixnet_contract_address(&mut self, mixnet_contract_address: cosmos_sdk::AccountId) {
+    pub fn set_mixnet_contract_address(&mut self, mixnet_contract_address: cosmrs::AccountId) {
         self.mixnet_contract_address = Some(mixnet_contract_address)
     }
 
@@ -245,7 +245,7 @@ impl<C> Client<C> {
 
     pub async fn get_all_nymd_reverse_mixnode_delegations(
         &self,
-        delegation_owner: &cosmos_sdk::AccountId,
+        delegation_owner: &cosmrs::AccountId,
     ) -> Result<Vec<mixnet_contract::IdentityKey>, ValidatorClientError>
     where
         C: CosmWasmClient + Sync,
@@ -275,7 +275,7 @@ impl<C> Client<C> {
 
     pub async fn get_all_nymd_mixnode_delegations_of_owner(
         &self,
-        delegation_owner: &cosmos_sdk::AccountId,
+        delegation_owner: &cosmrs::AccountId,
     ) -> Result<Vec<mixnet_contract::Delegation>, ValidatorClientError>
     where
         C: CosmWasmClient + Sync,
@@ -327,7 +327,7 @@ impl<C> Client<C> {
 
     pub async fn get_all_nymd_reverse_gateway_delegations(
         &self,
-        delegation_owner: &cosmos_sdk::AccountId,
+        delegation_owner: &cosmrs::AccountId,
     ) -> Result<Vec<mixnet_contract::IdentityKey>, ValidatorClientError>
     where
         C: CosmWasmClient + Sync,
@@ -357,7 +357,7 @@ impl<C> Client<C> {
 
     pub async fn get_all_nymd_gateway_delegations_of_owner(
         &self,
-        delegation_owner: &cosmos_sdk::AccountId,
+        delegation_owner: &cosmrs::AccountId,
     ) -> Result<Vec<mixnet_contract::Delegation>, ValidatorClientError>
     where
         C: CosmWasmClient + Sync,

--- a/common/client-libs/validator-client/src/nymd/cosmwasm_client/client.rs
+++ b/common/client-libs/validator-client/src/nymd/cosmwasm_client/client.rs
@@ -8,21 +8,21 @@ use crate::nymd::cosmwasm_client::types::{
 };
 use crate::nymd::error::NymdError;
 use async_trait::async_trait;
-use cosmos_sdk::proto::cosmos::auth::v1beta1::{
+use cosmrs::proto::cosmos::auth::v1beta1::{
     BaseAccount, QueryAccountRequest, QueryAccountResponse,
 };
-use cosmos_sdk::proto::cosmos::bank::v1beta1::{
+use cosmrs::proto::cosmos::bank::v1beta1::{
     QueryAllBalancesRequest, QueryAllBalancesResponse, QueryBalanceRequest, QueryBalanceResponse,
 };
-use cosmos_sdk::proto::cosmwasm::wasm::v1beta1::*;
-use cosmos_sdk::rpc::endpoint::block::Response as BlockResponse;
-use cosmos_sdk::rpc::endpoint::broadcast;
-use cosmos_sdk::rpc::endpoint::tx::Response as TxResponse;
-use cosmos_sdk::rpc::query::Query;
-use cosmos_sdk::rpc::{self, HttpClient, Order};
-use cosmos_sdk::tendermint::abci::Transaction;
-use cosmos_sdk::tendermint::{abci, block, chain};
-use cosmos_sdk::{AccountId, Coin, Denom};
+use cosmrs::proto::cosmwasm::wasm::v1beta1::*;
+use cosmrs::rpc::endpoint::block::Response as BlockResponse;
+use cosmrs::rpc::endpoint::broadcast;
+use cosmrs::rpc::endpoint::tx::Response as TxResponse;
+use cosmrs::rpc::query::Query;
+use cosmrs::rpc::{self, HttpClient, Order};
+use cosmrs::tendermint::abci::Transaction;
+use cosmrs::tendermint::{abci, block, chain};
+use cosmrs::{AccountId, Coin, Denom};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};

--- a/common/client-libs/validator-client/src/nymd/cosmwasm_client/helpers.rs
+++ b/common/client-libs/validator-client/src/nymd/cosmwasm_client/helpers.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::nymd::error::NymdError;
-use cosmos_sdk::proto::cosmos::base::query::v1beta1::PageRequest;
-use cosmos_sdk::rpc::endpoint::broadcast;
+use cosmrs::proto::cosmos::base::query::v1beta1::PageRequest;
+use cosmrs::rpc::endpoint::broadcast;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use std::io::Write;

--- a/common/client-libs/validator-client/src/nymd/cosmwasm_client/logs.rs
+++ b/common/client-libs/validator-client/src/nymd/cosmwasm_client/logs.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::nymd::error::NymdError;
-use cosmos_sdk::tendermint::abci;
+use cosmrs::tendermint::abci;
 use itertools::Itertools;
 use serde::Deserialize;
 

--- a/common/client-libs/validator-client/src/nymd/cosmwasm_client/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/cosmwasm_client/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::nymd::error::NymdError;
 use crate::nymd::wallet::DirectSecp256k1HdWallet;
-use cosmos_sdk::rpc::{Error as TendermintRpcError, HttpClient, HttpClientUrl};
+use cosmrs::rpc::{Error as TendermintRpcError, HttpClient, HttpClientUrl};
 use std::convert::TryInto;
 
 pub mod client;

--- a/common/client-libs/validator-client/src/nymd/cosmwasm_client/signing_client.rs
+++ b/common/client-libs/validator-client/src/nymd/cosmwasm_client/signing_client.rs
@@ -8,13 +8,13 @@ use crate::nymd::cosmwasm_client::types::*;
 use crate::nymd::error::NymdError;
 use crate::nymd::wallet::DirectSecp256k1HdWallet;
 use async_trait::async_trait;
-use cosmos_sdk::bank::MsgSend;
-use cosmos_sdk::distribution::MsgWithdrawDelegatorReward;
-use cosmos_sdk::rpc::endpoint::broadcast;
-use cosmos_sdk::rpc::{Error as TendermintRpcError, HttpClient, HttpClientUrl, SimpleRequest};
-use cosmos_sdk::staking::{MsgDelegate, MsgUndelegate};
-use cosmos_sdk::tx::{Fee, Msg, MsgType, SignDoc, SignerInfo};
-use cosmos_sdk::{cosmwasm, rpc, tx, AccountId, Coin};
+use cosmrs::bank::MsgSend;
+use cosmrs::distribution::MsgWithdrawDelegatorReward;
+use cosmrs::rpc::endpoint::broadcast;
+use cosmrs::rpc::{Error as TendermintRpcError, HttpClient, HttpClientUrl, SimpleRequest};
+use cosmrs::staking::{MsgDelegate, MsgUndelegate};
+use cosmrs::tx::{Fee, Msg, MsgType, SignDoc, SignerInfo};
+use cosmrs::{cosmwasm, rpc, tx, AccountId, Coin};
 use serde::Serialize;
 use sha2::Digest;
 use sha2::Sha256;
@@ -287,7 +287,7 @@ pub trait SigningCosmWasmClient: CosmWasmClient {
         let delegate_msg = MsgDelegate {
             delegator_address: delegator_address.to_owned(),
             validator_address: validator_address.to_owned(),
-            amount: Some(amount),
+            amount,
         }
         .to_msg()
         .map_err(|_| NymdError::SerializationError("MsgDelegate".to_owned()))?;
@@ -407,7 +407,7 @@ pub trait SigningCosmWasmClient: CosmWasmClient {
         let auth_info = signer_info.auth_info(fee);
 
         // ideally I'd prefer to have the entire error put into the NymdError::SigningFailure
-        // but I'm super hesitant to trying to downcast the eyre::Report to cosmos_sdk::error::Error
+        // but I'm super hesitant to trying to downcast the eyre::Report to cosmrs::error::Error
         let sign_doc = SignDoc::new(
             &tx_body,
             &auth_info,

--- a/common/client-libs/validator-client/src/nymd/cosmwasm_client/types.rs
+++ b/common/client-libs/validator-client/src/nymd/cosmwasm_client/types.rs
@@ -5,15 +5,15 @@
 
 use crate::nymd::cosmwasm_client::logs::Log;
 use crate::nymd::error::NymdError;
-use cosmos_sdk::crypto::PublicKey;
-use cosmos_sdk::proto::cosmos::auth::v1beta1::BaseAccount;
-use cosmos_sdk::proto::cosmwasm::wasm::v1beta1::{
+use cosmrs::crypto::PublicKey;
+use cosmrs::proto::cosmos::auth::v1beta1::BaseAccount;
+use cosmrs::proto::cosmwasm::wasm::v1beta1::{
     CodeInfoResponse, ContractCodeHistoryEntry as ProtoContractCodeHistoryEntry,
     ContractCodeHistoryOperationType, ContractInfo as ProtoContractInfo,
 };
-use cosmos_sdk::tendermint::chain;
-use cosmos_sdk::tx::{AccountNumber, SequenceNumber};
-use cosmos_sdk::{tx, AccountId, Coin};
+use cosmrs::tendermint::chain;
+use cosmrs::tx::{AccountNumber, SequenceNumber};
+use cosmrs::{tx, AccountId, Coin};
 use serde::Serialize;
 use std::convert::TryFrom;
 

--- a/common/client-libs/validator-client/src/nymd/error.rs
+++ b/common/client-libs/validator-client/src/nymd/error.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::nymd::cosmwasm_client::types::ContractCodeId;
-use cosmos_sdk::tendermint::block;
-use cosmos_sdk::{bip32, rpc, tx, AccountId};
+use cosmrs::tendermint::block;
+use cosmrs::{bip32, rpc, tx, AccountId};
 use std::io;
 use thiserror::Error;
 

--- a/common/client-libs/validator-client/src/nymd/fee_helpers.rs
+++ b/common/client-libs/validator-client/src/nymd/fee_helpers.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::nymd::GasPrice;
-use cosmos_sdk::tx::{Fee, Gas};
-use cosmos_sdk::Coin;
+use cosmrs::tx::{Fee, Gas};
+use cosmrs::Coin;
 use cosmwasm_std::Uint128;
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]

--- a/common/client-libs/validator-client/src/nymd/gas_price.rs
+++ b/common/client-libs/validator-client/src/nymd/gas_price.rs
@@ -3,7 +3,7 @@
 
 use crate::nymd::error::NymdError;
 use config::defaults;
-use cosmos_sdk::Denom;
+use cosmrs::Denom;
 use cosmwasm_std::Decimal;
 use std::str::FromStr;
 

--- a/common/client-libs/validator-client/src/nymd/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/mod.rs
@@ -12,8 +12,7 @@ use crate::nymd::wallet::DirectSecp256k1HdWallet;
 use cosmrs::rpc::endpoint::broadcast;
 use cosmrs::rpc::{Error as TendermintRpcError, HttpClientUrl};
 use cosmrs::tx::{Fee, Gas};
-use cosmrs::Coin as CosmosCoin;
-use cosmrs::{AccountId, Denom};
+
 use cosmwasm_std::Coin;
 use mixnet_contract::{
     Addr, Delegation, ExecuteMsg, Gateway, GatewayOwnershipResponse, IdentityKey,
@@ -30,6 +29,8 @@ pub use crate::nymd::cosmwasm_client::client::CosmWasmClient;
 pub use crate::nymd::cosmwasm_client::signing_client::SigningCosmWasmClient;
 pub use crate::nymd::gas_price::GasPrice;
 pub use cosmrs::rpc::HttpClient as QueryNymdClient;
+pub use cosmrs::Coin as CosmosCoin;
+pub use cosmrs::{AccountId, Denom};
 pub use signing_client::Client as SigningNymdClient;
 
 pub mod cosmwasm_client;

--- a/common/client-libs/validator-client/src/nymd/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/mod.rs
@@ -9,11 +9,11 @@ use crate::nymd::cosmwasm_client::types::{
 use crate::nymd::error::NymdError;
 use crate::nymd::fee_helpers::Operation;
 use crate::nymd::wallet::DirectSecp256k1HdWallet;
-use cosmos_sdk::rpc::endpoint::broadcast;
-use cosmos_sdk::rpc::{Error as TendermintRpcError, HttpClientUrl};
-use cosmos_sdk::tx::{Fee, Gas};
-use cosmos_sdk::Coin as CosmosCoin;
-use cosmos_sdk::{AccountId, Denom};
+use cosmrs::rpc::endpoint::broadcast;
+use cosmrs::rpc::{Error as TendermintRpcError, HttpClientUrl};
+use cosmrs::tx::{Fee, Gas};
+use cosmrs::Coin as CosmosCoin;
+use cosmrs::{AccountId, Denom};
 use cosmwasm_std::Coin;
 use mixnet_contract::{
     Addr, Delegation, ExecuteMsg, Gateway, GatewayOwnershipResponse, IdentityKey,
@@ -29,7 +29,7 @@ use std::convert::TryInto;
 pub use crate::nymd::cosmwasm_client::client::CosmWasmClient;
 pub use crate::nymd::cosmwasm_client::signing_client::SigningCosmWasmClient;
 pub use crate::nymd::gas_price::GasPrice;
-pub use cosmos_sdk::rpc::HttpClient as QueryNymdClient;
+pub use cosmrs::rpc::HttpClient as QueryNymdClient;
 pub use signing_client::Client as SigningNymdClient;
 
 pub mod cosmwasm_client;

--- a/common/client-libs/validator-client/src/nymd/wallet/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/wallet/mod.rs
@@ -3,11 +3,11 @@
 
 use crate::nymd::error::NymdError;
 use config::defaults;
-use cosmos_sdk::bip32::{DerivationPath, XPrv};
-use cosmos_sdk::crypto::secp256k1::SigningKey;
-use cosmos_sdk::crypto::PublicKey;
-use cosmos_sdk::tx::SignDoc;
-use cosmos_sdk::{tx, AccountId};
+use cosmrs::bip32::{DerivationPath, XPrv};
+use cosmrs::crypto::secp256k1::SigningKey;
+use cosmrs::crypto::PublicKey;
+use cosmrs::tx::SignDoc;
+use cosmrs::{tx, AccountId};
 
 /// Derivation information required to derive a keypair and an address from a mnemonic.
 struct Secp256k1Derivation {
@@ -95,7 +95,7 @@ impl DirectSecp256k1HdWallet {
         sign_doc: SignDoc,
     ) -> Result<tx::Raw, NymdError> {
         // ideally I'd prefer to have the entire error put into the NymdError::SigningFailure
-        // but I'm super hesitant to trying to downcast the eyre::Report to cosmos_sdk::error::Error
+        // but I'm super hesitant to trying to downcast the eyre::Report to cosmrs::error::Error
         sign_doc
             .sign(&signer.private_key)
             .map_err(|_| NymdError::SigningFailure)


### PR DESCRIPTION
`cosmos-sdk` got renamed to `cosmrs` . I've fixed up all the imports and also updated the dependency so we no longer have to point to the specific commit.