### PR TITLE
Make fee helpers public

### DIFF
--- a/common/client-libs/validator-client/src/nymd/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/mod.rs
@@ -35,7 +35,7 @@ pub use signing_client::Client as SigningNymdClient;
 
 pub mod cosmwasm_client;
 pub mod error;
-pub(crate) mod fee_helpers;
+pub mod fee_helpers;
 pub mod gas_price;
 pub mod wallet;
 


### PR DESCRIPTION
Allows using `Operation` publicly, useful for setting custom gas limits