### PR TITLE
Link 'Block Height' on Overview to Big Dipper blocks table

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -8323,11 +8323,6 @@
         "json5": "^2.1.2"
       }
     },
-    "loadjs": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/loadjs/-/loadjs-3.6.1.tgz",
-      "integrity": "sha512-AZEBw2GWdJk2IzBgQ+Wohoao5j+t0rajqK8dJu8jQqgYxDTxhmCt0ayMo/vCa0ZAMvZxnJcam6uLICfnVd8KAw=="
-    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -9865,14 +9860,6 @@
       "integrity": "sha512-78s5xOQOJvL+jIewrWQZEHtlVk+5Yh4zZy+ODA1on1o1FaRjKWXxoo4n4JQl1XuqkF/A9NWque3KqM6pMggjzQ==",
       "requires": {
         "react-load-script": "^0.0.6"
-      }
-    },
-    "react-google-charts-ts": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/react-google-charts-ts/-/react-google-charts-ts-0.1.1.tgz",
-      "integrity": "sha512-pIYF+wj/ffsyLeBIAXJwFskTE5ILmRMu6AukUKvUekVOobdKgAPpIaYqpsDNGqZazVt3McNHcjr8JAA2C5pFEA==",
-      "requires": {
-        "loadjs": "^3.5.2"
       }
     },
     "react-is": {

--- a/explorer/src/api/constants.ts
+++ b/explorer/src/api/constants.ts
@@ -2,6 +2,7 @@
 // master APIs
 export const MASTER_URL = 'https://testnet-milhon-explorer.nymtech.net';
 export const MASTER_VALIDATOR_URL = 'https://testnet-milhon-validator1.nymtech.net';
+export const BIG_DIPPER = 'https://testnet-milhon-blocks.nymtech.net';
 
 // specific API routes
 export const MIXNODE_PING = `${MASTER_URL}/api/ping`;

--- a/explorer/src/components/ContentCard.tsx
+++ b/explorer/src/components/ContentCard.tsx
@@ -1,9 +1,10 @@
+import { ReactJSXElement } from '@emotion/react/types/jsx-namespace';
 import { Card, CardHeader, CardContent, Typography } from '@mui/material';
 import React, { ReactEventHandler } from 'react';
 
 
 type ContentCardProps = {
-  title?: string,
+  title?: string | ReactJSXElement,
   subtitle?: string,
   Icon?: React.ReactNode,
   Action?: React.ReactNode,

--- a/explorer/src/components/ContentCard.tsx
+++ b/explorer/src/components/ContentCard.tsx
@@ -1,14 +1,26 @@
 import { Card, CardHeader, CardContent, Typography } from '@mui/material';
-import React from 'react';
+import React, { ReactEventHandler } from 'react';
 
-export const ContentCard: React.FC<{
-  title?: string;
-  subtitle?: string;
-  Icon?: React.ReactNode;
-  Action?: React.ReactNode;
-  errorMsg?: string;
-}> = ({ title, Icon, Action, subtitle, errorMsg, children }) => (
-  <Card>
+
+type ContentCardProps = {
+  title?: string,
+  subtitle?: string,
+  Icon?: React.ReactNode,
+  Action?: React.ReactNode,
+  errorMsg?: string,
+  onClick?: ReactEventHandler,
+}
+
+export const ContentCard: React.FC<ContentCardProps> = ({
+  title,
+  Icon,
+  Action,
+  subtitle,
+  errorMsg,
+  children,
+  onClick,
+}) => (
+  <Card onClick={onClick}>
     <CardHeader
       title={title}
       avatar={Icon}

--- a/explorer/src/pages/Overview/index.tsx
+++ b/explorer/src/pages/Overview/index.tsx
@@ -9,6 +9,7 @@ import { useHistory } from 'react-router-dom';
 import { MainContext } from 'src/context/main';
 import { formatNumber } from 'src/utils';
 import { ContentCard } from '../../components/ContentCard';
+import { BIG_DIPPER } from 'src/api/constants';
 
 export const PageOverview: React.FC = () => {
   const history = useHistory();
@@ -84,9 +85,16 @@ export const PageOverview: React.FC = () => {
 
           <Grid item xs={12}>
             <ContentCard
-              title={`Current block height is ${formatNumber(block?.data)}`}
-              onClick={() =>
-                window.open('https://testnet-milhon-blocks.nymtech.net/blocks')
+              title={
+                <a
+                  href={`${BIG_DIPPER}/blocks`}
+                  target="_blank" style={{
+                    textDecoration: 'none',
+                    color: 'white',
+                  }}
+                >
+                  Current block height is ${formatNumber(block?.data)}
+                </a>
               }
             />
           </Grid>

--- a/explorer/src/pages/Overview/index.tsx
+++ b/explorer/src/pages/Overview/index.tsx
@@ -85,6 +85,9 @@ export const PageOverview: React.FC = () => {
           <Grid item xs={12}>
             <ContentCard
               title={`Current block height is ${formatNumber(block?.data)}`}
+              onClick={() =>
+                window.open('https://testnet-milhon-blocks.nymtech.net/blocks')
+              }
             />
           </Grid>
 

--- a/explorer/src/pages/Overview/index.tsx
+++ b/explorer/src/pages/Overview/index.tsx
@@ -93,7 +93,7 @@ export const PageOverview: React.FC = () => {
                     color: 'white',
                   }}
                 >
-                  Current block height is ${formatNumber(block?.data)}
+                  Current block height is {formatNumber(block?.data)}
                 </a>
               }
             />


### PR DESCRIPTION
- added onClick to <ContentCard /> props
- if it exists, launches to arg passed down
- this arg is a `window.open(...` to take user to Big Dipper.
- If/when Blocks table is brought into the app, pretty easy to switch this to a `history.push('/network-components/blocks')`.

