### PR TITLE
Fixed most recent nightly clippy warnings

### DIFF
--- a/clients/client-core/src/config/mod.rs
+++ b/clients/client-core/src/config/mod.rs
@@ -328,15 +328,9 @@ impl<T: NymConfig> Client<T> {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Logging {}
-
-impl Default for Logging {
-    fn default() -> Self {
-        Logging {}
-    }
-}
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]

--- a/common/client-libs/gateway-client/src/client.rs
+++ b/common/client-libs/gateway-client/src/client.rs
@@ -147,7 +147,7 @@ impl GatewayClient {
     async fn _close_connection(&mut self) -> Result<(), GatewayClientError> {
         match std::mem::replace(&mut self.connection, SocketState::NotConnected) {
             SocketState::Available(mut socket) => {
-                socket.close(None).await;
+                (*socket).close(None).await;
                 Ok(())
             }
             SocketState::PartiallyDelegated(_) => {
@@ -183,7 +183,7 @@ impl GatewayClient {
             Err(e) => return Err(GatewayClientError::NetworkErrorWasm(e)),
         };
 
-        self.connection = SocketState::Available(ws_stream);
+        self.connection = SocketState::Available(Box::new(ws_stream));
         Ok(())
     }
 

--- a/common/client-libs/gateway-client/src/client.rs
+++ b/common/client-libs/gateway-client/src/client.rs
@@ -135,7 +135,7 @@ impl GatewayClient {
     #[cfg(not(target_arch = "wasm32"))]
     async fn _close_connection(&mut self) -> Result<(), GatewayClientError> {
         match std::mem::replace(&mut self.connection, SocketState::NotConnected) {
-            SocketState::Available(mut socket) => Ok(socket.close(None).await?),
+            SocketState::Available(mut socket) => Ok((*socket).close(None).await?),
             SocketState::PartiallyDelegated(_) => {
                 unreachable!("this branch should have never been reached!")
             }
@@ -172,7 +172,7 @@ impl GatewayClient {
             Err(e) => return Err(GatewayClientError::NetworkError(e)),
         };
 
-        self.connection = SocketState::Available(ws_stream);
+        self.connection = SocketState::Available(Box::new(ws_stream));
         Ok(())
     }
 
@@ -605,7 +605,7 @@ impl GatewayClient {
             _ => unreachable!(),
         };
 
-        self.connection = SocketState::Available(conn);
+        self.connection = SocketState::Available(Box::new(conn));
         Ok(())
     }
 
@@ -628,7 +628,7 @@ impl GatewayClient {
             match std::mem::replace(&mut self.connection, SocketState::Invalid) {
                 SocketState::Available(conn) => {
                     PartiallyDelegated::split_and_listen_for_mixnet_messages(
-                        conn,
+                        *conn,
                         self.packet_router.clone(),
                         Arc::clone(
                             self.shared_key

--- a/common/client-libs/gateway-client/src/socket_state.rs
+++ b/common/client-libs/gateway-client/src/socket_state.rs
@@ -193,7 +193,7 @@ impl PartiallyDelegated {
 // by notifying the future owning it to finish the execution and awaiting the result
 // which should be almost immediate (or an invalid state which should never, ever happen)
 pub(crate) enum SocketState {
-    Available(WsConn),
+    Available(Box<WsConn>),
     PartiallyDelegated(PartiallyDelegated),
     NotConnected,
     Invalid,

--- a/gateway/gateway-requests/src/registration/handshake/shared_key.rs
+++ b/gateway/gateway-requests/src/registration/handshake/shared_key.rs
@@ -126,14 +126,14 @@ impl SharedKeys {
 
         // couldn't have made the first borrow mutable as you can't have an immutable borrow
         // together with a mutable one
-        let mut message_bytes_mut = &mut enc_data.to_vec()[mac_size..];
+        let message_bytes_mut = &mut enc_data.to_vec()[mac_size..];
 
         let zero_iv = stream_cipher::zero_iv::<GatewayEncryptionAlgorithm>();
         let iv = iv.unwrap_or(&zero_iv);
         stream_cipher::decrypt_in_place::<GatewayEncryptionAlgorithm>(
             self.encryption_key(),
             iv,
-            &mut message_bytes_mut,
+            message_bytes_mut,
         );
         Ok(message_bytes_mut.to_vec())
     }

--- a/gateway/src/config/mod.rs
+++ b/gateway/src/config/mod.rs
@@ -335,15 +335,9 @@ impl Default for Gateway {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Logging {}
-
-impl Default for Logging {
-    fn default() -> Self {
-        Logging {}
-    }
-}
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default)]

--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -391,15 +391,9 @@ impl Default for MixNode {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Logging {}
-
-impl Default for Logging {
-    fn default() -> Self {
-        Logging {}
-    }
-}
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -210,16 +210,12 @@ impl ServiceProvider {
         };
 
         match deserialized_request {
-            Request::Connect {
-                conn_id,
-                remote_addr,
-                return_address,
-            } => self.handle_proxy_connect(
+            Request::Connect(req) => self.handle_proxy_connect(
                 controller_sender,
                 mix_input_sender,
-                conn_id,
-                remote_addr,
-                return_address,
+                req.conn_id,
+                req.remote_addr,
+                req.return_address,
             ),
             Request::Send(conn_id, data, closed) => {
                 self.handle_proxy_send(controller_sender, conn_id, data, closed)

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -263,9 +263,10 @@ fn override_config(mut config: Config, matches: &ArgMatches) -> Config {
     {
         let monitor_threshold =
             monitor_threshold.expect("Provided monitor threshold is not a number!");
-        if monitor_threshold > 100 {
-            panic!("Provided monitor threshold is greater than 100!");
-        }
+        assert!(
+            !(monitor_threshold > 100),
+            "Provided monitor threshold is greater than 100!"
+        );
         config = config.with_minimum_epoch_monitor_threshold(monitor_threshold)
     }
 


### PR DESCRIPTION
This is basically a CI test to see what happens. When run locally, `stable` didn't report any issues, `beta` didn't even compile, while `nightly` produced warnings which this PR should fix.