### PR TITLE
Linting fixes

### DIFF
--- a/explorer/src/api/index.ts
+++ b/explorer/src/api/index.ts
@@ -33,11 +33,6 @@ function getFromCache(key: string) {
 function storeInCache(key: string, data: any) {
   localStorage.setItem(key, data);
 }
-
-function clearCache(key: string) {
-  return localStorage.removeItem(key);
-}
-
 export class Api {
   static fetchMixnodes = async (): Promise<MixNodeResponse> => {
     const cachedMixnodes = getFromCache('mixnodes');

--- a/explorer/src/components/BondBreakdown.tsx
+++ b/explorer/src/components/BondBreakdown.tsx
@@ -15,7 +15,7 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { MainContext } from 'src/context/main';
 
-export function BondBreakdownTable() {
+export const BondBreakdownTable: React.FC = () => {
   const { mixnodeDetailInfo, delegations, mode } =
     React.useContext(MainContext);
   const [allContentLoaded, setAllContentLoaded] =
@@ -200,4 +200,4 @@ export function BondBreakdownTable() {
     );
   }
   return null;
-}
+};

--- a/explorer/src/components/ComponentError.tsx
+++ b/explorer/src/components/ComponentError.tsx
@@ -1,11 +1,7 @@
 import { Typography } from '@mui/material';
 import React from 'react';
 
-type ErrorProps = {
-  text: string;
-};
-
-export const ComponentError = ({ text }: ErrorProps) => (
+export const ComponentError: React.FC<{ text: string }> = ({ text }) => (
   <Typography
     sx={{ marginTop: 2, color: 'primary.main', fontSize: 10 }}
     variant="body1"

--- a/explorer/src/components/ContentCard.tsx
+++ b/explorer/src/components/ContentCard.tsx
@@ -54,8 +54,8 @@ export const ContentCard: React.FC<ContentCardProps> = ({
 ContentCard.defaultProps = {
   title: undefined,
   subtitle: undefined,
-  Icon: () => null,
-  Action: () => null,
+  Icon: null,
+  Action: null,
   errorMsg: undefined,
   onClick: () => null,
 };

--- a/explorer/src/components/ContentCard.tsx
+++ b/explorer/src/components/ContentCard.tsx
@@ -1,10 +1,9 @@
-import { ReactJSXElement } from '@emotion/react/types/jsx-namespace';
 import { Card, CardHeader, CardContent, Typography } from '@mui/material';
 import React, { ReactEventHandler } from 'react';
 import { MainContext } from 'src/context/main';
 
 type ContentCardProps = {
-  title?: string | ReactJSXElement;
+  title?: string | React.ReactNode;
   subtitle?: string;
   Icon?: React.ReactNode;
   Action?: React.ReactNode;
@@ -37,7 +36,7 @@ export const ContentCard: React.FC<ContentCardProps> = ({
           color: (theme) =>
             mode === 'dark' ? theme.palette.primary.main : 'secondary.main',
         }}
-        title={title}
+        title={title || ''}
         avatar={Icon}
         action={Action}
         subheader={subtitle}
@@ -50,4 +49,13 @@ export const ContentCard: React.FC<ContentCardProps> = ({
       )}
     </Card>
   );
+};
+
+ContentCard.defaultProps = {
+  title: undefined,
+  subtitle: undefined,
+  Icon: () => null,
+  Action: () => null,
+  errorMsg: undefined,
+  onClick: () => null,
 };

--- a/explorer/src/components/CustomColumnHeading.tsx
+++ b/explorer/src/components/CustomColumnHeading.tsx
@@ -3,10 +3,9 @@ import { Box, Typography } from '@mui/material';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { MainContext } from 'src/context/main';
 
-type HeadingProps = {
-  headingTitle: string;
-};
-export const CustomColumnHeading = ({ headingTitle }: HeadingProps) => {
+export const CustomColumnHeading: React.FC<{ headingTitle: string }> = ({
+  headingTitle,
+}) => {
   const { mode } = React.useContext(MainContext);
   const [filter, toggleFilter] = React.useState<boolean>(false);
 

--- a/explorer/src/components/Nav.tsx
+++ b/explorer/src/components/Nav.tsx
@@ -279,7 +279,7 @@ const ExpandableButton: React.FC<ExpandableButtonType> = ({
 
 ExpandableButton.defaultProps = {
   Icon: null,
-  nested: [],
+  nested: undefined,
   isExpandedChild: false,
 };
 

--- a/explorer/src/components/Nav.tsx
+++ b/explorer/src/components/Nav.tsx
@@ -277,6 +277,12 @@ const ExpandableButton: React.FC<ExpandableButtonType> = ({
   );
 };
 
+ExpandableButton.defaultProps = {
+  Icon: null,
+  nested: [],
+  isExpandedChild: false,
+};
+
 export const Nav: React.FC = ({ children }) => {
   const { toggleMode, mode } = React.useContext(MainContext);
   const [open, setOpen] = React.useState(true);
@@ -343,9 +349,9 @@ export const Nav: React.FC = ({ children }) => {
         </DrawerHeader>
 
         <List sx={{ pt: 0, pb: 0 }}>
-          {originalNavOptions.map((props, i) => (
+          {originalNavOptions.map((props) => (
             <ExpandableButton
-              key={i}
+              key={props.id}
               openDrawer={handleDrawerOpen}
               drawIsOpen={open}
               {...props}
@@ -370,3 +376,5 @@ export const Nav: React.FC = ({ children }) => {
     </Box>
   );
 };
+
+Nav.defaultProps = {};

--- a/explorer/src/components/Nav.tsx
+++ b/explorer/src/components/Nav.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import * as React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {

--- a/explorer/src/components/TableToolbar.tsx
+++ b/explorer/src/components/TableToolbar.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
-import { useMediaQuery, useTheme, TextField, MenuItem } from '@mui/material';
-import { Box } from '@mui/system';
+import {
+  Box,
+  useMediaQuery,
+  useTheme,
+  TextField,
+  MenuItem,
+} from '@mui/material';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 
 type TableToolBarProps = {
@@ -10,12 +15,12 @@ type TableToolBarProps = {
   searchTerm: string;
 };
 
-export const TableToolbar = ({
+export const TableToolbar: React.FC<TableToolBarProps> = ({
   searchTerm,
   onChangeSearch,
   onChangePageSize,
   pageSize,
-}: TableToolBarProps) => {
+}) => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down('sm'));
   return (

--- a/explorer/src/components/Title.tsx
+++ b/explorer/src/components/Title.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Box, Grid, Typography } from '@mui/material';
 
-export interface TitleProps {
-  text: string;
-}
-
-export const Title = ({ text }: TitleProps) => (
+export const Title: React.FC<{ text: string }> = ({ text }) => (
   <Grid
     item
     xs={12}

--- a/explorer/src/components/TwoColSmallTable.tsx
+++ b/explorer/src/components/TwoColSmallTable.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-  useMediaQuery,
-  useTheme,
-  CircularProgress,
-  Typography,
-} from '@mui/material';
+import { useTheme, CircularProgress, Typography } from '@mui/material';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -26,7 +21,7 @@ interface TableProps {
   loading: boolean;
 }
 
-export function TwoColSmallTable({
+export const TwoColSmallTable: React.FC<TableProps> = ({
   loading,
   title,
   icons,
@@ -34,7 +29,7 @@ export function TwoColSmallTable({
   values,
   marginBottom,
   error,
-}: TableProps) {
+}) => {
   const theme = useTheme();
   const { mode } = React.useContext(MainContext);
   return (
@@ -49,7 +44,7 @@ export function TwoColSmallTable({
           <TableBody>
             {keys.map((each: string, i: number) => (
               <TableRow
-                key={i}
+                key={each}
                 sx={{
                   background:
                     mode === 'dark'
@@ -90,4 +85,11 @@ export function TwoColSmallTable({
       </TableContainer>
     </>
   );
-}
+};
+
+TwoColSmallTable.defaultProps = {
+  title: undefined,
+  icons: [],
+  marginBottom: false,
+  error: undefined,
+};

--- a/explorer/src/components/Universal-DataGrid.tsx
+++ b/explorer/src/components/Universal-DataGrid.tsx
@@ -23,14 +23,14 @@ export const cellStyles = {
   'white-space': 'break-spaces',
 };
 
-export const UniversalDataGrid = ({
+export const UniversalDataGrid: React.FC<DataGridProps> = ({
   loading,
   rows,
   columnsData,
   pageSize,
   pagination,
   hideFooter,
-}: DataGridProps) => {
+}) => {
   if (columnsData && rows) {
     return (
       <DataGrid
@@ -53,4 +53,11 @@ export const UniversalDataGrid = ({
     );
   }
   return null;
+};
+
+UniversalDataGrid.defaultProps = {
+  loading: false,
+  pageSize: undefined,
+  pagination: false,
+  hideFooter: true,
 };

--- a/explorer/src/components/UptimeChart.tsx
+++ b/explorer/src/components/UptimeChart.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
 import { CircularProgress, Typography } from '@mui/material';
 import { Chart } from 'react-google-charts';
 import { ApiState, UptimeStoryResponse } from 'src/typeDefs/explorer-api';
@@ -18,13 +17,13 @@ type FormattedDateRecord = [string, number, number];
 type FormattedChartHeadings = string[];
 type FormattedChartData = [FormattedChartHeadings | FormattedDateRecord];
 
-export function UptimeChart({
+export const UptimeChart: React.FC<ChartProps> = ({
   title,
   xLabel,
   yLabel,
   uptimeStory,
   loading,
-}: ChartProps) {
+}) => {
   const [formattedChartData, setFormattedChartData] =
     React.useState<FormattedChartData>();
   const { mode }: any = React.useContext(MainContext);
@@ -34,7 +33,7 @@ export function UptimeChart({
       const allFormattedChartData: FormattedChartData = [
         ['Date', 'UptimeV4', 'UptimeV6'],
       ];
-      uptimeStory.data.history.map((eachDate) => {
+      uptimeStory.data.history.forEach((eachDate) => {
         const formattedDateUptimeRecord: FormattedDateRecord = [
           format(new Date(eachDate.date), 'MMM dd'),
           eachDate.ipv4_uptime,
@@ -121,4 +120,8 @@ export function UptimeChart({
       )}
     </>
   );
-}
+};
+
+UptimeChart.defaultProps = {
+  title: undefined,
+};

--- a/explorer/src/components/WorldMap.tsx
+++ b/explorer/src/components/WorldMap.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import React from 'react';
 import { scaleLinear, ScaleLinear } from 'd3-scale';
 import {

--- a/explorer/src/components/WorldMap.tsx
+++ b/explorer/src/components/WorldMap.tsx
@@ -9,12 +9,12 @@ import {
 } from 'react-simple-maps';
 import ReactTooltip from 'react-tooltip';
 import { CountryDataResponse, ApiState } from 'src/typeDefs/explorer-api';
+import { CircularProgress } from '@mui/material';
 import { MainContext } from '../context/main';
 import MAP_TOPOJSON from '../assets/world-110m.json';
 import { palette } from '../index';
 
 type MapProps = {
-  title?: string;
   userLocation?: [number, number];
   countryData?: ApiState<CountryDataResponse>;
   loading: boolean;
@@ -47,6 +47,10 @@ export const WorldMap: React.FC<MapProps> = ({
       setColorScale(() => cs);
     }
   }, [countryData, userLocation]);
+
+  if (loading) {
+    return <CircularProgress />;
+  }
 
   return (
     <>
@@ -132,4 +136,9 @@ export const WorldMap: React.FC<MapProps> = ({
       <ReactTooltip>{tooltipContent}</ReactTooltip>
     </>
   );
+};
+
+WorldMap.defaultProps = {
+  userLocation: undefined,
+  countryData: undefined,
 };

--- a/explorer/src/components/WorldMap.tsx
+++ b/explorer/src/components/WorldMap.tsx
@@ -75,7 +75,6 @@ export const WorldMap: React.FC<MapProps> = ({
             {({ geographies }: any) =>
               (colorScale || userLocation) &&
               geographies.map((geo: any) => {
-                // @ts-ignore
                 const d =
                   countryData &&
                   countryData.data &&

--- a/explorer/src/context/main.tsx
+++ b/explorer/src/context/main.tsx
@@ -226,7 +226,6 @@ export const MainContextProvider: React.FC = ({ children }) => {
   const fetchBlock = async () => {
     try {
       const data = await Api.fetchBlock();
-      console.log('block is ', typeof data);
       setBlock({ data, isLoading: false });
     } catch (error) {
       setBlock({

--- a/explorer/src/context/main.tsx
+++ b/explorer/src/context/main.tsx
@@ -226,6 +226,7 @@ export const MainContextProvider: React.FC = ({ children }) => {
   const fetchBlock = async () => {
     try {
       const data = await Api.fetchBlock();
+      console.log('block is ', typeof data);
       setBlock({ data, isLoading: false });
     } catch (error) {
       setBlock({

--- a/explorer/src/pages/Gateways/index.tsx
+++ b/explorer/src/pages/Gateways/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Grid, Typography } from '@mui/material';
+import { Grid, Typography, Button } from '@mui/material';
 import { GridRenderCellParams, GridColDef } from '@mui/x-data-grid';
 import { printableCoin } from '@nymproject/nym-validator-client';
 import { SelectChangeEvent } from '@mui/material/Select';
@@ -37,6 +37,7 @@ export const PageGateways: React.FC = () => {
         ) {
           return g;
         }
+        return null;
       });
       if (filtered) {
         setFilteredGateways(filtered);
@@ -96,12 +97,12 @@ export const PageGateways: React.FC = () => {
       headerAlign: 'left',
       headerClassName: 'MuiDataGrid-header-override',
       renderCell: (params: GridRenderCellParams) => (
-        <div
+        <Button
           onClick={() => handleSearch(params.value as string)}
-          style={cellStyles}
+          sx={cellStyles}
         >
           {params.value}
-        </div>
+        </Button>
       ),
     },
   ];

--- a/explorer/src/pages/MixnodeDetail/index.tsx
+++ b/explorer/src/pages/MixnodeDetail/index.tsx
@@ -262,7 +262,6 @@ export const PageMixnodeDetail: React.FC = () => {
                   mixnodeDetailInfo?.data[0]?.location && (
                     <WorldMap
                       loading={mixnodeDetailInfo.isLoading}
-                      title="Location"
                       userLocation={[
                         mixnodeDetailInfo?.data[0]?.location?.lng,
                         mixnodeDetailInfo?.data[0]?.location?.lat,

--- a/explorer/src/pages/Mixnodes/index.tsx
+++ b/explorer/src/pages/Mixnodes/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { GridRenderCellParams, GridColDef } from '@mui/x-data-grid';
 import { printableCoin } from '@nymproject/nym-validator-client';
 import { Link as RRDLink } from 'react-router-dom';
-import { Grid, Link as MuiLink, Typography } from '@mui/material';
+import { Button, Grid, Link as MuiLink, Typography } from '@mui/material';
 import { SelectChangeEvent } from '@mui/material/Select';
 import {
   cellStyles,
@@ -39,6 +39,7 @@ export const PageMixnodes: React.FC = () => {
         ) {
           return m;
         }
+        return null;
       });
       if (filtered) {
         setFilteredMixnodes(filtered);
@@ -125,12 +126,12 @@ export const PageMixnodes: React.FC = () => {
       headerAlign: 'left',
       headerClassName: 'MuiDataGrid-header-override',
       renderCell: (params: GridRenderCellParams) => (
-        <div
+        <Button
           onClick={() => handleSearch(params.value as string)}
-          style={cellStyles}
+          sx={cellStyles}
         >
           {params.value}
-        </div>
+        </Button>
       ),
     },
     {

--- a/explorer/src/tests/Nav.test.tsx
+++ b/explorer/src/tests/Nav.test.tsx
@@ -1,4 +1,4 @@
-import React, { render, screen } from '@testing-library/react';
+import React, { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Nav } from '../components/Nav';
 

--- a/explorer/src/tests/WorldMap.test.tsx
+++ b/explorer/src/tests/WorldMap.test.tsx
@@ -25,7 +25,4 @@ describe('WorldMap', () => {
     expect(screen.getByTestId('svg')).toHaveAttribute('width', expectedWidth);
     expect(screen.getByTestId('svg')).toHaveAttribute('height', expectedHeight);
   });
-  it('should render countries', () => {
-    // test number of path elements?
-  });
 });

--- a/explorer/src/typeDefs/explorer-api.ts
+++ b/explorer/src/typeDefs/explorer-api.ts
@@ -5,12 +5,6 @@ export interface ClientConfig {
   version: string;
 }
 
-export enum Layer {
-  One = 'One',
-  Two = 'Two',
-  Three = 'Three',
-}
-
 export interface MixNode {
   host: string;
   location: string;
@@ -41,7 +35,7 @@ export interface MixNodeResponseItem {
   bond_amount: Amount;
   total_delegation: Amount;
   owner: string;
-  layer: Layer;
+  layer: string;
   location: {
     country_name: string;
     lat: number;
@@ -140,7 +134,7 @@ export type DelegationsResponse = Delegation[];
 
 export type CountryDataResponse = CountryData[];
 
-export type BlockType = {};
+export type BlockType = number;
 export type BlockResponse = BlockType;
 
 export interface ApiState<RESPONSE> {

--- a/explorer/src/utils/index.ts
+++ b/explorer/src/utils/index.ts
@@ -1,13 +1,15 @@
 /* eslint-disable camelcase */
+import { MutableRefObject } from 'react';
 import { GatewayResponse, MixNodeResponse } from 'src/typeDefs/explorer-api';
 
 export function formatNumber(num: number): string {
   return new Intl.NumberFormat().format(num);
 }
 
-// TO-DO revert with TS type for passed in Ref arg
-export function scrollToRef(ref: any): void {
-  ref.current.scrollIntoView();
+export function scrollToRef(
+  ref: MutableRefObject<HTMLDivElement | undefined>,
+): void {
+  if (ref?.current) ref.current.scrollIntoView();
 }
 
 export type MixnodeRowType = {

--- a/explorer/src/utils/index.ts
+++ b/explorer/src/utils/index.ts
@@ -1,12 +1,14 @@
 /* eslint-disable camelcase */
+import React from 'react';
 import { GatewayResponse, MixNodeResponse } from 'src/typeDefs/explorer-api';
 
-export function formatNumber(num: number) {
+export function formatNumber(num: number): string {
   return new Intl.NumberFormat().format(num);
 }
 
-export function scrollToRef(ref: any) {
-  return ref.current.scrollIntoView();
+// TO-DO revert with TS type for passed in Ref arg
+export function scrollToRef(ref: any): void {
+  ref.current.scrollIntoView();
 }
 
 export type MixnodeRowType = {
@@ -18,6 +20,7 @@ export type MixnodeRowType = {
   host: string;
   layer: string;
 };
+
 export type GatewayRowType = {
   id: string;
   owner: string;

--- a/explorer/src/utils/index.ts
+++ b/explorer/src/utils/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase */
-import React from 'react';
 import { GatewayResponse, MixNodeResponse } from 'src/typeDefs/explorer-api';
 
 export function formatNumber(num: number): string {


### PR DESCRIPTION
I've left 2 linting errors still in there with `// @ts-ignore` 

1. `WorldMap.tsx` - which does not come with type declarations, generates errors with the d3 scale pkg. I need to look into this a bit deeper but dont believe it should hold up progress elsewhere in app. 

2. `Nav.tsx`- which doesnt like my nested ternary (does anyone?). I think correcting that should be incorporated into a broader refactor of Nav to fix the orange line bug vs selecting and unselecting network components. Creating a branch for that now. Disabling the rule on this branch though.