### PR TITLE
Mixnode Detail Alignment

### DIFF
--- a/explorer/src/components/ContentCard.tsx
+++ b/explorer/src/components/ContentCard.tsx
@@ -29,6 +29,7 @@ export const ContentCard: React.FC<ContentCardProps> = ({
           mode === 'dark'
             ? theme.palette.secondary.dark
             : theme.palette.primary.light,
+        height: '100%',
       }}
     >
       <CardHeader

--- a/explorer/src/components/CustomColumnHeading.tsx
+++ b/explorer/src/components/CustomColumnHeading.tsx
@@ -22,6 +22,7 @@ export const CustomColumnHeading: React.FC<{ headingTitle: string }> = ({
               ? theme.palette.primary.main
               : theme.palette.secondary.main,
           fontSize: 14,
+          padding: 0,
         }}
       >
         {headingTitle}&nbsp;

--- a/explorer/src/components/Universal-DataGrid.tsx
+++ b/explorer/src/components/Universal-DataGrid.tsx
@@ -11,7 +11,9 @@ type DataGridProps = {
 };
 
 export const cellStyles = {
-  width: 'auto',
+  width: '100%',
+  padding: 0,
+  'text-align': 'start',
   maxWidth: 170,
   maxHeight: 100,
   color: 'inherit',

--- a/explorer/src/pages/Gateways/index.tsx
+++ b/explorer/src/pages/Gateways/index.tsx
@@ -68,7 +68,7 @@ export const PageGateways: React.FC = () => {
     },
     {
       field: 'bond',
-      width: 120,
+      flex: 1,
       renderHeader: () => <CustomColumnHeading headingTitle="Bond" />,
       headerClassName: 'MuiDataGrid-header-override',
       headerAlign: 'left',
@@ -83,7 +83,7 @@ export const PageGateways: React.FC = () => {
     {
       field: 'host',
       renderHeader: () => <CustomColumnHeading headingTitle="IP:Port" />,
-      width: 130,
+      flex: 1,
       headerAlign: 'left',
       headerClassName: 'MuiDataGrid-header-override',
       renderCell: (params: GridRenderCellParams) => (
@@ -93,13 +93,13 @@ export const PageGateways: React.FC = () => {
     {
       field: 'location',
       renderHeader: () => <CustomColumnHeading headingTitle="Location" />,
-      width: 120,
+      flex: 1,
       headerAlign: 'left',
       headerClassName: 'MuiDataGrid-header-override',
       renderCell: (params: GridRenderCellParams) => (
         <Button
           onClick={() => handleSearch(params.value as string)}
-          sx={cellStyles}
+          sx={{ ...cellStyles, justifyContent: 'flex-start' }}
         >
           {params.value}
         </Button>
@@ -119,7 +119,7 @@ export const PageGateways: React.FC = () => {
         </Typography>
 
         <Grid container>
-          <Grid item xs={12} md={12} lg={8} xl={8}>
+          <Grid item xs={12} md={12} lg={10} xl={10}>
             <ContentCard>
               <TableToolbar
                 onChangeSearch={handleSearch}

--- a/explorer/src/pages/MixnodeDetail/index.tsx
+++ b/explorer/src/pages/MixnodeDetail/index.tsx
@@ -47,7 +47,7 @@ const columns: GridColDef[] = [
     field: 'bond',
     headerName: 'Bond',
     renderHeader: () => <CustomColumnHeading headingTitle="Bond" />,
-    width: 120,
+    flex: 1,
     headerAlign: 'left',
     headerClassName: 'MuiDataGrid-header-override',
     renderCell: (params: GridRenderCellParams) => {
@@ -61,7 +61,7 @@ const columns: GridColDef[] = [
   {
     field: 'host',
     renderHeader: () => <CustomColumnHeading headingTitle="IP:Port" />,
-    width: 130,
+    flex: 1,
     headerAlign: 'left',
     headerClassName: 'MuiDataGrid-header-override',
     renderCell: (params: GridRenderCellParams) => (
@@ -73,7 +73,7 @@ const columns: GridColDef[] = [
   {
     field: 'location',
     renderHeader: () => <CustomColumnHeading headingTitle="Location" />,
-    width: 120,
+    flex: 1,
     headerAlign: 'left',
     headerClassName: 'MuiDataGrid-header-override',
     renderCell: (params: GridRenderCellParams) => (
@@ -85,14 +85,12 @@ const columns: GridColDef[] = [
   {
     field: 'layer',
     renderHeader: () => <CustomColumnHeading headingTitle="Layer" />,
-    width: 100,
+    flex: 1,
     headerAlign: 'left',
     headerClassName: 'MuiDataGrid-header-override',
     type: 'number',
     renderCell: (params: GridRenderCellParams) => (
-      <div>
-        <Typography sx={cellStyles}>{params.value}</Typography>
-      </div>
+      <Typography sx={cellStyles}>{params.value}</Typography>
     ),
   },
 ];
@@ -152,33 +150,38 @@ export const PageMixnodeDetail: React.FC = () => {
               Mix node Detail
             </Typography>
           </Grid>
+        </Grid>
+
+        <Grid container sx={{ mt: 2 }}>
           <Grid item xs={12} xl={9}>
             {mixnodeDetailInfo && (
-              <>
-                <Grid container>
-                  <Grid item xs={12} md={12} lg={12} xl={12}>
-                    <ContentCard>
-                      <UniversalDataGrid
-                        columnsData={columns}
-                        rows={mixnodeToGridRow(row)}
-                        loading={mixnodeDetailInfo.isLoading}
-                        pageSize="1"
-                        pagination={false}
-                        hideFooter
-                      />
-                    </ContentCard>
-                  </Grid>
+              <Grid container>
+                <Grid item xs={12} md={12} lg={12} xl={12}>
+                  <ContentCard>
+                    <UniversalDataGrid
+                      columnsData={columns}
+                      rows={mixnodeToGridRow(row)}
+                      loading={mixnodeDetailInfo.isLoading}
+                      pageSize="1"
+                      pagination={false}
+                      hideFooter
+                    />
+                  </ContentCard>
                 </Grid>
-              </>
+              </Grid>
             )}
           </Grid>
+        </Grid>
+
+        <Grid container spacing={2} sx={{ mt: 0 }}>
           <Grid item xs={12} xl={9}>
             <ContentCard title="Bond Breakdown">
               <BondBreakdownTable />
             </ContentCard>
           </Grid>
         </Grid>
-        <Grid container spacing={2} sx={{ marginTop: 1 }}>
+
+        <Grid container spacing={2} sx={{ mt: 0 }}>
           <Grid item xs={12} md={4} xl={3}>
             <ContentCard title="Mixnode Stats">
               {stats && (
@@ -232,7 +235,8 @@ export const PageMixnodeDetail: React.FC = () => {
             )}
           </Grid>
         </Grid>
-        <Grid container spacing={2} sx={{ marginTop: 1 }}>
+
+        <Grid container spacing={2} sx={{ mt: 0 }}>
           <Grid item xs={12} md={4} xl={3}>
             {status && (
               <ContentCard title="Mixnode Status">

--- a/explorer/src/pages/Mixnodes/index.tsx
+++ b/explorer/src/pages/Mixnodes/index.tsx
@@ -84,7 +84,7 @@ export const PageMixnodes: React.FC = () => {
       field: 'bond',
       headerName: 'Bond',
       headerAlign: 'left',
-      width: 120,
+      flex: 1,
       headerClassName: 'MuiDataGrid-header-override',
       renderHeader: () => <CustomColumnHeading headingTitle="Bond" />,
       renderCell: (params: GridRenderCellParams) => {
@@ -106,7 +106,7 @@ export const PageMixnodes: React.FC = () => {
     {
       field: 'host',
       renderHeader: () => <CustomColumnHeading headingTitle="IP:Port" />,
-      width: 130,
+      flex: 1,
       headerAlign: 'left',
       headerClassName: 'MuiDataGrid-header-override',
       renderCell: (params: GridRenderCellParams) => (
@@ -122,13 +122,13 @@ export const PageMixnodes: React.FC = () => {
     {
       field: 'location',
       renderHeader: () => <CustomColumnHeading headingTitle="Location" />,
-      width: 120,
+      flex: 1,
       headerAlign: 'left',
       headerClassName: 'MuiDataGrid-header-override',
       renderCell: (params: GridRenderCellParams) => (
         <Button
           onClick={() => handleSearch(params.value as string)}
-          sx={cellStyles}
+          sx={{ ...cellStyles, justifyContent: 'flex-start' }}
         >
           {params.value}
         </Button>
@@ -139,7 +139,7 @@ export const PageMixnodes: React.FC = () => {
       headerAlign: 'left',
       headerClassName: 'MuiDataGrid-header-override',
       renderHeader: () => <CustomColumnHeading headingTitle="Layer" />,
-      width: 100,
+      flex: 1,
       type: 'number',
       renderCell: (params: GridRenderCellParams) => (
         <MuiLink
@@ -164,7 +164,7 @@ export const PageMixnodes: React.FC = () => {
       </Typography>
 
       <Grid container>
-        <Grid item xs={12} md={12} lg={9} xl={9}>
+        <Grid item xs={12} md={12} lg={10} xl={10}>
           <ContentCard>
             <TableToolbar
               onChangeSearch={handleSearch}

--- a/explorer/src/styles.css
+++ b/explorer/src/styles.css
@@ -12,10 +12,15 @@ in <DataGrid /> */
     visibility: hidden;
 }
 
-/* TODO - this should be disabled somehow in MUI DataGrid
-but documentation doesnt offer an obvious way to do it. Possibly only
+/* TODO - this should be managed somehow in MUI DataGrid
+but documentation doesnt offer a way to do it. Possibly only
 included in Data Grid Pro package */
 .MuiDataGrid-header-override {
     height: 55px;
     min-height: 55px;
+}
+/* Again, no offered way to add sx to this specific div to kill the padding
+which puts it out of sync with other (sx styled) cells */
+div div.MuiDataGrid-root .MuiDataGrid-columnHeaderTitleContainer {
+    padding-left: 0;
 }


### PR DESCRIPTION
1. styles.css override - no offered way to adjust padding on that one specific `TitleContainer` div, which is putting the header out of alignment with the cells.
2. Added `flex: 1` (mui doc'd approach) to the _non_ word-wrapping headers in DataGrid. This helps them to space out more responsively, as per Figma designs.
3. added `height: 100%` to ContentCard so reuseable cards like those in Mixnode Detail page match the height of the grid item and thus the container row. This generates the expected alignment.
4. Adjustments to margin/padding to keep the same spacing in between Detail page cards.