### PR TITLE
Equalise spacing pages

### DIFF
--- a/explorer/src/components/Title.tsx
+++ b/explorer/src/components/Title.tsx
@@ -1,23 +1,14 @@
 import React from 'react';
-import { Box, Grid, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 
 export const Title: React.FC<{ text: string }> = ({ text }) => (
-  <Grid
-    item
-    xs={12}
+  <Typography
+    variant="h5"
     sx={{
-      justifyContent: 'flex-start',
-      padding: 2,
-      bgcolor: 'primary.dark',
+      color: 'primary.main',
+      mb: 3,
     }}
   >
-    <Box
-      sx={{
-        padding: 3,
-        bgcolor: 'primary.light',
-      }}
-    >
-      <Typography sx={{ color: 'primary.main' }}>{text}</Typography>
-    </Box>
-  </Grid>
+    {text}
+  </Typography>
 );

--- a/explorer/src/pages/Gateways/index.tsx
+++ b/explorer/src/pages/Gateways/index.tsx
@@ -13,6 +13,7 @@ import { GatewayResponse } from 'src/typeDefs/explorer-api';
 import { TableToolbar } from 'src/components/TableToolbar';
 import { ContentCard } from 'src/components/ContentCard';
 import { CustomColumnHeading } from 'src/components/CustomColumnHeading';
+import { Title } from 'src/components/Title';
 
 export const PageGateways: React.FC = () => {
   const { gateways } = React.useContext(MainContext);
@@ -114,10 +115,7 @@ export const PageGateways: React.FC = () => {
   if (gateways?.data) {
     return (
       <>
-        <Typography sx={{ marginBottom: 3 }} variant="h5">
-          Gateways
-        </Typography>
-
+        <Title text="Gateways" />
         <Grid container>
           <Grid item xs={12} md={12} lg={8} xl={8}>
             <ContentCard>

--- a/explorer/src/pages/Overview/index.tsx
+++ b/explorer/src/pages/Overview/index.tsx
@@ -9,6 +9,7 @@ import { BIG_DIPPER } from 'src/api/constants';
 import { ValidatorsSVG } from 'src/icons/ValidatorsSVG';
 import { GatewaysSVG } from 'src/icons/GatewaysSVG';
 import { MixnodesSVG } from 'src/icons/MixnodesSVG';
+import { Title } from 'src/components/Title';
 import { ContentCard } from '../../components/ContentCard';
 
 export const PageOverview: React.FC = () => {
@@ -19,85 +20,90 @@ export const PageOverview: React.FC = () => {
   return (
     <>
       <Box component="main" sx={{ flexGrow: 1 }}>
-        <Grid container spacing={2}>
+        <Grid container>
           <Grid item xs={12}>
-            <Typography sx={{ marginLeft: 3 }}>Overview</Typography>
+            <Title text="Overview" />
           </Grid>
+          <Grid item xs={12} lg={9}>
+            <Grid container spacing={2}>
+              {mixnodes && (
+                <Grid item xs={12} md={4}>
+                  <ContentCard
+                    onClick={() => history.push('/network-components/mixnodes')}
+                    title="Mixnodes"
+                    subtitle={mixnodes?.data?.length || ''}
+                    errorMsg={mixnodes?.error}
+                    Icon={<MixnodesSVG />}
+                    Action={
+                      <IconButton>
+                        <ArrowForwardSharp />
+                      </IconButton>
+                    }
+                  />
+                </Grid>
+              )}
 
-          {mixnodes && (
-            <Grid item xs={12} md={4} lg={4}>
-              <ContentCard
-                onClick={() => history.push('/network-components/mixnodes')}
-                title="Mixnodes"
-                subtitle={mixnodes?.data?.length || ''}
-                errorMsg={mixnodes?.error}
-                Icon={<MixnodesSVG />}
-                Action={
-                  <IconButton>
-                    <ArrowForwardSharp />
-                  </IconButton>
-                }
-              />
-            </Grid>
-          )}
-          {gateways && (
-            <Grid item xs={12} md={4} lg={4}>
-              <ContentCard
-                onClick={() => history.push('/network-components/gateways')}
-                title="Gateways"
-                subtitle={gateways?.data?.length || ''}
-                errorMsg={gateways?.error}
-                Icon={<GatewaysSVG />}
-                Action={
-                  <IconButton>
-                    <ArrowForwardSharp />
-                  </IconButton>
-                }
-              />
-            </Grid>
-          )}
-          {validators && (
-            <Grid item xs={12} md={4} lg={4}>
-              <ContentCard
-                onClick={() => window.open(`${BIG_DIPPER}/validators`)}
-                title="Validators"
-                subtitle={validators?.data?.count || ''}
-                errorMsg={validators?.error}
-                Icon={<ValidatorsSVG />}
-                Action={
-                  <IconButton>
-                    <ArrowForwardSharp />
-                  </IconButton>
-                }
-              />
-            </Grid>
-          )}
+              {gateways && (
+                <Grid item xs={12} md={4}>
+                  <ContentCard
+                    onClick={() => history.push('/network-components/gateways')}
+                    title="Gateways"
+                    subtitle={gateways?.data?.length || ''}
+                    errorMsg={gateways?.error}
+                    Icon={<GatewaysSVG />}
+                    Action={
+                      <IconButton>
+                        <ArrowForwardSharp />
+                      </IconButton>
+                    }
+                  />
+                </Grid>
+              )}
 
-          <Grid item xs={12}>
-            <ContentCard
-              title={
-                <a
-                  href={`${BIG_DIPPER}/blocks`}
-                  target="_blank"
-                  style={{
-                    textDecoration: 'none',
-                    color:
-                      mode === 'dark'
-                        ? theme.palette.primary.main
-                        : theme.palette.secondary.main,
-                  }}
-                  rel="noreferrer"
-                >
-                  Current block height is {formatNumber(block?.data)}
-                </a>
-              }
-            />
-          </Grid>
-
-          <Grid item xs={12}>
-            <ContentCard title="Distribution of nodes around the world">
-              <WorldMap loading={false} countryData={countryData} />
-            </ContentCard>
+              {validators && (
+                <Grid item xs={12} md={4}>
+                  <ContentCard
+                    onClick={() => window.open(`${BIG_DIPPER}/validators`)}
+                    title="Validators"
+                    subtitle={validators?.data?.count || ''}
+                    errorMsg={validators?.error}
+                    Icon={<ValidatorsSVG />}
+                    Action={
+                      <IconButton>
+                        <ArrowForwardSharp />
+                      </IconButton>
+                    }
+                  />
+                </Grid>
+              )}
+              {block && (
+                <Grid item xs={12}>
+                  <ContentCard
+                    title={
+                      <a
+                        href={`${BIG_DIPPER}/blocks`}
+                        target="_blank"
+                        style={{
+                          textDecoration: 'none',
+                          color:
+                            mode === 'dark'
+                              ? theme.palette.primary.main
+                              : theme.palette.secondary.main,
+                        }}
+                        rel="noreferrer"
+                      >
+                        Current block height is {formatNumber(block?.data)}
+                      </a>
+                    }
+                  />
+                </Grid>
+              )}
+              <Grid item xs={12}>
+                <ContentCard title="Distribution of nodes around the world">
+                  <WorldMap loading={false} countryData={countryData} />
+                </ContentCard>
+              </Grid>
+            </Grid>
           </Grid>
         </Grid>
       </Box>

--- a/explorer/src/pages/Overview/index.tsx
+++ b/explorer/src/pages/Overview/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTheme, Box, Grid, IconButton, Typography } from '@mui/material';
+import { useTheme, Box, Grid, IconButton } from '@mui/material';
 import { ArrowForwardSharp } from '@mui/icons-material';
 import { WorldMap } from 'src/components/WorldMap';
 import { useHistory } from 'react-router-dom';


### PR DESCRIPTION
1. added a nested Mui container to Overview, wraps the existing content. So now the container and child items all sit within a parent `<Grid item xs={12} lg={9}>`. This seeks to stop content stretching out on larger displays; much neater overall appearance.

2. brought the page title `<Title text="foobar" />` in, prev these instances were recurring instances of `<Typography>....` - Now all sanitized into one presentational/dumb component.

Linting 100%