### PR TITLE
Mixnode-map page

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -18,6 +18,7 @@
         "@nymproject/nym-validator-client": "^0.18.0",
         "d3-scale": "^4.0.0",
         "date-fns": "^2.24.0",
+        "i18n-iso-countries": "^6.8.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-google-charts": "^3.0.15",
@@ -6017,6 +6018,11 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
+    "node_modules/diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha1-PvqHMj67hj5mls67AILUj/PW96E="
+    },
     "node_modules/diff-sequences": {
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
@@ -8467,6 +8473,17 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
+    "node_modules/i18n-iso-countries": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-6.8.0.tgz",
+      "integrity": "sha512-jJs/+CA6+VUICFxqGcB0vFMERGfhfvyNk+8Vb9EagSZkl7kSpm/kT0VyhvzM/zixDWEV/+oN9L7v/GT9BwzoGg==",
+      "dependencies": {
+        "diacritics": "1.3.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -21716,6 +21733,11 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
+    "diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha1-PvqHMj67hj5mls67AILUj/PW96E="
+    },
     "diff-sequences": {
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
@@ -23617,6 +23639,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
+    "i18n-iso-countries": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-6.8.0.tgz",
+      "integrity": "sha512-jJs/+CA6+VUICFxqGcB0vFMERGfhfvyNk+8Vb9EagSZkl7kSpm/kT0VyhvzM/zixDWEV/+oN9L7v/GT9BwzoGg==",
+      "requires": {
+        "diacritics": "1.3.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -13,6 +13,7 @@
     "@nymproject/nym-validator-client": "^0.18.0",
     "d3-scale": "^4.0.0",
     "date-fns": "^2.24.0",
+    "i18n-iso-countries": "^6.8.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-google-charts": "^3.0.15",

--- a/explorer/src/context/main.tsx
+++ b/explorer/src/context/main.tsx
@@ -236,6 +236,7 @@ export const MainContextProvider: React.FC = ({ children }) => {
   };
 
   const fetchCountryData = async () => {
+    setCountryData({ data: undefined, isLoading: true });
     try {
       const res = await Api.fetchCountryData();
       setCountryData({ data: res, isLoading: false });

--- a/explorer/src/pages/Mixnodes/index.tsx
+++ b/explorer/src/pages/Mixnodes/index.tsx
@@ -20,7 +20,7 @@ export const PageMixnodes: React.FC = () => {
   const { mixnodes } = React.useContext(MainContext);
   const [filteredMixnodes, setFilteredMixnodes] =
     React.useState<MixNodeResponse>([]);
-  const [pageSize, setPageSize] = React.useState<string>('50');
+  const [pageSize, setPageSize] = React.useState<string>('10');
   const [searchTerm, setSearchTerm] = React.useState<string>('');
 
   const handleSearch = (str: string) => {

--- a/explorer/src/pages/MixnodesMap/index.tsx
+++ b/explorer/src/pages/MixnodesMap/index.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Box, Grid, Typography } from '@mui/material';
+import {
+  Box,
+  CircularProgress,
+  Grid,
+  SelectChangeEvent,
+  Typography,
+  Alert,
+} from '@mui/material';
 import { WorldMap } from 'src/components/WorldMap';
 import { MainContext } from 'src/context/main';
 import {
@@ -8,14 +15,28 @@ import {
 } from 'src/components/Universal-DataGrid';
 import { CustomColumnHeading } from 'src/components/CustomColumnHeading';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
+// import { CountryData } from 'src/typeDefs/explorer-api';
+import { TableToolbar } from 'src/components/TableToolbar';
+import { countryDataToGridRow } from 'src/utils';
 import { ContentCard } from '../../components/ContentCard';
 
 export const PageMixnodesMap: React.FC = () => {
-  const { countryData, mode } = React.useContext(MainContext);
+  const { countryData } = React.useContext(MainContext);
+  const [pageSize, setPageSize] = React.useState<string>('10');
+  const [formattedCountries, setFormattedCountries] = React.useState<any>([]);
+  const [searchTerm, setSearchTerm] = React.useState<string>('');
+
+  const handleSearch = (str: string) => {
+    setSearchTerm(str.toLowerCase());
+  };
+
+  const handlePageSize = (event: SelectChangeEvent<string>) => {
+    setPageSize(event.target.value);
+  };
 
   const columns: GridColDef[] = [
     {
-      field: 'location',
+      field: 'countryName',
       renderHeader: () => <CustomColumnHeading headingTitle="Location" />,
       flex: 1,
       headerAlign: 'left',
@@ -24,28 +45,74 @@ export const PageMixnodesMap: React.FC = () => {
         <Typography sx={cellStyles}>{params.value}</Typography>
       ),
     },
+    {
+      field: 'nodes',
+      renderHeader: () => (
+        <CustomColumnHeading headingTitle="Number of Nodes" />
+      ),
+      flex: 1,
+      headerAlign: 'left',
+      headerClassName: 'MuiDataGrid-header-override',
+      renderCell: (params: GridRenderCellParams) => (
+        <Typography sx={cellStyles}>{params.value}</Typography>
+      ),
+    },
+    {
+      field: 'percentage',
+      renderHeader: () => <CustomColumnHeading headingTitle="Percentage %" />,
+      flex: 1,
+      headerAlign: 'left',
+      headerClassName: 'MuiDataGrid-header-override',
+      renderCell: (params: GridRenderCellParams) => (
+        <Typography sx={cellStyles}>{params.value}</Typography>
+      ),
+    },
   ];
-  return (
-    <Box component="main" sx={{ flexGrow: 1 }}>
-      <Grid container spacing={1} sx={{ mb: 4 }}>
-        <Grid item xs={4}>
-          <Typography sx={{ marginLeft: 3, fontSize: '24px' }}>
-            Mixnodes Around the Globe
-          </Typography>
+
+  React.useEffect(() => {
+    if (countryData?.data !== undefined) {
+      setFormattedCountries(countryDataToGridRow(countryData.data));
+    }
+  }, [countryData?.data]);
+
+  if (countryData?.isLoading) {
+    return <CircularProgress />;
+  }
+  if (countryData?.data && !countryData.isLoading) {
+    return (
+      <Box component="main" sx={{ flexGrow: 1 }}>
+        <Grid container spacing={1} sx={{ mb: 4 }}>
+          <Grid item xs={4}>
+            <Typography sx={{ marginLeft: 3, fontSize: '24px' }}>
+              Mixnodes Around the Globe
+            </Typography>
+          </Grid>
         </Grid>
-      </Grid>
-      <Grid container spacing={2}>
-        <Grid item xs={12} xl={9} sx={{ maxHeight: 500 }}>
-          <ContentCard title="Distribution of nodes">
-            <WorldMap loading={false} countryData={countryData} />
-          </ContentCard>
+        <Grid container spacing={2}>
+          <Grid item xs={12} xl={9} sx={{ maxHeight: 500 }}>
+            <ContentCard title="Distribution of nodes">
+              <WorldMap loading={false} countryData={countryData} />
+            </ContentCard>
+
+            <ContentCard>
+              <TableToolbar
+                onChangeSearch={handleSearch}
+                onChangePageSize={handlePageSize}
+                pageSize={pageSize}
+                searchTerm={searchTerm}
+              />
+              <UniversalDataGrid
+                loading={countryData?.isLoading}
+                columnsData={columns}
+                rows={formattedCountries}
+                pageSize={pageSize}
+                pagination
+              />
+            </ContentCard>
+          </Grid>
         </Grid>
-      </Grid>
-      <Grid container spacing={2}>
-        <Grid item xs={12} xl={9} sx={{ maxHeight: 500 }}>
-          <UniversalDataGrid loading={false} columnsData={columns} rows={} />
-        </Grid>
-      </Grid>
-    </Box>
-  );
+      </Box>
+    );
+  }
+  return <Alert severity="error">{countryData?.error}</Alert>;
 };

--- a/explorer/src/pages/MixnodesMap/index.tsx
+++ b/explorer/src/pages/MixnodesMap/index.tsx
@@ -1,50 +1,51 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
+import { Box, Grid, Typography } from '@mui/material';
+import { WorldMap } from 'src/components/WorldMap';
+import { MainContext } from 'src/context/main';
+import {
+  cellStyles,
+  UniversalDataGrid,
+} from 'src/components/Universal-DataGrid';
+import { CustomColumnHeading } from 'src/components/CustomColumnHeading';
+import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
+import { ContentCard } from '../../components/ContentCard';
 
-const DrawerHeader = styled('div')(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'flex-end',
-  padding: theme.spacing(0, 1),
-  // necessary for content to be below app bar
-  ...theme.mixins.toolbar,
-}));
+export const PageMixnodesMap: React.FC = () => {
+  const { countryData, mode } = React.useContext(MainContext);
 
-export const PageMixnodesMap: React.FC = () => (
-  <>
-    <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
-      <DrawerHeader />
-      <Typography paragraph>
-        Mix Nodes Map is here and Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-        magna aliqua. Rhoncus dolor purus non enim praesent elementum facilisis
-        leo vel. Risus at ultrices mi tempus imperdiet. Semper risus in
-        hendrerit gravida rutrum quisque non tellus. Convallis convallis tellus
-        id interdum velit laoreet id donec ultrices. Odio morbi quis commodo
-        odio aenean sed adipiscing. Amet nisl suscipit adipiscing bibendum est
-        ultricies integer quis. Cursus euismod quis viverra nibh cras. Metus
-        vulputate eu scelerisque felis imperdiet proin fermentum leo. Mauris
-        commodo quis imperdiet massa tincidunt. Cras tincidunt lobortis feugiat
-        vivamus at augue. At augue eget arcu dictum varius duis at consectetur
-        lorem. Velit sed ullamcorper morbi tincidunt. Lorem donec massa sapien
-        faucibus et molestie ac.
-      </Typography>
-      <Typography paragraph>
-        Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
-        ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar elementum
-        integer enim neque volutpat ac tincidunt. Ornare suspendisse sed nisi
-        lacus sed viverra tellus. Purus sit amet volutpat consequat mauris.
-        Elementum eu facilisis sed odio morbi. Euismod lacinia at quis risus sed
-        vulputate odio. Morbi tincidunt ornare massa eget egestas purus viverra
-        accumsan in. In hendrerit gravida rutrum quisque non tellus orci ac.
-        Pellentesque nec nam aliquam sem et tortor. Habitant morbi tristique
-        senectus et. Adipiscing elit duis tristique sollicitudin nibh sit.
-        Ornare aenean euismod elementum nisi quis eleifend. Commodo viverra
-        maecenas accumsan lacus vel facilisis. Nulla posuere sollicitudin
-        aliquam ultrices sagittis orci a.
-      </Typography>
+  const columns: GridColDef[] = [
+    {
+      field: 'location',
+      renderHeader: () => <CustomColumnHeading headingTitle="Location" />,
+      flex: 1,
+      headerAlign: 'left',
+      headerClassName: 'MuiDataGrid-header-override',
+      renderCell: (params: GridRenderCellParams) => (
+        <Typography sx={cellStyles}>{params.value}</Typography>
+      ),
+    },
+  ];
+  return (
+    <Box component="main" sx={{ flexGrow: 1 }}>
+      <Grid container spacing={1} sx={{ mb: 4 }}>
+        <Grid item xs={4}>
+          <Typography sx={{ marginLeft: 3, fontSize: '24px' }}>
+            Mixnodes Around the Globe
+          </Typography>
+        </Grid>
+      </Grid>
+      <Grid container spacing={2}>
+        <Grid item xs={12} xl={9} sx={{ maxHeight: 500 }}>
+          <ContentCard title="Distribution of nodes">
+            <WorldMap loading={false} countryData={countryData} />
+          </ContentCard>
+        </Grid>
+      </Grid>
+      <Grid container spacing={2}>
+        <Grid item xs={12} xl={9} sx={{ maxHeight: 500 }}>
+          <UniversalDataGrid loading={false} columnsData={columns} rows={} />
+        </Grid>
+      </Grid>
     </Box>
-  </>
-);
+  );
+};

--- a/explorer/src/pages/MixnodesMap/index.tsx
+++ b/explorer/src/pages/MixnodesMap/index.tsx
@@ -15,15 +15,16 @@ import {
 } from 'src/components/Universal-DataGrid';
 import { CustomColumnHeading } from 'src/components/CustomColumnHeading';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
-// import { CountryData } from 'src/typeDefs/explorer-api';
 import { TableToolbar } from 'src/components/TableToolbar';
-import { countryDataToGridRow } from 'src/utils';
+import { CountryDataRowType, countryDataToGridRow } from 'src/utils';
 import { ContentCard } from '../../components/ContentCard';
 
 export const PageMixnodesMap: React.FC = () => {
   const { countryData } = React.useContext(MainContext);
   const [pageSize, setPageSize] = React.useState<string>('10');
-  const [formattedCountries, setFormattedCountries] = React.useState<any>([]);
+  const [formattedCountries, setFormattedCountries] = React.useState<
+    CountryDataRowType[]
+  >([]);
   const [searchTerm, setSearchTerm] = React.useState<string>('');
 
   const handleSearch = (str: string) => {
@@ -70,45 +71,63 @@ export const PageMixnodesMap: React.FC = () => {
   ];
 
   React.useEffect(() => {
-    if (countryData?.data !== undefined) {
+    if (countryData?.data && searchTerm === '') {
       setFormattedCountries(countryDataToGridRow(countryData.data));
+    } else if (countryData?.data !== undefined && searchTerm !== '') {
+      const formatted = countryDataToGridRow(countryData?.data);
+      const filtered = formatted.filter((m) => {
+        if (
+          m.countryName.toLowerCase().includes(searchTerm) ||
+          m.ISO3.toLowerCase().includes(searchTerm)
+        ) {
+          return m;
+        }
+        return null;
+      });
+      if (filtered) {
+        setFormattedCountries(filtered);
+      }
     }
-  }, [countryData?.data]);
+  }, [searchTerm, countryData?.data]);
 
   if (countryData?.isLoading) {
     return <CircularProgress />;
   }
+
   if (countryData?.data && !countryData.isLoading) {
     return (
       <Box component="main" sx={{ flexGrow: 1 }}>
         <Grid container spacing={1} sx={{ mb: 4 }}>
-          <Grid item xs={4}>
-            <Typography sx={{ marginLeft: 3, fontSize: '24px' }}>
+          <Grid item xs={12}>
+            <Typography sx={{ marginBottom: 2, fontSize: '24px' }}>
               Mixnodes Around the Globe
             </Typography>
           </Grid>
-        </Grid>
-        <Grid container spacing={2}>
-          <Grid item xs={12} xl={9} sx={{ maxHeight: 500 }}>
+
+          <Grid item xs={12} lg={9}>
             <ContentCard title="Distribution of nodes">
               <WorldMap loading={false} countryData={countryData} />
             </ContentCard>
 
-            <ContentCard>
-              <TableToolbar
-                onChangeSearch={handleSearch}
-                onChangePageSize={handlePageSize}
-                pageSize={pageSize}
-                searchTerm={searchTerm}
-              />
-              <UniversalDataGrid
-                loading={countryData?.isLoading}
-                columnsData={columns}
-                rows={formattedCountries}
-                pageSize={pageSize}
-                pagination
-              />
-            </ContentCard>
+            <Grid container spacing={2}>
+              <Grid item xs={12}>
+                <ContentCard>
+                  <TableToolbar
+                    onChangeSearch={handleSearch}
+                    onChangePageSize={handlePageSize}
+                    pageSize={pageSize}
+                    searchTerm={searchTerm}
+                  />
+                  <UniversalDataGrid
+                    loading={countryData?.isLoading}
+                    columnsData={columns}
+                    rows={formattedCountries}
+                    pageSize={pageSize}
+                    pagination
+                  />
+                </ContentCard>
+              </Grid>
+            </Grid>
           </Grid>
         </Grid>
       </Box>

--- a/explorer/src/pages/Overview/index.tsx
+++ b/explorer/src/pages/Overview/index.tsx
@@ -21,7 +21,9 @@ export const PageOverview: React.FC = () => {
       <Box component="main" sx={{ flexGrow: 1 }}>
         <Grid container spacing={2}>
           <Grid item xs={12}>
-            <Typography sx={{ marginLeft: 3 }}>Overview</Typography>
+            <Typography sx={{ marginLeft: 3, fontSize: '24px' }}>
+              Overview
+            </Typography>
           </Grid>
 
           {mixnodes && (

--- a/explorer/src/utils/index.ts
+++ b/explorer/src/utils/index.ts
@@ -1,6 +1,13 @@
 /* eslint-disable camelcase */
 import { MutableRefObject } from 'react';
-import { GatewayResponse, MixNodeResponse } from 'src/typeDefs/explorer-api';
+import {
+  CountryData,
+  GatewayResponse,
+  MixNodeResponse,
+} from 'src/typeDefs/explorer-api';
+import { registerLocale, getName } from 'i18n-iso-countries';
+
+registerLocale(require('i18n-iso-countries/langs/en.json'));
 
 export function formatNumber(num: number): string {
   return new Intl.NumberFormat().format(num);
@@ -30,6 +37,32 @@ export type GatewayRowType = {
   host: string;
   location: string;
 };
+
+export type CountryDataRowType = {
+  id: number;
+  ISO3: string;
+  nodes: number;
+  countryName: string;
+  percentage: string;
+};
+
+export function countryDataToGridRow(
+  countriesData: CountryData[],
+): CountryDataRowType[] {
+  const totalNodes = countriesData.reduce((acc, obj) => acc + obj.nodes, 0);
+  const formatted = countriesData.map((each: CountryData, index: number) => {
+    const updatedCountryRecord: CountryDataRowType = {
+      ...each,
+      id: index,
+      countryName: getName(each.ISO3, 'en', { select: 'official' }),
+      percentage: ((each.nodes * 100) / totalNodes).toFixed(1),
+    };
+    return updatedCountryRecord;
+  });
+
+  const sorted = formatted.sort((a, b) => (a.nodes < b.nodes ? 1 : -1));
+  return sorted;
+}
 
 export function mixnodeToGridRow(
   arrayOfMixnodes: MixNodeResponse,


### PR DESCRIPTION
- Mixnode map page
- DataGrid showing the % of nodes vs total nodes
- Search and Sort working

NOTE: MUI DataGrids sort natively as follows:

First Click: sorts higher > lower, A > Z.
Second Click: reverses that order, lower to higher, or Z > A.
Third Click: *returns the grid to its original order*. Feels slightly buggy. Datagrid 'returns' to having Russia at 24% (not the highest) but 'original' order was pre-sorted to highest %/nodes at the top, so it's more of a 'mix' of results. Will tighten up as a bug, separate card - unless strong feelings otherwise.

