### PR TITLE
Bug bond column

### DIFF
--- a/explorer/src/pages/Gateways/index.tsx
+++ b/explorer/src/pages/Gateways/index.tsx
@@ -69,6 +69,7 @@ export const PageGateways: React.FC = () => {
     {
       field: 'bond',
       width: 120,
+      type: 'number',
       renderHeader: () => <CustomColumnHeading headingTitle="Bond" />,
       headerClassName: 'MuiDataGrid-header-override',
       headerAlign: 'left',

--- a/explorer/src/pages/MixnodeDetail/index.tsx
+++ b/explorer/src/pages/MixnodeDetail/index.tsx
@@ -46,6 +46,7 @@ const columns: GridColDef[] = [
   {
     field: 'bond',
     headerName: 'Bond',
+    type: 'number',
     renderHeader: () => <CustomColumnHeading headingTitle="Bond" />,
     width: 120,
     headerAlign: 'left',

--- a/explorer/src/pages/Mixnodes/index.tsx
+++ b/explorer/src/pages/Mixnodes/index.tsx
@@ -83,6 +83,7 @@ export const PageMixnodes: React.FC = () => {
     {
       field: 'bond',
       headerName: 'Bond',
+      type: 'number',
       headerAlign: 'left',
       width: 120,
       headerClassName: 'MuiDataGrid-header-override',

--- a/explorer/src/utils/index.ts
+++ b/explorer/src/utils/index.ts
@@ -41,7 +41,9 @@ export function mixnodeToGridRow(
         owner: mn.owner,
         location: mn?.location?.country_name || '',
         identity_key: mn.mix_node.identity_key || '',
-        bond: mn.bond_amount.amount || 0,
+        bond:
+          Number(mn.bond_amount.amount) + Number(mn.total_delegation.amount) ||
+          0,
         host: mn.mix_node.host || '',
         layer: mn.layer || '',
       }));


### PR DESCRIPTION
BUG:

- bond column in mix nodes should show a value of "node.bond_amount + node.total_delegation" in PUNK
- sorting should be by the decimal value, not the string value

Fixed:
Adjusted so mapping `mixnodeToGridRow()` returns correct figure.
sorting: added `type: number` to cell config

NOTE:
The logic in `mixnodeToGridRow` is similar to `gatewayToGridRow()` - the latter does NOT total the two figures. It just returns the `bond_amount.amount`. Assume this is correct as Gateways `bond` col returns same figure on both Vue and React apps. 