### PR TITLE
Add Percent Self to Mixnodes Datagrid

### DIFF
--- a/explorer/src/pages/MixnodeDetail/index.tsx
+++ b/explorer/src/pages/MixnodeDetail/index.tsx
@@ -59,6 +59,20 @@ const columns: GridColDef[] = [
     },
   },
   {
+    field: 'self_percentage',
+    headerName: 'Self %',
+    headerAlign: 'left',
+    type: 'number',
+    width: 99,
+    headerClassName: 'MuiDataGrid-header-override',
+    renderHeader: () => <CustomColumnHeading headingTitle="Self %" />,
+    renderCell: (params: GridRenderCellParams) => (
+      <div>
+        <Typography sx={cellStyles}>{params.value}%</Typography>
+      </div>
+    ),
+  },
+  {
     field: 'host',
     renderHeader: () => <CustomColumnHeading headingTitle="IP:Port" />,
     width: 130,

--- a/explorer/src/pages/Mixnodes/index.tsx
+++ b/explorer/src/pages/Mixnodes/index.tsx
@@ -107,6 +107,7 @@ export const PageMixnodes: React.FC = () => {
       field: 'self_percentage',
       headerName: 'Self %',
       headerAlign: 'left',
+      type: 'number',
       width: 99,
       headerClassName: 'MuiDataGrid-header-override',
       renderHeader: () => <CustomColumnHeading headingTitle="Self %" />,

--- a/explorer/src/pages/Mixnodes/index.tsx
+++ b/explorer/src/pages/Mixnodes/index.tsx
@@ -104,6 +104,23 @@ export const PageMixnodes: React.FC = () => {
       },
     },
     {
+      field: 'self_percentage',
+      headerName: 'Self %',
+      headerAlign: 'left',
+      width: 99,
+      headerClassName: 'MuiDataGrid-header-override',
+      renderHeader: () => <CustomColumnHeading headingTitle="Self %" />,
+      renderCell: (params: GridRenderCellParams) => (
+        <MuiLink
+          sx={cellStyles}
+          component={RRDLink}
+          to={`/network-components/mixnodes/${params.row.identity_key}`}
+        >
+          {params.value}%
+        </MuiLink>
+      ),
+    },
+    {
       field: 'host',
       renderHeader: () => <CustomColumnHeading headingTitle="IP:Port" />,
       width: 130,

--- a/explorer/src/utils/index.ts
+++ b/explorer/src/utils/index.ts
@@ -36,15 +36,23 @@ export function mixnodeToGridRow(
 ): MixnodeRowType[] {
   return !arrayOfMixnodes
     ? []
-    : arrayOfMixnodes.map((mn) => ({
-        id: mn.owner,
-        owner: mn.owner,
-        location: mn?.location?.country_name || '',
-        identity_key: mn.mix_node.identity_key || '',
-        bond: mn.bond_amount.amount || 0,
-        host: mn.mix_node.host || '',
-        layer: mn.layer || '',
-      }));
+    : arrayOfMixnodes.map((mn) => {
+        const pledge = Number(mn.bond_amount.amount) || 0;
+        const delegations = Number(mn.total_delegation.amount) || 0;
+        const totalBond = pledge + delegations;
+        const selfPercentage = ((pledge * 100) / totalBond).toFixed(2);
+
+        return {
+          id: mn.owner,
+          owner: mn.owner,
+          location: mn?.location?.country_name || '',
+          identity_key: mn.mix_node.identity_key || '',
+          bond: totalBond || 0,
+          self_percentage: selfPercentage,
+          host: mn.mix_node.host || '',
+          layer: mn.layer || '',
+        };
+      });
 }
 
 export function gatewayToGridRow(


### PR DESCRIPTION
As per card on board:

"To show ratio of the pledge to the bond. Pledge*100/total Bond"

- Added new field to data grid
- Adjusted mixnodeToGridRow logic to incorporate the new logic/field.
- Changed field type to number so sorting works correctly for this new addition.