### PR TITLE
Scrollable delegators

### DIFF
--- a/explorer/src/components/BondBreakdown.tsx
+++ b/explorer/src/components/BondBreakdown.tsx
@@ -3,11 +3,9 @@ import { printableCoin } from '@nymproject/nym-validator-client';
 import {
   Alert,
   CircularProgress,
-  Typography,
   useMediaQuery,
   useTheme,
   Box,
-  Button,
 } from '@mui/material';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -18,10 +16,6 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { MainContext } from 'src/context/main';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
-import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
-// import { delegationsToGridRow } from 'src/utils';
-import { cellStyles, UniversalDataGrid } from './Universal-DataGrid';
-import { CustomColumnHeading } from './CustomColumnHeading';
 
 export const BondBreakdownTable: React.FC = () => {
   const { mixnodeDetailInfo, delegations, mode } =
@@ -92,7 +86,6 @@ export const BondBreakdownTable: React.FC = () => {
 
   const expandDelegations = () => {
     toggleShowDelegations(!showDelegations);
-    console.log('show or hide: ', showDelegations);
   };
   const calcBondPercentage = (num: number) => {
     if (mixnodeDetailInfo?.data !== undefined && mixnodeDetailInfo?.data[0]) {
@@ -108,48 +101,6 @@ export const BondBreakdownTable: React.FC = () => {
     return 0;
   };
 
-  const columns: GridColDef[] = [
-    {
-      field: 'delegators',
-      renderHeader: () => <CustomColumnHeading headingTitle="Delegators" />,
-      // width: 300,
-      flex: 1,
-      headerAlign: 'left',
-      headerClassName: 'MuiDataGrid-header-override',
-      renderCell: (params: GridRenderCellParams) => (
-        <Typography
-          sx={{
-            ...cellStyles,
-            wordBreak: 'normal',
-          }}
-        >
-          {params.value}
-        </Typography>
-      ),
-    },
-    {
-      field: 'stake',
-      renderHeader: () => <CustomColumnHeading headingTitle="Stake" />,
-      flex: 1,
-      headerAlign: 'left',
-      headerClassName: 'MuiDataGrid-header-override',
-      renderCell: (params: GridRenderCellParams) => (
-        <Typography sx={cellStyles}>{params.value}</Typography>
-      ),
-    },
-    {
-      field: 'share_from_bond',
-      renderHeader: () => (
-        <CustomColumnHeading headingTitle="Share from bond" />
-      ),
-      flex: 1,
-      headerAlign: 'left',
-      headerClassName: 'MuiDataGrid-header-override',
-      renderCell: (params: GridRenderCellParams) => (
-        <Typography sx={cellStyles}>{params.value}</Typography>
-      ),
-    },
-  ];
   if (mixnodeDetailInfo?.isLoading) {
     return <CircularProgress />;
   }
@@ -225,7 +176,7 @@ export const BondBreakdownTable: React.FC = () => {
                 overflowY: 'scroll',
               }}
             >
-              <Table>
+              <Table stickyHeader>
                 <TableHead>
                   <TableRow>
                     <TableCell
@@ -276,16 +227,6 @@ export const BondBreakdownTable: React.FC = () => {
               </Table>
             </Box>
           )}
-
-          {/* {delegations?.data && (
-            <UniversalDataGrid
-              columnsData={columns}
-              rows={delegationsToGridRow(delegations.data)}
-              pageSize="5"
-              pagination
-              hideFooter={false}
-            />
-          )} */}
         </TableContainer>
       </>
     );

--- a/explorer/src/components/BondBreakdown.tsx
+++ b/explorer/src/components/BondBreakdown.tsx
@@ -85,7 +85,9 @@ export const BondBreakdownTable: React.FC = () => {
   }, [mixnodeDetailInfo, delegations]);
 
   const expandDelegations = () => {
-    toggleShowDelegations(!showDelegations);
+    if (delegations?.data && delegations.data.length > 0) {
+      toggleShowDelegations(!showDelegations);
+    }
   };
   const calcBondPercentage = (num: number) => {
     if (mixnodeDetailInfo?.data !== undefined && mixnodeDetailInfo?.data[0]) {
@@ -156,13 +158,20 @@ export const BondBreakdownTable: React.FC = () => {
                   onClick={expandDelegations}
                   sx={{
                     width: matches ? '150px' : 'auto',
-                    display: 'flex',
-                    alignItems: 'center',
                   }}
                   align="left"
                 >
-                  Delegation total {'\u00A0'}
-                  {showDelegations ? <ExpandLess /> : <ExpandMore />}
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                    }}
+                  >
+                    Delegation total {'\u00A0'}
+                    {delegations?.data && delegations?.data?.length > 0 && (
+                      <ExpandMore />
+                    )}
+                  </Box>
                 </TableCell>
                 <TableCell align="left">{bonds.delegations}</TableCell>
               </TableRow>

--- a/explorer/src/components/BondBreakdown.tsx
+++ b/explorer/src/components/BondBreakdown.tsx
@@ -3,8 +3,10 @@ import { printableCoin } from '@nymproject/nym-validator-client';
 import {
   Alert,
   CircularProgress,
+  Typography,
   useMediaQuery,
   useTheme,
+  Box,
 } from '@mui/material';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -14,6 +16,10 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { MainContext } from 'src/context/main';
+import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
+import { delegationsToGridRow } from 'src/utils';
+import { cellStyles, UniversalDataGrid } from './Universal-DataGrid';
+import { CustomColumnHeading } from './CustomColumnHeading';
 
 export const BondBreakdownTable: React.FC = () => {
   const { mixnodeDetailInfo, delegations, mode } =
@@ -94,6 +100,48 @@ export const BondBreakdownTable: React.FC = () => {
     return 0;
   };
 
+  const columns: GridColDef[] = [
+    {
+      field: 'delegators',
+      renderHeader: () => <CustomColumnHeading headingTitle="Delegators" />,
+      // width: 300,
+      flex: 1,
+      headerAlign: 'left',
+      headerClassName: 'MuiDataGrid-header-override',
+      renderCell: (params: GridRenderCellParams) => (
+        <Typography
+          sx={{
+            ...cellStyles,
+            wordBreak: 'normal',
+          }}
+        >
+          {params.value}
+        </Typography>
+      ),
+    },
+    {
+      field: 'stake',
+      renderHeader: () => <CustomColumnHeading headingTitle="Stake" />,
+      flex: 1,
+      headerAlign: 'left',
+      headerClassName: 'MuiDataGrid-header-override',
+      renderCell: (params: GridRenderCellParams) => (
+        <Typography sx={cellStyles}>{params.value}</Typography>
+      ),
+    },
+    {
+      field: 'share_from_bond',
+      renderHeader: () => (
+        <CustomColumnHeading headingTitle="Share from bond" />
+      ),
+      flex: 1,
+      headerAlign: 'left',
+      headerClassName: 'MuiDataGrid-header-override',
+      renderCell: (params: GridRenderCellParams) => (
+        <Typography sx={cellStyles}>{params.value}</Typography>
+      ),
+    },
+  ];
   if (mixnodeDetailInfo?.isLoading) {
     return <CircularProgress />;
   }
@@ -158,42 +206,73 @@ export const BondBreakdownTable: React.FC = () => {
             </TableBody>
           </Table>
 
+          {/* {delegations?.data && (
+            <UniversalDataGrid
+              columnsData={columns}
+              rows={delegationsToGridRow(delegations.data)}
+              pageSize="5"
+              pagination
+              hideFooter={false}
+            />
+          )} */}
+
           {delegations?.data !== undefined && delegations?.data[0] && (
-            <Table sx={{ minWidth: 650 }} aria-label="delegation totals">
-              <TableHead>
-                <TableRow>
-                  <TableCell sx={{ fontWeight: 'bold' }} align="left">
-                    Delegators
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 'bold' }} align="left">
-                    Stake
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 'bold' }} align="left">
-                    % of Bond
-                  </TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {delegations.data.map(
-                  ({ owner, amount: { amount, denom } }) => (
-                    <TableRow key={owner}>
-                      <TableCell
-                        sx={matches ? { width: 190 } : null}
-                        align="left"
-                      >
-                        {owner}
-                      </TableCell>
-                      <TableCell align="left">
-                        {printableCoin({ amount: amount.toString(), denom })}
-                      </TableCell>
-                      <TableCell align="left">
-                        {calcBondPercentage(amount)}%
-                      </TableCell>
-                    </TableRow>
-                  ),
-                )}
-              </TableBody>
-            </Table>
+            <Box
+              sx={{
+                maxHeight: 400,
+                overflowY: 'scroll',
+              }}
+            >
+              <Table
+                sx={{ minWidth: 650 }}
+                stickyHeader
+                aria-label="delegation totals"
+              >
+                <TableHead>
+                  <TableRow>
+                    <TableCell
+                      sx={{ fontWeight: 'bold', background: '#242C3D' }}
+                      align="left"
+                    >
+                      Delegators
+                    </TableCell>
+                    <TableCell
+                      sx={{ fontWeight: 'bold', background: '#242C3D' }}
+                      align="left"
+                    >
+                      Stake
+                    </TableCell>
+                    <TableCell
+                      sx={{ fontWeight: 'bold', background: '#242C3D' }}
+                      align="left"
+                    >
+                      % of Bond
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+
+                <TableBody>
+                  {delegations.data.map(
+                    ({ owner, amount: { amount, denom } }) => (
+                      <TableRow key={owner}>
+                        <TableCell
+                          sx={matches ? { width: 190 } : null}
+                          align="left"
+                        >
+                          {owner}
+                        </TableCell>
+                        <TableCell align="left">
+                          {printableCoin({ amount: amount.toString(), denom })}
+                        </TableCell>
+                        <TableCell align="left">
+                          {calcBondPercentage(amount)}%
+                        </TableCell>
+                      </TableRow>
+                    ),
+                  )}
+                </TableBody>
+              </Table>
+            </Box>
           )}
         </TableContainer>
       </>

--- a/explorer/src/components/BondBreakdown.tsx
+++ b/explorer/src/components/BondBreakdown.tsx
@@ -7,6 +7,7 @@ import {
   useMediaQuery,
   useTheme,
   Box,
+  Button,
 } from '@mui/material';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -16,8 +17,9 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { MainContext } from 'src/context/main';
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
-import { delegationsToGridRow } from 'src/utils';
+// import { delegationsToGridRow } from 'src/utils';
 import { cellStyles, UniversalDataGrid } from './Universal-DataGrid';
 import { CustomColumnHeading } from './CustomColumnHeading';
 
@@ -27,6 +29,8 @@ export const BondBreakdownTable: React.FC = () => {
   const [allContentLoaded, setAllContentLoaded] =
     React.useState<boolean>(false);
   const [showError, setShowError] = React.useState<boolean>(false);
+  const [showDelegations, toggleShowDelegations] =
+    React.useState<boolean>(false);
 
   const [bonds, setBonds] = React.useState({
     delegations: '0',
@@ -86,6 +90,10 @@ export const BondBreakdownTable: React.FC = () => {
     setAllContentLoaded(hasAllData);
   }, [mixnodeDetailInfo, delegations]);
 
+  const expandDelegations = () => {
+    toggleShowDelegations(!showDelegations);
+    console.log('show or hide: ', showDelegations);
+  };
   const calcBondPercentage = (num: number) => {
     if (mixnodeDetailInfo?.data !== undefined && mixnodeDetailInfo?.data[0]) {
       const rawDeligationAmount = Number(
@@ -173,7 +181,7 @@ export const BondBreakdownTable: React.FC = () => {
                 <TableCell
                   sx={{
                     fontWeight: 'bold',
-                    width: matches ? '90px' : 'auto',
+                    width: matches ? '150px' : 'auto',
                   }}
                   align="left"
                 >
@@ -184,7 +192,7 @@ export const BondBreakdownTable: React.FC = () => {
               <TableRow>
                 <TableCell
                   sx={{
-                    width: matches ? '90px' : 'auto',
+                    width: matches ? '150px' : 'auto',
                   }}
                   align="left"
                 >
@@ -194,40 +202,30 @@ export const BondBreakdownTable: React.FC = () => {
               </TableRow>
               <TableRow>
                 <TableCell
+                  onClick={expandDelegations}
                   sx={{
-                    width: matches ? '90px' : 'auto',
+                    width: matches ? '150px' : 'auto',
+                    display: 'flex',
+                    alignItems: 'center',
                   }}
                   align="left"
                 >
-                  Delegation total
+                  Delegation total {'\u00A0'}
+                  {showDelegations ? <ExpandLess /> : <ExpandMore />}
                 </TableCell>
                 <TableCell align="left">{bonds.delegations}</TableCell>
               </TableRow>
             </TableBody>
           </Table>
 
-          {/* {delegations?.data && (
-            <UniversalDataGrid
-              columnsData={columns}
-              rows={delegationsToGridRow(delegations.data)}
-              pageSize="5"
-              pagination
-              hideFooter={false}
-            />
-          )} */}
-
-          {delegations?.data !== undefined && delegations?.data[0] && (
+          {showDelegations && (
             <Box
               sx={{
                 maxHeight: 400,
                 overflowY: 'scroll',
               }}
             >
-              <Table
-                sx={{ minWidth: 650 }}
-                stickyHeader
-                aria-label="delegation totals"
-              >
+              <Table>
                 <TableHead>
                   <TableRow>
                     <TableCell
@@ -243,16 +241,20 @@ export const BondBreakdownTable: React.FC = () => {
                       Stake
                     </TableCell>
                     <TableCell
-                      sx={{ fontWeight: 'bold', background: '#242C3D' }}
+                      sx={{
+                        fontWeight: 'bold',
+                        background: '#242C3D',
+                        width: '200px',
+                      }}
                       align="left"
                     >
-                      % of Bond
+                      Share from bond
                     </TableCell>
                   </TableRow>
                 </TableHead>
 
                 <TableBody>
-                  {delegations.data.map(
+                  {delegations?.data?.map(
                     ({ owner, amount: { amount, denom } }) => (
                       <TableRow key={owner}>
                         <TableCell
@@ -274,6 +276,16 @@ export const BondBreakdownTable: React.FC = () => {
               </Table>
             </Box>
           )}
+
+          {/* {delegations?.data && (
+            <UniversalDataGrid
+              columnsData={columns}
+              rows={delegationsToGridRow(delegations.data)}
+              pageSize="5"
+              pagination
+              hideFooter={false}
+            />
+          )} */}
         </TableContainer>
       </>
     );


### PR DESCRIPTION
This PR seeks to implement a _scrollable_ area for multiple delegators in the Mixnode Detail view.
From [Issue 69](https://github.com/nymtech/nym/issues/2625)

✅ Tested on given node ID.
✅  "_or make the table scrollable (but keep the headers visible, so only scroll the table content rows - use MUI's equivalent of tbody { overflow: auto; } )_"

Put simply: List of delegators would prev render to length of array. But now `Delegation Total` section of the `<BondBreakdown />` card:-

- offers expand more/less button (if delegates exist)
- toggles new `table` showing 'Delegators', 'Stake' and 'Share from bond', specific to the mixnode - as per Figma
- Card now surfaces scrollable rows, so the overall `MixnodeDetail` view, proportions etc remain consistent for every node.
- StickyHeader keeps cell headers present on scroll.


