### PR TITLE
pagination and spacing of gateways cols

### DIFF
--- a/explorer/src/components/BondBreakdown.tsx
+++ b/explorer/src/components/BondBreakdown.tsx
@@ -15,7 +15,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { MainContext } from 'src/context/main';
-import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import { ExpandMore } from '@mui/icons-material';
 
 export const BondBreakdownTable: React.FC = () => {
   const { mixnodeDetailInfo, delegations, mode } =

--- a/explorer/src/components/Universal-DataGrid.tsx
+++ b/explorer/src/components/Universal-DataGrid.tsx
@@ -1,5 +1,18 @@
 import * as React from 'react';
-import { DataGrid, GridColumns, GridRowData } from '@mui/x-data-grid';
+import { makeStyles } from '@mui/styles';
+import {
+  DataGrid,
+  GridColumns,
+  GridRowData,
+  useGridSlotComponentProps,
+} from '@mui/x-data-grid';
+import Pagination from '@mui/material/Pagination';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+  },
+});
 
 type DataGridProps = {
   loading?: boolean;
@@ -25,6 +38,21 @@ export const cellStyles = {
   'white-space': 'break-spaces',
 };
 
+function CustomPagination() {
+  const { state, apiRef } = useGridSlotComponentProps();
+  const classes = useStyles();
+
+  return (
+    <Pagination
+      className={classes.root}
+      color="primary"
+      count={state.pagination.pageCount}
+      page={state.pagination.page + 1}
+      onChange={(event, value) => apiRef.current.setPage(value - 1)}
+    />
+  );
+}
+
 export const UniversalDataGrid: React.FC<DataGridProps> = ({
   loading,
   rows,
@@ -36,6 +64,10 @@ export const UniversalDataGrid: React.FC<DataGridProps> = ({
   if (columnsData && rows) {
     return (
       <DataGrid
+        pagination
+        components={{
+          Pagination: CustomPagination,
+        }}
         loading={loading}
         columns={columnsData}
         rows={rows}
@@ -50,6 +82,7 @@ export const UniversalDataGrid: React.FC<DataGridProps> = ({
         hideFooter={hideFooter}
         style={{
           width: '100%',
+          border: 'none',
         }}
       />
     );

--- a/explorer/src/index.tsx
+++ b/explorer/src/index.tsx
@@ -77,6 +77,20 @@ const AppWrapper = () => {
       },
     },
     components: {
+      MuiPaginationItem: {
+        styleOverrides: {
+          root: {
+            '&.Mui-selected': {
+              border: '4px solid orange',
+              background: palette.brandOrange,
+              color: palette.white,
+            },
+            background: palette.blackBg,
+            color: palette.white,
+            fontWeight: 700,
+          },
+        },
+      },
       MuiCardHeader: {
         styleOverrides: {
           title: {

--- a/explorer/src/pages/Gateways/index.tsx
+++ b/explorer/src/pages/Gateways/index.tsx
@@ -85,7 +85,7 @@ export const PageGateways: React.FC = () => {
     {
       field: 'host',
       renderHeader: () => <CustomColumnHeading headingTitle="IP:Port" />,
-      flex: 1,
+      width: 150,
       headerAlign: 'left',
       headerClassName: 'MuiDataGrid-header-override',
       renderCell: (params: GridRenderCellParams) => (
@@ -118,7 +118,7 @@ export const PageGateways: React.FC = () => {
       <>
         <Title text="Gateways" />
         <Grid container>
-          <Grid item xs={12} md={12} lg={10} xl={10}>
+          <Grid item xs={12} md={12} lg={8} xl={8}>
             <ContentCard>
               <TableToolbar
                 onChangeSearch={handleSearch}
@@ -131,7 +131,8 @@ export const PageGateways: React.FC = () => {
                 columnsData={columns}
                 rows={gatewayToGridRow(filteredGateways)}
                 pageSize={pageSize}
-                pagination={gateways?.data?.length > 12}
+                pagination={gateways?.data?.length >= 12}
+                hideFooter={gateways?.data?.length < 12}
               />
             </ContentCard>
           </Grid>

--- a/explorer/src/pages/Mixnodes/index.tsx
+++ b/explorer/src/pages/Mixnodes/index.tsx
@@ -195,6 +195,7 @@ export const PageMixnodes: React.FC = () => {
               rows={mixnodeToGridRow(filteredMixnodes)}
               pageSize={pageSize}
               pagination
+              hideFooter={false}
             />
           </ContentCard>
         </Grid>


### PR DESCRIPTION
This PR seeks to add pagination 'circles' at the bottom of the `<UniversalDatagrid />`, allowing users to flick between page 1 or 5 or 9 etc of the results rows.

Changes:
- pagination (bool) and `<CustomPagination />` component as per MUI docs
- adjusted spacing of columns for Gateway datagrid, as fewer of them than Mixnodes. Instead defined width of column and adjusted media query of container so more responsive.
- removed border from DataGrid as per designs.

NOTES:
Colour of pagination 'circle' should correspond to brand orange defined in palette, but that doesn't fit within MUI colors (primary, secondary etc).
Can either wait until @mmsinclair theme PR is in and iterate or overwrite in styles.css. 