### PR TITLE
Hamburger Menu & Fixed AppBar

### DIFF
--- a/explorer/src/api/constants.ts
+++ b/explorer/src/api/constants.ts
@@ -21,3 +21,4 @@ export const MIXNODE_API_ERROR =
 export const TELEGRAM_LINK = 'https://t.me/nymchan';
 export const TWITTER_LINK = 'https://twitter.com/nymproject';
 export const GITHUB_LINK = 'https://github.com/nymtech';
+export const NYM_WEBSITE = 'https://nymtech.net';

--- a/explorer/src/components/BondBreakdown.tsx
+++ b/explorer/src/components/BondBreakdown.tsx
@@ -15,7 +15,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import { MainContext } from 'src/context/main';
-import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import { ExpandMore } from '@mui/icons-material';
 
 export const BondBreakdownTable: React.FC = () => {
   const { mixnodeDetailInfo, delegations, mode } =

--- a/explorer/src/components/Nav.tsx
+++ b/explorer/src/components/Nav.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable no-nested-ternary */
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { ChevronLeft, ExpandLess, ExpandMore } from '@mui/icons-material';
+import { ChevronLeft, ExpandLess, ExpandMore, Menu } from '@mui/icons-material';
 import { styled, CSSObject, Theme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import ListItem from '@mui/material/ListItem';
 import MuiDrawer from '@mui/material/Drawer';
-import MuiAppBar, { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar';
+import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import List from '@mui/material/List';
 import Typography from '@mui/material/Typography';
@@ -15,7 +15,7 @@ import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { NymLogoSVG } from 'src/icons/NymLogoSVG';
-import { BIG_DIPPER } from 'src/api/constants';
+import { BIG_DIPPER, NYM_WEBSITE } from 'src/api/constants';
 import { useMediaQuery, useTheme } from '@mui/material';
 import { OverviewSVG } from '../icons/OverviewSVG';
 import { NetworkComponentsSVG } from '../icons/NetworksSVG';
@@ -42,10 +42,7 @@ const closedMixin = (theme: Theme): CSSObject => ({
     duration: theme.transitions.duration.leavingScreen,
   }),
   overflowX: 'hidden',
-  width: `calc(${theme.spacing(9)} + 1px)`,
-  [theme.breakpoints.up('sm')]: {
-    width: `calc(${theme.spacing(7)} + 1px)`,
-  },
+  width: `calc(${theme.spacing(7)} + 1px)`,
 });
 
 const DrawerHeader = styled('div')(({ theme }) => ({
@@ -55,27 +52,6 @@ const DrawerHeader = styled('div')(({ theme }) => ({
   padding: theme.spacing(0, 1),
   // necessary for content to be below app bar
   ...theme.mixins.toolbar,
-}));
-interface AppBarProps extends MuiAppBarProps {
-  open?: boolean;
-}
-
-const AppBar = styled(MuiAppBar, {
-  shouldForwardProp: (prop) => prop !== 'open',
-})<AppBarProps>(({ theme, open }) => ({
-  zIndex: theme.zIndex.drawer + 1,
-  transition: theme.transitions.create(['width', 'margin'], {
-    easing: theme.transitions.easing.sharp,
-    duration: theme.transitions.duration.leavingScreen,
-  }),
-  ...(open && {
-    marginLeft: drawerWidth,
-    width: `calc(100% - ${drawerWidth}px)`,
-    transition: theme.transitions.create(['width', 'margin'], {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  }),
 }));
 
 const Drawer = styled(MuiDrawer, {
@@ -179,20 +155,14 @@ const ExpandableButton: React.FC<ExpandableButtonType> = ({
 
   const handleClick = () => {
     openDrawer();
-    // 1. if it's NetworkComponents parent...
     if (title === 'Network Components') {
       if (nested) {
-        // 2. if it contains nested routes
-        // open them up
         toggleNestedOptions(!nestedOptions);
       }
     }
-    // 3. if its NOT NetworkComponents and the drawer was open
-    // close it, and implicitly this closes nest via useEffect below
     if (drawIsOpen && title !== 'Network Components') {
       closeDrawer();
     }
-    // 4. update isActive in parent
     setToActive(id);
   };
 
@@ -326,8 +296,6 @@ export const Nav: React.FC = ({ children }) => {
     <>
       <Box sx={{ display: 'flex' }}>
         <AppBar
-          position="fixed"
-          open={open}
           sx={{
             background: theme.palette.primary.dark,
           }}
@@ -335,35 +303,26 @@ export const Nav: React.FC = ({ children }) => {
           <Toolbar
             disableGutters
             sx={{
-              paddingLeft: 2,
               display: 'flex',
               justifyContent: 'space-between',
             }}
           >
-            <Box display="flex" alignItems="center">
-              <IconButton
-                color="inherit"
-                aria-label="open drawer"
-                onClick={handleDrawerOpen}
-                edge="start"
-                sx={{
-                  ...(open && {
-                    display: 'none',
-                    margin: 0,
-                    padding: 2,
-                  }),
-                }}
-              >
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                width: 205,
+              }}
+            >
+              <IconButton component="a" href={NYM_WEBSITE} target="_blank">
                 <NymLogoSVG />
               </IconButton>
               <Typography
                 variant="h6"
                 noWrap
-                component="div"
-                sx={{
-                  marginLeft: 3,
-                  color: theme.palette.primary.main,
-                }}
+                sx={{ color: theme.palette.primary.main, fontSize: '18px' }}
               >
                 Network Explorer
               </Typography>
@@ -395,6 +354,7 @@ export const Nav: React.FC = ({ children }) => {
             </Box>
           </Toolbar>
         </AppBar>
+
         <Drawer
           variant="permanent"
           open={open}
@@ -402,9 +362,22 @@ export const Nav: React.FC = ({ children }) => {
             background: palette.blackBg,
           }}
         >
-          <DrawerHeader sx={{ background: theme.palette.primary.dark }}>
-            <IconButton onClick={handleDrawerClose}>
-              <ChevronLeft color="primary" />
+          <DrawerHeader
+            sx={{
+              background: theme.palette.primary.dark,
+              justifyContent: open ? 'flex-end' : 'center',
+              paddingLeft: 0,
+            }}
+          >
+            <IconButton
+              onClick={open ? handleDrawerClose : handleDrawerOpen}
+              sx={{ padding: 0, ml: '3px' }}
+            >
+              {open ? (
+                <ChevronLeft color="primary" />
+              ) : (
+                <Menu color="primary" />
+              )}
             </IconButton>
           </DrawerHeader>
 

--- a/explorer/src/components/Nav.tsx
+++ b/explorer/src/components/Nav.tsx
@@ -155,10 +155,8 @@ const ExpandableButton: React.FC<ExpandableButtonType> = ({
 
   const handleClick = () => {
     openDrawer();
-    if (title === 'Network Components') {
-      if (nested) {
-        toggleNestedOptions(!nestedOptions);
-      }
+    if (title === 'Network Components' && nested) {
+      toggleNestedOptions(!nestedOptions);
     }
     if (drawIsOpen && title !== 'Network Components') {
       closeDrawer();

--- a/explorer/src/index.tsx
+++ b/explorer/src/index.tsx
@@ -89,6 +89,7 @@ const AppWrapper = () => {
         styleOverrides: {
           paper: {
             background: palette.secondary.dark,
+            marginTop: 64,
           },
         },
       },


### PR DESCRIPTION
This PR seeks to implement a *fixed Appbar at the top of the screen*, adding an external link to the NYM logo (taking the user to the main NymTech.net website & adds a 'hamburger' menu to the sidebar, to match Figma designs.

Logic is essentially that i've moved the sidebar down by the same height as the AppBar, and added the Hamburger to it.

`<Appbar />` is a much leaner (but still native MUI) version. Previously popping the drawer pushed the NYM logo / "Network Explorer" to the side. Now that AppBar sits outside of that logic and no longer requires transition etc, hence killing that code.
