### PR TITLE
Reverted gateway registration handshake to its 0.11.0 version

### DIFF
--- a/gateway/gateway-requests/src/registration/handshake/gateway.rs
+++ b/gateway/gateway-requests/src/registration/handshake/gateway.rs
@@ -49,14 +49,11 @@ impl<'a> GatewayHandshake<'a> {
                 }
 
                 // init: <- pub_key || g^x
-                let init_message = check_processing_error(
+                let (remote_identity, remote_ephemeral_key) = check_processing_error(
                     State::<S>::parse_init_message(received_init_payload),
                     &mut state,
                 )
                 .await?;
-
-                let remote_identity = init_message.local_id_pubkey();
-                let remote_ephemeral_key = init_message.ephemeral_key();
                 state.update_remote_identity(remote_identity);
 
                 // hkdf::<blake3>::(g^xy)

--- a/gateway/gateway-requests/src/registration/handshake/state.rs
+++ b/gateway/gateway-requests/src/registration/handshake/state.rs
@@ -15,46 +15,9 @@ use futures::{Sink, SinkExt, Stream, StreamExt};
 use log::*;
 use nymsphinx::params::{GatewayEncryptionAlgorithm, GatewaySharedKeyHkdfAlgorithm};
 use rand::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use tungstenite::Message as WsMessage;
 
-#[derive(Serialize, Deserialize)]
-pub struct InitMessage {
-    local_id_pubkey: [u8; identity::PUBLIC_KEY_LENGTH],
-    ephemeral_key: [u8; identity::PUBLIC_KEY_LENGTH],
-}
-
-impl InitMessage {
-    fn new(local_id_pubkey: &identity::PublicKey, ephemeral_key: &encryption::PublicKey) -> Self {
-        InitMessage {
-            local_id_pubkey: local_id_pubkey.to_bytes(),
-            ephemeral_key: ephemeral_key.to_bytes(),
-        }
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn local_id_pubkey(&self) -> identity::PublicKey {
-        identity::PublicKey::from_bytes(&self.local_id_pubkey).unwrap()
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn ephemeral_key(&self) -> encryption::PublicKey {
-        encryption::PublicKey::from_bytes(&self.ephemeral_key).unwrap()
-    }
-
-    fn to_bytes(&self) -> Vec<u8> {
-        bincode::serialize(self).unwrap()
-    }
-}
-
-impl TryFrom<&[u8]> for InitMessage {
-    type Error = HandshakeError;
-
-    fn try_from(value: &[u8]) -> Result<InitMessage, Self::Error> {
-        bincode::deserialize(value).map_err(|e| e.into())
-    }
-}
 /// Handshake state.
 pub(crate) struct State<'a, S> {
     /// The underlying WebSocket stream.
@@ -101,17 +64,41 @@ impl<'a, S> State<'a, S> {
     // Eventually the ID_PUBKEY prefix will get removed and recipient will know
     // initializer's identity from another source.
     pub(crate) fn init_message(&self) -> Vec<u8> {
-        InitMessage::new(
-            self.identity.public_key(),
-            self.ephemeral_keypair.public_key(),
-        )
-        .to_bytes()
+        self.identity
+            .public_key()
+            .to_bytes()
+            .iter()
+            .cloned()
+            .chain(
+                self.ephemeral_keypair
+                    .public_key()
+                    .to_bytes()
+                    .iter()
+                    .cloned(),
+            )
+            .collect()
     }
 
     // this will need to be adjusted when REMOTE_ID_PUBKEY is removed
     #[cfg(not(target_arch = "wasm32"))]
-    pub(crate) fn parse_init_message(init_message: Vec<u8>) -> Result<InitMessage, HandshakeError> {
-        InitMessage::try_from(init_message.as_slice()).map_err(|_| HandshakeError::MalformedRequest)
+    pub(crate) fn parse_init_message(
+        mut init_message: Vec<u8>,
+    ) -> Result<(identity::PublicKey, encryption::PublicKey), HandshakeError> {
+        if init_message.len() != identity::PUBLIC_KEY_LENGTH + encryption::PUBLIC_KEY_SIZE {
+            return Err(HandshakeError::MalformedRequest);
+        }
+
+        let remote_ephemeral_key_bytes = init_message.split_off(identity::PUBLIC_KEY_LENGTH);
+        // this can only fail if the provided bytes have len different from encryption::PUBLIC_KEY_SIZE
+        // which is impossible
+        let remote_ephemeral_key =
+            encryption::PublicKey::from_bytes(&remote_ephemeral_key_bytes).unwrap();
+
+        // this could actually fail if the curve point fails to get decompressed
+        let remote_identity = identity::PublicKey::from_bytes(&init_message)
+            .map_err(|_| HandshakeError::MalformedRequest)?;
+
+        Ok((remote_identity, remote_ephemeral_key))
     }
 
     pub(crate) fn derive_shared_key(&mut self, remote_ephemeral_key: &encryption::PublicKey) {


### PR DESCRIPTION
This PR restores gateway handshake to its 0.11.0 variant. This makes it significantly easier to test things against already deployed testnet gateways without having to go through some weird hacks. Ping @durch 