### PR TITLE
GitHub Actions: only run job to generate types when not in a PR

### DIFF
--- a/.github/workflows/tauri-wallet-types.yml
+++ b/.github/workflows/tauri-wallet-types.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   tauri-wallet-types:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
       - name: Prepare
         run: sudo apt-get update && sudo apt-get install -y libpango1.0-dev libatk1.0-dev libgdk-pixbuf2.0-dev libsoup2.4-dev librust-gdk-dev libwebkit2gtk-4.0-dev


### PR DESCRIPTION
This PR attempts to fix the case where another commit is created when a PR is opened and this messes up the checks for that PR and it becomes stuck. 

My working theory for why it happens is as follows: the status of the PR never gets updated by the original job, because another commit is created immediately by the typegen and it skips CI, so never updates the status.