### PR TITLE
Network explorer side bar behaviour - work in progress.

### DIFF
--- a/explorer/src/components/Nav.tsx
+++ b/explorer/src/components/Nav.tsx
@@ -133,6 +133,8 @@ type ExpandableButtonType = {
   closeDrawer: () => void;
   drawIsTempOpen: boolean;
   drawIsFixed: boolean;
+  fixDrawerClose: () => void;
+  isMobile: boolean;
   setToActive: (num: number) => void;
 };
 
@@ -145,9 +147,11 @@ const ExpandableButton: React.FC<ExpandableButtonType> = ({
   closeDrawer,
   drawIsTempOpen,
   drawIsFixed,
+  fixDrawerClose,
   Icon,
   title,
   nested,
+  isMobile,
   isChild,
 }) => {
   const [dynamicStyle, setDynamicStyle] = React.useState({});
@@ -162,6 +166,9 @@ const ExpandableButton: React.FC<ExpandableButtonType> = ({
     }
     if (!nested && !drawIsFixed) {
       closeDrawer();
+    }
+    if (!nested && isMobile) {
+      fixDrawerClose();
     }
   };
 
@@ -245,6 +252,8 @@ const ExpandableButton: React.FC<ExpandableButtonType> = ({
             closeDrawer={closeDrawer}
             setToActive={setToActive}
             drawIsFixed={drawIsFixed}
+            fixDrawerClose={fixDrawerClose}
+            isMobile={isMobile}
             isChild
           />
         ))}
@@ -330,6 +339,7 @@ export const Nav: React.FC = ({ children }) => {
                 sx={{
                   color: theme.palette.nym.networkExplorer.nav.text,
                   fontSize: '18px',
+                  fontWeight: 800,
                 }}
               >
                 <MuiLink
@@ -405,8 +415,10 @@ export const Nav: React.FC = ({ children }) => {
                 closeDrawer={tempDrawerClose}
                 drawIsTempOpen={drawerIsOpen}
                 drawIsFixed={fixedOpen}
+                fixDrawerClose={fixDrawerClose}
                 openDrawer={tempDrawerOpen}
                 setToActive={setToActive}
+                isMobile={isMobile}
                 {...props}
               />
             ))}

--- a/explorer/src/components/Nav.tsx
+++ b/explorer/src/components/Nav.tsx
@@ -159,6 +159,9 @@ const ExpandableButton: React.FC<ExpandableButtonType> = ({
       toggleNestedOptions(!nestedOptions);
     }
     setToActive(id);
+    if (!nested) {
+      closeDrawer();
+    }
   };
 
   React.useEffect(() => {

--- a/explorer/src/components/Nav.tsx
+++ b/explorer/src/components/Nav.tsx
@@ -352,6 +352,8 @@ export const Nav: React.FC = ({ children }) => {
         <Drawer
           variant="permanent"
           open={open}
+          onMouseEnter={handleDrawerOpen}
+          onMouseLeave={handleDrawerClose}
           sx={{
             background: theme.palette.nym.networkExplorer.nav.background,
           }}

--- a/explorer/src/components/Nav.tsx
+++ b/explorer/src/components/Nav.tsx
@@ -160,7 +160,7 @@ const ExpandableButton: React.FC<ExpandableButtonType> = ({
     if (title === 'Network Components' && nested) {
       toggleNestedOptions(!nestedOptions);
     }
-    if ((!nested || isChild) && !drawIsFixed) {
+    if (!nested && !drawIsFixed) {
       closeDrawer();
     }
   };
@@ -262,8 +262,8 @@ ExpandableButton.defaultProps = {
 export const Nav: React.FC = ({ children }) => {
   const [navOptionsState, updateNavOptionsState] =
     React.useState(originalNavOptions);
-  const [tempOpen, setTempOpen] = React.useState(false);
-  const [drawIsFixed, setDrawIsFixed] = React.useState(false);
+  const [drawerIsOpen, setDrawerToOpen] = React.useState(false);
+  const [fixedOpen, setFixedOpen] = React.useState(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -275,25 +275,25 @@ export const Nav: React.FC = ({ children }) => {
     updateNavOptionsState(updated);
   };
 
-  const handleDrawerOpen = () => {
-    setDrawIsFixed(true);
-    setTempOpen(true);
+  const fixDrawerOpen = () => {
+    setFixedOpen(true);
+    setDrawerToOpen(true);
   };
 
-  const handleDrawerClose = () => {
-    setDrawIsFixed(false);
-    setTempOpen(false);
+  const fixDrawerClose = () => {
+    setFixedOpen(false);
+    setDrawerToOpen(false);
   };
 
-  const handleMouseEnterOpen = () => {
-    if (!drawIsFixed) {
-      setTempOpen(true);
+  const tempDrawerOpen = () => {
+    if (!fixedOpen) {
+      setDrawerToOpen(true);
     }
   };
 
-  const handleMouseLeaveClose = () => {
-    if (!drawIsFixed) {
-      setTempOpen(false);
+  const tempDrawerClose = () => {
+    if (!fixedOpen) {
+      setDrawerToOpen(false);
     }
   };
 
@@ -371,41 +371,41 @@ export const Nav: React.FC = ({ children }) => {
         </AppBar>
         <Drawer
           variant="permanent"
-          open={tempOpen}
+          open={drawerIsOpen}
           sx={{
             background: theme.palette.nym.networkExplorer.nav.background,
           }}
         >
           <DrawerHeader
             sx={{
-              justifyContent: tempOpen ? 'flex-end' : 'center',
+              justifyContent: drawerIsOpen ? 'flex-end' : 'center',
               paddingLeft: 0,
             }}
           >
             <IconButton
-              onClick={tempOpen ? handleDrawerClose : handleDrawerOpen}
+              onClick={drawerIsOpen ? fixDrawerClose : fixDrawerOpen}
               sx={{
                 padding: 0,
                 ml: '7px',
                 color: theme.palette.nym.networkExplorer.nav.text,
               }}
             >
-              {tempOpen ? <ChevronLeft /> : <Menu />}
+              {drawerIsOpen ? <ChevronLeft /> : <Menu />}
             </IconButton>
           </DrawerHeader>
 
           <List
             sx={{ pt: 0, pb: 0 }}
-            onMouseEnter={handleMouseEnterOpen}
-            onMouseLeave={handleMouseLeaveClose}
+            onMouseEnter={tempDrawerOpen}
+            onMouseLeave={tempDrawerClose}
           >
             {navOptionsState.map((props) => (
               <ExpandableButton
                 key={props.url}
-                closeDrawer={handleDrawerClose}
-                drawIsTempOpen={tempOpen}
-                drawIsFixed={drawIsFixed}
-                openDrawer={handleDrawerOpen}
+                closeDrawer={tempDrawerClose}
+                drawIsTempOpen={drawerIsOpen}
+                drawIsFixed={fixedOpen}
+                openDrawer={tempDrawerOpen}
                 setToActive={setToActive}
                 {...props}
               />


### PR DESCRIPTION
This PR seeks to improve the UX of the (MUI) Nav and partnering Drawer, by implementing the following Assessment Criteria from card 88:

FIXED NAV
✅  - as a user, when I click the closed Hamburger/Menu, then the `drawer` nav should *fix* open.
✅  - as a user, when I click the (already fixed open) Hamburger/Menu, then the `drawer` nav should return to closed.
✅  - as a user, when I click the Hamburger to *fix* open, if i then hover on and off list items, it should remain open.
 
NON-FIXED NAV + HOVERING
✅  - as a user, when I hover on the nav-list items, then the drawer should *temporarily* open.
✅  - as a user, when I hover *off* the (previously open-drawer) nav-list items, then the drawer should return as closed.
 
 NON-FIXED + NESTED ROUTES
✅  - as a user, when I hover on an option *with nested/child routes* (Network Components), then the drawer should open, but when i click the child routes (or any other actual destination nav options), then the drawer should return to closed.
✅  - as a user, when I hover on an option *with nested/child routes* (Network Components), then the drawer should open, but when i click the parent containing the child/nested routes (Network Components), then the drawer should remain open.

Code / Flow:

2 ways to expand drawer:

1. click `<Menu />` - fixes open using `fixDrawerOpen()` and clicking again, reverses.
2. hover over List Items - fires `tempDrawerOpen()`.
Both those values are used in the `<ExpandableButton />` component. If the button houses `nested` routes, clicking on it expands them. If there are no nested routes, close the drawer (unless we've 'fixed' it open).