### PR TITLE
Explorer UI tests missing data-testid

### DIFF
--- a/explorer/src/components/DetailTable.tsx
+++ b/explorer/src/components/DetailTable.tsx
@@ -66,6 +66,7 @@ export const DetailTable: React.FC<{
                   padding: 2,
                   width: 200,
                 }}
+                data-testid={`${_.title.replace(/ /g, '-')}-value`}
               >
                 {formatCellValues(
                   eachRow[columnsData[index].field],


### PR DESCRIPTION
- This `data-testid` was missing and is needed after changes to DataGrid into MUI-Table