### PR TITLE
Bugfix/monitor initial values wait

### DIFF
--- a/validator-api/src/network_monitor/monitor/mod.rs
+++ b/validator-api/src/network_monitor/monitor/mod.rs
@@ -297,7 +297,7 @@ impl Monitor {
 
         // wait for validator cache to be ready
         self.packet_preparer
-            .wait_for_validator_cache_initial_values(self.test_routes)
+            .wait_for_validator_cache_initial_values(self.minimum_test_routes)
             .await;
 
         self.packet_sender

--- a/validator-api/src/network_monitor/monitor/preparer.rs
+++ b/validator-api/src/network_monitor/monitor/preparer.rs
@@ -188,6 +188,11 @@ impl PacketPreparer {
             let mixnodes = self.validator_cache.rewarded_mixnodes().await;
 
             if gateways.into_inner().len() < minimum_full_routes {
+                info!(
+                    "Minimal topology is still not offline. Going to check again in {:?}",
+                    initialisation_backoff
+                );
+                tokio::time::sleep(initialisation_backoff).await;
                 continue;
             }
 


### PR DESCRIPTION
Fixes the bug that the validator API would have waited for the ideal number of testing routes (by default 9 mixnodes and 3 gateways) to be online before starting the network monitor, rather than just the minimal value (i.e. 3 mixnodes and 1 gateway)