### PR TITLE
Introduces query for contract build information

### DIFF
--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -10,11 +10,12 @@ use mixnet_contract::ContractSettingsParams;
 
 use crate::{validator_api, ValidatorClientError};
 use coconut_interface::{BlindSignRequestBody, BlindedSignatureResponse, VerificationKeyResponse};
-use mixnet_contract::{
-    GatewayBond, MixNodeBond, MixnetContractVersion, MixnodeRewardingStatusResponse,
-};
+use mixnet_contract::{GatewayBond, MixNodeBond};
 #[cfg(feature = "nymd-client")]
-use mixnet_contract::{RawDelegationData, RewardingIntervalResponse};
+use mixnet_contract::{
+    MixnetContractVersion, MixnodeRewardingStatusResponse, RawDelegationData,
+    RewardingIntervalResponse,
+};
 use url::Url;
 
 #[cfg(feature = "nymd-client")]

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -10,7 +10,9 @@ use mixnet_contract::ContractSettingsParams;
 
 use crate::{validator_api, ValidatorClientError};
 use coconut_interface::{BlindSignRequestBody, BlindedSignatureResponse, VerificationKeyResponse};
-use mixnet_contract::{GatewayBond, MixNodeBond, MixnodeRewardingStatusResponse};
+use mixnet_contract::{
+    GatewayBond, MixNodeBond, MixnetContractVersion, MixnodeRewardingStatusResponse,
+};
 #[cfg(feature = "nymd-client")]
 use mixnet_contract::{RawDelegationData, RewardingIntervalResponse};
 use url::Url;
@@ -172,6 +174,13 @@ impl<C> Client<C> {
         C: CosmWasmClient + Sync,
     {
         Ok(self.nymd.get_contract_settings().await?)
+    }
+
+    pub async fn get_mixnet_contract_version(&self) -> Result<MixnetContractVersion, NymdError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        Ok(self.nymd.get_mixnet_contract_version().await?)
     }
 
     pub async fn get_current_rewarding_interval(

--- a/common/client-libs/validator-client/src/nymd/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/mod.rs
@@ -14,10 +14,10 @@ use cosmrs::rpc::{Error as TendermintRpcError, HttpClientUrl};
 use cosmwasm_std::{Coin, Uint128};
 use mixnet_contract::{
     Addr, ContractSettingsParams, Delegation, ExecuteMsg, Gateway, GatewayOwnershipResponse,
-    IdentityKey, LayerDistribution, MixNode, MixOwnershipResponse, MixnodeRewardingStatusResponse,
-    PagedAllDelegationsResponse, PagedGatewayResponse, PagedMixDelegationsResponse,
-    PagedMixnodeResponse, PagedReverseMixDelegationsResponse, QueryMsg, RawDelegationData,
-    RewardingIntervalResponse,
+    IdentityKey, LayerDistribution, MixNode, MixOwnershipResponse, MixnetContractVersion,
+    MixnodeRewardingStatusResponse, PagedAllDelegationsResponse, PagedGatewayResponse,
+    PagedMixDelegationsResponse, PagedMixnodeResponse, PagedReverseMixDelegationsResponse,
+    QueryMsg, RawDelegationData, RewardingIntervalResponse,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -213,6 +213,16 @@ impl<C> NymdClient<C> {
         C: CosmWasmClient + Sync,
     {
         let request = QueryMsg::StateParams {};
+        self.client
+            .query_contract_smart(self.contract_address()?, &request)
+            .await
+    }
+
+    pub async fn get_mixnet_contract_version(&self) -> Result<MixnetContractVersion, NymdError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        let request = QueryMsg::GetContractVersion {};
         self.client
             .query_contract_smart(self.contract_address()?, &request)
             .await

--- a/common/mixnet-contract/src/msg.rs
+++ b/common/mixnet-contract/src/msg.rs
@@ -61,6 +61,7 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
+    GetContractVersion {},
     GetMixNodes {
         limit: Option<u32>,
         start_after: Option<IdentityKey>,

--- a/common/mixnet-contract/src/types.rs
+++ b/common/mixnet-contract/src/types.rs
@@ -97,6 +97,27 @@ pub struct MixnodeRewardingStatusResponse {
     pub status: Option<RewardingStatus>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MixnetContractVersion {
+    // VERGEN_BUILD_TIMESTAMP
+    pub build_timestamp: String,
+
+    // VERGEN_BUILD_SEMVER
+    pub build_version: String,
+
+    // VERGEN_GIT_SHA
+    pub commit_sha: String,
+
+    // VERGEN_GIT_COMMIT_TIMESTAMP
+    pub commit_timestamp: String,
+
+    // VERGEN_GIT_BRANCH
+    pub commit_branch: String,
+
+    // VERGEN_RUSTC_SEMVER
+    pub rustc_version: String,
+}
+
 // type aliases for better reasoning about available data
 pub type IdentityKey = String;
 pub type IdentityKeyRef<'a> = &'a str;

--- a/contracts/mixnet/Cargo.lock
+++ b/contracts/mixnet/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
+
+[[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "az"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +25,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -63,10 +81,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time 0.1.43",
+ "winapi",
+]
 
 [[package]]
 name = "config"
@@ -266,6 +306,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +403,31 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b328c01a4d71d2d8173daa93562a73ab0fe85616876f02500f53d82948c504"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "git2"
+version = "0.13.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "845e007a28f1fcac035715988a234e8ec5458fd825b20a20c7dec74237ef341f"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -432,6 +517,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "k256"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +542,30 @@ name = "libc"
 version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.12.25+1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68169ef08d6519b2fe133ecc637408d933c0174b23b80bb2f79828966fbaab"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "log"
@@ -498,6 +616,7 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
+ "vergen",
 ]
 
 [[package]]
@@ -506,8 +625,27 @@ version = "0.1.0"
 dependencies = [
  "hex-literal",
  "serde",
- "time",
+ "time 0.3.4",
  "url",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -582,6 +720,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +792,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +835,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
@@ -804,6 +993,16 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
@@ -900,6 +1099,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "5.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf88d94e969e7956d924ba70741316796177fa0c79a2c9f4ab04998d96e966e"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "chrono",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustc_version",
+ "rustversion",
+ "thiserror",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +1138,28 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"

--- a/contracts/mixnet/Cargo.toml
+++ b/contracts/mixnet/Cargo.toml
@@ -50,3 +50,6 @@ thiserror = { version = "1.0.23" }
 [dev-dependencies]
 cosmwasm-schema = { version = "0.14.0" }
 fixed = "1.1"
+
+[build-dependencies]
+vergen = { version = "5", default-features = false, features = ["build", "git", "rustc"] }

--- a/contracts/mixnet/build.rs
+++ b/contracts/mixnet/build.rs
@@ -1,0 +1,8 @@
+// Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use vergen::{vergen, Config};
+
+fn main() {
+    vergen(Config::default()).expect("failed to extract build metadata")
+}

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -5,8 +5,10 @@ use crate::error::ContractError;
 use crate::gateways::queries::query_gateways_paged;
 use crate::gateways::queries::query_owns_gateway;
 use crate::mixnet_contract_settings::models::ContractSettings;
-use crate::mixnet_contract_settings::queries::query_contract_settings_params;
 use crate::mixnet_contract_settings::queries::query_rewarding_interval;
+use crate::mixnet_contract_settings::queries::{
+    query_contract_settings_params, query_contract_version,
+};
 use crate::mixnet_contract_settings::storage as mixnet_params_storage;
 use crate::mixnodes::bonding_queries as mixnode_queries;
 use crate::mixnodes::bonding_queries::query_mixnode_delegations_paged;
@@ -158,6 +160,7 @@ pub fn execute(
 #[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, ContractError> {
     let query_res = match msg {
+        QueryMsg::GetContractVersion {} => to_binary(&query_contract_version()),
         QueryMsg::GetMixNodes { start_after, limit } => {
             to_binary(&query_mixnodes_paged(deps, start_after, limit)?)
         }

--- a/contracts/mixnet/src/mixnet_contract_settings/queries.rs
+++ b/contracts/mixnet/src/mixnet_contract_settings/queries.rs
@@ -21,22 +21,13 @@ pub(crate) fn query_contract_version() -> MixnetContractVersion {
     // as per docs
     // env! macro will expand to the value of the named environment variable at
     // compile time, yielding an expression of type `&'static str`
-    // MixnetContractVersion {
-    //     build_timestamp: env!("VERGEN_BUILD_TIMESTAMP").to_string(),
-    //     build_version: env!("VERGEN_BUILD_SEMVER").to_string(),
-    //     commit_sha: env!("VERGEN_GIT_SHA").to_string(),
-    //     commit_timestamp: env!("VERGEN_GIT_COMMIT_TIMESTAMP").to_string(),
-    //     commit_branch: env!("VERGEN_GIT_BRANCH").to_string(),
-    //     rustc_version: env!("VERGEN_RUSTC_SEMVER").to_string(),
-    // }
-
     MixnetContractVersion {
-        build_timestamp: ("VERGEN_BUILD_TIMESTAMP").to_string(),
-        build_version: ("VERGEN_BUILD_SEMVER").to_string(),
-        commit_sha: ("VERGEN_GIT_SHA").to_string(),
-        commit_timestamp: ("VERGEN_GIT_COMMIT_TIMESTAMP").to_string(),
-        commit_branch: ("VERGEN_GIT_BRANCH").to_string(),
-        rustc_version: ("VERGEN_RUSTC_SEMVER").to_string(),
+        build_timestamp: env!("VERGEN_BUILD_TIMESTAMP").to_string(),
+        build_version: env!("VERGEN_BUILD_SEMVER").to_string(),
+        commit_sha: env!("VERGEN_GIT_SHA").to_string(),
+        commit_timestamp: env!("VERGEN_GIT_COMMIT_TIMESTAMP").to_string(),
+        commit_branch: env!("VERGEN_GIT_BRANCH").to_string(),
+        rustc_version: env!("VERGEN_RUSTC_SEMVER").to_string(),
     }
 }
 
@@ -86,9 +77,5 @@ pub(crate) mod tests {
         assert!(!version.commit_timestamp.is_empty());
         assert!(!version.commit_branch.is_empty());
         assert!(!version.rustc_version.is_empty());
-
-        println!("{:?}", version);
-
-        assert!(false);
     }
 }

--- a/contracts/mixnet/src/mixnet_contract_settings/queries.rs
+++ b/contracts/mixnet/src/mixnet_contract_settings/queries.rs
@@ -1,6 +1,6 @@
 use super::storage;
 use cosmwasm_std::Deps;
-use mixnet_contract::{ContractSettingsParams, RewardingIntervalResponse};
+use mixnet_contract::{ContractSettingsParams, MixnetContractVersion, RewardingIntervalResponse};
 
 pub(crate) fn query_contract_settings_params(deps: Deps) -> ContractSettingsParams {
     storage::read_contract_settings_params(deps.storage)
@@ -14,6 +14,29 @@ pub(crate) fn query_rewarding_interval(deps: Deps) -> RewardingIntervalResponse 
         current_rewarding_interval_starting_block: state.rewarding_interval_starting_block,
         current_rewarding_interval_nonce: state.latest_rewarding_interval_nonce,
         rewarding_in_progress: state.rewarding_in_progress,
+    }
+}
+
+pub(crate) fn query_contract_version() -> MixnetContractVersion {
+    // as per docs
+    // env! macro will expand to the value of the named environment variable at
+    // compile time, yielding an expression of type `&'static str`
+    // MixnetContractVersion {
+    //     build_timestamp: env!("VERGEN_BUILD_TIMESTAMP").to_string(),
+    //     build_version: env!("VERGEN_BUILD_SEMVER").to_string(),
+    //     commit_sha: env!("VERGEN_GIT_SHA").to_string(),
+    //     commit_timestamp: env!("VERGEN_GIT_COMMIT_TIMESTAMP").to_string(),
+    //     commit_branch: env!("VERGEN_GIT_BRANCH").to_string(),
+    //     rustc_version: env!("VERGEN_RUSTC_SEMVER").to_string(),
+    // }
+
+    MixnetContractVersion {
+        build_timestamp: ("VERGEN_BUILD_TIMESTAMP").to_string(),
+        build_version: ("VERGEN_BUILD_SEMVER").to_string(),
+        commit_sha: ("VERGEN_GIT_SHA").to_string(),
+        commit_timestamp: ("VERGEN_GIT_COMMIT_TIMESTAMP").to_string(),
+        commit_branch: ("VERGEN_GIT_BRANCH").to_string(),
+        rustc_version: ("VERGEN_RUSTC_SEMVER").to_string(),
     }
 }
 
@@ -51,5 +74,21 @@ pub(crate) mod tests {
             dummy_state.params,
             query_contract_settings_params(deps.as_ref())
         )
+    }
+
+    #[test]
+    fn query_for_contract_version_works() {
+        // this basically means _something_ was grabbed from the environment at compilation time
+        let version = query_contract_version();
+        assert!(!version.build_timestamp.is_empty());
+        assert!(!version.build_version.is_empty());
+        assert!(!version.commit_sha.is_empty());
+        assert!(!version.commit_timestamp.is_empty());
+        assert!(!version.commit_branch.is_empty());
+        assert!(!version.rustc_version.is_empty());
+
+        println!("{:?}", version);
+
+        assert!(false);
     }
 }


### PR DESCRIPTION
This pull request solves the problem of "what version of the contract have we exactly deployed?". It introduces a query that returns the build information. Currently it includes the following:
```
MixnetContractVersion {
    build_timestamp: "2021-11-25T12:18:41.573392838+00:00",
    build_version: "0.1.0",
    commit_sha: "39c7b131b69a8d3217372853afb7e776207b6d19",
    commit_timestamp: "2021-11-25T10:27:31+00:00",
    commit_branch: "feature/contract-version",
    rustc_version: "1.56.1",
}
```

If anyone feels like something else could be added there, full list of available options is here: https://docs.rs/vergen/5.1.17/vergen/