### PR TITLE
Fixing go warning re unused btc lib

### DIFF
--- a/clients/native/examples/go-examples/websocket/go.mod
+++ b/clients/native/examples/go-examples/websocket/go.mod
@@ -3,6 +3,5 @@ module github.com/nymtech/nym/clients/native/examples/go
 go 1.14
 
 require (
-	// github.com/btcsuite/btcutil v1.0.2 // indirect
 	github.com/gorilla/websocket v1.4.2
 )

--- a/clients/native/examples/go-examples/websocket/go.mod
+++ b/clients/native/examples/go-examples/websocket/go.mod
@@ -3,6 +3,6 @@ module github.com/nymtech/nym/clients/native/examples/go
 go 1.14
 
 require (
-	github.com/btcsuite/btcutil v1.0.2 // indirect
+	// github.com/btcsuite/btcutil v1.0.2 // indirect
 	github.com/gorilla/websocket v1.4.2
 )


### PR DESCRIPTION
A tiny PR to remove an annoying bit of yellow in my editor - the btc library is not used anymore in our example. 