### PR TITLE
Adding tx_hash to wallet response

### DIFF
--- a/nym-wallet/src-tauri/src/operations/send.rs
+++ b/nym-wallet/src-tauri/src/operations/send.rs
@@ -12,31 +12,31 @@ use validator_client::nymd::{AccountId, CosmosCoin};
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[derive(Deserialize, Serialize)]
 pub struct TauriTxResult {
-  code: u32,
-  gas_wanted: u64,
-  gas_used: u64,
   block_height: u64,
+  code: u32,
   details: TransactionDetails,
+  gas_used: u64,
+  gas_wanted: u64,
   tx_hash: String,
 }
 
 #[cfg_attr(test, derive(ts_rs::TS))]
 #[derive(Deserialize, Serialize)]
 pub struct TransactionDetails {
+  amount: Coin,
   from_address: String,
   to_address: String,
-  amount: Coin,
 }
 
 impl TauriTxResult {
   fn new(t: Response, details: TransactionDetails) -> TauriTxResult {
     TauriTxResult {
-      code: t.check_tx.code.value(),
-      gas_wanted: t.check_tx.gas_wanted.value(),
-      gas_used: t.check_tx.gas_used.value(),
       block_height: t.height.value(),
-      tx_hash: t.hash.to_string(),
+      code: t.check_tx.code.value(),
       details,
+      gas_used: t.check_tx.gas_used.value(),
+      gas_wanted: t.check_tx.gas_wanted.value(),
+      tx_hash: t.hash.to_string(),
     }
   }
 }

--- a/nym-wallet/src-tauri/src/operations/send.rs
+++ b/nym-wallet/src-tauri/src/operations/send.rs
@@ -17,6 +17,7 @@ pub struct TauriTxResult {
   gas_used: u64,
   block_height: u64,
   details: TransactionDetails,
+  tx_hash: String,
 }
 
 #[cfg_attr(test, derive(ts_rs::TS))]
@@ -34,6 +35,7 @@ impl TauriTxResult {
       gas_wanted: t.check_tx.gas_wanted.value(),
       gas_used: t.check_tx.gas_used.value(),
       block_height: t.height.value(),
+      tx_hash: t.hash.to_string(),
       details,
     }
   }

--- a/nym-wallet/src/types/rust/tauritxresult.ts
+++ b/nym-wallet/src/types/rust/tauritxresult.ts
@@ -6,4 +6,5 @@ export interface TauriTxResult {
   gas_used: bigint;
   block_height: bigint;
   details: TransactionDetails;
+  tx_hash: string;
 }


### PR DESCRIPTION
This will allow the wallet ui, later, to  provide a link to Big Dipper.

 The user can then see which block the transaction happened in, and other associated information. cc @jessgess 