### PR TITLE
Feature/pre cosmrs updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,8 +868,7 @@ dependencies = [
 [[package]]
 name = "cosmos-sdk-proto"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb5204c6ddc4352c74297638b5561f2929d6334866c156e5f3c75e1e1a1436a"
+source = "git+https://github.com/jstuczyn/cosmos-rust/?branch=jstuczyn/wasmd-021-update#d8b23881ca833bf9b3284142c4f90b588afc56e3"
 dependencies = [
  "prost",
  "prost-types",
@@ -879,8 +878,7 @@ dependencies = [
 [[package]]
 name = "cosmrs"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31147fe89e547e74e2692e4bec35387e1ea406fe8cfb14c0ea177b58fd2a8a9"
+source = "git+https://github.com/jstuczyn/cosmos-rust/?branch=jstuczyn/wasmd-021-update#d8b23881ca833bf9b3284142c4f90b588afc56e3"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -26,7 +26,8 @@ network-defaults = { path = "../../network-defaults" }
 async-trait = { version = "0.1.51", optional = true }
 bip39 = { version = "1", features = ["rand"], optional = true }
 config = { path = "../../config", optional = true }
-cosmrs = { version = "0.3", features = ["rpc", "bip32", "cosmwasm"], optional = true }
+#cosmrs = { version = "0.3", features = ["rpc", "bip32", "cosmwasm"], optional = true }
+cosmrs = { git = "https://github.com/jstuczyn/cosmos-rust/", branch="jstuczyn/wasmd-021-update", features = ["rpc", "bip32", "cosmwasm"], optional = true }
 prost = { version = "0.9", default-features = false, optional = true }
 flate2 = { version = "1.0.20", optional = true }
 sha2 = { version = "0.9.5", optional = true }

--- a/common/client-libs/validator-client/src/nymd/cosmwasm_client/client.rs
+++ b/common/client-libs/validator-client/src/nymd/cosmwasm_client/client.rs
@@ -14,7 +14,7 @@ use cosmrs::proto::cosmos::auth::v1beta1::{
 use cosmrs::proto::cosmos::bank::v1beta1::{
     QueryAllBalancesRequest, QueryAllBalancesResponse, QueryBalanceRequest, QueryBalanceResponse,
 };
-use cosmrs::proto::cosmwasm::wasm::v1beta1::*;
+use cosmrs::proto::cosmwasm::wasm::v1::*;
 use cosmrs::rpc::endpoint::block::Response as BlockResponse;
 use cosmrs::rpc::endpoint::broadcast;
 use cosmrs::rpc::endpoint::tx::Response as TxResponse;
@@ -213,7 +213,7 @@ pub trait CosmWasmClient: rpc::Client {
     }
 
     async fn get_codes(&self) -> Result<Vec<Code>, NymdError> {
-        let path = Some("/cosmwasm.wasm.v1beta1.Query/Codes".parse().unwrap());
+        let path = Some("/cosmwasm.wasm.v1.Query/Codes".parse().unwrap());
 
         let mut raw_codes = Vec::new();
         let mut pagination = None;
@@ -240,7 +240,7 @@ pub trait CosmWasmClient: rpc::Client {
     }
 
     async fn get_code_details(&self, code_id: ContractCodeId) -> Result<CodeDetails, NymdError> {
-        let path = Some("/cosmwasm.wasm.v1beta1.Query/Code".parse().unwrap());
+        let path = Some("/cosmwasm.wasm.v1.Query/Code".parse().unwrap());
 
         let req = QueryCodeRequest { code_id };
 
@@ -255,11 +255,7 @@ pub trait CosmWasmClient: rpc::Client {
         }
     }
     async fn get_contracts(&self, code_id: ContractCodeId) -> Result<Vec<AccountId>, NymdError> {
-        let path = Some(
-            "/cosmwasm.wasm.v1beta1.Query/ContractsByCode"
-                .parse()
-                .unwrap(),
-        );
+        let path = Some("/cosmwasm.wasm.v1.Query/ContractsByCode".parse().unwrap());
 
         let mut raw_contracts = Vec::new();
         let mut pagination = None;
@@ -290,7 +286,7 @@ pub trait CosmWasmClient: rpc::Client {
     }
 
     async fn get_contract(&self, address: &AccountId) -> Result<Contract, NymdError> {
-        let path = Some("/cosmwasm.wasm.v1beta1.Query/ContractInfo".parse().unwrap());
+        let path = Some("/cosmwasm.wasm.v1.Query/ContractInfo".parse().unwrap());
 
         let req = QueryContractInfoRequest {
             address: address.to_string(),
@@ -315,11 +311,7 @@ pub trait CosmWasmClient: rpc::Client {
         &self,
         address: &AccountId,
     ) -> Result<Vec<ContractCodeHistoryEntry>, NymdError> {
-        let path = Some(
-            "/cosmwasm.wasm.v1beta1.Query/ContractHistory"
-                .parse()
-                .unwrap(),
-        );
+        let path = Some("/cosmwasm.wasm.v1.Query/ContractHistory".parse().unwrap());
 
         let mut raw_entries = Vec::new();
         let mut pagination = None;
@@ -353,11 +345,7 @@ pub trait CosmWasmClient: rpc::Client {
         address: &AccountId,
         query_data: Vec<u8>,
     ) -> Result<Vec<u8>, NymdError> {
-        let path = Some(
-            "/cosmwasm.wasm.v1beta1.Query/RawContractState"
-                .parse()
-                .unwrap(),
-        );
+        let path = Some("/cosmwasm.wasm.v1.Query/RawContractState".parse().unwrap());
 
         let req = QueryRawContractStateRequest {
             address: address.to_string(),
@@ -381,7 +369,7 @@ pub trait CosmWasmClient: rpc::Client {
         for<'a> T: Deserialize<'a>,
     {
         let path = Some(
-            "/cosmwasm.wasm.v1beta1.Query/SmartContractState"
+            "/cosmwasm.wasm.v1.Query/SmartContractState"
                 .parse()
                 .unwrap(),
         );

--- a/common/client-libs/validator-client/src/nymd/cosmwasm_client/signing_client.rs
+++ b/common/client-libs/validator-client/src/nymd/cosmwasm_client/signing_client.rs
@@ -57,7 +57,7 @@ pub trait SigningCosmWasmClient: CosmWasmClient {
         // the reason I think unwrap here is fine is that if the transaction succeeded and those
         // fields do not exist or code_id is not a number, there's no way we can recover, we're probably connected
         // to wrong validator or something
-        let code_id = logs::find_attribute(&logs, "message", "code_id")
+        let code_id = logs::find_attribute(&logs, "store_code", "code_id")
             .unwrap()
             .value
             .parse()
@@ -119,7 +119,7 @@ pub trait SigningCosmWasmClient: CosmWasmClient {
         // the reason I think unwrap here is fine is that if the transaction succeeded and those
         // fields do not exist or address is malformed, there's no way we can recover, we're probably connected
         // to wrong validator or something
-        let contract_address = logs::find_attribute(&logs, "message", "contract_address")
+        let contract_address = logs::find_attribute(&logs, "instantiate", "_contract_address")
             .unwrap()
             .value
             .parse()

--- a/common/client-libs/validator-client/src/nymd/cosmwasm_client/types.rs
+++ b/common/client-libs/validator-client/src/nymd/cosmwasm_client/types.rs
@@ -7,7 +7,7 @@ use crate::nymd::cosmwasm_client::logs::Log;
 use crate::nymd::error::NymdError;
 use cosmrs::crypto::PublicKey;
 use cosmrs::proto::cosmos::auth::v1beta1::BaseAccount;
-use cosmrs::proto::cosmwasm::wasm::v1beta1::{
+use cosmrs::proto::cosmwasm::wasm::v1::{
     CodeInfoResponse, ContractCodeHistoryEntry as ProtoContractCodeHistoryEntry,
     ContractCodeHistoryOperationType, ContractInfo as ProtoContractInfo,
 };
@@ -70,18 +70,6 @@ pub struct Code {
 
     /// sha256 hash of the code stored
     pub data_hash: Vec<u8>,
-
-    /// An URL to a .tar.gz archive of the source code of the contract,
-    /// which can be used to reproducibly build the Wasm bytecode.
-    ///
-    /// @see https://github.com/CosmWasm/cosmwasm-verify
-    pub source: Option<String>,
-
-    /// A docker image (including version) to reproducibly build the Wasm bytecode from the source code.
-    ///
-    /// @example ```cosmwasm/rust-optimizer:0.8.0```
-    /// @see https://github.com/CosmWasm/cosmwasm-verify
-    pub builder: Option<String>,
 }
 
 impl TryFrom<CodeInfoResponse> for Code {
@@ -92,31 +80,16 @@ impl TryFrom<CodeInfoResponse> for Code {
             code_id,
             creator,
             data_hash,
-            source,
-            builder,
         } = value;
 
         let creator = creator
             .parse()
             .map_err(|_| NymdError::MalformedAccountAddress(creator))?;
 
-        let source = if source.is_empty() {
-            None
-        } else {
-            Some(source)
-        };
-        let builder = if builder.is_empty() {
-            None
-        } else {
-            Some(builder)
-        };
-
         Ok(Code {
             code_id,
             creator,
             data_hash,
-            source,
-            builder,
         })
     }
 }
@@ -252,21 +225,6 @@ pub struct SignerData {
     pub account_number: AccountNumber,
     pub sequence: SequenceNumber,
     pub chain_id: chain::Id,
-}
-
-#[derive(Debug)]
-pub struct UploadMeta {
-    /// An URL to a .tar.gz archive of the source code of the contract,
-    /// which can be used to reproducibly build the Wasm bytecode.
-    ///
-    /// @see https://github.com/CosmWasm/cosmwasm-verify
-    pub source: Option<String>,
-
-    /// A docker image (including version) to reproducibly build the Wasm bytecode from the source code.
-    ///
-    /// @example ```cosmwasm/rust-optimizer:0.8.0```
-    /// @see https://github.com/CosmWasm/cosmwasm-verify
-    pub builder: Option<String>,
 }
 
 #[derive(Debug)]

--- a/common/client-libs/validator-client/src/nymd/fee_helpers.rs
+++ b/common/client-libs/validator-client/src/nymd/fee_helpers.rs
@@ -59,7 +59,7 @@ impl Operation {
     // TODO: some value tweaking
     pub fn default_gas_limit(&self) -> Gas {
         match self {
-            Operation::Upload => 2_500_000u64.into(),
+            Operation::Upload => 3_000_000u64.into(),
             Operation::Init => 500_000u64.into(),
             Operation::Migrate => 200_000u64.into(),
             Operation::ChangeAdmin => 80_000u64.into(),

--- a/common/client-libs/validator-client/src/nymd/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/mod.rs
@@ -4,7 +4,7 @@
 use crate::nymd::cosmwasm_client::signing_client;
 use crate::nymd::cosmwasm_client::types::{
     ChangeAdminResult, ContractCodeId, ExecuteResult, InstantiateOptions, InstantiateResult,
-    MigrateResult, SequenceResponse, UploadMeta, UploadResult,
+    MigrateResult, SequenceResponse, UploadResult,
 };
 use crate::nymd::error::NymdError;
 use crate::nymd::fee_helpers::Operation;
@@ -501,14 +501,13 @@ impl<C> NymdClient<C> {
         &self,
         wasm_code: Vec<u8>,
         memo: impl Into<String> + Send + 'static,
-        meta: Option<UploadMeta>,
     ) -> Result<UploadResult, NymdError>
     where
         C: SigningCosmWasmClient + Sync,
     {
         let fee = self.get_fee(Operation::Upload);
         self.client
-            .upload(self.address(), wasm_code, fee, memo, meta)
+            .upload(self.address(), wasm_code, fee, memo)
             .await
     }
 

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -665,8 +665,7 @@ dependencies = [
 [[package]]
 name = "cosmos-sdk-proto"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb5204c6ddc4352c74297638b5561f2929d6334866c156e5f3c75e1e1a1436a"
+source = "git+https://github.com/jstuczyn/cosmos-rust/?branch=jstuczyn/wasmd-021-update#a3dbc2b28fc0c117c894df478799dea9f7fbd186"
 dependencies = [
  "prost",
  "prost-types",
@@ -676,8 +675,7 @@ dependencies = [
 [[package]]
 name = "cosmrs"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31147fe89e547e74e2692e4bec35387e1ea406fe8cfb14c0ea177b58fd2a8a9"
+source = "git+https://github.com/jstuczyn/cosmos-rust/?branch=jstuczyn/wasmd-021-update#a3dbc2b28fc0c117c894df478799dea9f7fbd186"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",

--- a/nym-wallet/src-tauri/Cargo.toml
+++ b/nym-wallet/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ url = "2.0"
 rand = "0.6.5"
 
 
-cosmrs = { version = "0.3", features = ["rpc", "bip32", "cosmwasm"] }
+cosmrs = { git = "https://github.com/jstuczyn/cosmos-rust/", branch="jstuczyn/wasmd-021-update", features = ["rpc", "bip32", "cosmwasm"] }
 cosmwasm-std = "1.0.0-beta2"
 
 validator-client = { path = "../../common/client-libs/validator-client", features = [


### PR DESCRIPTION
Fixes our nymd client to be compatible with `wasmd` 0.18+. It relies on `cosmrs` fork until https://github.com/cosmos/cosmos-rust/pull/158 is merged.