### PR TITLE
Ability to query for mixnode bond value (pledge and delegation) at given height

### DIFF
--- a/common/mixnet-contract/src/lib.rs
+++ b/common/mixnet-contract/src/lib.rs
@@ -16,6 +16,8 @@ pub use delegation::{
     PagedMixDelegationsResponse,
 };
 pub use gateway::{Gateway, GatewayBond, GatewayOwnershipResponse, PagedGatewayResponse};
-pub use mixnode::{Layer, MixNode, MixNodeBond, MixOwnershipResponse, PagedMixnodeResponse};
+pub use mixnode::{
+    Layer, MixNode, MixNodeBond, MixNodeBondValues, MixOwnershipResponse, PagedMixnodeResponse,
+};
 pub use msg::*;
 pub use types::*;

--- a/common/mixnet-contract/src/mixnode.rs
+++ b/common/mixnet-contract/src/mixnode.rs
@@ -457,6 +457,19 @@ impl Display for MixNodeBond {
     }
 }
 
+// Note: this is named according to the new terminology where bond = [operator] pledge + delegations
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
+pub struct MixNodeBondValues {
+    pub pledge: Uint128,
+    pub delegations: Uint128,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
+pub struct MixNodeBondValuesResponse {
+    pub height: u64,
+    pub bond_values: Option<MixNodeBondValues>,
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
 pub struct PagedMixnodeResponse {
     pub nodes: Vec<MixNodeBond>,

--- a/common/mixnet-contract/src/msg.rs
+++ b/common/mixnet-contract/src/msg.rs
@@ -98,6 +98,10 @@ pub enum QueryMsg {
     OwnsGateway {
         address: String,
     },
+    MixnodeBondAtHeight {
+        mix_identity: IdentityKey,
+        height: u64,
+    },
     StateParams {},
     CurrentRewardingInterval {},
     // gets all [paged] delegations in the entire network

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -98,7 +98,7 @@ pub fn execute(
             crate::mixnodes::transactions::try_add_mixnode(deps, env, info, mix_node)
         }
         ExecuteMsg::UnbondMixnode {} => {
-            crate::mixnodes::transactions::try_remove_mixnode(deps, info)
+            crate::mixnodes::transactions::try_remove_mixnode(env, deps, info)
         }
         ExecuteMsg::BondGateway { gateway } => {
             crate::gateways::transactions::try_add_gateway(deps, env, info, gateway)
@@ -182,7 +182,7 @@ pub fn execute(
             )
         }
         ExecuteMsg::UnbondMixnodeOnBehalf { owner } => {
-            crate::mixnodes::transactions::try_remove_mixnode_on_behalf(deps, info, owner)
+            crate::mixnodes::transactions::try_remove_mixnode_on_behalf(env, deps, info, owner)
         }
         ExecuteMsg::BondGatewayOnBehalf { gateway, owner } => {
             crate::gateways::transactions::try_add_gateway_on_behalf(

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -15,7 +15,7 @@ use crate::mixnet_contract_settings::queries::{
 };
 use crate::mixnet_contract_settings::storage as mixnet_params_storage;
 use crate::mixnodes::bonding_queries as mixnode_queries;
-use crate::mixnodes::bonding_queries::query_mixnodes_paged;
+use crate::mixnodes::bonding_queries::{query_mixnode_bond_values_at_height, query_mixnodes_paged};
 use crate::mixnodes::layer_queries::query_layer_distribution;
 use crate::rewards::queries::query_reward_pool;
 use crate::rewards::queries::{query_circulating_supply, query_rewarding_status};
@@ -209,6 +209,14 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
             to_binary(&mixnode_queries::query_owns_mixnode(deps, address)?)
         }
         QueryMsg::OwnsGateway { address } => to_binary(&query_owns_gateway(deps, address)?),
+        QueryMsg::MixnodeBondAtHeight {
+            mix_identity,
+            height,
+        } => to_binary(&query_mixnode_bond_values_at_height(
+            deps,
+            mix_identity,
+            height,
+        )?),
         QueryMsg::StateParams {} => to_binary(&query_contract_settings_params(deps)?),
         QueryMsg::CurrentRewardingInterval {} => to_binary(&query_rewarding_interval(deps)?),
         QueryMsg::LayerDistribution {} => to_binary(&query_layer_distribution(deps)?),

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -214,7 +214,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
             height,
         } => to_binary(&query_mixnode_bond_values_at_height(
             deps,
-            mix_identity,
+            &mix_identity,
             height,
         )?),
         QueryMsg::StateParams {} => to_binary(&query_contract_settings_params(deps)?),

--- a/contracts/mixnet/src/mixnodes/bonding_queries.rs
+++ b/contracts/mixnet/src/mixnodes/bonding_queries.rs
@@ -7,8 +7,7 @@ use cosmwasm_std::{Deps, Order, StdResult};
 use cw_storage_plus::Bound;
 use mixnet_contract::mixnode::MixNodeBondValuesResponse;
 use mixnet_contract::{
-    IdentityKey, IdentityKeyRef, MixNodeBond, MixNodeBondValues, MixOwnershipResponse,
-    PagedMixnodeResponse,
+    IdentityKey, IdentityKeyRef, MixNodeBond, MixOwnershipResponse, PagedMixnodeResponse,
 };
 
 pub fn query_mixnodes_paged(

--- a/contracts/mixnet/src/mixnodes/bonding_queries.rs
+++ b/contracts/mixnet/src/mixnodes/bonding_queries.rs
@@ -70,9 +70,7 @@ pub fn query_mixnode_bond_values_at_height(
     mix_identity: IdentityKeyRef,
     height: u64,
 ) -> StdResult<MixNodeBondValuesResponse> {
-    let bond_values = TOTAL_BOND
-        .may_load_at_height(deps.storage, mix_identity, height)?
-        .flatten();
+    let bond_values = TOTAL_BOND.may_load_at_height(deps.storage, mix_identity, height)?;
 
     Ok(MixNodeBondValuesResponse {
         height,

--- a/contracts/mixnet/src/mixnodes/bonding_queries.rs
+++ b/contracts/mixnet/src/mixnodes/bonding_queries.rs
@@ -65,7 +65,7 @@ pub fn query_owns_mixnode(deps: Deps, address: String) -> StdResult<MixOwnership
     })
 }
 
-pub fn query_mixnode_total_bond_at_height(
+pub fn query_mixnode_bond_values_at_height(
     deps: Deps,
     mix_identity: IdentityKeyRef,
     height: u64,

--- a/contracts/mixnet/src/mixnodes/bonding_queries.rs
+++ b/contracts/mixnet/src/mixnodes/bonding_queries.rs
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::storage;
+use crate::mixnodes::storage::TOTAL_BOND;
 use cosmwasm_std::{Deps, Order, StdResult};
 use cw_storage_plus::Bound;
-use mixnet_contract::{IdentityKey, MixNodeBond, MixOwnershipResponse, PagedMixnodeResponse};
+use mixnet_contract::mixnode::MixNodeBondValuesResponse;
+use mixnet_contract::{
+    IdentityKey, IdentityKeyRef, MixNodeBond, MixNodeBondValues, MixOwnershipResponse,
+    PagedMixnodeResponse,
+};
 
 pub fn query_mixnodes_paged(
     deps: Deps,
@@ -57,6 +62,21 @@ pub fn query_owns_mixnode(deps: Deps, address: String) -> StdResult<MixOwnership
     Ok(MixOwnershipResponse {
         address: validated_addr,
         mixnode,
+    })
+}
+
+pub fn query_mixnode_total_bond_at_height(
+    deps: Deps,
+    mix_identity: IdentityKeyRef,
+    height: u64,
+) -> StdResult<MixNodeBondValuesResponse> {
+    let bond_values = TOTAL_BOND
+        .may_load_at_height(deps.storage, mix_identity, height)?
+        .flatten();
+
+    Ok(MixNodeBondValuesResponse {
+        height,
+        bond_values,
     })
 }
 

--- a/contracts/mixnet/src/mixnodes/storage.rs
+++ b/contracts/mixnet/src/mixnodes/storage.rs
@@ -3,8 +3,8 @@
 
 use config::defaults::DENOM;
 use cosmwasm_std::{StdResult, Storage, Uint128};
-use cw_storage_plus::{Index, IndexList, IndexedMap, Map, UniqueIndex};
-use mixnet_contract::{Addr, Coin, IdentityKeyRef, Layer, MixNode, MixNodeBond};
+use cw_storage_plus::{Index, IndexList, IndexedMap, Map, SnapshotMap, Strategy, UniqueIndex};
+use mixnet_contract::{Addr, Coin, IdentityKeyRef, Layer, MixNode, MixNodeBond, MixNodeBondValues};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
@@ -13,12 +13,25 @@ const TOTAL_DELEGATION_NAMESPACE: &str = "td";
 const MIXNODES_PK_NAMESPACE: &str = "mn";
 const MIXNODES_OWNER_IDX_NAMESPACE: &str = "mno";
 
+const TOTAL_BOND_KEY: &str = "tb";
+const TOTAL_BOND_CHECKPOINTS: &str = "tbcp";
+const TOTAL_BOND_CHANGELOG: &str = "tbcl";
+
 // paged retrieval limits for all queries and transactions
 pub(crate) const BOND_PAGE_MAX_LIMIT: u32 = 75;
 pub(crate) const BOND_PAGE_DEFAULT_LIMIT: u32 = 50;
 
 pub(crate) const TOTAL_DELEGATION: Map<IdentityKeyRef, Uint128> =
     Map::new(TOTAL_DELEGATION_NAMESPACE);
+
+// Note: this is named according to the new terminology where bond = [operator] pledge + delegations
+pub(crate) const TOTAL_BOND: SnapshotMap<IdentityKeyRef, Option<MixNodeBondValues>> =
+    SnapshotMap::new(
+        TOTAL_BOND_KEY,
+        TOTAL_BOND_CHECKPOINTS,
+        TOTAL_BOND_CHANGELOG,
+        Strategy::EveryBlock,
+    );
 
 pub(crate) struct MixnodeBondIndex<'a> {
     pub(crate) owner: UniqueIndex<'a, Addr, StoredMixnodeBond>,

--- a/contracts/mixnet/src/mixnodes/storage.rs
+++ b/contracts/mixnet/src/mixnodes/storage.rs
@@ -25,13 +25,12 @@ pub(crate) const TOTAL_DELEGATION: Map<IdentityKeyRef, Uint128> =
     Map::new(TOTAL_DELEGATION_NAMESPACE);
 
 // Note: this is named according to the new terminology where bond = [operator] pledge + delegations
-pub(crate) const TOTAL_BOND: SnapshotMap<IdentityKeyRef, Option<MixNodeBondValues>> =
-    SnapshotMap::new(
-        TOTAL_BOND_KEY,
-        TOTAL_BOND_CHECKPOINTS,
-        TOTAL_BOND_CHANGELOG,
-        Strategy::EveryBlock,
-    );
+pub(crate) const TOTAL_BOND: SnapshotMap<IdentityKeyRef, MixNodeBondValues> = SnapshotMap::new(
+    TOTAL_BOND_KEY,
+    TOTAL_BOND_CHECKPOINTS,
+    TOTAL_BOND_CHANGELOG,
+    Strategy::EveryBlock,
+);
 
 pub(crate) struct MixnodeBondIndex<'a> {
     pub(crate) owner: UniqueIndex<'a, Addr, StoredMixnodeBond>,

--- a/contracts/mixnet/src/mixnodes/transactions.rs
+++ b/contracts/mixnet/src/mixnodes/transactions.rs
@@ -95,19 +95,25 @@ fn _try_add_mixnode(
 }
 
 pub fn try_remove_mixnode_on_behalf(
+    env: Env,
     deps: DepsMut,
     info: MessageInfo,
     owner: String,
 ) -> Result<Response, ContractError> {
     let proxy = info.sender;
-    _try_remove_mixnode(deps, &owner, Some(proxy))
+    _try_remove_mixnode(env, deps, &owner, Some(proxy))
 }
 
-pub fn try_remove_mixnode(deps: DepsMut, info: MessageInfo) -> Result<Response, ContractError> {
-    _try_remove_mixnode(deps, info.sender.as_ref(), None)
+pub fn try_remove_mixnode(
+    env: Env,
+    deps: DepsMut,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
+    _try_remove_mixnode(env, deps, info.sender.as_ref(), None)
 }
 
 pub(crate) fn _try_remove_mixnode(
+    env: Env,
     deps: DepsMut,
     owner: &str,
     proxy: Option<Addr>,
@@ -143,6 +149,9 @@ pub(crate) fn _try_remove_mixnode(
 
     // decrement layer count
     mixnet_params_storage::decrement_layer_count(deps.storage, mixnode_bond.layer)?;
+
+    // update snapshot data
+    storage::TOTAL_BOND.remove(deps.storage, mixnode_bond.identity(), env.block.height)?;
 
     let mut response = Response::new()
         .add_message(return_tokens)


### PR DESCRIPTION
This PR is nowhere near done, however, I have created this draft to keep track of the remaining work. 

It's going to introduce ability to query for total bond (i.e. pledge and delegation) of particular mixnode at given block height. This is required to fix https://github.com/orgs/nymtech/projects/1#card-74259208

Open questions:
- [ ] Should this snapshoting be only performed on pledge/delegation values or should it be done on the entire `MixNodeBond` struct?
- [ ] Do we want to snapshot at every block or at selected ones? i.e. `Strategy::EveryBlock` vs `Strategy::Selected`

Required work:
- [x] Define Snapshot map that would contain the historical data
- [x] Introduce query for the bond values at particular height
- [ ] Update the snapshot map whenever bond values change, i.e. at: 
  - [ ] Mixnode bonding
  - [x] Mixnode unbonding
  - [ ] Delegating
  - [ ] Undelegating
  - [ ] MixnodeRewarding
  - [ ] DelegatorsRewarding
- [ ] Ideally some unit tests, but realistically only bare minimum will be done in this PR and more extensive testing will be performed in another PR.