### PR TITLE
Add custom denom balance query

### DIFF
--- a/common/client-libs/validator-client/src/nymd/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/mod.rs
@@ -227,14 +227,7 @@ impl<C> NymdClient<C> {
             .map(|block| block.block_id.hash)
     }
 
-    pub async fn get_balance(&self, address: &AccountId) -> Result<Option<CosmosCoin>, NymdError>
-    where
-        C: CosmWasmClient + Sync,
-    {
-        self.client.get_balance(address, self.denom()?).await
-    }
-
-    pub async fn get_denom_balance(
+    pub async fn get_balance(
         &self,
         address: &AccountId,
         denom: Denom,
@@ -243,6 +236,16 @@ impl<C> NymdClient<C> {
         C: CosmWasmClient + Sync,
     {
         self.client.get_balance(address, denom).await
+    }
+
+    pub async fn get_mixnet_balance(
+        &self,
+        address: &AccountId,
+    ) -> Result<Option<CosmosCoin>, NymdError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        self.get_balance(address, self.denom()?).await
     }
 
     pub async fn get_contract_settings(&self) -> Result<ContractStateParams, NymdError>

--- a/common/client-libs/validator-client/src/nymd/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/mod.rs
@@ -234,6 +234,17 @@ impl<C> NymdClient<C> {
         self.client.get_balance(address, self.denom()?).await
     }
 
+    pub async fn get_denom_balance(
+        &self,
+        address: &AccountId,
+        denom: Denom,
+    ) -> Result<Option<CosmosCoin>, NymdError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        self.client.get_balance(address, denom).await
+    }
+
     pub async fn get_contract_settings(&self) -> Result<ContractStateParams, NymdError>
     where
         C: CosmWasmClient + Sync,


### PR DESCRIPTION
This is needed so that we can query other denom balances, which is important especially for testing purposes at this moment.