### PR TITLE
Differentiate staking and ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7275,11 +7275,12 @@ dependencies = [
  "config",
  "cosmwasm-std",
  "cw-storage-plus",
+ "getrandom 0.2.3",
  "mixnet-contract",
+ "rand 0.8.4",
  "schemars",
  "serde",
  "thiserror",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0-beta2"
+version = "1.0.0-beta3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16b255449b3f5cd7fa4b79acd5225b5185655261087a3d8aaac44f88a0e23e9"
+checksum = "a380b87642204557629c9b72988c47b55fbfe6d474960adba56b22331504956a"
 dependencies = [
  "digest 0.9.0",
  "ed25519-zebra",
@@ -920,18 +920,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0-beta2"
+version = "1.0.0-beta3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abad1a6ff427a2f66890a4dce6354b4563cd07cee91a942300e011c921c09ed2"
+checksum = "866713b2fe13f23038c7d8824c3059d1f28dd94685fb406d1533c4eeeefeefae"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0-beta2"
+version = "1.0.0-beta3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1660ee3d5734672e1eb4f0ceda403e2d83345e15143a48845f340f3252ce99a6"
+checksum = "8dbb9939b31441dfa9af3ec9740c8a24d585688401eff1b6b386abb7ad0d10a8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7279,6 +7279,7 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: clippy test fmt
+all: clippy test wasm fmt
 clippy: clippy-main clippy-contracts clippy-wallet
 test: test-main test-contracts test-wallet
 fmt: fmt-main fmt-contracts fmt-wallet
@@ -29,3 +29,6 @@ fmt-contracts:
 
 fmt-wallet:
 	cargo fmt --manifest-path nym-wallet/Cargo.toml --all
+
+wasm:
+	RUSTFLAGS='-C link-arg=-s' cargo build --manifest-path contracts/Cargo.toml --release --target wasm32-unknown-unknown

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,36 @@
-all: clippy test wasm fmt
-clippy: clippy-main clippy-contracts clippy-wallet
+all: clippy-all test fmt
+happy: clippy-happy test fmt
+clippy-all: clippy-all-main clippy-all-contracts clippy-all-wallet
+clippy-happy: clippy-happy-main clippy-happy-contracts clippy-happy-wallet
 test: test-main test-contracts test-wallet
 fmt: fmt-main fmt-contracts fmt-wallet
 
-clippy-main:
+clippy-happy-main:
 	cargo clippy
 
-clippy-contracts:
-	cargo clippy --manifest-path contracts/Cargo.toml
+clippy-happy-contracts:
+	cargo clippy --manifest-path contracts/Cargo.toml --target wasm32-unknown-unknown
 
-clippy-wallet: 
+clippy-happy-wallet: 
 	cargo clippy --manifest-path nym-wallet/Cargo.toml
 
+clippy-all-main:
+	cargo clippy --all-features -- -D warnings 
+
+clippy-all-contracts:
+	cargo clippy --manifest-path contracts/Cargo.toml --all-features --target wasm32-unknown-unknown -- -D warnings
+
+clippy-all-wallet: 
+	cargo clippy --manifest-path nym-wallet/Cargo.toml --all-features -- -D warnings
+
 test-main:
-	cargo test
+	cargo test --all-features
 
 test-contracts:
-	cargo test --manifest-path contracts/Cargo.toml
+	cargo test --manifest-path contracts/Cargo.toml --all-features
 
 test-wallet:
-	cargo test --manifest-path nym-wallet/Cargo.toml
+	cargo test --manifest-path nym-wallet/Cargo.toml --all-features
 
 fmt-main:
 	cargo fmt --all

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -33,7 +33,7 @@ prost = { version = "0.9", default-features = false, optional = true }
 flate2 = { version = "1.0.20", optional = true }
 sha2 = { version = "0.9.5", optional = true }
 itertools = { version = "0.10", optional = true }
-cosmwasm-std = { version = "1.0.0-beta2", optional = true }
+cosmwasm-std = { version = "1.0.0-beta3", optional = true }
 ts-rs = {version = "5.1", optional = true}
 
 [features]

--- a/common/client-libs/validator-client/src/nymd/traits/vesting_signing_client.rs
+++ b/common/client-libs/validator-client/src/nymd/traits/vesting_signing_client.rs
@@ -64,7 +64,8 @@ pub trait VestingSigningClient {
 
     async fn create_periodic_vesting_account(
         &self,
-        address: &str,
+        owner_address: &str,
+        staking_address: Option<String>,
         start_time: Option<u64>,
         amount: Coin,
     ) -> Result<ExecuteResult, NymdError>;
@@ -271,13 +272,15 @@ impl<C: SigningCosmWasmClient + Sync + Send> VestingSigningClient for NymdClient
     }
     async fn create_periodic_vesting_account(
         &self,
-        address: &str,
+        owner_address: &str,
+        staking_address: Option<String>,
         start_time: Option<u64>,
         amount: Coin,
     ) -> Result<ExecuteResult, NymdError> {
         let fee = self.operation_fee(Operation::CreatePeriodicVestingAccount);
         let req = VestingExecuteMsg::CreateAccount {
-            address: address.to_string(),
+            owner_address: owner_address.to_string(),
+            staking_address,
             start_time,
         };
         self.client

--- a/common/mixnet-contract/Cargo.toml
+++ b/common/mixnet-contract/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = "1.0.0-beta2"
+cosmwasm-std = "1.0.0-beta3"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1"

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -326,8 +326,8 @@ dependencies = [
  "log",
  "nymsphinx-types",
  "pemstore",
- "rand",
  "subtle-encoding",
+ "rand 0.7.3",
  "x25519-dalek",
 ]
 
@@ -458,7 +458,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand 0.7.3",
  "serde",
  "sha2",
  "zeroize",
@@ -592,8 +592,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -856,8 +858,8 @@ dependencies = [
  "cw-storage-plus",
  "fixed",
  "mixnet-contract",
- "rand",
- "rand_chacha",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
  "schemars",
  "serde",
  "thiserror",
@@ -1065,9 +1067,21 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -1078,6 +1092,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1105,7 +1129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -1115,6 +1139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1297,7 +1330,7 @@ dependencies = [
  "hmac",
  "lioness",
  "log",
- "rand",
+ "rand 0.7.3",
  "rand_distr",
  "sha2",
  "subtle 2.4.1",
@@ -1490,15 +1523,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.3",
-]
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,11 +1558,12 @@ dependencies = [
  "config",
  "cosmwasm-std",
  "cw-storage-plus",
+ "getrandom 0.2.3",
  "mixnet-contract",
+ "rand 0.8.4",
  "schemars",
  "serde",
  "thiserror",
- "uuid",
 ]
 
 [[package]]

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -326,8 +326,8 @@ dependencies = [
  "log",
  "nymsphinx-types",
  "pemstore",
- "subtle-encoding",
  "rand 0.7.3",
+ "subtle-encoding",
  "x25519-dalek",
 ]
 

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1490,6 +1490,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.3",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1538,7 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -238,9 +238,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0-beta2"
+version = "1.0.0-beta3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16b255449b3f5cd7fa4b79acd5225b5185655261087a3d8aaac44f88a0e23e9"
+checksum = "a380b87642204557629c9b72988c47b55fbfe6d474960adba56b22331504956a"
 dependencies = [
  "digest 0.9.0",
  "ed25519-zebra",
@@ -251,18 +251,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0-beta2"
+version = "1.0.0-beta3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abad1a6ff427a2f66890a4dce6354b4563cd07cee91a942300e011c921c09ed2"
+checksum = "866713b2fe13f23038c7d8824c3059d1f28dd94685fb406d1533c4eeeefeefae"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0-beta2"
+version = "1.0.0-beta3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe52b19d45fe3f8359db6cc24df44dbe05e5ae32539afc0f5b7f790a21aa6fd0"
+checksum = "818b928263c09a3269c2bed22494a62107a43ef87900e273af8ad2cb9f7e4440"
 dependencies = [
  "schemars",
  "serde_json",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0-beta2"
+version = "1.0.0-beta3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1660ee3d5734672e1eb4f0ceda403e2d83345e15143a48845f340f3252ce99a6"
+checksum = "8dbb9939b31441dfa9af3ec9740c8a24d585688401eff1b6b386abb7ad0d10a8"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0-beta2"
+version = "1.0.0-beta3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3b4efe3b4f86df668520a02e9a29c23eea99b64dfcacb0e59b98346418af7f"
+checksum = "b4a4e55f0d64fed54cd2202301b8d466af8de044589247dabd77a4222f52f749"
 dependencies = [
  "cosmwasm-std",
  "serde",

--- a/contracts/bandwidth-claim/Cargo.toml
+++ b/contracts/bandwidth-claim/Cargo.toml
@@ -8,18 +8,14 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
-
 [dev-dependencies]
 config = { path = "../../common/config"}
 
 [dependencies]
 bandwidth-claim-contract = { path = "../../common/bandwidth-claim-contract" }
 
-cosmwasm-std = "1.0.0-beta2"
-cosmwasm-storage = "1.0.0-beta2"
+cosmwasm-std = "1.0.0-beta3"
+cosmwasm-storage = "1.0.0-beta3"
 
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/mixnet/Cargo.toml
+++ b/contracts/mixnet/Cargo.toml
@@ -15,17 +15,13 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
-
 [dependencies]
 mixnet-contract = { path = "../../common/mixnet-contract" }
 config = { path = "../../common/config"}
 vesting-contract = { path = "../vesting" }
 
-cosmwasm-std = "1.0.0-beta2"
-cosmwasm-storage = "1.0.0-beta2"
+cosmwasm-std = "1.0.0-beta3"
+cosmwasm-storage = "1.0.0-beta3"
 cw-storage-plus = "0.10.3"
 
 bs58 = "0.4.0"
@@ -34,7 +30,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0-beta2"
+cosmwasm-schema = "1.0.0-beta3"
 fixed = "1.1"
 rand_chacha = "0.2"
 rand = "0.7"

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -28,3 +28,4 @@ cw-storage-plus = { version = "0.10.3", features = ["iterator"] }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
+uuid = {version = "0.8.2", features = ["v4"]}

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -21,11 +21,11 @@ backtraces = ["cosmwasm-std/backtraces"]
 mixnet-contract = { path = "../../common/mixnet-contract" }
 config = { path = "../../common/config" }
 
-# this branch is identical to 0.14.1 with addition of updated k256 dependency required to help poor cargo choose correct version
-cosmwasm-std = { version = "1.0.0-beta2", features = ["iterator"]}
+cosmwasm-std = { version = "1.0.0-beta2"}
 cw-storage-plus = { version = "0.10.3", features = ["iterator"] }
 
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
-uuid = {version = "0.8.2", features = ["v4"]}
+rand = {version = "0.8.4", features = ["std_rng"]}
+getrandom = { version = "0.2.3", features = ["js"]}

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -13,15 +13,11 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-# for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
-
 [dependencies]
 mixnet-contract = { path = "../../common/mixnet-contract" }
 config = { path = "../../common/config" }
 
-cosmwasm-std = { version = "1.0.0-beta2"}
+cosmwasm-std = { version = "1.0.0-beta3"}
 cw-storage-plus = { version = "0.10.3", features = ["iterator"] }
 
 schemars = "0.8"

--- a/contracts/vesting/src/errors.rs
+++ b/contracts/vesting/src/errors.rs
@@ -38,4 +38,8 @@ pub enum ContractError {
     Underflow,
     #[error("No bond found for account {0}")]
     NoBondFound(String),
+    #[error("Action can only be executed by account owner -> {0}")]
+    NotOwner(String),
+    #[error("Invalid address: {0}")]
+    InvalidAddress(String),
 }

--- a/contracts/vesting/src/messages.rs
+++ b/contracts/vesting/src/messages.rs
@@ -18,7 +18,8 @@ pub enum ExecuteMsg {
         mix_identity: IdentityKey,
     },
     CreateAccount {
-        address: String,
+        owner_address: String,
+        staking_address: Option<String>,
         start_time: Option<u64>,
     },
     WithdrawVestedCoins {
@@ -46,6 +47,12 @@ pub enum ExecuteMsg {
     TrackUnbondGateway {
         owner: String,
         amount: Coin,
+    },
+    TransferOwnership {
+        to_address: String,
+    },
+    UpdateStakingAddress {
+        to_address: Option<String>,
     },
 }
 

--- a/contracts/vesting/src/storage.rs
+++ b/contracts/vesting/src/storage.rs
@@ -5,8 +5,18 @@ use cw_storage_plus::Map;
 
 const ACCOUNTS: Map<Addr, Account> = Map::new("acc");
 
+pub fn delete_account(address: &Addr, storage: &mut dyn Storage) -> Result<(), ContractError> {
+    ACCOUNTS.remove(storage, address.to_owned());
+    Ok(())
+}
+
 pub fn save_account(account: &Account, storage: &mut dyn Storage) -> Result<(), ContractError> {
-    Ok(ACCOUNTS.save(storage, account.address(), account)?)
+    // This is a bit dirty, but its a simple way to allow for both staking account and owner to load it from storage
+    if let Some(staking_address) = account.staking_address() {
+        ACCOUNTS.save(storage, staking_address.to_owned(), account)?;
+    }
+    ACCOUNTS.save(storage, account.owner_address(), account)?;
+    Ok(())
 }
 
 pub fn load_account(

--- a/contracts/vesting/src/support/tests.rs
+++ b/contracts/vesting/src/support/tests.rs
@@ -21,7 +21,8 @@ pub mod helpers {
         let periods = populate_vesting_periods(start_time.seconds(), NUM_VESTING_PERIODS);
 
         Account::new(
-            Addr::unchecked("fixture"),
+            Addr::unchecked("owner"),
+            Some(Addr::unchecked("staking")),
             Coin {
                 amount: Uint128::new(1_000_000_000_000),
                 denom: DENOM.to_string(),

--- a/contracts/vesting/src/traits/vesting_account.rs
+++ b/contracts/vesting/src/traits/vesting_account.rs
@@ -1,5 +1,5 @@
 use crate::errors::ContractError;
-use cosmwasm_std::{Coin, Env, Storage, Timestamp, Addr};
+use cosmwasm_std::{Addr, Coin, Env, Storage, Timestamp};
 
 pub trait VestingAccount {
     // locked_coins returns the set of coins that are not spendable (can still be delegated tough) (i.e. locked),

--- a/contracts/vesting/src/traits/vesting_account.rs
+++ b/contracts/vesting/src/traits/vesting_account.rs
@@ -1,5 +1,5 @@
 use crate::errors::ContractError;
-use cosmwasm_std::{Coin, Env, Storage, Timestamp};
+use cosmwasm_std::{Coin, Env, Storage, Timestamp, Addr};
 
 pub trait VestingAccount {
     // locked_coins returns the set of coins that are not spendable (can still be delegated tough) (i.e. locked),
@@ -62,4 +62,14 @@ pub trait VestingAccount {
         env: &Env,
         storage: &dyn Storage,
     ) -> Result<Coin, ContractError>;
+    fn transfer_ownership(
+        &mut self,
+        to_address: &Addr,
+        storage: &mut dyn Storage,
+    ) -> Result<(), ContractError>;
+    fn update_staking_address(
+        &mut self,
+        to_address: Option<Addr>,
+        storage: &mut dyn Storage,
+    ) -> Result<(), ContractError>;
 }

--- a/contracts/vesting/src/vesting/account/delegating_account.rs
+++ b/contracts/vesting/src/vesting/account/delegating_account.rs
@@ -2,6 +2,7 @@ use crate::errors::ContractError;
 use crate::traits::DelegatingAccount;
 use config::defaults::{DEFAULT_MIXNET_CONTRACT_ADDRESS, DENOM};
 use cosmwasm_std::{wasm_execute, Coin, Env, Order, Response, Storage, Timestamp, Uint128};
+use cw_storage_plus::Map;
 use mixnet_contract::ExecuteMsg as MixnetExecuteMsg;
 use mixnet_contract::IdentityKey;
 
@@ -76,17 +77,17 @@ impl DelegatingAccount for Account {
         storage: &mut dyn Storage,
     ) -> Result<(), ContractError> {
         let delegation_key = (mix_identity.as_bytes(), block_time.seconds());
+        let delegations_storage_key = self.delegations_key();
+        let delegations: Map<(&[u8], u64), Uint128> = Map::new(&delegations_storage_key);
 
-        let new_delegation = if let Some(existing_delegation) =
-            self.delegations().may_load(storage, delegation_key)?
-        {
-            existing_delegation + delegation.amount
-        } else {
-            delegation.amount
-        };
+        let new_delegation =
+            if let Some(existing_delegation) = delegations.may_load(storage, delegation_key)? {
+                existing_delegation + delegation.amount
+            } else {
+                delegation.amount
+            };
 
-        self.delegations()
-            .save(storage, delegation_key, &new_delegation)?;
+        delegations.save(storage, delegation_key, &new_delegation)?;
 
         let new_balance = Uint128::new(current_balance.u128() - delegation.amount.u128());
 
@@ -102,10 +103,11 @@ impl DelegatingAccount for Account {
         storage: &mut dyn Storage,
     ) -> Result<(), ContractError> {
         let mix_bytes = mix_identity.as_bytes();
+        let delegations_key = self.delegations_key();
+        let delegations: Map<(&[u8], u64), Uint128> = Map::new(&delegations_key);
 
         // Iterate over keys matching the prefix and remove them from the map
-        let block_times = self
-            .delegations()
+        let block_times = delegations
             .prefix_de(mix_bytes)
             .keys_de(storage, None, None, Order::Ascending)
             // Scan will blow up on first error
@@ -113,7 +115,7 @@ impl DelegatingAccount for Account {
             .collect::<Vec<u64>>();
 
         for t in block_times {
-            self.delegations().remove(storage, (mix_bytes, t))
+            delegations.remove(storage, (mix_bytes, t))
         }
 
         let new_balance = Uint128::new(self.load_balance(storage)?.u128() + amount.amount.u128());

--- a/contracts/vesting/src/vesting/account/delegating_account.rs
+++ b/contracts/vesting/src/vesting/account/delegating_account.rs
@@ -19,14 +19,14 @@ impl DelegatingAccount for Account {
 
         if current_balance < coin.amount {
             return Err(ContractError::InsufficientBalance(
-                self.address.as_str().to_string(),
+                self.owner_address().as_str().to_string(),
                 current_balance.u128(),
             ));
         }
 
         let msg = MixnetExecuteMsg::DelegateToMixnodeOnBehalf {
             mix_identity: mix_identity.clone(),
-            delegate: self.address().into_string(),
+            delegate: self.owner_address().into_string(),
         };
         let delegate_to_mixnode =
             wasm_execute(DEFAULT_MIXNET_CONTRACT_ADDRESS, &msg, vec![coin.clone()])?;
@@ -44,14 +44,14 @@ impl DelegatingAccount for Account {
     ) -> Result<Response, ContractError> {
         if !self.any_delegation_for_mix(&mix_identity, storage) {
             return Err(ContractError::NoSuchDelegation(
-                self.address(),
+                self.owner_address(),
                 mix_identity,
             ));
         }
 
         let msg = MixnetExecuteMsg::UndelegateFromMixnodeOnBehalf {
             mix_identity,
-            delegate: self.address().into_string(),
+            delegate: self.owner_address().into_string(),
         };
         let undelegate_from_mixnode = wasm_execute(
             DEFAULT_MIXNET_CONTRACT_ADDRESS,

--- a/contracts/vesting/src/vesting/account/gateway_bonding_account.rs
+++ b/contracts/vesting/src/vesting/account/gateway_bonding_account.rs
@@ -20,14 +20,14 @@ impl GatewayBondingAccount for Account {
 
         if current_balance < pledge.amount {
             return Err(ContractError::InsufficientBalance(
-                self.address.as_str().to_string(),
+                self.owner_address().as_str().to_string(),
                 current_balance.u128(),
             ));
         }
 
         let pledge_data = if self.load_gateway_pledge(storage)?.is_some() {
             return Err(ContractError::AlreadyBonded(
-                self.address.as_str().to_string(),
+                self.owner_address().as_str().to_string(),
             ));
         } else {
             PledgeData {
@@ -38,7 +38,7 @@ impl GatewayBondingAccount for Account {
 
         let msg = MixnetExecuteMsg::BondGatewayOnBehalf {
             gateway,
-            owner: self.address().into_string(),
+            owner: self.owner_address().into_string(),
             owner_signature,
         };
 
@@ -56,7 +56,7 @@ impl GatewayBondingAccount for Account {
 
     fn try_unbond_gateway(&self, storage: &dyn Storage) -> Result<Response, ContractError> {
         let msg = MixnetExecuteMsg::UnbondGatewayOnBehalf {
-            owner: self.address().into_string(),
+            owner: self.owner_address().into_string(),
         };
 
         if let Some(_bond) = self.load_gateway_pledge(storage)? {
@@ -67,7 +67,7 @@ impl GatewayBondingAccount for Account {
                 .add_message(unbond_msg))
         } else {
             Err(ContractError::NoBondFound(
-                self.address.as_str().to_string(),
+                self.owner_address().as_str().to_string(),
             ))
         }
     }

--- a/contracts/vesting/src/vesting/account/gateway_bonding_account.rs
+++ b/contracts/vesting/src/vesting/account/gateway_bonding_account.rs
@@ -80,7 +80,7 @@ impl GatewayBondingAccount for Account {
         let new_balance = Uint128::new(self.load_balance(storage)?.u128() + amount.amount.u128());
         self.save_balance(new_balance, storage)?;
 
-        self.remove_gateway_bond(storage)?;
+        self.remove_gateway_pledge(storage)?;
         Ok(())
     }
 }

--- a/contracts/vesting/src/vesting/account/mixnode_bonding_account.rs
+++ b/contracts/vesting/src/vesting/account/mixnode_bonding_account.rs
@@ -80,7 +80,7 @@ impl MixnodeBondingAccount for Account {
         let new_balance = Uint128::new(self.load_balance(storage)?.u128() + amount.amount.u128());
         self.save_balance(new_balance, storage)?;
 
-        self.remove_mixnode_bond(storage)?;
+        self.remove_mixnode_pledge(storage)?;
         Ok(())
     }
 }

--- a/contracts/vesting/src/vesting/account/mixnode_bonding_account.rs
+++ b/contracts/vesting/src/vesting/account/mixnode_bonding_account.rs
@@ -20,14 +20,14 @@ impl MixnodeBondingAccount for Account {
 
         if current_balance < pledge.amount {
             return Err(ContractError::InsufficientBalance(
-                self.address.as_str().to_string(),
+                self.owner_address().as_str().to_string(),
                 current_balance.u128(),
             ));
         }
 
         let pledge_data = if self.load_mixnode_pledge(storage)?.is_some() {
             return Err(ContractError::AlreadyBonded(
-                self.address.as_str().to_string(),
+                self.owner_address().as_str().to_string(),
             ));
         } else {
             PledgeData {
@@ -38,7 +38,7 @@ impl MixnodeBondingAccount for Account {
 
         let msg = MixnetExecuteMsg::BondMixnodeOnBehalf {
             mix_node,
-            owner: self.address().into_string(),
+            owner: self.owner_address().into_string(),
             owner_signature,
         };
 
@@ -56,7 +56,7 @@ impl MixnodeBondingAccount for Account {
 
     fn try_unbond_mixnode(&self, storage: &dyn Storage) -> Result<Response, ContractError> {
         let msg = MixnetExecuteMsg::UnbondMixnodeOnBehalf {
-            owner: self.address().into_string(),
+            owner: self.owner_address().into_string(),
         };
 
         if self.load_mixnode_pledge(storage)?.is_some() {
@@ -67,7 +67,7 @@ impl MixnodeBondingAccount for Account {
                 .add_message(unbond_msg))
         } else {
             Err(ContractError::NoBondFound(
-                self.address.as_str().to_string(),
+                self.owner_address().as_str().to_string(),
             ))
         }
     }

--- a/contracts/vesting/src/vesting/account/vesting_account.rs
+++ b/contracts/vesting/src/vesting/account/vesting_account.rs
@@ -1,8 +1,9 @@
 use crate::contract::NUM_VESTING_PERIODS;
 use crate::errors::ContractError;
+use crate::storage::{delete_account, save_account};
 use crate::traits::VestingAccount;
 use config::defaults::DENOM;
-use cosmwasm_std::{Coin, Env, Order, Storage, Timestamp, Uint128};
+use cosmwasm_std::{Addr, Coin, Env, Order, Storage, Timestamp, Uint128};
 
 use super::Account;
 
@@ -208,5 +209,30 @@ impl VestingAccount for Account {
                 denom: DENOM.to_string(),
             })
         }
+    }
+
+    fn transfer_ownership(
+        &mut self,
+        to_address: &Addr,
+        storage: &mut dyn Storage,
+    ) -> Result<(), ContractError> {
+        delete_account(&self.owner_address(), storage)?;
+        self.owner_address = to_address.clone();
+
+        save_account(self, storage)?;
+        Ok(())
+    }
+
+    fn update_staking_address(
+        &mut self,
+        to_address: Option<Addr>,
+        storage: &mut dyn Storage,
+    ) -> Result<(), ContractError> {
+        if let Some(staking_address) = self.staking_address() {
+            delete_account(staking_address, storage)?;
+        }
+        self.staking_address = to_address;
+        save_account(self, storage)?;
+        Ok(())
     }
 }

--- a/contracts/vesting/src/vesting/mod.rs
+++ b/contracts/vesting/src/vesting/mod.rs
@@ -36,7 +36,7 @@ pub fn populate_vesting_periods(start_time: u64, n: usize) -> Vec<VestingPeriod>
 
 #[cfg(test)]
 mod tests {
-    use crate::contract::{execute, NUM_VESTING_PERIODS, VESTING_PERIOD};
+    use crate::contract::{execute, ADMIN_ADDRESS, NUM_VESTING_PERIODS, VESTING_PERIOD};
     use crate::messages::ExecuteMsg;
     use crate::storage::load_account;
     use crate::support::tests::helpers::{init_contract, vesting_account_fixture};
@@ -45,29 +45,44 @@ mod tests {
     use crate::traits::{GatewayBondingAccount, MixnodeBondingAccount};
     use config::defaults::DENOM;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{Addr, Coin, Timestamp, Uint128};
+    use cosmwasm_std::{coins, Addr, Coin, Timestamp, Uint128};
     use mixnet_contract::{Gateway, MixNode};
 
     #[test]
     fn test_account_creation() {
         let mut deps = init_contract();
         let env = mock_env();
-        let account = vesting_account_fixture(&mut deps.storage, &env);
-        let created_account = load_account(&account.owner_address(), &deps.storage).unwrap();
-        let created_account_test = load_account(&Addr::unchecked("owner"), &deps.storage).unwrap();
+        let info = mock_info("not_admin", &coins(1_000_000_000_000, DENOM));
+        let msg = ExecuteMsg::CreateAccount {
+            owner_address: "owner".to_string(),
+            staking_address: Some("staking".to_string()),
+            start_time: None,
+        };
+        let response = execute(deps.as_mut(), env.clone(), info, msg.clone());
+        assert!(response.is_err());
+
+        let info = mock_info(ADMIN_ADDRESS, &coins(1_000_000_000_000, DENOM));
+        let _response = execute(deps.as_mut(), env.clone(), info, msg.clone());
+        let created_account = load_account(&Addr::unchecked("owner"), &deps.storage)
+            .unwrap()
+            .unwrap();
         let created_account_test_by_staking =
-            load_account(&Addr::unchecked("staking"), &deps.storage).unwrap();
-        assert_eq!(Some(&account), created_account.as_ref());
-        assert_eq!(Some(&account), created_account_test.as_ref());
-        assert_eq!(created_account_test_by_staking, created_account_test);
+            load_account(&Addr::unchecked("staking"), &deps.storage)
+                .unwrap()
+                .unwrap();
+        assert_eq!(created_account_test_by_staking, created_account);
         assert_eq!(
-            account.load_balance(&deps.storage).unwrap(),
+            created_account.load_balance(&deps.storage).unwrap(),
             Uint128::new(1_000_000_000_000)
         );
+        // Test key collision avoidance
+
+        let account_again = vesting_account_fixture(&mut deps.storage, &env);
         assert_eq!(
-            account.load_balance(&deps.storage).unwrap(),
-            Uint128::new(1_000_000_000_000)
-        )
+            created_account.balance_key(),
+            "5032709489228919411ba".to_string()
+        );
+        assert_ne!(created_account.balance_key(), account_again.balance_key());
     }
 
     #[test]

--- a/gateway/src/commands/sign.rs
+++ b/gateway/src/commands/sign.rs
@@ -5,14 +5,9 @@ use crate::commands::*;
 use crate::config::{persistence::pathfinder::GatewayPathfinder, Config};
 use clap::{App, Arg, ArgMatches};
 use colored::Colorize;
-#[cfg(feature = "coconut")]
-use config::defaults::BECH32_PREFIX;
 use config::NymConfig;
 use crypto::asymmetric::identity;
 use log::error;
-use std::process;
-#[cfg(feature = "coconut")]
-use subtle_encoding::bech32;
 #[cfg(not(feature = "coconut"))]
 use validator_client::nymd::AccountId;
 
@@ -111,7 +106,7 @@ fn sign_derived_address(private_key: &identity::PrivateKey, address: &AccountId)
 
 // we do tiny bit of sanity check validation
 #[cfg(feature = "coconut")]
-fn print_signed_address(private_key: &identity::PrivateKey, raw_address: &str) -> String {
+fn sign_provided_address(private_key: &identity::PrivateKey, raw_address: &str) {
     let trimmed = raw_address.trim();
     validate_bech32_address_or_exit(trimmed);
     let signature = private_key.sign_text(trimmed);
@@ -119,8 +114,7 @@ fn print_signed_address(private_key: &identity::PrivateKey, raw_address: &str) -
     println!(
         "The base58-encoded signature on '{}' is: {}",
         trimmed, signature
-    );
-    signature
+    )
 }
 
 fn print_signed_text(private_key: &identity::PrivateKey, text: &str) {

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -5188,11 +5188,12 @@ dependencies = [
  "config",
  "cosmwasm-std",
  "cw-storage-plus",
+ "getrandom 0.2.3",
  "mixnet-contract",
+ "rand 0.8.4",
  "schemars",
  "serde",
  "thiserror",
- "uuid",
 ]
 
 [[package]]

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -5192,6 +5192,7 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]

--- a/nym-wallet/src-tauri/Cargo.toml
+++ b/nym-wallet/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ eyre = "0.6.5"
 
 
 cosmrs = { git = "https://github.com/cosmos/cosmos-rust", rev="e5a1872083abb3d88fa62dda966e7f5408deba58", features = ["rpc", "bip32", "cosmwasm"] }
-cosmwasm-std = "1.0.0-beta2"
+cosmwasm-std = "1.0.0-beta3"
 
 validator-client = { path = "../../common/client-libs/validator-client", features = [
     "nymd-client",


### PR DESCRIPTION
Closes https://github.com/nymtech/nym/issues/2067 and https://github.com/nymtech/nym/issues/2066

We slightly abuse storage for the implementation as we save the account twice once to ownership key, and once to staking key. This allows us to have a very simple implementation of everything else, and guarantees that both addresses will point to the same data

ToDo:

- [x] use consistent random keys