### PR TITLE
Feature/node info command

### DIFF
--- a/gateway/src/commands/init.rs
+++ b/gateway/src/commands/init.rs
@@ -4,6 +4,7 @@
 use crate::commands::*;
 use crate::config::persistence::pathfinder::GatewayPathfinder;
 use crate::config::Config;
+use crate::node::Gateway;
 use clap::{App, Arg, ArgMatches};
 use config::NymConfig;
 use crypto::asymmetric::{encryption, identity};
@@ -76,58 +77,6 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
     app
 }
 
-fn show_bonding_info(config: &Config) {
-    fn load_sphinx_keys(pathfinder: &GatewayPathfinder) -> encryption::KeyPair {
-        let sphinx_keypair: encryption::KeyPair =
-            pemstore::load_keypair(&pemstore::KeyPairPath::new(
-                pathfinder.private_encryption_key().to_owned(),
-                pathfinder.public_encryption_key().to_owned(),
-            ))
-            .expect("Failed to read stored sphinx key files");
-        println!(
-            "Public sphinx key: {}\n",
-            sphinx_keypair.public_key().to_base58_string()
-        );
-        sphinx_keypair
-    }
-
-    fn load_identity_keys(pathfinder: &GatewayPathfinder) -> identity::KeyPair {
-        let identity_keypair: identity::KeyPair =
-            pemstore::load_keypair(&pemstore::KeyPairPath::new(
-                pathfinder.private_identity_key().to_owned(),
-                pathfinder.public_identity_key().to_owned(),
-            ))
-            .expect("Failed to read stored identity key files");
-        println!(
-            "Public identity key: {}\n",
-            identity_keypair.public_key().to_base58_string()
-        );
-        identity_keypair
-    }
-
-    let pathfinder = GatewayPathfinder::new_from_config(config);
-    let identity_keypair = load_identity_keys(&pathfinder);
-    let sphinx_keypair = load_sphinx_keys(&pathfinder);
-
-    println!(
-        "\nTo bond your gateway you will [most likely] need to provide the following:
-    Identity key: {}
-    Sphinx key: {}
-    Host: {}
-    Mix Port: {}
-    Clients Port: {}
-    Location: [physical location of your node's server]
-    Version: {}
-    ",
-        identity_keypair.public_key().to_base58_string(),
-        sphinx_keypair.public_key().to_base58_string(),
-        config.get_announce_address(),
-        config.get_mix_port(),
-        config.get_clients_port(),
-        config.get_version(),
-    );
-}
-
 pub async fn execute(matches: ArgMatches<'static>) {
     let id = matches.value_of(ID_ARG_NAME).unwrap();
     println!("Initialising gateway {}...", id);
@@ -176,7 +125,7 @@ pub async fn execute(matches: ArgMatches<'static>) {
         .save_to_file(None)
         .expect("Failed to save the config file");
     println!("Saved configuration file to {:?}", config_save_location);
-
     println!("Gateway configuration completed.\n\n\n");
-    show_bonding_info(&config);
+
+    Gateway::new(config).await.print_node_details()
 }

--- a/gateway/src/commands/mod.rs
+++ b/gateway/src/commands/mod.rs
@@ -6,6 +6,7 @@ use clap::ArgMatches;
 use url::Url;
 
 pub(crate) mod init;
+pub(crate) mod node_details;
 pub(crate) mod run;
 pub(crate) mod sign;
 pub(crate) mod upgrade;

--- a/gateway/src/commands/node_details.rs
+++ b/gateway/src/commands/node_details.rs
@@ -1,0 +1,35 @@
+// Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::*;
+use crate::config::Config;
+use crate::node::Gateway;
+use clap::{App, Arg, ArgMatches};
+use config::NymConfig;
+use log::error;
+
+pub fn command_args<'a, 'b>() -> App<'a, 'b> {
+    App::new("node-details")
+        .about("Show details of this gateway")
+        .arg(
+            Arg::with_name(ID_ARG_NAME)
+                .long(ID_ARG_NAME)
+                .help("The id of the gateway you want to show details for")
+                .takes_value(true)
+                .required(true),
+        )
+}
+
+pub async fn execute(matches: ArgMatches<'static>) {
+    let id = matches.value_of(ID_ARG_NAME).unwrap();
+
+    let config = match Config::load_from_file(Some(id)) {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            error!("Failed to load config for {}. Are you sure you have run `init` before? (Error was: {})", id, err);
+            return;
+        }
+    };
+
+    Gateway::new(config).await.print_node_details()
+}

--- a/gateway/src/commands/run.rs
+++ b/gateway/src/commands/run.rs
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::commands::*;
-use crate::config::persistence::pathfinder::GatewayPathfinder;
 use crate::config::Config;
 use crate::node::Gateway;
 use clap::{App, Arg, ArgMatches};
 use config::NymConfig;
-use crypto::asymmetric::{encryption, identity};
 use log::*;
 use version_checker::is_minor_version_compatible;
 
@@ -92,32 +90,6 @@ fn special_addresses() -> Vec<&'static str> {
     vec!["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]
 }
 
-fn load_sphinx_keys(pathfinder: &GatewayPathfinder) -> encryption::KeyPair {
-    let sphinx_keypair: encryption::KeyPair = pemstore::load_keypair(&pemstore::KeyPairPath::new(
-        pathfinder.private_encryption_key().to_owned(),
-        pathfinder.public_encryption_key().to_owned(),
-    ))
-    .expect("Failed to read stored sphinx key files");
-    println!(
-        "Public sphinx key: {}\n",
-        sphinx_keypair.public_key().to_base58_string()
-    );
-    sphinx_keypair
-}
-
-fn load_identity_keys(pathfinder: &GatewayPathfinder) -> identity::KeyPair {
-    let identity_keypair: identity::KeyPair = pemstore::load_keypair(&pemstore::KeyPairPath::new(
-        pathfinder.private_identity_key().to_owned(),
-        pathfinder.public_identity_key().to_owned(),
-    ))
-    .expect("Failed to read stored identity key files");
-    println!(
-        "Public identity key: {}\n",
-        identity_keypair.public_key().to_base58_string()
-    );
-    identity_keypair
-}
-
 // this only checks compatibility between config the binary. It does not take into consideration
 // network version. It might do so in the future.
 fn version_check(cfg: &Config) -> bool {
@@ -157,32 +129,12 @@ pub async fn execute(matches: ArgMatches<'static>) {
         return;
     }
 
-    let pathfinder = GatewayPathfinder::new_from_config(&config);
-    let sphinx_keypair = load_sphinx_keys(&pathfinder);
-    let identity = load_identity_keys(&pathfinder);
-
     if special_addresses().contains(&&*config.get_listening_address().to_string()) {
         show_binding_warning(config.get_listening_address().to_string());
     }
 
-    println!(
-        "Validator API servers: {:?}",
-        config.get_validator_api_endpoints()
-    );
+    let mut gateway = Gateway::new(config).await;
+    gateway.print_node_details();
 
-    println!(
-        "Listening for incoming packets on {}",
-        config.get_listening_address()
-    );
-    println!(
-        "Announcing the following address: {}",
-        config.get_announce_address()
-    );
-
-    println!("Data store is at: {:?}", config.get_persistent_store_path());
-
-    Gateway::new(config, sphinx_keypair, identity)
-        .await
-        .run()
-        .await;
+    gateway.run().await;
 }

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -21,6 +21,7 @@ async fn main() {
         .subcommand(commands::run::command_args())
         .subcommand(commands::sign::command_args())
         .subcommand(commands::upgrade::command_args())
+        .subcommand(commands::node_details::command_args())
         .get_matches();
 
     execute(arg_matches).await;
@@ -32,6 +33,7 @@ async fn execute(matches: ArgMatches<'static>) {
         ("run", Some(m)) => commands::run::execute(m.clone()).await,
         ("upgrade", Some(m)) => commands::upgrade::execute(m.clone()).await,
         ("sign", Some(m)) => commands::sign::execute(m),
+        ("node-details", Some(m)) => commands::node_details::execute(m.clone()).await,
         _ => println!("{}", usage()),
     }
 }

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -93,6 +93,11 @@ impl Gateway {
             self.config.get_listening_address()
         );
         println!("Version: {}", self.config.get_version());
+        println!(
+            "Mix Port: {}, Clients port: {}",
+            self.config.get_mix_port(),
+            self.config.get_clients_port()
+        );
 
         println!(
             "Data store is at: {:?}",

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -15,6 +15,7 @@ use std::net::SocketAddr;
 use std::process;
 use std::sync::Arc;
 
+use crate::config::persistence::pathfinder::GatewayPathfinder;
 #[cfg(not(feature = "coconut"))]
 use crate::node::client_handling::websocket::connection_handler::eth_events::ERC20Bridge;
 #[cfg(feature = "coconut")]
@@ -29,13 +30,25 @@ pub(crate) mod storage;
 pub struct Gateway {
     config: Config,
     /// ed25519 keypair used to assert one's identity.
-    identity: Arc<identity::KeyPair>,
+    identity_keypair: Arc<identity::KeyPair>,
     /// x25519 keypair used for Diffie-Hellman. Currently only used for sphinx key derivation.
-    encryption_keys: Arc<encryption::KeyPair>,
+    sphinx_keypair: Arc<encryption::KeyPair>,
     storage: PersistentStorage,
 }
 
 impl Gateway {
+    pub async fn new(config: Config) -> Self {
+        let storage = Self::initialise_storage(&config).await;
+        let pathfinder = GatewayPathfinder::new_from_config(&config);
+
+        Gateway {
+            config,
+            identity_keypair: Arc::new(Self::load_identity_keys(&pathfinder)),
+            sphinx_keypair: Arc::new(Self::load_sphinx_keys(&pathfinder)),
+            storage,
+        }
+    }
+
     async fn initialise_storage(config: &Config) -> PersistentStorage {
         let path = config.get_persistent_store_path();
         let retrieval_limit = config.get_message_retrieval_limit();
@@ -45,19 +58,46 @@ impl Gateway {
         }
     }
 
-    pub async fn new(
-        config: Config,
-        encryption_keys: encryption::KeyPair,
-        identity: identity::KeyPair,
-    ) -> Self {
-        let storage = Self::initialise_storage(&config).await;
+    fn load_identity_keys(pathfinder: &GatewayPathfinder) -> identity::KeyPair {
+        let identity_keypair: identity::KeyPair =
+            pemstore::load_keypair(&pemstore::KeyPairPath::new(
+                pathfinder.private_identity_key().to_owned(),
+                pathfinder.public_identity_key().to_owned(),
+            ))
+            .expect("Failed to read stored identity key files");
+        identity_keypair
+    }
 
-        Gateway {
-            config,
-            identity: Arc::new(identity),
-            encryption_keys: Arc::new(encryption_keys),
-            storage,
-        }
+    fn load_sphinx_keys(pathfinder: &GatewayPathfinder) -> encryption::KeyPair {
+        let sphinx_keypair: encryption::KeyPair =
+            pemstore::load_keypair(&pemstore::KeyPairPath::new(
+                pathfinder.private_encryption_key().to_owned(),
+                pathfinder.public_encryption_key().to_owned(),
+            ))
+            .expect("Failed to read stored sphinx key files");
+        sphinx_keypair
+    }
+
+    pub(crate) fn print_node_details(&self) {
+        println!(
+            "Identity Key: {}",
+            self.identity_keypair.public_key().to_base58_string()
+        );
+        println!(
+            "Sphinx Key: {}",
+            self.sphinx_keypair.public_key().to_base58_string()
+        );
+        println!(
+            "Host: {} (bind address: {})",
+            self.config.get_announce_address(),
+            self.config.get_listening_address()
+        );
+        println!("Version: {}", self.config.get_version());
+
+        println!(
+            "Data store is at: {:?}",
+            self.config.get_persistent_store_path()
+        );
     }
 
     fn start_mix_socket_listener(
@@ -68,7 +108,7 @@ impl Gateway {
         info!("Starting mix socket listener...");
 
         let packet_processor =
-            mixnet_handling::PacketProcessor::new(self.encryption_keys.private_key());
+            mixnet_handling::PacketProcessor::new(self.sphinx_keypair.private_key());
 
         let connection_handler = ConnectionHandler::new(
             packet_processor,
@@ -101,7 +141,7 @@ impl Gateway {
 
         websocket::Listener::new(
             listening_address,
-            Arc::clone(&self.identity),
+            Arc::clone(&self.identity_keypair),
             #[cfg(feature = "coconut")]
             verification_key,
             #[cfg(not(feature = "coconut"))]
@@ -168,7 +208,7 @@ impl Gateway {
         info!("Starting nym gateway!");
 
         if let Some(duplicate_node_key) = self.check_if_same_ip_gateway_exists().await {
-            if duplicate_node_key == self.identity.public_key().to_base58_string() {
+            if duplicate_node_key == self.identity_keypair.public_key().to_base58_string() {
                 warn!("We seem to have not unregistered after going offline - there's a node with identical identity and announce-host as us registered.")
             } else {
                 error!(

--- a/mixnode/src/commands/mod.rs
+++ b/mixnode/src/commands/mod.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 pub(crate) mod describe;
 pub(crate) mod init;
+pub(crate) mod node_details;
 pub(crate) mod run;
 pub(crate) mod sign;
 pub(crate) mod upgrade;

--- a/mixnode/src/commands/node_details.rs
+++ b/mixnode/src/commands/node_details.rs
@@ -1,0 +1,34 @@
+// Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::commands::*;
+use crate::config::Config;
+use crate::node::MixNode;
+use clap::{App, Arg, ArgMatches};
+use config::NymConfig;
+
+pub fn command_args<'a, 'b>() -> App<'a, 'b> {
+    App::new("node-details")
+        .about("Show details of this mixnode")
+        .arg(
+            Arg::with_name(ID_ARG_NAME)
+                .long(ID_ARG_NAME)
+                .help("The id of the mixnode you want to show details for")
+                .takes_value(true)
+                .required(true),
+        )
+}
+
+pub fn execute(matches: &ArgMatches) {
+    let id = matches.value_of(ID_ARG_NAME).unwrap();
+
+    let config = match Config::load_from_file(Some(id)) {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            error!("Failed to load config for {}. Are you sure you have run `init` before? (Error was: {})", id, err);
+            return;
+        }
+    };
+
+    MixNode::new(config).print_node_details()
+}

--- a/mixnode/src/commands/run.rs
+++ b/mixnode/src/commands/run.rs
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::commands::*;
-use crate::config::{persistence::pathfinder::MixNodePathfinder, Config};
-use crate::node::node_description::NodeDescription;
+use crate::config::Config;
 use crate::node::MixNode;
 use clap::{App, Arg, ArgMatches};
 use config::NymConfig;
-use crypto::asymmetric::{encryption, identity};
 use log::warn;
 use version_checker::is_minor_version_compatible;
 
@@ -75,24 +73,6 @@ fn special_addresses() -> Vec<&'static str> {
     vec!["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]
 }
 
-fn load_identity_keys(pathfinder: &MixNodePathfinder) -> identity::KeyPair {
-    let identity_keypair: identity::KeyPair = pemstore::load_keypair(&pemstore::KeyPairPath::new(
-        pathfinder.private_identity_key().to_owned(),
-        pathfinder.public_identity_key().to_owned(),
-    ))
-    .expect("Failed to read stored identity key files");
-    identity_keypair
-}
-
-fn load_sphinx_keys(pathfinder: &MixNodePathfinder) -> encryption::KeyPair {
-    let sphinx_keypair: encryption::KeyPair = pemstore::load_keypair(&pemstore::KeyPairPath::new(
-        pathfinder.private_encryption_key().to_owned(),
-        pathfinder.public_encryption_key().to_owned(),
-    ))
-    .expect("Failed to read stored sphinx key files");
-    sphinx_keypair
-}
-
 // this only checks compatibility between config the binary. It does not take into consideration
 // network version. It might do so in the future.
 fn version_check(cfg: &Config) -> bool {
@@ -132,41 +112,15 @@ pub fn execute(matches: &ArgMatches) {
         return;
     }
 
-    let pathfinder = MixNodePathfinder::new_from_config(&config);
-    let identity_keypair = load_identity_keys(&pathfinder);
-    let sphinx_keypair = load_sphinx_keys(&pathfinder);
-
     if special_addresses().contains(&&*config.get_listening_address().to_string()) {
         show_binding_warning(config.get_listening_address().to_string());
     }
 
-    let description = NodeDescription::load_from_file(Config::default_config_directory(Some(id)))
-        .unwrap_or_default();
+    let mut mixnode = MixNode::new(config);
 
     println!(
-        "Validator servers: {:?}",
-        config.get_validator_api_endpoints()
-    );
-    println!(
-        "Listening for incoming packets on {}",
-        config.get_listening_address()
-    );
-    println!(
-        "Announcing the following address: {}",
-        config.get_announce_address()
-    );
+        "\nTo bond your mixnode, go to https://testnet-milhon-wallet.nymtech.net/.  You will need to provide the following:");
+    mixnode.print_node_details();
 
-    println!(
-        "\nTo bond your mixnode, go to https://testnet-milhon-wallet.nymtech.net/.  You will need to provide the following:
-    Identity key: {}
-    Sphinx key: {}
-    Address: {}
-    Version: {}
-    ",
-        identity_keypair.public_key().to_base58_string(),
-        sphinx_keypair.public_key().to_base58_string(),
-        config.get_announce_address(),
-        config.get_version(),
-    );
-    MixNode::new(config, description, identity_keypair, sphinx_keypair).run();
+    mixnode.run()
 }

--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -197,6 +197,10 @@ impl Config {
     }
 
     // getters
+    pub fn get_id(&self) -> String {
+        self.mixnode.id.clone()
+    }
+
     pub fn get_config_file_save_location(&self) -> PathBuf {
         self.config_directory().join(Self::config_file_name())
     }

--- a/mixnode/src/main.rs
+++ b/mixnode/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
         .subcommand(commands::run::command_args())
         .subcommand(commands::upgrade::command_args())
         .subcommand(commands::sign::command_args())
+        .subcommand(commands::node_details::command_args())
         .get_matches();
 
     execute(arg_matches);
@@ -36,6 +37,7 @@ fn execute(matches: ArgMatches) {
         ("run", Some(m)) => commands::run::execute(m),
         ("sign", Some(m)) => commands::sign::execute(m),
         ("upgrade", Some(m)) => commands::upgrade::execute(m),
+        ("node-details", Some(m)) => commands::node_details::execute(m),
         _ => println!("{}", usage()),
     }
 }

--- a/mixnode/src/node/mod.rs
+++ b/mixnode/src/node/mod.rs
@@ -94,6 +94,12 @@ impl MixNode {
             self.config.get_listening_address()
         );
         println!("Version: {}", self.config.get_version());
+        println!(
+            "Mix Port: {}, Verloc port: {}, Http Port: {}",
+            self.config.get_mix_port(),
+            self.config.get_version(),
+            self.config.get_http_api_port()
+        );
     }
 
     fn start_http_api(


### PR DESCRIPTION
Introduces `node-details` command that basically prints out all information required for node bonding. Also removed some duplicate code.