### PR TITLE
Update message to bond mixnode

### DIFF
--- a/mixnode/src/commands/run.rs
+++ b/mixnode/src/commands/run.rs
@@ -119,7 +119,8 @@ pub fn execute(matches: &ArgMatches) {
     let mut mixnode = MixNode::new(config);
 
     println!(
-        "\nTo bond your mixnode, go to https://testnet-milhon-wallet.nymtech.net/.  You will need to provide the following:");
+        "\nTo bond your mixnode you will need to install the Nym wallet, go to https://nymtech.net/get-involved and select the Download button.\n\
+         Select the correct version and install it to your machine. You will need to provide the following: \n ");
     mixnode.print_node_details();
 
     mixnode.run()


### PR DESCRIPTION
- This prevents the user navigating to the deprecated web-wallet.