### PR TITLE
Feature/user info

### DIFF
--- a/explorer/src/components/UserInfoHeader.tsx
+++ b/explorer/src/components/UserInfoHeader.tsx
@@ -1,0 +1,151 @@
+import * as React from 'react';
+import { Box, Button, Grid, Typography, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import {
+  AccountCircleOutlined as AccountCircleOutlinedIcon,
+  PauseCircleOutline as PauseCircleOutlineIcon,
+  CircleOutlined as CircleOutlinedIcon,
+  CheckCircleOutlined as CheckCircleOutlinedIcon,
+} from '@mui/icons-material';
+
+interface UserInfoHeaderProps {
+  status: 'active' | 'inactive' | 'stand-by';
+  name?: string;
+  description?: string;
+  profilePic?: string;
+}
+export const UserInfoHeader: React.FC<UserInfoHeaderProps> = ({
+  status,
+  name,
+  description,
+  profilePic,
+}) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  const dynamicColor = () => {
+    let c = theme.palette.nym.success;
+    if (status === 'inactive') {
+      c = 'inherit';
+    }
+    if (status === 'stand-by') {
+      c = theme.palette.nym.info;
+    }
+    return c;
+  };
+
+  return (
+    <>
+      <Box sx={{ mt: 2, mb: 2 }}>
+        <Grid container>
+          <Grid item xs={12} md={6}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: isMobile ? 'column' : 'row',
+                alignItems: 'center',
+              }}
+            >
+              {profilePic && (
+                <img src={profilePic} alt="my pic" height={66} width={66} />
+              )}
+              <AccountCircleOutlinedIcon
+                style={{ height: '66px', width: '66px' }}
+              />
+              <Typography
+                variant="h6"
+                sx={{ fontWeight: 600, ml: isMobile ? 0 : 2 }}
+              >
+                Mixnode
+              </Typography>
+            </Box>
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'flex-end',
+              }}
+            >
+              {!isMobile && (
+                <Typography
+                  variant="body1"
+                  sx={{ fontWeight: 600, textAlign: 'end' }}
+                >
+                  Node Status:
+                </Typography>
+              )}
+              <Typography
+                variant="body1"
+                sx={{
+                  textAlign: 'end',
+                  color: dynamicColor(),
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: isMobile ? 'center' : 'flex-end',
+                  mt: isMobile ? 2 : 0,
+                  mb: isMobile ? 2 : 0,
+                }}
+              >
+                {status === 'active' && <CheckCircleOutlinedIcon />}
+                {status === 'inactive' && <CircleOutlinedIcon />}
+                {status === 'stand-by' && <PauseCircleOutlineIcon />}
+                &nbsp;{status}
+              </Typography>
+              {status === 'stand-by' && (
+                <Typography
+                  variant="body1"
+                  sx={{
+                    color: 'darkgrey',
+                    textAlign: isMobile ? 'center' : 'end',
+                  }}
+                >
+                  This node is on standy by in this epoch
+                </Typography>
+              )}
+            </Box>
+          </Grid>
+          <Grid item xs={12} sx={{ mt: isMobile ? 4 : 2 }}>
+            <Typography sx={{ fontSize: 21 }}>
+              {name || 'This node has not yet set a name'}
+            </Typography>
+          </Grid>
+          <Grid item xs={12} sx={{ mb: isMobile ? 2 : 2 }}>
+            <Typography sx={{ fontSize: 16 }}>
+              {description || 'This node has not yet set a description'}
+            </Typography>
+          </Grid>
+          <Grid item xs={12}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: isMobile ? 'column' : 'row',
+                alignItems: 'center',
+              }}
+            >
+              <Button
+                variant="contained"
+                onClick={() => null}
+                sx={{
+                  background:
+                    'linear-gradient(90deg, #F4731B 1.05%, #F12D50 100%)',
+                  borderRadius: 30,
+                  fontWeight: 800,
+                }}
+              >
+                THIS IS A LINK
+              </Button>
+            </Box>
+          </Grid>
+        </Grid>
+      </Box>
+    </>
+  );
+};
+
+UserInfoHeader.defaultProps = {
+  name: undefined,
+  description: undefined,
+  profilePic: undefined,
+};

--- a/explorer/src/pages/MixnodeDetail/index.tsx
+++ b/explorer/src/pages/MixnodeDetail/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Box, Button, Grid, Typography, useMediaQuery } from '@mui/material';
+import { Box, Grid, Typography, useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { ColumnsType, DetailTable } from 'src/components/DetailTable';
 import { mixnodeToGridRow, scrollToRef } from 'src/utils';
@@ -13,8 +13,7 @@ import { TwoColSmallTable } from 'src/components/TwoColSmallTable';
 import { UptimeChart } from 'src/components/UptimeChart';
 import { WorldMap } from 'src/components/WorldMap';
 import { useMainContext } from 'src/context/main';
-import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
-import PauseCircleOutlineIcon from '@mui/icons-material/PauseCircleOutline';
+import { UserInfoHeader } from 'src/components/UserInfoHeader';
 
 const columns: ColumnsType[] = [
   {
@@ -109,103 +108,11 @@ export const PageMixnodeDetail: React.FC = () => {
             <Title text="Mixnode Detail" />
           </Grid>
         </Grid>
-        <Box sx={{ mt: 2, mb: 2 }}>
-          <Grid container>
-            <Grid item xs={12} md={6}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: isMobile ? 'column' : 'row',
-                  alignItems: 'center',
-                }}
-              >
-                <AccountCircleOutlinedIcon
-                  style={{ height: '66px', width: '66px' }}
-                />
-                <Typography
-                  variant="h6"
-                  sx={{ fontWeight: 600, ml: isMobile ? 0 : 2 }}
-                >
-                  Mixnode
-                </Typography>
-              </Box>
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'flex-end',
-                }}
-              >
-                {!isMobile && (
-                  <Typography
-                    variant="body1"
-                    sx={{ fontWeight: 600, textAlign: 'end' }}
-                  >
-                    Node Status:
-                  </Typography>
-                )}
-                <Typography
-                  variant="body1"
-                  sx={{
-                    textAlign: 'end',
-                    color: '#60D7EF',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: isMobile ? 'center' : 'flex-end',
-                    mt: isMobile ? 2 : 0,
-                    mb: isMobile ? 2 : 0,
-                  }}
-                >
-                  <PauseCircleOutlineIcon />
-                  &nbsp;Stand-by
-                </Typography>
-                <Typography
-                  variant="body1"
-                  sx={{
-                    color: 'darkgrey',
-                    textAlign: isMobile ? 'center' : 'end',
-                  }}
-                >
-                  This node is on standy by in this epoch
-                </Typography>
-              </Box>
-            </Grid>
-            <Grid item xs={12} sx={{ mt: isMobile ? 4 : 2 }}>
-              <Typography sx={{ fontSize: 21 }}>
-                This node has not yet set a name.
-              </Typography>
-            </Grid>
-            <Grid item xs={12} sx={{ mb: isMobile ? 2 : 2 }}>
-              <Typography sx={{ fontSize: 16 }}>
-                This node has not yet set a description
-              </Typography>
-            </Grid>
-            <Grid item xs={12}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: isMobile ? 'column' : 'row',
-                  alignItems: 'center',
-                }}
-              >
-                <Button
-                  variant="contained"
-                  onClick={() => null}
-                  sx={{
-                    background:
-                      'linear-gradient(90deg, #F4731B 1.05%, #F12D50 100%)',
-                    borderRadius: 30,
-                    fontWeight: 800,
-                  }}
-                >
-                  THIS IS A LINK
-                </Button>
-              </Box>
-            </Grid>
-          </Grid>
-        </Box>
+        <UserInfoHeader
+          status="active"
+          name="This node has not yet set a name"
+          description="This node has not yet set a description"
+        />
         <Grid container>
           <Grid item xs={12}>
             <DetailTable

--- a/explorer/src/pages/MixnodeDetail/index.tsx
+++ b/explorer/src/pages/MixnodeDetail/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Box, Grid, Typography, useMediaQuery } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
+import { Box, Grid, Typography } from '@mui/material';
 import { ColumnsType, DetailTable } from 'src/components/DetailTable';
 import { mixnodeToGridRow, scrollToRef } from 'src/utils';
 import { useParams } from 'react-router-dom';
@@ -63,8 +62,6 @@ const columns: ColumnsType[] = [
 
 export const PageMixnodeDetail: React.FC = () => {
   const ref = React.useRef();
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [row, setRow] = React.useState<MixNodeResponseItem[]>([]);
   const {
     fetchMixnodeById,

--- a/explorer/src/pages/MixnodeDetail/index.tsx
+++ b/explorer/src/pages/MixnodeDetail/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Box, Grid, Typography } from '@mui/material';
+import { Box, Button, Grid, Typography, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { ColumnsType, DetailTable } from 'src/components/DetailTable';
 import { mixnodeToGridRow, scrollToRef } from 'src/utils';
 import { useParams } from 'react-router-dom';
@@ -12,6 +13,8 @@ import { TwoColSmallTable } from 'src/components/TwoColSmallTable';
 import { UptimeChart } from 'src/components/UptimeChart';
 import { WorldMap } from 'src/components/WorldMap';
 import { useMainContext } from 'src/context/main';
+import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
+import PauseCircleOutlineIcon from '@mui/icons-material/PauseCircleOutline';
 
 const columns: ColumnsType[] = [
   {
@@ -61,6 +64,8 @@ const columns: ColumnsType[] = [
 
 export const PageMixnodeDetail: React.FC = () => {
   const ref = React.useRef();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [row, setRow] = React.useState<MixNodeResponseItem[]>([]);
   const {
     fetchMixnodeById,
@@ -104,7 +109,103 @@ export const PageMixnodeDetail: React.FC = () => {
             <Title text="Mixnode Detail" />
           </Grid>
         </Grid>
-
+        <Box sx={{ mt: 2, mb: 2 }}>
+          <Grid container>
+            <Grid item xs={12} md={6}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: isMobile ? 'column' : 'row',
+                  alignItems: 'center',
+                }}
+              >
+                <AccountCircleOutlinedIcon
+                  style={{ height: '66px', width: '66px' }}
+                />
+                <Typography
+                  variant="h6"
+                  sx={{ fontWeight: 600, ml: isMobile ? 0 : 2 }}
+                >
+                  Mixnode
+                </Typography>
+              </Box>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'flex-end',
+                }}
+              >
+                {!isMobile && (
+                  <Typography
+                    variant="body1"
+                    sx={{ fontWeight: 600, textAlign: 'end' }}
+                  >
+                    Node Status:
+                  </Typography>
+                )}
+                <Typography
+                  variant="body1"
+                  sx={{
+                    textAlign: 'end',
+                    color: '#60D7EF',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: isMobile ? 'center' : 'flex-end',
+                    mt: isMobile ? 2 : 0,
+                    mb: isMobile ? 2 : 0,
+                  }}
+                >
+                  <PauseCircleOutlineIcon />
+                  &nbsp;Stand-by
+                </Typography>
+                <Typography
+                  variant="body1"
+                  sx={{
+                    color: 'darkgrey',
+                    textAlign: isMobile ? 'center' : 'end',
+                  }}
+                >
+                  This node is on standy by in this epoch
+                </Typography>
+              </Box>
+            </Grid>
+            <Grid item xs={12} sx={{ mt: isMobile ? 4 : 2 }}>
+              <Typography sx={{ fontSize: 21 }}>
+                This node has not yet set a name.
+              </Typography>
+            </Grid>
+            <Grid item xs={12} sx={{ mb: isMobile ? 2 : 2 }}>
+              <Typography sx={{ fontSize: 16 }}>
+                This node has not yet set a description
+              </Typography>
+            </Grid>
+            <Grid item xs={12}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: isMobile ? 'column' : 'row',
+                  alignItems: 'center',
+                }}
+              >
+                <Button
+                  variant="contained"
+                  onClick={() => null}
+                  sx={{
+                    background:
+                      'linear-gradient(90deg, #F4731B 1.05%, #F12D50 100%)',
+                    borderRadius: 30,
+                    fontWeight: 800,
+                  }}
+                >
+                  THIS IS A LINK
+                </Button>
+              </Box>
+            </Grid>
+          </Grid>
+        </Box>
         <Grid container>
           <Grid item xs={12}>
             <DetailTable

--- a/explorer/src/theme/mui-theme.d.ts
+++ b/explorer/src/theme/mui-theme.d.ts
@@ -34,6 +34,8 @@ declare module '@mui/material/styles' {
    */
   interface NymPalette {
     highlight: string;
+    info: string;
+    success: string;
     text: {
       nav: string;
       footer: string;

--- a/explorer/src/theme/theme.ts
+++ b/explorer/src/theme/theme.ts
@@ -21,6 +21,8 @@ import {
 const nymPalette: NymPalette = {
   /** emphasises important elements */
   highlight: '#FB6E4E',
+  info: '#60D7EF',
+  success: '#21D072',
   text: {
     nav: '#F2F2F2',
     /** footer text colour */


### PR DESCRIPTION
This PR seeks to implement a new user info Header for the Mixnode Detail page.

**NOTE** Should not be merged until API updated and able to return the correct prop data:

**ANOTHER NOTE** I have currently 'turned it off' with a boolean at the top of the MixnodeDetailPage `apiIsReady` set to false. Obviously once the API is ready, that can go.

Example:
```
<UserInfoHeader
   status="active"
   name="I am the mixnode name"
   description="This node now has a description"
   profilePic="base64kwjdngjnsdbjknskldnklsnfklnslkdgnlksdnbklnslkdbn"
/>
```