### PR TITLE
Make the separation between testnet-mode and erc20 bandwidth mode clearer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3573,7 +3573,7 @@ dependencies = [
 
 [[package]]
 name = "nym-client"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "clap",
  "client-core",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-client"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "clap",
  "client-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "nym-gateway"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bandwidth-claim-contract",
  "bip39",

--- a/clients/native/Cargo.toml
+++ b/clients/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym-client"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Dave Hrycyszyn <futurechimp@users.noreply.github.com>", "Jędrzej Stuczyński <andrew@nymtech.net>"]
 edition = "2018"
 rust-version = "1.56"

--- a/clients/native/Cargo.toml
+++ b/clients/native/Cargo.toml
@@ -48,6 +48,7 @@ network-defaults = { path = "../../common/network-defaults" }
 
 [features]
 coconut = ["coconut-interface", "credentials", "gateway-requests/coconut", "gateway-client/coconut"]
+eth = []
 
 [dev-dependencies]
 serde_json = "1.0" # for the "textsend" example

--- a/clients/native/src/commands/init.rs
+++ b/clients/native/src/commands/init.rs
@@ -69,20 +69,24 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
         .arg(
             Arg::with_name(TESTNET_MODE_ARG_NAME)
                 .long(TESTNET_MODE_ARG_NAME)
-                .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement")
+                .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
+                .conflicts_with_all(&["eth_endpoint", "eth_private_key"])
         );
     #[cfg(not(feature = "coconut"))]
         let app = app
         .arg(Arg::with_name("eth_endpoint")
             .long("eth_endpoint")
-            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens")
+            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true)
+            .default_value_if(TESTNET_MODE_ARG_NAME, None, "https://rinkeby.infura.io/v3/00000000000000000000000000000000")
             .required(true))
         .arg(Arg::with_name("eth_private_key")
             .long("eth_private_key")
-            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens")
+            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true)
-            .required(true));
+            .default_value_if(TESTNET_MODE_ARG_NAME, None, "0000000000000000000000000000000000000000000000000000000000000001")
+            .required(true)
+        );
 
     app
 }

--- a/clients/native/src/commands/init.rs
+++ b/clients/native/src/commands/init.rs
@@ -30,7 +30,12 @@ use topology::{filter::VersionFilterable, gateway};
 use url::Url;
 
 use crate::client::config::Config;
-use crate::commands::{override_config, TESTNET_MODE_ARG_NAME};
+use crate::commands::override_config;
+#[cfg(feature = "eth")]
+use crate::commands::{
+    DEFAULT_ETH_ENDPOINT, DEFAULT_ETH_PRIVATE_KEY, ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME,
+    TESTNET_MODE_ARG_NAME,
+};
 
 pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
     let app = App::new("init")
@@ -65,26 +70,26 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
             .long("fastmode")
             .hidden(true) // this will prevent this flag from being displayed in `--help`
             .help("Mostly debug-related option to increase default traffic rate so that you would not need to modify config post init")
-        )
+        );
+    #[cfg(feature = "eth")]
+        let app = app
         .arg(
             Arg::with_name(TESTNET_MODE_ARG_NAME)
                 .long(TESTNET_MODE_ARG_NAME)
                 .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
-                .conflicts_with_all(&["eth_endpoint", "eth_private_key"])
-        );
-    #[cfg(not(feature = "coconut"))]
-        let app = app
-        .arg(Arg::with_name("eth_endpoint")
-            .long("eth_endpoint")
+                .conflicts_with_all(&[ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME])
+        )
+        .arg(Arg::with_name(ETH_ENDPOINT_ARG_NAME)
+            .long(ETH_ENDPOINT_ARG_NAME)
             .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true)
-            .default_value_if(TESTNET_MODE_ARG_NAME, None, "https://rinkeby.infura.io/v3/00000000000000000000000000000000")
+            .default_value_if(TESTNET_MODE_ARG_NAME, None, DEFAULT_ETH_ENDPOINT)
             .required(true))
-        .arg(Arg::with_name("eth_private_key")
-            .long("eth_private_key")
+        .arg(Arg::with_name(ETH_PRIVATE_KEY_ARG_NAME)
+            .long(ETH_PRIVATE_KEY_ARG_NAME)
             .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true)
-            .default_value_if(TESTNET_MODE_ARG_NAME, None, "0000000000000000000000000000000000000000000000000000000000000001")
+            .default_value_if(TESTNET_MODE_ARG_NAME, None, DEFAULT_ETH_PRIVATE_KEY)
             .required(true)
         );
 

--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -6,6 +6,12 @@ use clap::ArgMatches;
 use url::Url;
 
 pub(crate) const TESTNET_MODE_ARG_NAME: &str = "testnet-mode";
+pub(crate) const ETH_ENDPOINT_ARG_NAME: &str = "eth_endpoint";
+pub(crate) const ETH_PRIVATE_KEY_ARG_NAME: &str = "eth_private_key";
+pub(crate) const DEFAULT_ETH_ENDPOINT: &str =
+    "https://rinkeby.infura.io/v3/00000000000000000000000000000000";
+pub(crate) const DEFAULT_ETH_PRIVATE_KEY: &str =
+    "0000000000000000000000000000000000000000000000000000000000000001";
 
 pub(crate) mod init;
 pub(crate) mod run;
@@ -46,15 +52,23 @@ pub(crate) fn override_config(mut config: Config, matches: &ArgMatches) -> Confi
     }
 
     #[cfg(not(feature = "coconut"))]
-    if let Some(eth_endpoint) = matches.value_of("eth_endpoint") {
+    if let Some(eth_endpoint) = matches.value_of(ETH_ENDPOINT_ARG_NAME) {
         config.get_base_mut().with_eth_endpoint(eth_endpoint);
+    } else {
+        config
+            .get_base_mut()
+            .with_eth_endpoint(DEFAULT_ETH_ENDPOINT);
     }
     #[cfg(not(feature = "coconut"))]
-    if let Some(eth_private_key) = matches.value_of("eth_private_key") {
+    if let Some(eth_private_key) = matches.value_of(ETH_PRIVATE_KEY_ARG_NAME) {
         config.get_base_mut().with_eth_private_key(eth_private_key);
+    } else {
+        config
+            .get_base_mut()
+            .with_eth_private_key(DEFAULT_ETH_PRIVATE_KEY);
     }
 
-    if matches.is_present(TESTNET_MODE_ARG_NAME) {
+    if !cfg!(feature = "eth") || matches.is_present(TESTNET_MODE_ARG_NAME) {
         config.get_base_mut().with_testnet_mode(true)
     }
 

--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -6,10 +6,14 @@ use clap::ArgMatches;
 use url::Url;
 
 pub(crate) const TESTNET_MODE_ARG_NAME: &str = "testnet-mode";
+#[cfg(not(feature = "coconut"))]
 pub(crate) const ETH_ENDPOINT_ARG_NAME: &str = "eth_endpoint";
+#[cfg(not(feature = "coconut"))]
 pub(crate) const ETH_PRIVATE_KEY_ARG_NAME: &str = "eth_private_key";
+#[cfg(not(feature = "coconut"))]
 pub(crate) const DEFAULT_ETH_ENDPOINT: &str =
     "https://rinkeby.infura.io/v3/00000000000000000000000000000000";
+#[cfg(not(feature = "coconut"))]
 pub(crate) const DEFAULT_ETH_PRIVATE_KEY: &str =
     "0000000000000000000000000000000000000000000000000000000000000001";
 

--- a/clients/native/src/commands/run.rs
+++ b/clients/native/src/commands/run.rs
@@ -42,17 +42,18 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
         .arg(
             Arg::with_name(TESTNET_MODE_ARG_NAME)
                 .long(TESTNET_MODE_ARG_NAME)
-                .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement")
+                .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
+                .conflicts_with_all(&["eth_endpoint", "eth_private_key"])
         );
     #[cfg(not(feature = "coconut"))]
         let app = app
         .arg(Arg::with_name("eth_endpoint")
             .long("eth_endpoint")
-            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens")
+            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true))
         .arg(Arg::with_name("eth_private_key")
             .long("eth_private_key")
-            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens")
+            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true));
 
     app

--- a/clients/native/src/commands/run.rs
+++ b/clients/native/src/commands/run.rs
@@ -3,7 +3,9 @@
 
 use crate::client::config::Config;
 use crate::client::NymClient;
-use crate::commands::{override_config, TESTNET_MODE_ARG_NAME};
+use crate::commands::override_config;
+#[cfg(feature = "eth")]
+use crate::commands::{ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME, TESTNET_MODE_ARG_NAME};
 use clap::{App, Arg, ArgMatches};
 use config::NymConfig;
 use log::*;
@@ -38,21 +40,21 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
             .long("port")
             .help("Port for the socket (if applicable) to listen on")
             .takes_value(true)
-        )
+        );
+    #[cfg(feature = "eth")]
+        let app = app
         .arg(
             Arg::with_name(TESTNET_MODE_ARG_NAME)
                 .long(TESTNET_MODE_ARG_NAME)
                 .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
-                .conflicts_with_all(&["eth_endpoint", "eth_private_key"])
-        );
-    #[cfg(not(feature = "coconut"))]
-        let app = app
-        .arg(Arg::with_name("eth_endpoint")
-            .long("eth_endpoint")
+                .conflicts_with_all(&[ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME])
+        )
+        .arg(Arg::with_name(ETH_ENDPOINT_ARG_NAME)
+            .long(ETH_ENDPOINT_ARG_NAME)
             .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true))
-        .arg(Arg::with_name("eth_private_key")
-            .long("eth_private_key")
+        .arg(Arg::with_name(ETH_PRIVATE_KEY_ARG_NAME)
+            .long(ETH_PRIVATE_KEY_ARG_NAME)
             .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true));
 

--- a/clients/socks5/Cargo.toml
+++ b/clients/socks5/Cargo.toml
@@ -43,6 +43,7 @@ network-defaults = { path = "../../common/network-defaults" }
 
 [features]
 coconut = ["coconut-interface", "credentials", "gateway-requests/coconut", "gateway-client/coconut"]
+eth = []
 
 [build-dependencies]
 vergen = { version = "5", default-features = false, features = ["build", "git", "rustc", "cargo"] }

--- a/clients/socks5/Cargo.toml
+++ b/clients/socks5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym-socks5-client"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Dave Hrycyszyn <futurechimp@users.noreply.github.com>"]
 edition = "2018"
 rust-version = "1.56"

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -69,20 +69,24 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
         .arg(
             Arg::with_name(TESTNET_MODE_ARG_NAME)
                 .long(TESTNET_MODE_ARG_NAME)
-                .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement")
+                .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
+                .conflicts_with_all(&["eth_endpoint", "eth_private_key"])
         );
     #[cfg(not(feature = "coconut"))]
         let app = app
         .arg(Arg::with_name("eth_endpoint")
             .long("eth_endpoint")
-            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens")
+            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true)
+            .default_value_if(TESTNET_MODE_ARG_NAME, None, "https://rinkeby.infura.io/v3/00000000000000000000000000000000")
             .required(true))
         .arg(Arg::with_name("eth_private_key")
             .long("eth_private_key")
-            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens")
+            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true)
-            .required(true));
+            .default_value_if(TESTNET_MODE_ARG_NAME, None, "0000000000000000000000000000000000000000000000000000000000000001")
+            .required(true)
+        );
 
     app
 }

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -28,7 +28,12 @@ use topology::{filter::VersionFilterable, gateway};
 use url::Url;
 
 use crate::client::config::Config;
-use crate::commands::{override_config, TESTNET_MODE_ARG_NAME};
+use crate::commands::override_config;
+#[cfg(feature = "eth")]
+use crate::commands::{
+    DEFAULT_ETH_ENDPOINT, DEFAULT_ETH_PRIVATE_KEY, ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME,
+    TESTNET_MODE_ARG_NAME,
+};
 
 pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
     let app = App::new("init")
@@ -65,26 +70,26 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
             .long("fastmode")
             .hidden(true) // this will prevent this flag from being displayed in `--help`
             .help("Mostly debug-related option to increase default traffic rate so that you would not need to modify config post init")
-        )
+        );
+    #[cfg(feature = "eth")]
+        let app = app
         .arg(
             Arg::with_name(TESTNET_MODE_ARG_NAME)
                 .long(TESTNET_MODE_ARG_NAME)
                 .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
-                .conflicts_with_all(&["eth_endpoint", "eth_private_key"])
-        );
-    #[cfg(not(feature = "coconut"))]
-        let app = app
-        .arg(Arg::with_name("eth_endpoint")
-            .long("eth_endpoint")
+                .conflicts_with_all(&[ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME])
+        )
+        .arg(Arg::with_name(ETH_ENDPOINT_ARG_NAME)
+            .long(ETH_ENDPOINT_ARG_NAME)
             .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true)
-            .default_value_if(TESTNET_MODE_ARG_NAME, None, "https://rinkeby.infura.io/v3/00000000000000000000000000000000")
+            .default_value_if(TESTNET_MODE_ARG_NAME, None, DEFAULT_ETH_ENDPOINT)
             .required(true))
-        .arg(Arg::with_name("eth_private_key")
-            .long("eth_private_key")
+        .arg(Arg::with_name(ETH_PRIVATE_KEY_ARG_NAME)
+            .long(ETH_PRIVATE_KEY_ARG_NAME)
             .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true)
-            .default_value_if(TESTNET_MODE_ARG_NAME, None, "0000000000000000000000000000000000000000000000000000000000000001")
+            .default_value_if(TESTNET_MODE_ARG_NAME, None, DEFAULT_ETH_PRIVATE_KEY)
             .required(true)
         );
 

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -10,6 +10,12 @@ pub(crate) mod run;
 pub(crate) mod upgrade;
 
 pub(crate) const TESTNET_MODE_ARG_NAME: &str = "testnet-mode";
+pub(crate) const ETH_ENDPOINT_ARG_NAME: &str = "eth_endpoint";
+pub(crate) const ETH_PRIVATE_KEY_ARG_NAME: &str = "eth_private_key";
+pub(crate) const DEFAULT_ETH_ENDPOINT: &str =
+    "https://rinkeby.infura.io/v3/00000000000000000000000000000000";
+pub(crate) const DEFAULT_ETH_PRIVATE_KEY: &str =
+    "0000000000000000000000000000000000000000000000000000000000000001";
 
 fn parse_validators(raw: &str) -> Vec<Url> {
     raw.split(',')
@@ -42,15 +48,23 @@ pub(crate) fn override_config(mut config: Config, matches: &ArgMatches) -> Confi
     }
 
     #[cfg(not(feature = "coconut"))]
-    if let Some(eth_endpoint) = matches.value_of("eth_endpoint") {
+    if let Some(eth_endpoint) = matches.value_of(ETH_ENDPOINT_ARG_NAME) {
         config.get_base_mut().with_eth_endpoint(eth_endpoint);
+    } else {
+        config
+            .get_base_mut()
+            .with_eth_endpoint(DEFAULT_ETH_ENDPOINT);
     }
     #[cfg(not(feature = "coconut"))]
-    if let Some(eth_private_key) = matches.value_of("eth_private_key") {
+    if let Some(eth_private_key) = matches.value_of(ETH_PRIVATE_KEY_ARG_NAME) {
         config.get_base_mut().with_eth_private_key(eth_private_key);
+    } else {
+        config
+            .get_base_mut()
+            .with_eth_private_key(DEFAULT_ETH_PRIVATE_KEY);
     }
 
-    if matches.is_present(TESTNET_MODE_ARG_NAME) {
+    if !cfg!(feature = "eth") || matches.is_present(TESTNET_MODE_ARG_NAME) {
         config.get_base_mut().with_testnet_mode(true)
     }
 

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -10,10 +10,14 @@ pub(crate) mod run;
 pub(crate) mod upgrade;
 
 pub(crate) const TESTNET_MODE_ARG_NAME: &str = "testnet-mode";
+#[cfg(not(feature = "coconut"))]
 pub(crate) const ETH_ENDPOINT_ARG_NAME: &str = "eth_endpoint";
+#[cfg(not(feature = "coconut"))]
 pub(crate) const ETH_PRIVATE_KEY_ARG_NAME: &str = "eth_private_key";
+#[cfg(not(feature = "coconut"))]
 pub(crate) const DEFAULT_ETH_ENDPOINT: &str =
     "https://rinkeby.infura.io/v3/00000000000000000000000000000000";
+#[cfg(not(feature = "coconut"))]
 pub(crate) const DEFAULT_ETH_PRIVATE_KEY: &str =
     "0000000000000000000000000000000000000000000000000000000000000001";
 

--- a/clients/socks5/src/commands/run.rs
+++ b/clients/socks5/src/commands/run.rs
@@ -3,7 +3,9 @@
 
 use crate::client::config::Config;
 use crate::client::NymClient;
-use crate::commands::{override_config, TESTNET_MODE_ARG_NAME};
+use crate::commands::override_config;
+#[cfg(feature = "eth")]
+use crate::commands::{ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME, TESTNET_MODE_ARG_NAME};
 use clap::{App, Arg, ArgMatches};
 use config::NymConfig;
 use log::*;
@@ -44,21 +46,21 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
             .long("port")
             .help("Port for the socket to listen on")
             .takes_value(true)
-        )
+        );
+    #[cfg(feature = "eth")]
+    let app = app
         .arg(
             Arg::with_name(TESTNET_MODE_ARG_NAME)
                 .long(TESTNET_MODE_ARG_NAME)
                 .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
-                .conflicts_with_all(&["eth_endpoint", "eth_private_key"])
-        );
-    #[cfg(not(feature = "coconut"))]
-    let app = app
-        .arg(Arg::with_name("eth_endpoint")
-            .long("eth_endpoint")
+                .conflicts_with_all(&[ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME])
+        )
+        .arg(Arg::with_name(ETH_ENDPOINT_ARG_NAME)
+            .long(ETH_ENDPOINT_ARG_NAME)
             .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true))
-        .arg(Arg::with_name("eth_private_key")
-            .long("eth_private_key")
+        .arg(Arg::with_name(ETH_PRIVATE_KEY_ARG_NAME)
+            .long(ETH_PRIVATE_KEY_ARG_NAME)
             .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true));
 

--- a/clients/socks5/src/commands/run.rs
+++ b/clients/socks5/src/commands/run.rs
@@ -48,17 +48,18 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
         .arg(
             Arg::with_name(TESTNET_MODE_ARG_NAME)
                 .long(TESTNET_MODE_ARG_NAME)
-                .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement")
+                .help("Set this client to work in a testnet mode that would attempt to use gateway without bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
+                .conflicts_with_all(&["eth_endpoint", "eth_private_key"])
         );
     #[cfg(not(feature = "coconut"))]
     let app = app
         .arg(Arg::with_name("eth_endpoint")
             .long("eth_endpoint")
-            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens")
+            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true))
         .arg(Arg::with_name("eth_private_key")
             .long("eth_private_key")
-            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens")
+            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
             .takes_value(true));
 
     app

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -52,6 +52,7 @@ version-checker = { path = "../common/version-checker" }
 
 [features]
 coconut = ["coconut-interface", "gateway-requests/coconut", "gateway-client/coconut"]
+eth = []
 
 [build-dependencies]
 tokio = { version = "1.4", features = ["rt-multi-thread", "macros"] }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-gateway"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Dave Hrycyszyn <futurechimp@users.noreply.github.com>", "Jędrzej Stuczyński <andrew@nymtech.net>"]
 edition = "2018"
 rust-version = "1.56"

--- a/gateway/src/commands/init.rs
+++ b/gateway/src/commands/init.rs
@@ -57,11 +57,6 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name(TESTNET_MODE_ARG_NAME)
-                .long(TESTNET_MODE_ARG_NAME)
-                .help("Set this gateway to work in a testnet mode that would allow clients to bypass bandwidth credential requirement")
-        )
-        .arg(
             Arg::with_name(WALLET_ADDRESS)
             .long(WALLET_ADDRESS)
             .help("The wallet address you will use to bond this gateway, e.g. nymt1z9egw0knv47nmur0p8vk4rcx59h9gg4zuxrrr9")
@@ -69,8 +64,13 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
             .required(true)
         );
 
-    #[cfg(not(feature = "coconut"))]
+    #[cfg(feature = "eth")]
     let app = app
+        .arg(
+            Arg::with_name(TESTNET_MODE_ARG_NAME)
+                .long(TESTNET_MODE_ARG_NAME)
+                .help("Set this gateway to work in a testnet mode that would allow clients to bypass bandwidth credential requirement")
+        )
         .arg(Arg::with_name(ETH_ENDPOINT)
             .long(ETH_ENDPOINT)
             .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens")

--- a/gateway/src/commands/mod.rs
+++ b/gateway/src/commands/mod.rs
@@ -31,9 +31,12 @@ pub(crate) const DATASTORE_PATH: &str = "datastore";
 pub(crate) const TESTNET_MODE_ARG_NAME: &str = "testnet-mode";
 pub(crate) const WALLET_ADDRESS: &str = "wallet-address";
 
+#[cfg(not(feature = "coconut"))]
 const DEFAULT_ETH_ENDPOINT: &str = "https://rinkeby.infura.io/v3/00000000000000000000000000000000";
+#[cfg(not(feature = "coconut"))]
 const DEFAULT_VALIDATOR_ENDPOINT: &str = "http://localhost:26657";
 // A dummy mnemonic
+#[cfg(not(feature = "coconut"))]
 const DEFAULT_MNEMONIC: &str = "typical regret aware used tennis noise resource crisp defy join donate orient army item immense clean emerge globe gift chronic loan flat enter egg";
 
 fn parse_validators(raw: &str) -> Vec<Url> {

--- a/gateway/src/commands/mod.rs
+++ b/gateway/src/commands/mod.rs
@@ -31,6 +31,11 @@ pub(crate) const DATASTORE_PATH: &str = "datastore";
 pub(crate) const TESTNET_MODE_ARG_NAME: &str = "testnet-mode";
 pub(crate) const WALLET_ADDRESS: &str = "wallet-address";
 
+const DEFAULT_ETH_ENDPOINT: &str = "https://rinkeby.infura.io/v3/00000000000000000000000000000000";
+const DEFAULT_VALIDATOR_ENDPOINT: &str = "http://localhost:26657";
+// A dummy mnemonic
+const DEFAULT_MNEMONIC: &str = "typical regret aware used tennis noise resource crisp defy join donate orient army item immense clean emerge globe gift chronic loan flat enter egg";
+
 fn parse_validators(raw: &str) -> Vec<Url> {
     raw.split(',')
         .map(|raw_validator| {
@@ -85,11 +90,15 @@ pub(crate) fn override_config(mut config: Config, matches: &ArgMatches) -> Confi
     #[cfg(not(feature = "coconut"))]
     if let Some(raw_validators) = matches.value_of(VALIDATORS_ARG_NAME) {
         config = config.with_custom_validator_nymd(parse_validators(raw_validators));
+    } else {
+        config = config.with_custom_validator_nymd(parse_validators(DEFAULT_VALIDATOR_ENDPOINT));
     }
 
     #[cfg(not(feature = "coconut"))]
     if let Some(cosmos_mnemonic) = matches.value_of(COSMOS_MNEMONIC) {
         config = config.with_cosmos_mnemonic(String::from(cosmos_mnemonic));
+    } else {
+        config = config.with_cosmos_mnemonic(String::from(DEFAULT_MNEMONIC));
     }
 
     if let Some(datastore_path) = matches.value_of(DATASTORE_PATH) {
@@ -99,6 +108,8 @@ pub(crate) fn override_config(mut config: Config, matches: &ArgMatches) -> Confi
     #[cfg(not(feature = "coconut"))]
     if let Some(eth_endpoint) = matches.value_of(ETH_ENDPOINT) {
         config = config.with_eth_endpoint(String::from(eth_endpoint));
+    } else {
+        config = config.with_eth_endpoint(String::from(DEFAULT_ETH_ENDPOINT));
     }
 
     if let Some(wallet_address) = matches.value_of(WALLET_ADDRESS) {
@@ -107,7 +118,7 @@ pub(crate) fn override_config(mut config: Config, matches: &ArgMatches) -> Confi
         config = config.with_wallet_address(trimmed);
     }
 
-    if matches.is_present(TESTNET_MODE_ARG_NAME) {
+    if !cfg!(feature = "eth") || matches.is_present(TESTNET_MODE_ARG_NAME) {
         config.with_testnet_mode(true)
     } else {
         config


### PR DESCRIPTION
To fallback to using dummy bandwidth values, simply compile the binaries (native, socks5 and gateway) normally. To expose the bandwidth options, compilation with the feature flag `eth` must be done. The following lines describe the flow when building with `eth` enabled

This way, the user of a client (native or socks5) can either use the erc20 bandwidth path:

```
nym-client init --id test --eth_endpoint "https://rinkeby.infura.io/v3/00000000000000000000000000000001" --eth_private_key 0000000000000000000000000000000000000000000000000000000000000002  
```

or claim bandwidth for free, in testnet-mode:
```
nym-client init --id test --testnet-mode 
```

The two paths are however mutually exclusive, so one can't do:
```
nym-client init --id test --eth_endpoint 'https://rinkeby.infura.io/v3/00000000000000000000000000000001' --eth_private_key 0000000000000000000000000000000000000000000000000000000000000002 --testnet-mode`


      _ __  _   _ _ __ ___
     | '_ \| | | | '_ \ _ \
     | | | | |_| | | | | | |
     |_| |_|\__, |_| |_| |_|
            |___/

             (client - version 0.12.0)

    
error: The argument '--eth_endpoint <eth_endpoint>' cannot be used with '--testnet-mode'

USAGE:
    nym-client init --eth_endpoint <eth_endpoint> --eth_private_key <eth_private_key> --id <id> --testnet-mode

For more information try --help
```

Not choosing any path is also not possible:
```
nym-client init --id test`


      _ __  _   _ _ __ ___
     | '_ \| | | | '_ \ _ \
     | | | | |_| | | | | | |
     |_| |_|\__, |_| |_| |_|
            |___/

             (client - version 0.12.0)

    
error: The following required arguments were not provided:
    --eth_endpoint <eth_endpoint>
    --eth_private_key <eth_private_key>

USAGE:
    nym-client init [FLAGS] [OPTIONS] --eth_endpoint <eth_endpoint> --eth_private_key <eth_private_key> --id <id>

For more information try --help
```

But the `--help` command is now more informative:
```
nym-client init --help`


      _ __  _   _ _ __ ___
     | '_ \| | | | '_ \ _ \
     | | | | |_| | | | | | |
     |_| |_|\__, |_| |_| |_|
            |___/

             (client - version 0.12.0)

    
nym-client-init 
Initialise a Nym client. Do this first!

USAGE:
    nym-client init [FLAGS] [OPTIONS] --eth_endpoint <eth_endpoint> --eth_private_key <eth_private_key> --id <id>

FLAGS:
        --disable-socket    Whether to not start the websocket
    -h, --help              Prints help information
        --testnet-mode      Set this client to work in a testnet mode that would attempt to use gateway without
                            bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key
                            don't need to be set.
    -V, --version           Prints version information

OPTIONS:
        --eth_endpoint <eth_endpoint>          URL of an Ethereum full node that we want to use for getting bandwidth
                                               tokens from ERC20 tokens. If you don't want to set this value, use
                                               --testnet-mode instead
        --eth_private_key <eth_private_key>    Ethereum private key used for obtaining bandwidth tokens from ERC20
                                               tokens. If you don't want to set this value, use --testnet-mode instead
        --gateway <gateway>                    Id of the gateway we are going to connect to.
        --id <id>                              Id of the nym-mixnet-client we want to create config for.
    -p, --port <port>                          Port for the socket (if applicable) to listen on in all subsequent runs
        --validators <validators>              Comma separated list of rest endpoints of the validators
```