### PR TITLE
Feature/fix gateway sign

### DIFF
--- a/gateway/src/commands/mod.rs
+++ b/gateway/src/commands/mod.rs
@@ -148,3 +148,22 @@ pub(crate) fn validate_bech32_address_or_exit(address: &str) {
         process::exit(1);
     }
 }
+
+// this only checks compatibility between config the binary. It does not take into consideration
+// network version. It might do so in the future.
+pub(crate) fn version_check(cfg: &Config) -> bool {
+    let binary_version = env!("CARGO_PKG_VERSION");
+    let config_version = cfg.get_version();
+    if binary_version != config_version {
+        log::warn!("The gateway binary has different version than what is specified in config file! {} and {}", binary_version, config_version);
+        if version_checker::is_minor_version_compatible(binary_version, config_version) {
+            log::info!("but they are still semver compatible. However, consider running the `upgrade` command");
+            true
+        } else {
+            log::error!("and they are semver incompatible! - please run the `upgrade` command before attempting `run` again");
+            false
+        }
+    } else {
+        true
+    }
+}

--- a/gateway/src/commands/run.rs
+++ b/gateway/src/commands/run.rs
@@ -7,7 +7,6 @@ use crate::node::Gateway;
 use clap::{App, Arg, ArgMatches};
 use config::NymConfig;
 use log::*;
-use version_checker::is_minor_version_compatible;
 
 pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
     let app = App::new("run")
@@ -93,25 +92,6 @@ fn show_binding_warning(address: String) {
 
 fn special_addresses() -> Vec<&'static str> {
     vec!["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]
-}
-
-// this only checks compatibility between config the binary. It does not take into consideration
-// network version. It might do so in the future.
-fn version_check(cfg: &Config) -> bool {
-    let binary_version = env!("CARGO_PKG_VERSION");
-    let config_version = cfg.get_version();
-    if binary_version != config_version {
-        warn!("The mixnode binary has different version than what is specified in config file! {} and {}", binary_version, config_version);
-        if is_minor_version_compatible(binary_version, config_version) {
-            info!("but they are still semver compatible. However, consider running the `upgrade` command");
-            true
-        } else {
-            error!("and they are semver incompatible! - please run the `upgrade` command before attempting `run` again");
-            false
-        }
-    } else {
-        true
-    }
 }
 
 pub async fn execute(matches: ArgMatches<'static>) {

--- a/gateway/src/commands/sign.rs
+++ b/gateway/src/commands/sign.rs
@@ -141,6 +141,12 @@ pub fn execute(matches: &ArgMatches) {
             return;
         }
     };
+
+    if !version_check(&config) {
+        error!("failed the local version check");
+        return;
+    }
+
     let pathfinder = GatewayPathfinder::new_from_config(&config);
     let identity_keypair = load_identity_keys(&pathfinder);
 

--- a/gateway/src/commands/sign.rs
+++ b/gateway/src/commands/sign.rs
@@ -8,8 +8,6 @@ use colored::Colorize;
 use config::NymConfig;
 use crypto::asymmetric::identity;
 use log::error;
-#[cfg(not(feature = "coconut"))]
-use validator_client::nymd::AccountId;
 
 const SIGN_TEXT_ARG_NAME: &str = "text";
 const SIGN_ADDRESS_ARG_NAME: &str = "address";
@@ -55,58 +53,7 @@ pub fn load_identity_keys(pathfinder: &GatewayPathfinder) -> identity::KeyPair {
     identity_keypair
 }
 
-#[cfg(not(feature = "coconut"))]
-fn derive_address(raw_mnemonic: &str) -> AccountId {
-    let mnemonic = match raw_mnemonic.parse() {
-        Ok(mnemonic) => mnemonic,
-        Err(err) => {
-            let error_message = format!("failed to parse the provided mnemonic - {}", err).red();
-            println!("{}", error_message);
-            process::exit(1);
-        }
-    };
-    let wallet =
-        match validator_client::nymd::wallet::DirectSecp256k1HdWallet::from_mnemonic(mnemonic) {
-            Ok(wallet) => wallet,
-            Err(err) => {
-                let error_message = format!(
-                    "failed to derive your account with the provided mnemonic - {}",
-                    err
-                )
-                .red();
-                println!("{}", error_message);
-                process::exit(1);
-            }
-        };
-    let account_data = match wallet.try_derive_accounts() {
-        Ok(data) => data,
-        Err(err) => {
-            let error_message = format!(
-                "failed to derive your account with the provided mnemonic - {}",
-                err
-            )
-            .red();
-            println!("{}", error_message);
-            process::exit(1);
-        }
-    };
-    account_data[0].address().clone()
-}
-
-#[cfg(not(feature = "coconut"))]
-fn sign_derived_address(private_key: &identity::PrivateKey, address: &AccountId) {
-    let signature_bytes = private_key.sign(&address.to_bytes()).to_bytes();
-    let signature = bs58::encode(signature_bytes).into_string();
-
-    println!(
-        "The base58-encoded signature on '{}' is: {}",
-        address, signature
-    )
-}
-
-// we do tiny bit of sanity check validation
-#[cfg(feature = "coconut")]
-fn sign_provided_address(private_key: &identity::PrivateKey, raw_address: &str) {
+fn print_signed_address(private_key: &identity::PrivateKey, raw_address: &str) -> String {
     let trimmed = raw_address.trim();
     validate_bech32_address_or_exit(trimmed);
     let signature = private_key.sign_text(trimmed);
@@ -114,7 +61,8 @@ fn sign_provided_address(private_key: &identity::PrivateKey, raw_address: &str) 
     println!(
         "The base58-encoded signature on '{}' is: {}",
         trimmed, signature
-    )
+    );
+    signature
 }
 
 fn print_signed_text(private_key: &identity::PrivateKey, text: &str) {
@@ -152,23 +100,9 @@ pub fn execute(matches: &ArgMatches) {
 
     if let Some(text) = matches.value_of(SIGN_TEXT_ARG_NAME) {
         print_signed_text(identity_keypair.private_key(), text)
-    }
-
-    #[cfg(not(feature = "coconut"))]
-    {
-        if matches.is_present(SIGN_ADDRESS_ARG_NAME) {
-            let address = derive_address(&config.get_cosmos_mnemonic());
-            sign_derived_address(identity_keypair.private_key(), &address);
-        }
-    }
-    #[cfg(feature = "coconut")]
-    {
-        if let Some(address) = matches.value_of(SIGN_ADDRESS_ARG_NAME) {
-            sign_provided_address(identity_keypair.private_key(), address)
-        }
-    }
-
-    if !matches.is_present(SIGN_TEXT_ARG_NAME) && !matches.is_present(SIGN_ADDRESS_ARG_NAME) {
+    } else if let Some(address) = matches.value_of(SIGN_ADDRESS_ARG_NAME) {
+        print_signed_address(identity_keypair.private_key(), address);
+    } else {
         let error_message = format!(
             "You must specify either '--{}' or '--{}' argument!",
             SIGN_TEXT_ARG_NAME, SIGN_ADDRESS_ARG_NAME

--- a/mixnode/src/commands/mod.rs
+++ b/mixnode/src/commands/mod.rs
@@ -116,3 +116,22 @@ pub(crate) fn validate_bech32_address_or_exit(address: &str) {
         process::exit(1);
     }
 }
+
+// this only checks compatibility between config the binary. It does not take into consideration
+// network version. It might do so in the future.
+pub(crate) fn version_check(cfg: &Config) -> bool {
+    let binary_version = env!("CARGO_PKG_VERSION");
+    let config_version = cfg.get_version();
+    if binary_version != config_version {
+        warn!("The mixnode binary has different version than what is specified in config file! {} and {}", binary_version, config_version);
+        if version_checker::is_minor_version_compatible(binary_version, config_version) {
+            info!("but they are still semver compatible. However, consider running the `upgrade` command");
+            true
+        } else {
+            error!("and they are semver incompatible! - please run the `upgrade` command before attempting `run` again");
+            false
+        }
+    } else {
+        true
+    }
+}

--- a/mixnode/src/commands/run.rs
+++ b/mixnode/src/commands/run.rs
@@ -6,8 +6,6 @@ use crate::config::Config;
 use crate::node::MixNode;
 use clap::{App, Arg, ArgMatches};
 use config::NymConfig;
-use log::warn;
-use version_checker::is_minor_version_compatible;
 
 pub fn command_args<'a, 'b>() -> App<'a, 'b> {
     App::new("run")
@@ -71,25 +69,6 @@ fn show_binding_warning(address: String) {
 
 fn special_addresses() -> Vec<&'static str> {
     vec!["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]
-}
-
-// this only checks compatibility between config the binary. It does not take into consideration
-// network version. It might do so in the future.
-fn version_check(cfg: &Config) -> bool {
-    let binary_version = env!("CARGO_PKG_VERSION");
-    let config_version = cfg.get_version();
-    if binary_version != config_version {
-        warn!("The mixnode binary has different version than what is specified in config file! {} and {}", binary_version, config_version);
-        if is_minor_version_compatible(binary_version, config_version) {
-            info!("but they are still semver compatible. However, consider running the `upgrade` command");
-            true
-        } else {
-            error!("and they are semver incompatible! - please run the `upgrade` command before attempting `run` again");
-            false
-        }
-    } else {
-        true
-    }
 }
 
 pub fn execute(matches: &ArgMatches) {

--- a/mixnode/src/commands/sign.rs
+++ b/mixnode/src/commands/sign.rs
@@ -83,6 +83,12 @@ pub fn execute(matches: &ArgMatches) {
             return;
         }
     };
+
+    if !version_check(&config) {
+        error!("failed the local version check");
+        return;
+    }
+
     let pathfinder = MixNodePathfinder::new_from_config(&config);
     let identity_keypair = load_identity_keys(&pathfinder);
 


### PR DESCRIPTION
Remove the implicit derivation of the wallet address from the stored mnemonic for gateways. The reason for this is that the cosmos mnemonic that is asked at init is for the address that gets rewarded for gateway usage. Since that address is not necessarily set now and it can take a default value (see the `eth` feature flag), we won't be using that to derive the address in the signing process, but rather go with the same flow as for the mixnode.

A slightly different approach would be to use the wallet address that we already set at `init`, for both gateway and mixnode, by moving some code around, if we want that functionality. I personally think that would make the `sign` command less flexible, but I'm open to suggestions. 