### PR TITLE
Feature/remove unused profit margin

### DIFF
--- a/contracts/mixnet/src/mixnodes/storage.rs
+++ b/contracts/mixnet/src/mixnodes/storage.rs
@@ -49,7 +49,6 @@ pub(crate) struct StoredMixnodeBond {
     pub layer: Layer,
     pub block_height: u64,
     pub mix_node: MixNode,
-    pub profit_margin_percent: Option<u8>,
     pub proxy: Option<Addr>,
 }
 
@@ -60,7 +59,6 @@ impl StoredMixnodeBond {
         layer: Layer,
         block_height: u64,
         mix_node: MixNode,
-        profit_margin_percent: Option<u8>,
         proxy: Option<Addr>,
     ) -> Self {
         StoredMixnodeBond {
@@ -69,7 +67,6 @@ impl StoredMixnodeBond {
             layer,
             block_height,
             mix_node,
-            profit_margin_percent,
             proxy,
         }
     }

--- a/contracts/mixnet/src/mixnodes/storage.rs
+++ b/contracts/mixnet/src/mixnodes/storage.rs
@@ -177,7 +177,6 @@ mod tests {
                 identity_key: node_identity.clone(),
                 ..tests::fixtures::mix_node_fixture()
             },
-            profit_margin_percent: None,
             proxy: None,
         };
 

--- a/contracts/mixnet/src/mixnodes/transactions.rs
+++ b/contracts/mixnet/src/mixnodes/transactions.rs
@@ -114,7 +114,6 @@ fn _try_add_mixnode(
         layer,
         env.block.height,
         mix_node,
-        None,
         proxy,
     );
 

--- a/contracts/mixnet/src/rewards/transactions.rs
+++ b/contracts/mixnet/src/rewards/transactions.rs
@@ -930,7 +930,6 @@ pub mod tests {
                 identity_key: node_identity.clone(),
                 ..tests::fixtures::mix_node_fixture()
             },
-            profit_margin_percent: Some(10),
             proxy: None,
         };
 

--- a/contracts/mixnet/src/support/tests/fixtures.rs
+++ b/contracts/mixnet/src/support/tests/fixtures.rs
@@ -59,7 +59,6 @@ pub(crate) fn stored_mixnode_bond_fixture(owner: &str) -> mixnodes_storage::Stor
             ..super::fixtures::mix_node_fixture()
         },
         None,
-        None,
     )
 }
 


### PR DESCRIPTION
Do this as a separate PR, dependent on https://github.com/nymtech/nym/pull/1008 , to avoid having to do rebases. I'll remove it from draft once #1008 is merged

I successfully tested the migration locally with a mixnet containing aprox. 5000 bonded mixnodes.