### PR TITLE
Feature/additional mixnode endpoints

### DIFF
--- a/common/mixnet-contract/src/mixnode.rs
+++ b/common/mixnet-contract/src/mixnode.rs
@@ -327,6 +327,11 @@ impl MixNodeBond {
         self.total_delegation.clone()
     }
 
+    pub fn stake_saturation(&self, circulating_supply: u128, rewarded_set_size: u32) -> U128 {
+        self.total_bond_to_circulating_supply(circulating_supply)
+            * U128::from_num(rewarded_set_size)
+    }
+
     pub fn pledge_to_circulating_supply(&self, circulating_supply: u128) -> U128 {
         U128::from_num(self.pledge_amount().amount.u128()) / U128::from_num(circulating_supply)
     }

--- a/validator-api/src/cache/mod.rs
+++ b/validator-api/src/cache/mod.rs
@@ -168,7 +168,6 @@ impl ValidatorCache {
                     routes::get_gateways,
                     routes::get_active_mixnodes,
                     routes::get_rewarded_mixnodes,
-                    routes::get_mixnode_status,
                 ],
             )
         })

--- a/validator-api/src/cache/routes.rs
+++ b/validator-api/src/cache/routes.rs
@@ -1,11 +1,10 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cache::{MixnodeStatus, ValidatorCache};
+use crate::cache::ValidatorCache;
 use mixnet_contract::{GatewayBond, MixNodeBond};
 use rocket::serde::json::Json;
 use rocket::State;
-use serde::Serialize;
 
 #[get("/mixnodes")]
 pub(crate) async fn get_mixnodes(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBond>> {
@@ -25,19 +24,4 @@ pub(crate) async fn get_rewarded_mixnodes(cache: &State<ValidatorCache>) -> Json
 #[get("/mixnodes/active")]
 pub(crate) async fn get_active_mixnodes(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBond>> {
     Json(cache.active_mixnodes().await.value)
-}
-
-#[derive(Serialize)]
-pub(crate) struct MixnodeStatusResponse {
-    status: MixnodeStatus,
-}
-
-#[get("/mixnode/<identity>/status")]
-pub(crate) async fn get_mixnode_status(
-    cache: &State<ValidatorCache>,
-    identity: String,
-) -> Json<MixnodeStatusResponse> {
-    Json(MixnodeStatusResponse {
-        status: cache.mixnode_status(identity).await,
-    })
 }

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -399,6 +399,7 @@ fn expected_monitor_test_runs(config: &Config) -> usize {
 
 fn setup_rewarder(
     config: &Config,
+    first_epoch: Epoch,
     rocket: &Rocket<Ignite>,
     nymd_client: &Client<SigningNymdClient>,
 ) -> Option<Rewarder> {
@@ -407,10 +408,6 @@ fn setup_rewarder(
         let node_status_storage = rocket.state::<ValidatorApiStorage>().unwrap().clone();
         let validator_cache = rocket.state::<ValidatorCache>().unwrap().clone();
 
-        let first_epoch = Epoch::new(
-            config.get_first_rewarding_epoch(),
-            config.get_epoch_length(),
-        );
         Some(Rewarder::new(
             nymd_client.clone(),
             validator_cache,
@@ -427,11 +424,16 @@ fn setup_rewarder(
     }
 }
 
-async fn setup_rocket(config: &Config, liftoff_notify: Arc<Notify>) -> Result<Rocket<Ignite>> {
+async fn setup_rocket(
+    config: &Config,
+    first_epoch: Epoch,
+    liftoff_notify: Arc<Notify>,
+) -> Result<Rocket<Ignite>> {
     // let's build our rocket!
     let rocket = rocket::build()
         .attach(setup_cors()?)
         .attach(setup_liftoff_notify(liftoff_notify))
+        .manage(first_epoch)
         .attach(ValidatorCache::stage());
 
     #[cfg(feature = "coconut")]
@@ -440,13 +442,17 @@ async fn setup_rocket(config: &Config, liftoff_notify: Arc<Notify>) -> Result<Ro
     // see if we should start up network monitor and if so, attach the node status api
     if config.get_network_monitor_enabled() {
         Ok(rocket
-            .attach(node_status_api::stage(
+            .attach(storage::ValidatorApiStorage::stage(
                 config.get_node_status_api_database_path(),
             ))
+            .attach(node_status_api::stage_full())
             .ignite()
             .await?)
     } else {
-        Ok(rocket.ignite().await?)
+        Ok(rocket
+            .attach(node_status_api::stage_minimal())
+            .ignite()
+            .await?)
     }
 }
 
@@ -486,10 +492,15 @@ async fn run_validator_api(matches: ArgMatches<'static>) -> Result<()> {
             .map_err(|err| err.into());
     }
 
+    let first_epoch = Epoch::new(
+        config.get_first_rewarding_epoch(),
+        config.get_epoch_length(),
+    );
+
     let liftoff_notify = Arc::new(Notify::new());
 
     // let's build our rocket!
-    let rocket = setup_rocket(&config, Arc::clone(&liftoff_notify)).await?;
+    let rocket = setup_rocket(&config, first_epoch, Arc::clone(&liftoff_notify)).await?;
     let monitor_builder = setup_network_monitor(&config, system_version, &rocket);
 
     let validator_cache = rocket.state::<ValidatorCache>().unwrap().clone();
@@ -513,7 +524,7 @@ async fn run_validator_api(matches: ArgMatches<'static>) -> Result<()> {
         let uptime_updater = HistoricalUptimeUpdater::new(storage);
         tokio::spawn(async move { uptime_updater.run().await });
 
-        if let Some(rewarder) = setup_rewarder(&config, &rocket, &nymd_client) {
+        if let Some(rewarder) = setup_rewarder(&config, first_epoch, &rocket, &nymd_client) {
             info!("Periodic rewarding is starting...");
             tokio::spawn(async move { rewarder.run().await });
         } else {

--- a/validator-api/src/node_status_api/mod.rs
+++ b/validator-api/src/node_status_api/mod.rs
@@ -29,6 +29,7 @@ pub(crate) fn stage(database_path: PathBuf) -> AdHoc {
                     routes::gateway_uptime_history,
                     routes::mixnode_core_status_count,
                     routes::gateway_core_status_count,
+                    routes::get_mixnode_status,
                 ],
             )
     })

--- a/validator-api/src/node_status_api/mod.rs
+++ b/validator-api/src/node_status_api/mod.rs
@@ -1,9 +1,7 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::storage;
 use rocket::fairing::AdHoc;
-use std::path::PathBuf;
 use std::time::Duration;
 
 pub(crate) mod local_guard;
@@ -16,21 +14,28 @@ pub(crate) const FIFTEEN_MINUTES: Duration = Duration::from_secs(900);
 pub(crate) const ONE_HOUR: Duration = Duration::from_secs(3600);
 pub(crate) const ONE_DAY: Duration = Duration::from_secs(86400);
 
-pub(crate) fn stage(database_path: PathBuf) -> AdHoc {
-    AdHoc::on_ignite("SQLx Stage", |rocket| async {
-        rocket
-            .attach(storage::ValidatorApiStorage::stage(database_path))
-            .mount(
-                "/v1/status",
-                routes![
-                    routes::mixnode_report,
-                    routes::gateway_report,
-                    routes::mixnode_uptime_history,
-                    routes::gateway_uptime_history,
-                    routes::mixnode_core_status_count,
-                    routes::gateway_core_status_count,
-                    routes::get_mixnode_status,
-                ],
-            )
+pub(crate) fn stage_full() -> AdHoc {
+    AdHoc::on_ignite("Node Status API Stage", |rocket| async {
+        rocket.mount(
+            "/v1/status",
+            routes![
+                routes::mixnode_report,
+                routes::gateway_report,
+                routes::mixnode_uptime_history,
+                routes::gateway_uptime_history,
+                routes::mixnode_core_status_count,
+                routes::gateway_core_status_count,
+                routes::get_mixnode_status,
+                routes::get_mixnode_reward_estimation,
+            ],
+        )
+    })
+}
+
+// in the minimal variant we would not have access to endpoints relying on existence
+// of the network monitor and the associated storage
+pub(crate) fn stage_minimal() -> AdHoc {
+    AdHoc::on_ignite("Node Status API Stage", |rocket| async {
+        rocket.mount("/v1/status", routes![routes::get_mixnode_status,])
     })
 }

--- a/validator-api/src/node_status_api/mod.rs
+++ b/validator-api/src/node_status_api/mod.rs
@@ -27,6 +27,7 @@ pub(crate) fn stage_full() -> AdHoc {
                 routes::gateway_core_status_count,
                 routes::get_mixnode_status,
                 routes::get_mixnode_reward_estimation,
+                routes::get_mixnode_stake_saturation,
             ],
         )
     })
@@ -36,6 +37,12 @@ pub(crate) fn stage_full() -> AdHoc {
 // of the network monitor and the associated storage
 pub(crate) fn stage_minimal() -> AdHoc {
     AdHoc::on_ignite("Node Status API Stage", |rocket| async {
-        rocket.mount("/v1/status", routes![routes::get_mixnode_status,])
+        rocket.mount(
+            "/v1/status",
+            routes![
+                routes::get_mixnode_status,
+                routes::get_mixnode_stake_saturation,
+            ],
+        )
     })
 }

--- a/validator-api/src/node_status_api/models.rs
+++ b/validator-api/src/node_status_api/models.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::cache::MixnodeStatus;
 use crate::node_status_api::utils::NodeUptimes;
 use crate::storage::models::NodeStatus;
 use rocket::http::{ContentType, Status};
@@ -274,4 +275,9 @@ impl Display for ValidatorApiStorageError {
 pub struct CoreNodeStatus {
     pub(crate) identity: String,
     pub(crate) count: i32,
+}
+
+#[derive(Serialize)]
+pub(crate) struct MixnodeStatusResponse {
+    pub(crate) status: MixnodeStatus,
 }

--- a/validator-api/src/node_status_api/models.rs
+++ b/validator-api/src/node_status_api/models.rs
@@ -298,5 +298,6 @@ pub(crate) struct RewardEstimationResponse {
 
 #[derive(Serialize)]
 pub(crate) struct StakeSaturationResponse {
-    //
+    pub(crate) saturation: f32,
+    pub(crate) as_at: i64,
 }

--- a/validator-api/src/node_status_api/models.rs
+++ b/validator-api/src/node_status_api/models.rs
@@ -209,22 +209,24 @@ pub struct HistoricalUptime {
 }
 
 pub(crate) struct ErrorResponse {
-    error: ValidatorApiStorageError,
+    error_message: String,
     status: Status,
 }
 
 impl ErrorResponse {
-    pub(crate) fn new(error: ValidatorApiStorageError, status: Status) -> Self {
-        ErrorResponse { error, status }
+    pub(crate) fn new(error_message: impl Into<String>, status: Status) -> Self {
+        ErrorResponse {
+            error_message: error_message.into(),
+            status,
+        }
     }
 }
 
 impl<'r, 'o: 'r> Responder<'r, 'o> for ErrorResponse {
     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o> {
-        let message = format!("{}", self.error);
         Response::build()
             .header(ContentType::Plain)
-            .sized_body(message.len(), Cursor::new(message))
+            .sized_body(self.error_message.len(), Cursor::new(self.error_message))
             .status(self.status)
             .ok()
     }
@@ -280,4 +282,21 @@ pub struct CoreNodeStatus {
 #[derive(Serialize)]
 pub(crate) struct MixnodeStatusResponse {
     pub(crate) status: MixnodeStatus,
+}
+
+#[derive(Serialize)]
+pub(crate) struct RewardEstimationResponse {
+    pub(crate) estimated_total_node_reward: u128,
+    pub(crate) estimated_operator_reward: u128,
+    pub(crate) estimated_delegators_reward: u128,
+
+    pub(crate) current_epoch_start: i64,
+    pub(crate) current_epoch_end: i64,
+    pub(crate) current_epoch_uptime: Uptime,
+    pub(crate) as_at: i64,
+}
+
+#[derive(Serialize)]
+pub(crate) struct StakeSaturationResponse {
+    //
 }

--- a/validator-api/src/node_status_api/routes.rs
+++ b/validator-api/src/node_status_api/routes.rs
@@ -1,12 +1,16 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::node_status_api::models::{CoreNodeStatus, ErrorResponse, GatewayStatusReport, GatewayUptimeHistory, MixnodeStatusReport, MixnodeStatusResponse, MixnodeUptimeHistory};
+use crate::node_status_api::models::{
+    CoreNodeStatus, ErrorResponse, GatewayStatusReport, GatewayUptimeHistory, MixnodeStatusReport,
+    MixnodeStatusResponse, MixnodeUptimeHistory, RewardEstimationResponse, StakeSaturationResponse,
+};
 use crate::storage::ValidatorApiStorage;
+use crate::{Epoch, ValidatorCache};
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::State;
-use crate::ValidatorCache;
+use time::OffsetDateTime;
 
 #[get("/mixnode/<pubkey>/report")]
 pub(crate) async fn mixnode_report(
@@ -17,7 +21,7 @@ pub(crate) async fn mixnode_report(
         .construct_mixnode_report(pubkey)
         .await
         .map(Json)
-        .map_err(|err| ErrorResponse::new(err, Status::NotFound))
+        .map_err(|err| ErrorResponse::new(err.to_string(), Status::NotFound))
 }
 
 #[get("/gateway/<pubkey>/report")]
@@ -29,7 +33,7 @@ pub(crate) async fn gateway_report(
         .construct_gateway_report(pubkey)
         .await
         .map(Json)
-        .map_err(|err| ErrorResponse::new(err, Status::NotFound))
+        .map_err(|err| ErrorResponse::new(err.to_string(), Status::NotFound))
 }
 
 #[get("/mixnode/<pubkey>/history")]
@@ -41,7 +45,7 @@ pub(crate) async fn mixnode_uptime_history(
         .get_mixnode_uptime_history(pubkey)
         .await
         .map(Json)
-        .map_err(|err| ErrorResponse::new(err, Status::NotFound))
+        .map_err(|err| ErrorResponse::new(err.to_string(), Status::NotFound))
 }
 
 #[get("/gateway/<pubkey>/history")]
@@ -53,7 +57,7 @@ pub(crate) async fn gateway_uptime_history(
         .get_gateway_uptime_history(pubkey)
         .await
         .map(Json)
-        .map_err(|err| ErrorResponse::new(err, Status::NotFound))
+        .map_err(|err| ErrorResponse::new(err.to_string(), Status::NotFound))
 }
 
 #[get("/mixnode/<pubkey>/core-status-count?<since>")]
@@ -92,10 +96,61 @@ pub(crate) async fn gateway_core_status_count(
 
 #[get("/mixnode/<identity>/status")]
 pub(crate) async fn get_mixnode_status(
-    node_cache: &State<ValidatorCache>,
+    cache: &State<ValidatorCache>,
     identity: String,
 ) -> Json<MixnodeStatusResponse> {
     Json(MixnodeStatusResponse {
-        status: node_cache.mixnode_status(identity).await,
+        status: cache.mixnode_status(identity).await,
     })
+}
+
+#[get("/mixnode/<identity>/reward_estimation")]
+pub(crate) async fn get_mixnode_reward_estimation(
+    cache: &State<ValidatorCache>,
+    storage: &State<ValidatorApiStorage>,
+    first_epoch: &State<Epoch>,
+    identity: String,
+) -> Result<Json<RewardEstimationResponse>, ErrorResponse> {
+    let (bond, status) = cache.mixnode_details(&identity).await;
+    if let Some(bond) = bond {
+        let epoch_reward_params = cache.epoch_reward_params().await;
+        let as_at = epoch_reward_params.timestamp();
+        let epoch_reward_params = epoch_reward_params.into_inner();
+
+        let current_epoch = first_epoch.current(OffsetDateTime::now_utc());
+        let uptime = storage
+            .get_average_mixnode_uptime_in_interval(
+                &identity,
+                current_epoch.start_unix_timestamp(),
+                current_epoch.end_unix_timestamp(),
+            )
+            .await
+            .map_err(|err| ErrorResponse::new(err.to_string(), Status::NotFound))?;
+
+        let (estimated_total_node_reward, estimated_operator_reward, estimated_delegators_reward) =
+            epoch_reward_params.estimate_reward(&bond, uptime.u8(), status.is_active());
+
+        Ok(Json(RewardEstimationResponse {
+            estimated_total_node_reward,
+            estimated_operator_reward,
+            estimated_delegators_reward,
+            current_epoch_start: current_epoch.start_unix_timestamp(),
+            current_epoch_end: current_epoch.end_unix_timestamp(),
+            current_epoch_uptime: uptime,
+            as_at,
+        }))
+    } else {
+        Err(ErrorResponse::new(
+            "mixnode bond not found",
+            Status::NotFound,
+        ))
+    }
+}
+
+#[get("/mixnode/<identity>/stake_saturation")]
+pub(crate) async fn get_mixnode_stake_saturation(
+    node_cache: &State<ValidatorCache>,
+    identity: String,
+) -> Result<Json<StakeSaturationResponse>, ErrorResponse> {
+    todo!()
 }

--- a/validator-api/src/node_status_api/routes.rs
+++ b/validator-api/src/node_status_api/routes.rs
@@ -1,14 +1,12 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::node_status_api::models::{
-    CoreNodeStatus, ErrorResponse, GatewayStatusReport, GatewayUptimeHistory, MixnodeStatusReport,
-    MixnodeUptimeHistory,
-};
+use crate::node_status_api::models::{CoreNodeStatus, ErrorResponse, GatewayStatusReport, GatewayUptimeHistory, MixnodeStatusReport, MixnodeStatusResponse, MixnodeUptimeHistory};
 use crate::storage::ValidatorApiStorage;
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::State;
+use crate::ValidatorCache;
 
 #[get("/mixnode/<pubkey>/report")]
 pub(crate) async fn mixnode_report(
@@ -89,5 +87,15 @@ pub(crate) async fn gateway_core_status_count(
     Json(CoreNodeStatus {
         identity: pubkey.to_string(),
         count,
+    })
+}
+
+#[get("/mixnode/<identity>/status")]
+pub(crate) async fn get_mixnode_status(
+    node_cache: &State<ValidatorCache>,
+    identity: String,
+) -> Json<MixnodeStatusResponse> {
+    Json(MixnodeStatusResponse {
+        status: node_cache.mixnode_status(identity).await,
     })
 }

--- a/validator-api/src/nymd_client.rs
+++ b/validator-api/src/nymd_client.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Config;
-use crate::rewarding::{error::RewardingError, MixnodeToReward};
+use crate::rewarding::{error::RewardingError, EpochRewardParams, MixnodeToReward};
 use config::defaults::DEFAULT_VALIDATOR_API_PORT;
 use mixnet_contract::{
     ContractStateParams, Delegation, ExecuteMsg, GatewayBond, IdentityKey, MixNodeBond,
@@ -98,34 +98,6 @@ impl<C> Client<C> {
         Ok(time)
     }
 
-    pub(crate) async fn get_reward_pool(&self) -> Result<u128, ValidatorClientError>
-    where
-        C: CosmWasmClient + Sync,
-    {
-        Ok(self.0.read().await.get_reward_pool().await?)
-    }
-
-    pub(crate) async fn get_circulating_supply(&self) -> Result<u128, ValidatorClientError>
-    where
-        C: CosmWasmClient + Sync,
-    {
-        Ok(self.0.read().await.get_circulating_supply().await?)
-    }
-
-    pub(crate) async fn get_sybil_resistance_percent(&self) -> Result<u8, ValidatorClientError>
-    where
-        C: CosmWasmClient + Sync,
-    {
-        Ok(self.0.read().await.get_sybil_resistance_percent().await?)
-    }
-
-    pub(crate) async fn get_epoch_reward_percent(&self) -> Result<u8, ValidatorClientError>
-    where
-        C: CosmWasmClient + Sync,
-    {
-        Ok(self.0.read().await.get_epoch_reward_percent().await?)
-    }
-
     pub(crate) async fn get_mixnodes(&self) -> Result<Vec<MixNodeBond>, ValidatorClientError>
     where
         C: CosmWasmClient + Sync,
@@ -156,6 +128,31 @@ impl<C> Client<C> {
         C: CosmWasmClient + Sync,
     {
         self.0.read().await.get_current_rewarding_interval().await
+    }
+
+    pub(crate) async fn get_current_epoch_reward_params(
+        &self,
+    ) -> Result<EpochRewardParams, ValidatorClientError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        let this = self.0.read().await;
+
+        let state = this.get_contract_settings().await?;
+        let reward_pool = this.get_reward_pool().await?;
+        let epoch_reward_percent = this.get_epoch_reward_percent().await?;
+
+        let epoch_reward_params = EpochRewardParams {
+            reward_pool,
+            circulating_supply: this.get_circulating_supply().await?,
+            sybil_resistance_percent: this.get_sybil_resistance_percent().await?,
+            rewarded_set_size: state.mixnode_rewarded_set_size,
+            active_set_size: state.mixnode_active_set_size,
+            period_reward_pool: (reward_pool / 100) * epoch_reward_percent as u128,
+            active_set_work_factor: state.active_set_work_factor,
+        };
+
+        Ok(epoch_reward_params)
     }
 
     pub(crate) async fn get_rewarding_status(


### PR DESCRIPTION
This pull request introduces two additional endpoints on our validator API: 
- `/mixnode/<identity>/reward_estimation` that tries to estimate reward of the particular mixnode if nothing changed until the end of the epoch (i.e. its uptime and distribution of stake). I've got one question to @durch here, I actually don't remember whether in the end we updated calculation for situations where given node was only sometimes in the "active"/"rewarded" set (i.e say it it was "active" for first hour, then was on "standby" for another few, then it wasn't chosen at all, etc.), do you happen to know that? Or is it perhaps something that will be introduced in https://github.com/nymtech/nym/pull/1012 ?
- `/mixnode/<identity>/stake_saturation` that determines current stake saturation of particular node