### PR TITLE
Chore/stricter dependency requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd555c66291d5f836dbb6883b48660ece810fe25a31f3bdfb911945dff2691f"
+checksum = "526c210b4520e416420759af363083471656e819a75e831b8d2c9d5a584f2413"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.1",

--- a/common/crypto/Cargo.toml
+++ b/common/crypto/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 aes = { version = "0.7.4", features = ["ctr"] }
 bs58 = "0.4.0"
-blake3 = { version = "1.0.0", features = ["traits-preview"] }
+blake3 = { version = "~1.2.0", features = ["traits-preview"] }
 digest = "0.9.0"
 generic-array = "0.14"
 hkdf = "0.11.0"


### PR DESCRIPTION
~Builds on the chain of dependency updates, i.e. https://github.com/nymtech/nym/pull/1023 and thus requires the previous PR to be merged.~

This PR solves the problem of accidentally deleting `Cargo.lock` file from the repository and attempting to recreate it. If you try it right now (as in using `develop`), it will attempt to pull `blake3` version `1.3.0` which is not going to work as it's using reworked `digest` `0.10.1` and thus the build will fail.

I also considered just updating all our crypto-dependencies to be compatible with the most recent `digest` trait changes, but after having a glance at it, I figured it wouldn't be a five-minute trivial change and we don't really need it now.