### PR TITLE
Migrate to cw-storage-plus 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b8b840947313c1a1cccf056836cd79a60b4526bdcd6582995be37dc97be4ae"
+checksum = "7d7ee1963302b0ac2a9d42fe0faec826209c17452bfd36fbfd9d002a88929261"
 dependencies = [
  "cosmwasm-std",
  "schemars",

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0-beta3"
+version = "1.0.0-beta4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a380b87642204557629c9b72988c47b55fbfe6d474960adba56b22331504956a"
+checksum = "f903ebbabc0d4880dbc76148efb8be8fc29fa4bf294c440c3d70da1c8bcafff7"
 dependencies = [
  "digest 0.9.0",
  "ed25519-zebra",
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0-beta3"
+version = "1.0.0-beta4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866713b2fe13f23038c7d8824c3059d1f28dd94685fb406d1533c4eeeefeefae"
+checksum = "832bebef577ecb394603de8e2bf0de429b74aa364e17dec18e15ce37e71b0cae"
 dependencies = [
  "syn",
 ]
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0-beta3"
+version = "1.0.0-beta4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dbb9939b31441dfa9af3ec9740c8a24d585688401eff1b6b386abb7ad0d10a8"
+checksum = "6238c45840cc9de5a39f0f619e3a4f7c38c5d2c6ac9e3e4d72751ee045e6d7da"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0-beta3"
+version = "1.0.0-beta4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a4e55f0d64fed54cd2202301b8d466af8de044589247dabd77a4222f52f749"
+checksum = "f472c0bfd584a4510702537d0b65c5331095e76099586a12f749fd69afda9c5e"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b8b840947313c1a1cccf056836cd79a60b4526bdcd6582995be37dc97be4ae"
+checksum = "7d7ee1963302b0ac2a9d42fe0faec826209c17452bfd36fbfd9d002a88929261"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -1202,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50eef3672ec8fa45f3457fd423ba131117786784a895548021976117c1ded449"
+checksum = "042ac496d97e5885149d34139bad1d617192770d7eb8f1866da2317ff4501853"
 dependencies = [
  "serde",
 ]

--- a/contracts/mixnet/Cargo.toml
+++ b/contracts/mixnet/Cargo.toml
@@ -20,9 +20,9 @@ mixnet-contract-common = { path = "../../common/cosmwasm-smart-contracts/mixnet-
 config = { path = "../../common/config"}
 vesting-contract = { path = "../vesting" }
 
-cosmwasm-std = "1.0.0-beta3"
-cosmwasm-storage = "1.0.0-beta3"
-cw-storage-plus = "0.10.3"
+cosmwasm-std = "1.0.0-beta4"
+cosmwasm-storage = "1.0.0-beta4"
+cw-storage-plus = "0.11.1"
 
 bs58 = "0.4.0"
 schemars = "0.8"

--- a/contracts/mixnet/src/delegations/storage.rs
+++ b/contracts/mixnet/src/delegations/storage.rs
@@ -17,9 +17,9 @@ pub(crate) const DELEGATION_PAGE_DEFAULT_LIMIT: u32 = 250;
 type PrimaryKey = Vec<u8>;
 
 pub(crate) struct DelegationIndex<'a> {
-    pub(crate) owner: MultiIndex<'a, (Addr, PrimaryKey), Delegation>,
+    pub(crate) owner: MultiIndex<'a, Addr, Delegation>,
 
-    pub(crate) mixnode: MultiIndex<'a, (IdentityKey, PrimaryKey), Delegation>,
+    pub(crate) mixnode: MultiIndex<'a, IdentityKey, Delegation>,
 }
 
 impl<'a> IndexList<Delegation> for DelegationIndex<'a> {
@@ -46,12 +46,12 @@ impl<'a> IndexList<Delegation> for DelegationIndex<'a> {
 pub(crate) fn delegations<'a>() -> IndexedMap<'a, PrimaryKey, Delegation, DelegationIndex<'a>> {
     let indexes = DelegationIndex {
         owner: MultiIndex::new(
-            |d, pk| (d.owner.clone(), pk),
+            |d| d.owner.clone(),
             DELEGATION_PK_NAMESPACE,
             DELEGATION_OWNER_IDX_NAMESPACE,
         ),
         mixnode: MultiIndex::new(
-            |d, pk| (d.node_identity.clone(), pk),
+            |d| d.node_identity.clone(),
             DELEGATION_PK_NAMESPACE,
             DELEGATION_MIXNODE_IDX_NAMESPACE,
         ),

--- a/contracts/mixnet/src/rewards/helpers.rs
+++ b/contracts/mixnet/src/rewards/helpers.rs
@@ -64,7 +64,7 @@ pub(crate) fn update_rewarding_status(
     if let Some(next_start) = next_start {
         storage::REWARDING_STATUS.save(
             storage,
-            (rewarding_interval_nonce.into(), mix_identity),
+            (rewarding_interval_nonce, mix_identity),
             &RewardingStatus::PendingNextDelegatorPage(PendingDelegatorRewarding {
                 running_results: rewarding_results,
                 next_start,
@@ -74,7 +74,7 @@ pub(crate) fn update_rewarding_status(
     } else {
         storage::REWARDING_STATUS.save(
             storage,
-            (rewarding_interval_nonce.into(), mix_identity),
+            (rewarding_interval_nonce, mix_identity),
             &RewardingStatus::Complete(rewarding_results),
         )?;
     }

--- a/contracts/mixnet/src/rewards/queries.rs
+++ b/contracts/mixnet/src/rewards/queries.rs
@@ -19,10 +19,8 @@ pub(crate) fn query_rewarding_status(
     mix_identity: IdentityKey,
     rewarding_interval_nonce: u32,
 ) -> StdResult<MixnodeRewardingStatusResponse> {
-    let status = storage::REWARDING_STATUS.may_load(
-        deps.storage,
-        (rewarding_interval_nonce.into(), mix_identity),
-    )?;
+    let status = storage::REWARDING_STATUS
+        .may_load(deps.storage, (rewarding_interval_nonce, mix_identity))?;
 
     Ok(MixnodeRewardingStatusResponse { status })
 }

--- a/contracts/mixnet/src/rewards/storage.rs
+++ b/contracts/mixnet/src/rewards/storage.rs
@@ -4,11 +4,12 @@
 use crate::error::ContractError;
 use config::defaults::TOTAL_SUPPLY;
 use cosmwasm_std::{StdResult, Storage, Uint128};
-use cw_storage_plus::{Item, Map, U32Key};
+use cw_storage_plus::{Item, Map};
 use mixnet_contract_common::{IdentityKey, RewardingStatus};
 
 pub(crate) const REWARD_POOL: Item<Uint128> = Item::new("pool");
-pub(crate) const REWARDING_STATUS: Map<(U32Key, IdentityKey), RewardingStatus> = Map::new("rm");
+// TODO: Do we need a migration for this?
+pub(crate) const REWARDING_STATUS: Map<(u32, IdentityKey), RewardingStatus> = Map::new("rm");
 
 // approximately 1 day (assuming 5s per block)
 pub(crate) const MINIMUM_BLOCK_AGE_FOR_REWARDING: u64 = 17280;

--- a/contracts/mixnet/src/rewards/transactions.rs
+++ b/contracts/mixnet/src/rewards/transactions.rs
@@ -201,7 +201,7 @@ pub(crate) fn try_reward_next_mixnode_delegators(
 
     match storage::REWARDING_STATUS.may_load(
         deps.storage,
-        (rewarding_interval_nonce.into(), mix_identity.clone()),
+        (rewarding_interval_nonce, mix_identity.clone()),
     )? {
         None => {
             // we haven't called 'regular' try_reward_mixnode, i.e. the operator itself
@@ -271,7 +271,7 @@ pub(crate) fn try_reward_mixnode(
     // check if the mixnode hasn't been rewarded in this rewarding interval already
     match storage::REWARDING_STATUS.may_load(
         deps.storage,
-        (rewarding_interval_nonce.into(), mix_identity.clone()),
+        (rewarding_interval_nonce, mix_identity.clone()),
     )? {
         None => (),
         Some(RewardingStatus::Complete(_)) => {
@@ -304,7 +304,7 @@ pub(crate) fn try_reward_mixnode(
     if current_bond.block_height + storage::MINIMUM_BLOCK_AGE_FOR_REWARDING > env.block.height {
         storage::REWARDING_STATUS.save(
             deps.storage,
-            (rewarding_interval_nonce.into(), mix_identity.clone()),
+            (rewarding_interval_nonce, mix_identity.clone()),
             &RewardingStatus::Complete(Default::default()),
         )?;
 
@@ -320,7 +320,7 @@ pub(crate) fn try_reward_mixnode(
     if params.uptime() == 0 {
         storage::REWARDING_STATUS.save(
             deps.storage,
-            (rewarding_interval_nonce.into(), mix_identity.clone()),
+            (rewarding_interval_nonce, mix_identity.clone()),
             &RewardingStatus::Complete(Default::default()),
         )?;
 
@@ -1257,7 +1257,7 @@ pub mod tests {
 
         // it's all correctly saved
         match storage::REWARDING_STATUS
-            .load(deps.as_ref().storage, (1.into(), node_identity))
+            .load(deps.as_ref().storage, (1u32, node_identity))
             .unwrap()
         {
             RewardingStatus::Complete(result) => assert_eq!(
@@ -1635,7 +1635,7 @@ pub mod tests {
             .idx
             .mixnode
             .prefix(node_identity.clone())
-            .range(deps.as_ref().storage, None, None, Order::Ascending)
+            .range_raw(deps.as_ref().storage, None, None, Order::Ascending)
         {
             let (primary_key, delegation) = delegation.unwrap();
             let delegator_reward = Uint128::new(delegation.amount.amount.u128() - base_delegation);

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -19,7 +19,7 @@ vesting-contract-common = { path = "../../common/cosmwasm-smart-contracts/vestin
 config = { path = "../../common/config" }
 
 cosmwasm-std = { version = "1.0.0-beta3"}
-cw-storage-plus = { version = "0.10.3", features = ["iterator"] }
+cw-storage-plus = { version = "0.11.1", features = ["iterator"] }
 
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/vesting/src/vesting/account/delegating_account.rs
+++ b/contracts/vesting/src/vesting/account/delegating_account.rs
@@ -111,8 +111,8 @@ impl DelegatingAccount for Account {
 
         // Iterate over keys matching the prefix and remove them from the map
         let block_times = delegations
-            .prefix_de(mix_bytes)
-            .keys_de(storage, None, None, Order::Ascending)
+            .prefix(mix_bytes)
+            .keys(storage, None, None, Order::Ascending)
             // Scan will blow up on first error
             .scan((), |_, x| x.ok())
             .collect::<Vec<u64>>();

--- a/contracts/vesting/src/vesting/account/mod.rs
+++ b/contracts/vesting/src/vesting/account/mod.rs
@@ -196,8 +196,8 @@ impl Account {
         let key = self.delegations_key();
         let delegations: Map<(&[u8], u64), Uint128> = Map::new(&key);
         delegations
-            .prefix_de(mix.as_bytes())
-            .keys_de(storage, None, None, Order::Ascending)
+            .prefix(mix.as_bytes())
+            .keys(storage, None, None, Order::Ascending)
             // Scan will blow up on first error
             .scan((), |_, x| x.ok())
             .collect::<Vec<u64>>()

--- a/contracts/vesting/src/vesting/account/vesting_account.rs
+++ b/contracts/vesting/src/vesting/account/vesting_account.rs
@@ -119,7 +119,7 @@ impl VestingAccount for Account {
         let delegations: Map<(&[u8], u64), Uint128> = Map::new(&delegations_key);
 
         let delegations_keys = delegations
-            .keys_de(storage, None, None, Order::Ascending)
+            .keys(storage, None, None, Order::Ascending)
             .scan((), |_, x| x.ok())
             .filter(|(_mix, block_time)| *block_time < start_time)
             .map(|(mix, block_time)| (mix, block_time))

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -954,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b8b840947313c1a1cccf056836cd79a60b4526bdcd6582995be37dc97be4ae"
+checksum = "7d7ee1963302b0ac2a9d42fe0faec826209c17452bfd36fbfd9d002a88929261"
 dependencies = [
  "cosmwasm-std",
  "schemars",


### PR DESCRIPTION
There is an interesting change where the `U32Key` is deprecated in favour of `u32`. I'm not sure if we need a migration for this

Closes #1032 