### PR TITLE
Fix clippy on relevant lints

### DIFF
--- a/clients/client-core/src/client/key_manager.rs
+++ b/clients/client-core/src/client/key_manager.rs
@@ -79,9 +79,9 @@ impl KeyManager {
             ))?;
 
         let gateway_shared_key: SharedKeys =
-            pemstore::load_key(&client_pathfinder.gateway_shared_key().to_owned())?;
+            pemstore::load_key(client_pathfinder.gateway_shared_key())?;
 
-        let ack_key: AckKey = pemstore::load_key(&client_pathfinder.ack_key().to_owned())?;
+        let ack_key: AckKey = pemstore::load_key(client_pathfinder.ack_key())?;
 
         // TODO: ack key is never stored so it is generated now. But perhaps it should be stored
         // after all for consistency sake?

--- a/clients/client-core/src/client/reply_key_storage.rs
+++ b/clients/client-core/src/client/reply_key_storage.rs
@@ -59,7 +59,7 @@ impl ReplyKeyStorage {
     ) -> Result<(), ReplyKeyStorageError> {
         let digest = encryption_key.compute_digest();
 
-        let insertion_result = match self.db.insert(digest.to_vec(), encryption_key.to_bytes()) {
+        let insertion_result = match self.db.insert(digest, encryption_key.to_bytes()) {
             Err(e) => Err(ReplyKeyStorageError::DbWriteError(e)),
             Ok(existing_key) => {
                 if existing_key.is_some() {
@@ -79,7 +79,7 @@ impl ReplyKeyStorage {
         &self,
         key_digest: EncryptionKeyDigest,
     ) -> Result<Option<SurbEncryptionKey>, ReplyKeyStorageError> {
-        let removal_result = match self.db.remove(&key_digest.to_vec()) {
+        let removal_result = match self.db.remove(key_digest) {
             Err(e) => Err(ReplyKeyStorageError::DbReadError(e)),
             Ok(existing_key) => {
                 Ok(existing_key.map(|existing_key| self.read_encryption_key(existing_key)))

--- a/clients/native/examples/websocket_binarysend.rs
+++ b/clients/native/examples/websocket_binarysend.rs
@@ -35,7 +35,7 @@ async fn send_file_with_reply() {
     let (mut ws_stream, _) = connect_async(uri).await.unwrap();
 
     let recipient = get_self_address(&mut ws_stream).await;
-    println!("our full address is: {}", recipient.to_string());
+    println!("our full address is: {}", recipient);
 
     let read_data = std::fs::read("examples/dummy_file").unwrap();
 
@@ -83,7 +83,7 @@ async fn send_file_without_reply() {
     let (mut ws_stream, _) = connect_async(uri).await.unwrap();
 
     let recipient = get_self_address(&mut ws_stream).await;
-    println!("our full address is: {}", recipient.to_string());
+    println!("our full address is: {}", recipient);
 
     let read_data = std::fs::read("examples/dummy_file").unwrap();
 

--- a/clients/native/examples/websocket_textsend.rs
+++ b/clients/native/examples/websocket_textsend.rs
@@ -36,7 +36,7 @@ async fn send_text_with_reply() {
     let (mut ws_stream, _) = connect_async(uri).await.unwrap();
 
     let recipient = get_self_address(&mut ws_stream).await;
-    println!("our full address is: {}", recipient.to_string());
+    println!("our full address is: {}", recipient);
 
     let send_request = json!({
         "type" : "send",
@@ -76,7 +76,7 @@ async fn send_text_without_reply() {
     let (mut ws_stream, _) = connect_async(uri).await.unwrap();
 
     let recipient = get_self_address(&mut ws_stream).await;
-    println!("our full address is: {}", recipient.to_string());
+    println!("our full address is: {}", recipient);
 
     let send_request = json!({
         "type" : "send",

--- a/common/client-libs/validator-client/src/nymd/cosmwasm_client/signing_client.rs
+++ b/common/client-libs/validator-client/src/nymd/cosmwasm_client/signing_client.rs
@@ -162,8 +162,7 @@ pub trait SigningCosmWasmClient: CosmWasmClient {
             sender: sender_address.clone(),
             admin: options
                 .as_mut()
-                .map(|options| options.admin.take())
-                .flatten(),
+                .and_then(|options| options.admin.take()),
             code_id,
             // now this is a weird one. the protobuf files say this field is optional,
             // but if you omit it, the initialisation will fail CheckTx

--- a/common/client-libs/validator-client/src/nymd/cosmwasm_client/signing_client.rs
+++ b/common/client-libs/validator-client/src/nymd/cosmwasm_client/signing_client.rs
@@ -160,9 +160,7 @@ pub trait SigningCosmWasmClient: CosmWasmClient {
     {
         let init_msg = cosmwasm::MsgInstantiateContract {
             sender: sender_address.clone(),
-            admin: options
-                .as_mut()
-                .and_then(|options| options.admin.take()),
+            admin: options.as_mut().and_then(|options| options.admin.take()),
             code_id,
             // now this is a weird one. the protobuf files say this field is optional,
             // but if you omit it, the initialisation will fail CheckTx

--- a/common/crypto/src/hkdf.rs
+++ b/common/crypto/src/hkdf.rs
@@ -22,7 +22,7 @@ where
 
     let hkdf = Hkdf::<D>::new(salt, ikm);
     let mut okm = vec![0u8; okm_length];
-    hkdf.expand(info.unwrap_or_else(|| &[]), &mut okm)?;
+    hkdf.expand(info.unwrap_or(&[]), &mut okm)?;
 
     Ok(okm)
 }

--- a/common/nymsphinx/src/preparer/mod.rs
+++ b/common/nymsphinx/src/preparer/mod.rs
@@ -386,13 +386,7 @@ where
         // (note: surb_ack_bytes contains SURB_ACK_FIRST_HOP || SURB_ACK_DATA )
         let packet_payload: Vec<_> = surb_ack_bytes
             .into_iter()
-            .chain(
-                reply_surb
-                    .encryption_key()
-                    .compute_digest()
-                    .iter()
-                    .copied(),
-            )
+            .chain(reply_surb.encryption_key().compute_digest().iter().copied())
             .chain(reply_content.into_iter())
             .collect();
 

--- a/common/nymsphinx/src/preparer/mod.rs
+++ b/common/nymsphinx/src/preparer/mod.rs
@@ -390,8 +390,8 @@ where
                 reply_surb
                     .encryption_key()
                     .compute_digest()
-                    .to_vec()
-                    .into_iter(),
+                    .iter()
+                    .copied(),
             )
             .chain(reply_content.into_iter())
             .collect();

--- a/gateway/gateway-requests/src/registration/handshake/shared_key.rs
+++ b/gateway/gateway-requests/src/registration/handshake/shared_key.rs
@@ -148,9 +148,9 @@ impl SharedKeys {
 
     pub fn to_bytes(&self) -> Vec<u8> {
         self.encryption_key
-            .to_vec()
-            .into_iter()
-            .chain(self.mac_key.to_vec().into_iter())
+            .iter()
+            .copied()
+            .chain(self.mac_key.iter().copied())
             .collect()
     }
 

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -302,7 +302,7 @@ fn override_config(mut config: Config, matches: &ArgMatches) -> Config {
         let monitor_threshold =
             monitor_threshold.expect("Provided monitor threshold is not a number!");
         assert!(
-            !(monitor_threshold > 100),
+            monitor_threshold <= 100,
             "Provided monitor threshold is greater than 100!"
         );
         config = config.with_minimum_epoch_monitor_threshold(monitor_threshold)


### PR DESCRIPTION
return_self_not_must_use still produces errors, but that will be
auto-fixed once the change to move it to pedantic is released to beta
channel