### PR TITLE
Mixnet Contract constants extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,7 +3625,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "hex-literal",
  "serde",
- "time 0.3.5",
  "url",
 ]
 

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -270,6 +270,13 @@ impl<C> Client<C> {
         Ok(self.nymd.get_sybil_resistance_percent().await?)
     }
 
+    pub async fn get_active_set_work_factor(&self) -> Result<u8, ValidatorClientError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        Ok(self.nymd.get_active_set_work_factor().await?)
+    }
+
     pub async fn get_interval_reward_percent(&self) -> Result<u8, ValidatorClientError>
     where
         C: CosmWasmClient + Sync,

--- a/common/client-libs/validator-client/src/nymd/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/mod.rs
@@ -398,6 +398,16 @@ impl<C> NymdClient<C> {
             .await
     }
 
+    pub async fn get_active_set_work_factor(&self) -> Result<u8, NymdError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        let request = QueryMsg::GetActiveSetWorkFactor {};
+        self.client
+            .query_contract_smart(self.mixnet_contract_address()?, &request)
+            .await
+    }
+
     pub async fn get_interval_reward_percent(&self) -> Result<u8, NymdError>
     where
         C: CosmWasmClient + Sync,

--- a/common/cosmwasm-smart-contracts/mixnet-contract/Cargo.toml
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/Cargo.toml
@@ -22,5 +22,9 @@ time = { version = "0.3.5", features = ["serde"] }
 
 contracts-common = { path = "../contracts-common" }
 
+[dev-dependencies]
+time = { version = "0.3.5", features = ["serde", "macros"] }
+
+
 [features]
 default = []

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/events.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/events.rs
@@ -47,7 +47,6 @@ pub const NEW_MINIMUM_MIXNODE_PLEDGE_KEY: &str = "new_minimum_mixnode_pledge";
 pub const NEW_MINIMUM_GATEWAY_PLEDGE_KEY: &str = "new_minimum_gateway_pledge";
 pub const NEW_MIXNODE_REWARDED_SET_SIZE_KEY: &str = "new_mixnode_rewarded_set_size";
 pub const NEW_MIXNODE_ACTIVE_SET_SIZE_KEY: &str = "new_mixnode_active_set_size";
-pub const NEW_ACTIVE_SET_WORK_FACTOR_KEY: &str = "new_active_set_work_factor";
 
 // rewarding
 pub const INTERVAL_ID_KEY: &str = "interval_id";
@@ -236,18 +235,6 @@ pub fn new_settings_update_event(
             .add_attribute(
                 NEW_MIXNODE_ACTIVE_SET_SIZE_KEY,
                 new_params.mixnode_active_set_size.to_string(),
-            )
-    }
-
-    if old_params.active_set_work_factor != new_params.active_set_work_factor {
-        event = event
-            .add_attribute(
-                OLD_ACTIVE_SET_WORK_FACTOR_KEY,
-                old_params.active_set_work_factor.to_string(),
-            )
-            .add_attribute(
-                NEW_ACTIVE_SET_WORK_FACTOR_KEY,
-                new_params.active_set_work_factor.to_string(),
             )
     }
 

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
@@ -1,7 +1,6 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use network_defaults::{DEFAULT_FIRST_INTERVAL_START, DEFAULT_INTERVAL_LENGTH};
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
@@ -181,16 +180,6 @@ impl Display for Interval {
             self.end(),
             hours
         )
-    }
-}
-
-impl Default for Interval {
-    fn default() -> Self {
-        Interval {
-            id: 0,
-            start: DEFAULT_FIRST_INTERVAL_START,
-            length: DEFAULT_INTERVAL_LENGTH,
-        }
     }
 }
 

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
@@ -133,6 +133,7 @@ pub enum QueryMsg {
     GetCirculatingSupply {},
     GetIntervalRewardPercent {},
     GetSybilResistancePercent {},
+    GetActiveSetWorkFactor {},
     GetRewardingStatus {
         mix_identity: IdentityKey,
         interval_id: u32,

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/types.rs
@@ -43,7 +43,6 @@ pub struct ContractStateParams {
     // subset of rewarded mixnodes that are actively receiving mix traffic
     // used to handle shorter-term (e.g. hourly) fluctuations of demand
     pub mixnode_active_set_size: u32,
-    pub active_set_work_factor: u8,
 }
 
 impl Display for ContractStateParams {
@@ -68,11 +67,6 @@ impl Display for ContractStateParams {
             f,
             "mixnode active set size: {}",
             self.mixnode_active_set_size
-        )?;
-        write!(
-            f,
-            "mixnode active set work factor: {}",
-            self.active_set_work_factor
         )
     }
 }

--- a/common/network-defaults/Cargo.toml
+++ b/common/network-defaults/Cargo.toml
@@ -11,4 +11,3 @@ cfg-if = "1.0.0"
 hex-literal = "0.3.3"
 serde = {version = "1.0", features = ["derive"]}
 url = "2.2"
-time = { version = "0.3", features = ["macros"] }

--- a/common/network-defaults/src/lib.rs
+++ b/common/network-defaults/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
-use time::OffsetDateTime;
 use url::Url;
 
 pub mod all;
@@ -152,9 +150,7 @@ pub const DEFAULT_VALIDATOR_API_PORT: u16 = 8080;
 pub const VALIDATOR_API_VERSION: &str = "v1";
 
 // REWARDING
-pub const DEFAULT_FIRST_INTERVAL_START: OffsetDateTime =
-    time::macros::datetime!(2021-08-23 12:00 UTC);
-pub const DEFAULT_INTERVAL_LENGTH: Duration = Duration::from_secs(24 * 60 * 60 * 30); // 30 days, i.e. 720h
+
 /// We'll be assuming a few more things, profit margin and cost function. Since we don't have relialable package measurement, we'll be using uptime. We'll also set the value of 1 Nym to 1 $, to be able to translate interval costs to Nyms. We'll also assume a cost of 40$ per interval(month), converting that to Nym at our 1$ rate translates to 40_000_000 uNyms
 pub const DEFAULT_OPERATOR_INTERVAL_COST: u64 = 40_000_000; // 40$/(30 days) at 1 Nym == 1$
 

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -882,7 +882,6 @@ dependencies = [
  "cfg-if",
  "hex-literal",
  "serde",
- "time 0.3.5",
  "url",
 ]
 

--- a/contracts/mixnet/Cargo.toml
+++ b/contracts/mixnet/Cargo.toml
@@ -28,6 +28,7 @@ bs58 = "0.4.0"
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
+time = { version = "0.3", features = ["macros"] }
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0-beta3"
@@ -35,7 +36,6 @@ fixed = "1.1"
 rand_chacha = "0.2"
 rand = "0.7"
 crypto = { path = "../../common/crypto" }
-time = "0.3"
 
 [build-dependencies]
 vergen = { version = "5", default-features = false, features = ["build", "git", "rustc"] }

--- a/contracts/mixnet/src/constants.rs
+++ b/contracts/mixnet/src/constants.rs
@@ -9,6 +9,7 @@ pub const MINIMUM_BLOCK_AGE_FOR_REWARDING: u64 = 120960;
 
 pub const INTERVAL_REWARD_PERCENT: u8 = 2; // Used to calculate interval reward pool
 pub const SYBIL_RESISTANCE_PERCENT: u8 = 30;
+pub const ACTIVE_SET_WORK_FACTOR: u8 = 10;
 
 // TODO: this, in theory, represents "epoch" length.
 // However, since the blocktime is not EXACTLY 5s, we can't really guarantee 720 epochs in interval

--- a/contracts/mixnet/src/constants.rs
+++ b/contracts/mixnet/src/constants.rs
@@ -1,0 +1,19 @@
+// Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+// approximately 1 week (assuming 5s per block)
+// i.e. approximately quarter of the interval (there are 3600 * 60 * 7 = 604800 seconds in a week, i.e. ~604800 / 5 = 120960 blocks)
+pub const MINIMUM_BLOCK_AGE_FOR_REWARDING: u64 = 120960;
+
+pub const INTERVAL_REWARD_PERCENT: u8 = 2; // Used to calculate interval reward pool
+pub const SYBIL_RESISTANCE_PERCENT: u8 = 30;
+
+// TODO: this, in theory, represents "epoch" length.
+// However, since the blocktime is not EXACTLY 5s, we can't really guarantee 720 epochs in interval
+// and we can't change this easily to `Duration`, because then the entire rewarded set storage
+// would be messed up... (as we look up stuff "by blocks")
+pub const REWARDED_SET_REFRESH_BLOCKS: u64 = 720; // with blocktime being approximately 5s, it should be roughly 1h
+
+pub const REWARDING_INTERVAL_LENGTH: Duration = Duration::from_secs(60 * 60 * 720); // 720h, i.e. 30 days

--- a/contracts/mixnet/src/interval/queries.rs
+++ b/contracts/mixnet/src/interval/queries.rs
@@ -15,7 +15,7 @@ pub fn query_current_interval(storage: &dyn Storage) -> Result<Interval, Contrac
 }
 
 pub(crate) fn query_rewarded_set_refresh_minimum_blocks() -> u64 {
-    crate::contract::REWARDED_SET_REFRESH_BLOCKS
+    crate::constants::REWARDED_SET_REFRESH_BLOCKS
 }
 
 pub fn query_rewarded_set_heights_for_interval(
@@ -415,7 +415,7 @@ mod tests {
         // returns whatever is in the correct environment
         assert_eq!(
             RewardedSetUpdateDetails {
-                refresh_rate_blocks: crate::contract::REWARDED_SET_REFRESH_BLOCKS,
+                refresh_rate_blocks: crate::constants::REWARDED_SET_REFRESH_BLOCKS,
                 last_refreshed_block: current_height,
                 current_height: env.block.height
             },

--- a/contracts/mixnet/src/interval/transactions.rs
+++ b/contracts/mixnet/src/interval/transactions.rs
@@ -42,10 +42,10 @@ pub fn try_write_rewarded_set(
     let last_update = storage::CURRENT_REWARDED_SET_HEIGHT.load(deps.storage)?;
     let block_height = env.block.height;
 
-    if last_update + crate::contract::REWARDED_SET_REFRESH_BLOCKS > block_height {
+    if last_update + crate::constants::REWARDED_SET_REFRESH_BLOCKS > block_height {
         return Err(ContractError::TooFrequentRewardedSetUpdate {
             last_update,
-            minimum_delay: crate::contract::REWARDED_SET_REFRESH_BLOCKS,
+            minimum_delay: crate::constants::REWARDED_SET_REFRESH_BLOCKS,
             current_height: block_height,
         });
     }
@@ -176,7 +176,7 @@ mod tests {
         assert_eq!(
             Err(ContractError::TooFrequentRewardedSetUpdate {
                 last_update,
-                minimum_delay: crate::contract::REWARDED_SET_REFRESH_BLOCKS,
+                minimum_delay: crate::constants::REWARDED_SET_REFRESH_BLOCKS,
                 current_height: last_update + 1,
             }),
             try_write_rewarded_set(
@@ -189,7 +189,7 @@ mod tests {
         );
 
         // after successful rewarded set write, all internal storage structures are updated appropriately
-        env.block.height = last_update + crate::contract::REWARDED_SET_REFRESH_BLOCKS;
+        env.block.height = last_update + crate::constants::REWARDED_SET_REFRESH_BLOCKS;
         let expected_response = Response::new().add_event(new_change_rewarded_set_event(
             current_state.params.mixnode_active_set_size,
             current_state.params.mixnode_rewarded_set_size,

--- a/contracts/mixnet/src/lib.rs
+++ b/contracts/mixnet/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+mod constants;
 pub mod contract;
 mod delegations;
 mod error;

--- a/contracts/mixnet/src/mixnet_contract_settings/queries.rs
+++ b/contracts/mixnet/src/mixnet_contract_settings/queries.rs
@@ -45,7 +45,6 @@ pub(crate) mod tests {
                 minimum_gateway_pledge: 456u128.into(),
                 mixnode_rewarded_set_size: 1000,
                 mixnode_active_set_size: 500,
-                active_set_work_factor: 10,
             },
         };
 

--- a/contracts/mixnet/src/mixnet_contract_settings/transactions.rs
+++ b/contracts/mixnet/src/mixnet_contract_settings/transactions.rs
@@ -63,7 +63,6 @@ pub mod tests {
             minimum_gateway_pledge: INITIAL_GATEWAY_PLEDGE,
             mixnode_rewarded_set_size: 100,
             mixnode_active_set_size: 50,
-            active_set_work_factor: 10,
         };
 
         let initial_params = storage::CONTRACT_STATE

--- a/contracts/mixnet/src/rewards/queries.rs
+++ b/contracts/mixnet/src/rewards/queries.rs
@@ -34,8 +34,8 @@ pub(crate) mod tests {
 
     #[cfg(test)]
     mod querying_for_rewarding_status {
-        use super::storage;
         use super::*;
+        use crate::constants;
         use crate::delegations::transactions::try_delegate_to_mixnode;
         use crate::rewards::transactions::{
             try_reward_mixnode, try_reward_next_mixnode_delegators,
@@ -103,7 +103,7 @@ pub(crate) mod tests {
                 deps.as_mut(),
             );
 
-            env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING;
+            env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING;
 
             let info = mock_info(rewarding_validator_address.as_ref(), &[]);
             try_reward_mixnode(
@@ -151,7 +151,7 @@ pub(crate) mod tests {
                 .unwrap();
             }
 
-            env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING;
+            env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING;
             test_helpers::update_env_and_progress_interval(&mut env, deps.as_mut().storage);
 
             let info = mock_info(rewarding_validator_address.as_ref(), &[]);
@@ -214,7 +214,7 @@ pub(crate) mod tests {
                 .unwrap();
             }
 
-            env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING;
+            env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING;
 
             let info = mock_info(rewarding_validator_address.as_ref(), &[]);
 

--- a/contracts/mixnet/src/rewards/storage.rs
+++ b/contracts/mixnet/src/rewards/storage.rs
@@ -11,10 +11,6 @@ pub(crate) const REWARD_POOL: Item<Uint128> = Item::new("pool");
 // TODO: Do we need a migration for this?
 pub(crate) const REWARDING_STATUS: Map<(u32, IdentityKey), RewardingStatus> = Map::new("rm");
 
-// approximately 1 week (assuming 5s per block)
-// i.e. approximately quarter of the interval (there are 3600 * 60 * 7 = 604800 seconds in a week, i.e. ~604800 / 5 = 120960 blocks)
-pub(crate) const MINIMUM_BLOCK_AGE_FOR_REWARDING: u64 = 120960;
-
 #[allow(dead_code)]
 pub fn incr_reward_pool(
     amount: Uint128,

--- a/contracts/mixnet/src/rewards/transactions.rs
+++ b/contracts/mixnet/src/rewards/transactions.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::storage;
+use crate::constants;
 use crate::delegations::storage as delegations_storage;
 use crate::error::ContractError;
 use crate::interval::storage as interval_storage;
@@ -116,7 +117,7 @@ fn reward_mix_delegators(
             // and for each of them increase the stake proportionally to the reward
             // if at least `MINIMUM_BLOCK_AGE_FOR_REWARDING` blocks have been created
             // since they delegated
-            if delegation.block_height + storage::MINIMUM_BLOCK_AGE_FOR_REWARDING
+            if delegation.block_height + constants::MINIMUM_BLOCK_AGE_FOR_REWARDING
                 <= params.node_reward_params().reward_blockstamp()
             {
                 let reward = params.determine_delegation_reward(delegation.amount.amount);
@@ -244,7 +245,7 @@ pub(crate) fn try_reward_mixnode(
     };
 
     // check if node is old enough for rewarding
-    if current_bond.block_height + storage::MINIMUM_BLOCK_AGE_FOR_REWARDING > env.block.height {
+    if current_bond.block_height + constants::MINIMUM_BLOCK_AGE_FOR_REWARDING > env.block.height {
         storage::REWARDING_STATUS.save(
             deps.storage,
             (interval_id, mix_identity.clone()),
@@ -323,7 +324,7 @@ pub(crate) fn try_reward_mixnode(
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::contract::DEFAULT_SYBIL_RESISTANCE_PERCENT;
+    use crate::constants::SYBIL_RESISTANCE_PERCENT;
     use crate::delegations::transactions::try_delegate_to_mixnode;
     use crate::error::ContractError;
     use crate::mixnet_contract_settings::storage as mixnet_params_storage;
@@ -517,7 +518,7 @@ pub mod tests {
             .unwrap();
 
         // delegation happens later, but not later enough
-        env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING - 1;
+        env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING - 1;
 
         delegations_storage::delegations()
             .save(
@@ -609,7 +610,7 @@ pub mod tests {
         );
 
         // reward happens now, both for node owner and delegators
-        env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING - 1;
+        env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING - 1;
         test_helpers::update_env_and_progress_interval(&mut env, deps.as_mut().storage);
 
         let pledge_before_rewarding =
@@ -659,7 +660,8 @@ pub mod tests {
 
     #[test]
     fn test_tokenomics_rewarding() {
-        use crate::contract::{INITIAL_REWARD_POOL, INTERVAL_REWARD_PERCENT};
+        use crate::constants::INTERVAL_REWARD_PERCENT;
+        use crate::contract::INITIAL_REWARD_POOL;
 
         type U128 = fixed::types::U75F53;
 
@@ -701,7 +703,7 @@ pub mod tests {
         .unwrap();
 
         let info = mock_info(rewarding_validator_address.as_ref(), &[]);
-        env.block.height += 2 * storage::MINIMUM_BLOCK_AGE_FOR_REWARDING;
+        env.block.height += 2 * constants::MINIMUM_BLOCK_AGE_FOR_REWARDING;
 
         let mix_1 = mixnodes_storage::read_full_mixnode_bond(&deps.storage, &node_identity)
             .unwrap()
@@ -715,7 +717,7 @@ pub mod tests {
             0,
             circulating_supply,
             mix_1_uptime,
-            DEFAULT_SYBIL_RESISTANCE_PERCENT,
+            SYBIL_RESISTANCE_PERCENT,
             true,
             active_set_work_factor,
         );
@@ -841,7 +843,7 @@ pub mod tests {
                 .unwrap();
             }
 
-            env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING;
+            env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING;
 
             let info = mock_info(rewarding_validator_address.as_ref(), &[]);
             let res = try_reward_mixnode(
@@ -908,7 +910,7 @@ pub mod tests {
                 .unwrap();
             }
 
-            env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING;
+            env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING;
 
             let info = mock_info(rewarding_validator_address.as_ref(), &[]);
             let res = try_reward_mixnode(
@@ -975,7 +977,7 @@ pub mod tests {
                 .unwrap();
             }
 
-            env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING;
+            env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING;
 
             let info = mock_info(rewarding_validator_address.as_ref(), &[]);
             let res = try_reward_mixnode(
@@ -1049,7 +1051,7 @@ pub mod tests {
             .unwrap();
         }
 
-        env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING + 1;
+        env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING + 1;
         let mut node_rewarding_params = tests::fixtures::node_rewarding_params_fixture(100);
         node_rewarding_params.set_reward_blockstamp(env.block.height);
 
@@ -1104,7 +1106,7 @@ pub mod tests {
             .unwrap();
         }
 
-        env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING + 1;
+        env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING + 1;
         let mut node_rewarding_params = tests::fixtures::node_rewarding_params_fixture(100);
         node_rewarding_params.set_reward_blockstamp(env.block.height);
 
@@ -1231,7 +1233,7 @@ pub mod tests {
                 deps.as_mut(),
             );
 
-            env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING;
+            env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING;
 
             try_reward_mixnode(
                 deps.as_mut(),
@@ -1277,7 +1279,7 @@ pub mod tests {
                 .unwrap();
             }
 
-            env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING;
+            env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING;
             test_helpers::update_env_and_progress_interval(&mut env, deps.as_mut().storage);
 
             let info = mock_info(rewarding_validator_address.as_ref(), &[]);
@@ -1354,7 +1356,7 @@ pub mod tests {
                 .unwrap();
             }
 
-            env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING;
+            env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING;
 
             let info = mock_info(rewarding_validator_address.as_ref(), &[]);
             try_reward_mixnode(
@@ -1444,7 +1446,7 @@ pub mod tests {
                 .unwrap();
             }
 
-            env.block.height += storage::MINIMUM_BLOCK_AGE_FOR_REWARDING;
+            env.block.height += constants::MINIMUM_BLOCK_AGE_FOR_REWARDING;
 
             // update some delegations (on 'main' page and the secondary call)
             try_delegate_to_mixnode(

--- a/contracts/mixnet/src/support/tests/fixtures.rs
+++ b/contracts/mixnet/src/support/tests/fixtures.rs
@@ -1,7 +1,5 @@
-use crate::contract::{
-    DEFAULT_SYBIL_RESISTANCE_PERCENT, INITIAL_MIXNODE_PLEDGE, INITIAL_REWARD_POOL,
-    INTERVAL_REWARD_PERCENT,
-};
+use crate::constants::{INTERVAL_REWARD_PERCENT, SYBIL_RESISTANCE_PERCENT};
+use crate::contract::{INITIAL_MIXNODE_PLEDGE, INITIAL_REWARD_POOL};
 use crate::mixnodes::storage as mixnodes_storage;
 use crate::{mixnodes::storage::StoredMixnodeBond, support::tests};
 use config::defaults::{DENOM, TOTAL_SUPPLY};
@@ -85,7 +83,7 @@ pub fn node_rewarding_params_fixture(uptime: u128) -> NodeRewardParams {
         0,
         TOTAL_SUPPLY - INITIAL_REWARD_POOL,
         uptime,
-        DEFAULT_SYBIL_RESISTANCE_PERCENT,
+        SYBIL_RESISTANCE_PERCENT,
         true,
         10,
     )

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -2684,7 +2684,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "hex-literal",
  "serde",
- "time 0.3.5",
  "url",
 ]
 

--- a/nym-wallet/src-tauri/src/operations/mixnet/admin.rs
+++ b/nym-wallet/src-tauri/src/operations/mixnet/admin.rs
@@ -15,7 +15,6 @@ pub struct TauriContractStateParams {
   minimum_gateway_pledge: String,
   mixnode_rewarded_set_size: u32,
   mixnode_active_set_size: u32,
-  active_set_work_factor: u8,
 }
 
 impl From<ContractStateParams> for TauriContractStateParams {
@@ -25,7 +24,6 @@ impl From<ContractStateParams> for TauriContractStateParams {
       minimum_gateway_pledge: p.minimum_gateway_pledge.to_string(),
       mixnode_rewarded_set_size: p.mixnode_rewarded_set_size,
       mixnode_active_set_size: p.mixnode_active_set_size,
-      active_set_work_factor: p.active_set_work_factor,
     }
   }
 }
@@ -39,7 +37,6 @@ impl TryFrom<TauriContractStateParams> for ContractStateParams {
       minimum_gateway_pledge: Uint128::try_from(p.minimum_gateway_pledge.as_str())?,
       mixnode_rewarded_set_size: p.mixnode_rewarded_set_size,
       mixnode_active_set_size: p.mixnode_active_set_size,
-      active_set_work_factor: p.active_set_work_factor,
     })
   }
 }

--- a/nym-wallet/src/types/rust/stateparams.ts
+++ b/nym-wallet/src/types/rust/stateparams.ts
@@ -3,5 +3,4 @@ export interface TauriContractStateParams {
   minimum_gateway_pledge: string;
   mixnode_rewarded_set_size: number;
   mixnode_active_set_size: number;
-  active_set_work_factor: number;
 }

--- a/validator-api/src/config/mod.rs
+++ b/validator-api/src/config/mod.rs
@@ -2,15 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::template::config_template;
-use config::defaults::{
-    default_api_endpoints, DEFAULT_FIRST_INTERVAL_START, DEFAULT_INTERVAL_LENGTH,
-    DEFAULT_MIXNET_CONTRACT_ADDRESS,
-};
+use config::defaults::{default_api_endpoints, DEFAULT_MIXNET_CONTRACT_ADDRESS};
 use config::NymConfig;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::Duration;
-use time::OffsetDateTime;
 use url::Url;
 
 #[cfg(feature = "coconut")]
@@ -261,14 +257,6 @@ pub struct Rewarding {
     /// Mnemonic (currently of the network monitor) used for rewarding
     mnemonic: String,
 
-    /// Datetime of the first rewarding interval of the current length used for referencing
-    /// starting time of any subsequent interval.
-    first_rewarding_interval: OffsetDateTime,
-
-    /// Current length of the interval. If modified `first_rewarding_interval` should also get changed.
-    #[serde(with = "humantime_serde")]
-    interval_length: Duration,
-
     /// Specifies the minimum percentage of monitor test run data present in order to
     /// distribute rewards for given interval.
     /// Note, only values in range 0-100 are valid
@@ -280,8 +268,6 @@ impl Default for Rewarding {
         Rewarding {
             enabled: false,
             mnemonic: String::default(),
-            first_rewarding_interval: DEFAULT_FIRST_INTERVAL_START,
-            interval_length: DEFAULT_INTERVAL_LENGTH,
             minimum_interval_monitor_threshold: DEFAULT_MONITOR_THRESHOLD,
         }
     }
@@ -335,16 +321,6 @@ impl Config {
 
     pub fn with_custom_validator_apis(mut self, validator_api_urls: Vec<Url>) -> Self {
         self.network_monitor.all_validator_apis = validator_api_urls;
-        self
-    }
-
-    pub fn with_first_rewarding_interval(mut self, first_interval: OffsetDateTime) -> Self {
-        self.rewarding.first_rewarding_interval = first_interval;
-        self
-    }
-
-    pub fn with_interval_length(mut self, interval_length: Duration) -> Self {
-        self.rewarding.interval_length = interval_length;
         self
     }
 
@@ -460,16 +436,6 @@ impl Config {
     #[cfg(feature = "coconut")]
     pub fn get_all_validator_api_endpoints(&self) -> Vec<Url> {
         self.network_monitor.all_validator_apis.clone()
-    }
-
-    // TODO: Is this needed?
-    #[allow(dead_code)]
-    pub fn get_first_rewarding_interval(&self) -> OffsetDateTime {
-        self.rewarding.first_rewarding_interval
-    }
-
-    pub fn get_interval_length(&self) -> Duration {
-        self.rewarding.interval_length
     }
 
     pub fn get_minimum_interval_monitor_threshold(&self) -> u8 {

--- a/validator-api/src/config/template.rs
+++ b/validator-api/src/config/template.rs
@@ -99,13 +99,6 @@ enabled = {{ rewarding.enabled }}
 # Mnemonic (currently of the network monitor) used for rewarding
 mnemonic = '{{ rewarding.mnemonic }}'
 
-# Datetime of the first rewarding interval of the current length used for referencing
-# starting time of any subsequent interval.
-first_rewarding_interval = '{{ rewarding.first_rewarding_interval }}'
-
-# Current length of the interval. If modified `first_rewarding_interval` should also get changed.
-interval_length = '{{ rewarding.interval_length }}'
-
 # Specifies the minimum percentage of monitor test run data present in order to
 # distribute rewards for given interval.
 # Note, only values in range 0-100 are valid

--- a/validator-api/src/contract_cache/mod.rs
+++ b/validator-api/src/contract_cache/mod.rs
@@ -321,7 +321,13 @@ impl ValidatorCacheInner {
             rewarded_set: Cache::default(),
             active_set: Cache::default(),
             current_reward_params: Cache::new(IntervalRewardParams::new_empty()),
-            current_interval: Cache::default(),
+            // setting it to a dummy value on creation is fine, as nothing will be able to ready from it
+            // since 'initialised' flag won't be set
+            current_interval: Cache::new(Interval::new(
+                u32::MAX,
+                OffsetDateTime::UNIX_EPOCH,
+                Duration::default(),
+            )),
         }
     }
 }

--- a/validator-api/src/nymd_client.rs
+++ b/validator-api/src/nymd_client.rs
@@ -150,7 +150,7 @@ impl<C> Client<C> {
             rewarded_set_size: state.mixnode_rewarded_set_size,
             active_set_size: state.mixnode_active_set_size,
             period_reward_pool: (reward_pool / 100) * interval_reward_percent as u128,
-            active_set_work_factor: state.active_set_work_factor,
+            active_set_work_factor: this.get_active_set_work_factor().await?,
         };
 
         Ok(interval_reward_params)


### PR DESCRIPTION
This PR basically extracts relevant constants, i.e. those that could realistically be ever controlled by governance, such as reward percent per interval to a `constants.rs` file. 

There is, however, one question that I'd like to have @durch 's opinion on:
should `INITIAL_ACTIVE_SET_WORK_FACTOR` be treated similarly to `SYBIL_RESISTANCE_PERCENT`, ie. should only ever (if at all) be changed through governance rather than by permitted owner address? To remind, currently `active_set_work_factor` lives as field on our `ContractStateParams` that can be modified by the contract owner at any time.