### PR TITLE
Bump rust-version to latest stable for nym-mixnode

### DIFF
--- a/mixnode/Cargo.toml
+++ b/mixnode/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "Implementation of a Loopix-based Mixnode"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.58.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Captured identifiers in format strings was used in #1047, which requires the latest stable Rust compiler. Bump the rust-version in nym-mixnode to reflect this.