### PR TITLE
Tidy nym-mixnode module visibility

### DIFF
--- a/mixnode/src/commands/describe.rs
+++ b/mixnode/src/commands/describe.rs
@@ -1,6 +1,7 @@
-use crate::commands::*;
 use crate::config::Config;
 use crate::node::node_description::NodeDescription;
+use clap::Args;
+use colored::Colorize;
 use config::NymConfig;
 use std::io;
 use std::io::Write;

--- a/mixnode/src/commands/init.rs
+++ b/mixnode/src/commands/init.rs
@@ -1,12 +1,14 @@
 // Copyright 2020 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::commands::*;
-use crate::config::persistence::pathfinder::MixNodePathfinder;
 use crate::config::Config;
 use crate::node::MixNode;
+use crate::{commands::override_config, config::persistence::pathfinder::MixNodePathfinder};
+use clap::Args;
 use config::NymConfig;
 use crypto::asymmetric::{encryption, identity};
+
+use super::OverrideConfig;
 
 #[derive(Args, Clone)]
 pub(crate) struct Init {

--- a/mixnode/src/commands/mod.rs
+++ b/mixnode/src/commands/mod.rs
@@ -110,25 +110,6 @@ fn override_config(mut config: Config, args: OverrideConfig) -> Config {
     config
 }
 
-// this only checks compatibility between config the binary. It does not take into consideration
-// network version. It might do so in the future.
-pub(crate) fn version_check(cfg: &Config) -> bool {
-    let binary_version = env!("CARGO_PKG_VERSION");
-    let config_version = cfg.get_version();
-    if binary_version != config_version {
-        warn!("The mixnode binary has different version than what is specified in config file! {} and {}", binary_version, config_version);
-        if version_checker::is_minor_version_compatible(binary_version, config_version) {
-            info!("but they are still semver compatible. However, consider running the `upgrade` command");
-            true
-        } else {
-            error!("and they are semver incompatible! - please run the `upgrade` command before attempting `run` again");
-            false
-        }
-    } else {
-        true
-    }
-}
-
 /// Ensures that a given bech32 address is valid, or exits
 pub(crate) fn validate_bech32_address_or_exit(address: &str) {
     if let Err(bech32_address_validation::Bech32Error::DecodeFailed(err)) =
@@ -147,5 +128,24 @@ pub(crate) fn validate_bech32_address_or_exit(address: &str) {
         println!("{}", error_message);
         println!("Exiting...");
         process::exit(1);
+    }
+}
+
+// this only checks compatibility between config the binary. It does not take into consideration
+// network version. It might do so in the future.
+pub(crate) fn version_check(cfg: &Config) -> bool {
+    let binary_version = env!("CARGO_PKG_VERSION");
+    let config_version = cfg.get_version();
+    if binary_version != config_version {
+        warn!("The mixnode binary has different version than what is specified in config file! {} and {}", binary_version, config_version);
+        if version_checker::is_minor_version_compatible(binary_version, config_version) {
+            info!("but they are still semver compatible. However, consider running the `upgrade` command");
+            true
+        } else {
+            error!("and they are semver incompatible! - please run the `upgrade` command before attempting `run` again");
+            false
+        }
+    } else {
+        true
     }
 }

--- a/mixnode/src/commands/node_details.rs
+++ b/mixnode/src/commands/node_details.rs
@@ -1,9 +1,9 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::commands::*;
 use crate::config::Config;
 use crate::node::MixNode;
+use clap::Args;
 use config::NymConfig;
 
 #[derive(Args)]

--- a/mixnode/src/commands/run.rs
+++ b/mixnode/src/commands/run.rs
@@ -1,10 +1,13 @@
 // Copyright 2020 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::commands::*;
+use crate::commands::{override_config, version_check};
 use crate::config::Config;
 use crate::node::MixNode;
+use clap::Args;
 use config::NymConfig;
+
+use super::OverrideConfig;
 
 #[derive(Args, Clone)]
 pub(crate) struct Run {

--- a/mixnode/src/commands/upgrade.rs
+++ b/mixnode/src/commands/upgrade.rs
@@ -1,8 +1,8 @@
 // Copyright 2020 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::commands::*;
 use crate::config::{missing_string_value, Config};
+use clap::Args;
 use config::defaults::default_api_endpoints;
 use config::NymConfig;
 use std::fmt::Display;

--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -312,7 +312,7 @@ impl Config {
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-pub struct MixNode {
+struct MixNode {
     /// Version of the mixnode for which this configuration was created.
     #[serde(default = "missing_string_value")]
     version: String,
@@ -410,11 +410,11 @@ impl Default for MixNode {
 
 #[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct Logging {}
+struct Logging {}
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct Verloc {
+struct Verloc {
     /// Specifies number of echo packets sent to each node during a measurement run.
     packets_per_node: usize,
 
@@ -454,7 +454,7 @@ impl Default for Verloc {
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default)]
-pub struct Debug {
+struct Debug {
     /// Delay between each subsequent node statistics being logged to the console
     #[serde(with = "humantime_serde")]
     node_stats_logging_delay: Duration,

--- a/mixnode/src/main.rs
+++ b/mixnode/src/main.rs
@@ -34,18 +34,7 @@ async fn main() {
     println!("{}", banner());
 
     let args = Cli::parse();
-    execute(args).await;
-}
-
-async fn execute(args: Cli) {
-    match &args.command {
-        commands::Commands::Describe(m) => commands::describe::execute(m),
-        commands::Commands::Init(m) => commands::init::execute(m).await,
-        commands::Commands::Run(m) => commands::run::execute(m).await,
-        commands::Commands::Sign(m) => commands::sign::execute(m),
-        commands::Commands::Upgrade(m) => commands::upgrade::execute(m),
-        commands::Commands::NodeDetails(m) => commands::node_details::execute(m),
-    }
+    commands::execute(args).await;
 }
 
 fn banner() -> String {

--- a/mixnode/src/node/mod.rs
+++ b/mixnode/src/node/mod.rs
@@ -27,11 +27,11 @@ use std::process;
 use std::sync::Arc;
 use version_checker::parse_version;
 
-pub(crate) mod http;
+mod http;
 mod listener;
 pub(crate) mod node_description;
-pub(crate) mod node_statistics;
-pub(crate) mod packet_delayforwarder;
+mod node_statistics;
+mod packet_delayforwarder;
 
 // the MixNode will live for whole duration of this program
 pub struct MixNode {

--- a/mixnode/src/node/mod.rs
+++ b/mixnode/src/node/mod.rs
@@ -1,7 +1,6 @@
 // Copyright 2020 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::commands::sign::load_identity_keys;
 use crate::commands::validate_bech32_address_or_exit;
 use crate::config::persistence::pathfinder::MixNodePathfinder;
 use crate::config::Config;
@@ -60,7 +59,7 @@ impl MixNode {
     }
 
     /// Loads identity keys stored on disk
-    fn load_identity_keys(pathfinder: &MixNodePathfinder) -> identity::KeyPair {
+    pub(crate) fn load_identity_keys(pathfinder: &MixNodePathfinder) -> identity::KeyPair {
         let identity_keypair: identity::KeyPair =
             pemstore::load_keypair(&pemstore::KeyPairPath::new(
                 pathfinder.private_identity_key().to_owned(),
@@ -85,7 +84,7 @@ impl MixNode {
     /// Exits if the address isn't valid (which should protect against manual edits).
     fn generate_owner_signature(&self) -> String {
         let pathfinder = MixNodePathfinder::new_from_config(&self.config);
-        let identity_keypair = load_identity_keys(&pathfinder);
+        let identity_keypair = Self::load_identity_keys(&pathfinder);
         let address = self.config.get_wallet_address();
         validate_bech32_address_or_exit(address);
         let verification_code = identity_keypair.private_key().sign_text(address);


### PR DESCRIPTION
- Some minor module visibility stuff I noticed when reading through the code. 
- Remove duplicate `load_identity_keys()` function.