### PR TITLE
Feature/flexible vesting + utility queries

### DIFF
--- a/common/client-libs/validator-client/src/nymd/traits/vesting_query_client.rs
+++ b/common/client-libs/validator-client/src/nymd/traits/vesting_query_client.rs
@@ -7,6 +7,8 @@ use crate::nymd::NymdClient;
 use async_trait::async_trait;
 use cosmwasm_std::{Coin, Timestamp};
 use vesting_contract::messages::QueryMsg as VestingQueryMsg;
+use vesting_contract::vesting::Account;
+use vesting_contract::vesting::PledgeData;
 
 #[async_trait]
 pub trait VestingQueryClient {
@@ -55,6 +57,10 @@ pub trait VestingQueryClient {
         vesting_account_address: &str,
         block_time: Option<Timestamp>,
     ) -> Result<Coin, NymdError>;
+
+    async fn get_account(&self, address: &str) -> Result<Account, NymdError>;
+    async fn mixnode_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError>;
+    async fn gateway_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError>;
 }
 
 #[async_trait]
@@ -168,6 +174,31 @@ impl<C: CosmWasmClient + Sync + Send> VestingQueryClient for NymdClient<C> {
         let request = VestingQueryMsg::GetDelegatedVesting {
             vesting_account_address: vesting_account_address.to_string(),
             block_time,
+        };
+        self.client
+            .query_contract_smart(self.vesting_contract_address()?, &request)
+            .await
+    }
+
+    async fn get_account(&self, address: &str) -> Result<Account, NymdError> {
+        let request = VestingQueryMsg::GetAccount {
+            address: address.to_string(),
+        };
+        self.client
+            .query_contract_smart(self.vesting_contract_address()?, &request)
+            .await
+    }
+    async fn mixnode_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError> {
+        let request = VestingQueryMsg::GetMixnode {
+            address: address.to_string(),
+        };
+        self.client
+            .query_contract_smart(self.vesting_contract_address()?, &request)
+            .await
+    }
+    async fn gateway_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError> {
+        let request = VestingQueryMsg::GetGateway {
+            address: address.to_string(),
         };
         self.client
             .query_contract_smart(self.vesting_contract_address()?, &request)

--- a/common/client-libs/validator-client/src/nymd/traits/vesting_query_client.rs
+++ b/common/client-libs/validator-client/src/nymd/traits/vesting_query_client.rs
@@ -59,8 +59,8 @@ pub trait VestingQueryClient {
     ) -> Result<Coin, NymdError>;
 
     async fn get_account(&self, address: &str) -> Result<Account, NymdError>;
-    async fn mixnode_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError>;
-    async fn gateway_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError>;
+    async fn get_mixnode_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError>;
+    async fn get_gateway_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError>;
 }
 
 #[async_trait]
@@ -188,7 +188,7 @@ impl<C: CosmWasmClient + Sync + Send> VestingQueryClient for NymdClient<C> {
             .query_contract_smart(self.vesting_contract_address()?, &request)
             .await
     }
-    async fn mixnode_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError> {
+    async fn get_mixnode_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError> {
         let request = VestingQueryMsg::GetMixnode {
             address: address.to_string(),
         };
@@ -196,7 +196,7 @@ impl<C: CosmWasmClient + Sync + Send> VestingQueryClient for NymdClient<C> {
             .query_contract_smart(self.vesting_contract_address()?, &request)
             .await
     }
-    async fn gateway_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError> {
+    async fn get_gateway_pledge(&self, address: &str) -> Result<Option<PledgeData>, NymdError> {
         let request = VestingQueryMsg::GetGateway {
             address: address.to_string(),
         };

--- a/common/client-libs/validator-client/src/nymd/traits/vesting_signing_client.rs
+++ b/common/client-libs/validator-client/src/nymd/traits/vesting_signing_client.rs
@@ -9,7 +9,7 @@ use crate::nymd::{cosmwasm_coin_to_cosmos_coin, NymdClient};
 use async_trait::async_trait;
 use cosmwasm_std::Coin;
 use mixnet_contract_common::{Gateway, IdentityKey, IdentityKeyRef, MixNode};
-use vesting_contract::messages::ExecuteMsg as VestingExecuteMsg;
+use vesting_contract::messages::{ExecuteMsg as VestingExecuteMsg, VestingSpecification};
 
 #[async_trait]
 pub trait VestingSigningClient {
@@ -66,7 +66,7 @@ pub trait VestingSigningClient {
         &self,
         owner_address: &str,
         staking_address: Option<String>,
-        start_time: Option<u64>,
+        vesting_spec: Option<VestingSpecification>,
         amount: Coin,
     ) -> Result<ExecuteResult, NymdError>;
 }
@@ -277,14 +277,14 @@ impl<C: SigningCosmWasmClient + Sync + Send> VestingSigningClient for NymdClient
         &self,
         owner_address: &str,
         staking_address: Option<String>,
-        start_time: Option<u64>,
+        vesting_spec: Option<VestingSpecification>,
         amount: Coin,
     ) -> Result<ExecuteResult, NymdError> {
         let fee = self.operation_fee(Operation::CreatePeriodicVestingAccount);
         let req = VestingExecuteMsg::CreateAccount {
             owner_address: owner_address.to_string(),
             staking_address,
-            start_time,
+            vesting_spec,
         };
         self.client
             .execute(

--- a/contracts/vesting/src/contract.rs
+++ b/contracts/vesting/src/contract.rs
@@ -4,7 +4,7 @@ use crate::storage::{account_from_address, ADMIN, MIXNET_CONTRACT_ADDRESS};
 use crate::traits::{
     DelegatingAccount, GatewayBondingAccount, MixnodeBondingAccount, VestingAccount,
 };
-use crate::vesting::{populate_vesting_periods, Account};
+use crate::vesting::{populate_vesting_periods, Account, PledgeData};
 use config::defaults::DENOM;
 use cosmwasm_std::{
     coin, entry_point, to_binary, BankMsg, Coin, Deps, DepsMut, Env, MessageInfo, QueryResponse,
@@ -388,14 +388,25 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<QueryResponse, Contr
             deps,
         )?),
         QueryMsg::GetAccount { address } => to_binary(&try_get_account(&address, deps)?),
+        QueryMsg::GetMixnode { address } => to_binary(&try_get_mixnode(&address, deps)?),
+        QueryMsg::GetGateway { address } => to_binary(&try_get_gateway(&address, deps)?),
     };
 
     Ok(query_res?)
 }
 
-pub fn try_get_account(address: &str, deps: Deps) -> Result<Option<Account>, ContractError> {
+pub fn try_get_mixnode(address: &str, deps: Deps) -> Result<Option<PledgeData>, ContractError> {
     let account = account_from_address(address, deps.storage, deps.api)?;
-    Ok(Some(account))
+    account.load_mixnode_pledge(deps.storage)
+}
+
+pub fn try_get_gateway(address: &str, deps: Deps) -> Result<Option<PledgeData>, ContractError> {
+    let account = account_from_address(address, deps.storage, deps.api)?;
+    account.load_gateway_pledge(deps.storage)
+}
+
+pub fn try_get_account(address: &str, deps: Deps) -> Result<Account, ContractError> {
+    account_from_address(address, deps.storage, deps.api)
 }
 
 pub fn try_get_locked_coins(

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -4,4 +4,4 @@ pub mod messages;
 mod storage;
 mod support;
 mod traits;
-mod vesting;
+pub mod vesting;

--- a/contracts/vesting/src/messages.rs
+++ b/contracts/vesting/src/messages.rs
@@ -124,4 +124,10 @@ pub enum QueryMsg {
     GetAccount {
         address: String,
     },
+    GetMixnode {
+        address: String,
+    },
+    GetGateway {
+        address: String,
+    },
 }

--- a/contracts/vesting/src/messages.rs
+++ b/contracts/vesting/src/messages.rs
@@ -13,6 +13,27 @@ pub struct InitMsg {
 #[serde(rename_all = "snake_case")]
 pub struct MigrateMsg {}
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
+pub struct VestingSpecification {
+    start_time: Option<u64>,
+    period_seconds: Option<u32>,
+    num_periods: Option<u32>,
+}
+
+impl VestingSpecification {
+    pub fn start_time(&self) -> Option<u64> {
+        self.start_time
+    }
+
+    pub fn period_seconds(&self) -> u32 {
+        self.period_seconds.unwrap_or(3 * 30 * 86400)
+    }
+
+    pub fn num_periods(&self) -> u32 {
+        self.num_periods.unwrap_or(8)
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
@@ -26,7 +47,7 @@ pub enum ExecuteMsg {
     CreateAccount {
         owner_address: String,
         staking_address: Option<String>,
-        start_time: Option<u64>,
+        vesting_spec: Option<VestingSpecification>,
     },
     WithdrawVestedCoins {
         amount: Coin,

--- a/contracts/vesting/src/messages.rs
+++ b/contracts/vesting/src/messages.rs
@@ -16,8 +16,8 @@ pub struct MigrateMsg {}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
 pub struct VestingSpecification {
     start_time: Option<u64>,
-    period_seconds: Option<u32>,
-    num_periods: Option<u32>,
+    period_seconds: Option<u64>,
+    num_periods: Option<u64>,
 }
 
 impl VestingSpecification {
@@ -25,11 +25,11 @@ impl VestingSpecification {
         self.start_time
     }
 
-    pub fn period_seconds(&self) -> u32 {
+    pub fn period_seconds(&self) -> u64 {
         self.period_seconds.unwrap_or(3 * 30 * 86400)
     }
 
-    pub fn num_periods(&self) -> u32 {
+    pub fn num_periods(&self) -> u64 {
         self.num_periods.unwrap_or(8)
     }
 }

--- a/contracts/vesting/src/messages.rs
+++ b/contracts/vesting/src/messages.rs
@@ -15,9 +15,9 @@ pub struct MigrateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, Default)]
 pub struct VestingSpecification {
-    start_time: Option<u64>,
-    period_seconds: Option<u32>,
-    num_periods: Option<u32>,
+    pub start_time: Option<u64>,
+    pub period_seconds: Option<u32>,
+    pub num_periods: Option<u32>,
 }
 
 impl VestingSpecification {

--- a/contracts/vesting/src/support/tests.rs
+++ b/contracts/vesting/src/support/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 pub mod helpers {
-    use crate::contract::{instantiate, NUM_VESTING_PERIODS};
-    use crate::messages::InitMsg;
+    use crate::contract::instantiate;
+    use crate::messages::{InitMsg, VestingSpecification};
     use crate::vesting::{populate_vesting_periods, Account};
     use config::defaults::DENOM;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info, MockApi, MockQuerier};
@@ -20,7 +20,8 @@ pub mod helpers {
 
     pub fn vesting_account_fixture(storage: &mut dyn Storage, env: &Env) -> Account {
         let start_time = env.block.time;
-        let periods = populate_vesting_periods(start_time.seconds(), NUM_VESTING_PERIODS);
+        let periods =
+            populate_vesting_periods(start_time.seconds(), VestingSpecification::default());
 
         Account::new(
             Addr::unchecked("owner"),

--- a/contracts/vesting/src/vesting/account/mod.rs
+++ b/contracts/vesting/src/vesting/account/mod.rs
@@ -1,5 +1,4 @@
 use super::{PledgeData, VestingPeriod};
-use crate::contract::NUM_VESTING_PERIODS;
 use crate::errors::ContractError;
 use crate::storage::{
     load_balance, load_bond_pledge, load_gateway_pledge, remove_bond_pledge, remove_delegation,
@@ -57,6 +56,10 @@ impl Account {
         Ok(account)
     }
 
+    pub fn num_vesting_periods(&self) -> usize {
+        self.periods.len()
+    }
+
     pub fn storage_key(&self) -> u32 {
         self.storage_key
     }
@@ -81,11 +84,11 @@ impl Account {
 
     pub fn tokens_per_period(&self) -> Result<u128, ContractError> {
         let amount = self.coin.amount.u128();
-        if amount < NUM_VESTING_PERIODS as u128 {
+        if amount < self.num_vesting_periods() as u128 {
             Err(ContractError::ImprobableVestingAmount(amount))
         } else {
             // Remainder tokens will be lumped into the last period.
-            Ok(amount / NUM_VESTING_PERIODS as u128)
+            Ok(amount / self.num_vesting_periods() as u128)
         }
     }
 

--- a/contracts/vesting/src/vesting/account/vesting_account.rs
+++ b/contracts/vesting/src/vesting/account/vesting_account.rs
@@ -1,4 +1,3 @@
-use crate::contract::NUM_VESTING_PERIODS;
 use crate::errors::ContractError;
 use crate::storage::{delete_account, save_account, DELEGATIONS};
 use crate::traits::VestingAccount;
@@ -97,7 +96,7 @@ impl VestingAccount for Account {
     }
 
     fn get_end_time(&self) -> Timestamp {
-        self.periods[(NUM_VESTING_PERIODS - 1) as usize].end_time()
+        self.periods[(self.num_vesting_periods() - 1) as usize].end_time()
     }
 
     fn get_original_vesting(&self) -> Coin {

--- a/contracts/vesting/src/vesting/mod.rs
+++ b/contracts/vesting/src/vesting/mod.rs
@@ -10,7 +10,7 @@ use crate::messages::VestingSpecification;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct VestingPeriod {
     pub start_time: u64,
-    pub period_seconds: u32,
+    pub period_seconds: u64,
 }
 
 impl VestingPeriod {
@@ -32,7 +32,7 @@ pub fn populate_vesting_periods(
     let mut periods = Vec::with_capacity(vesting_spec.num_periods() as usize);
     for i in 0..vesting_spec.num_periods() {
         let period = VestingPeriod {
-            start_time: start_time + i as u64 * vesting_spec.period_seconds() as u64,
+            start_time: start_time + i as u64 * vesting_spec.period_seconds(),
             period_seconds: vesting_spec.period_seconds(),
         };
         periods.push(period);


### PR DESCRIPTION
Change log:

+ [`CreateAccount`](https://github.com/nymtech/nym/blob/90701f843fee7f2730d6a0a6db7478e870355250/contracts/vesting/src/messages.rs#L47) message now has a [`VestingSpecification`](https://github.com/nymtech/nym/blob/90701f843fee7f2730d6a0a6db7478e870355250/contracts/vesting/src/messages.rs#L17) attribute that allows for flexible vesting schedules. Rust `nymd` [`create_periodic_vesting_account`](https://github.com/nymtech/nym/blob/90701f843fee7f2730d6a0a6db7478e870355250/common/client-libs/validator-client/src/nymd/traits/vesting_signing_client.rs#L276) function has also changed to take the `vesting_spec` parameter.

Three utility functions added to Rust `nymd` vesting client:

+ [`get_account`](https://github.com/nymtech/nym/blob/90701f843fee7f2730d6a0a6db7478e870355250/common/client-libs/validator-client/src/nymd/traits/vesting_query_client.rs#L183)
+ [`get_mixnode_pledge`](https://github.com/nymtech/nym/blob/90701f843fee7f2730d6a0a6db7478e870355250/common/client-libs/validator-client/src/nymd/traits/vesting_query_client.rs#L191)
+ [`get_gateway_pledge`](https://github.com/nymtech/nym/blob/90701f843fee7f2730d6a0a6db7478e870355250/common/client-libs/validator-client/src/nymd/traits/vesting_query_client.rs#L199)
