### PR TITLE
Fix rust 2018 idioms warnings

### DIFF
--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -32,7 +32,7 @@ fn parse_validators(raw: &str) -> Vec<Url> {
         .collect()
 }
 
-pub(crate) fn override_config(mut config: Config, matches: &ArgMatches) -> Config {
+pub(crate) fn override_config(mut config: Config, matches: &ArgMatches<'_>) -> Config {
     if let Some(raw_validators) = matches.value_of("validators") {
         config
             .get_base_mut()

--- a/clients/native/src/commands/upgrade.rs
+++ b/clients/native/src/commands/upgrade.rs
@@ -95,7 +95,7 @@ fn parse_package_version() -> Version {
 
 fn minor_0_12_upgrade(
     mut config: Config,
-    _matches: &ArgMatches,
+    _matches: &ArgMatches<'_>,
     config_version: &Version,
     package_version: &Version,
 ) -> Config {
@@ -131,7 +131,7 @@ fn minor_0_12_upgrade(
     config
 }
 
-fn do_upgrade(mut config: Config, matches: &ArgMatches, package_version: Version) {
+fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: Version) {
     loop {
         let config_version = parse_config_version(&config);
 
@@ -151,7 +151,7 @@ fn do_upgrade(mut config: Config, matches: &ArgMatches, package_version: Version
     }
 }
 
-pub fn execute(matches: &ArgMatches) {
+pub fn execute(matches: &ArgMatches<'_>) {
     let package_version = parse_package_version();
 
     let id = matches.value_of("id").unwrap();

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -32,7 +32,7 @@ fn parse_validators(raw: &str) -> Vec<Url> {
         .collect()
 }
 
-pub(crate) fn override_config(mut config: Config, matches: &ArgMatches) -> Config {
+pub(crate) fn override_config(mut config: Config, matches: &ArgMatches<'_>) -> Config {
     if let Some(raw_validators) = matches.value_of("validators") {
         config
             .get_base_mut()

--- a/clients/socks5/src/commands/upgrade.rs
+++ b/clients/socks5/src/commands/upgrade.rs
@@ -95,7 +95,7 @@ fn parse_package_version() -> Version {
 
 fn minor_0_12_upgrade(
     mut config: Config,
-    _matches: &ArgMatches,
+    _matches: &ArgMatches<'_>,
     config_version: &Version,
     package_version: &Version,
 ) -> Config {
@@ -131,7 +131,7 @@ fn minor_0_12_upgrade(
     config
 }
 
-fn do_upgrade(mut config: Config, matches: &ArgMatches, package_version: Version) {
+fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: Version) {
     loop {
         let config_version = parse_config_version(&config);
 
@@ -151,7 +151,7 @@ fn do_upgrade(mut config: Config, matches: &ArgMatches, package_version: Version
     }
 }
 
-pub fn execute(matches: &ArgMatches) {
+pub fn execute(matches: &ArgMatches<'_>) {
     let package_version = parse_package_version();
 
     let id = matches.value_of("id").unwrap();

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/delegation.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/delegation.rs
@@ -66,7 +66,7 @@ impl Delegation {
 }
 
 impl Display for Delegation {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{} delegated towards {} by {} at block {}",

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/events.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/events.rs
@@ -73,7 +73,7 @@ pub fn new_delegation_event(
     delegator: &Addr,
     proxy: &Option<Addr>,
     amount: &Coin,
-    mix_identity: IdentityKeyRef,
+    mix_identity: IdentityKeyRef<'_>,
 ) -> Event {
     let mut event = Event::new(DELEGATION_EVENT_TYPE).add_attribute(DELEGATOR_KEY, delegator);
 
@@ -91,7 +91,7 @@ pub fn new_undelegation_event(
     delegator: &Addr,
     proxy: &Option<Addr>,
     old_delegation: &Delegation,
-    mix_identity: IdentityKeyRef,
+    mix_identity: IdentityKeyRef<'_>,
 ) -> Event {
     let mut event = Event::new(UNDELEGATION_EVENT_TYPE).add_attribute(DELEGATOR_KEY, delegator);
 
@@ -113,7 +113,7 @@ pub fn new_gateway_bonding_event(
     owner: &Addr,
     proxy: &Option<Addr>,
     amount: &Coin,
-    identity: IdentityKeyRef,
+    identity: IdentityKeyRef<'_>,
 ) -> Event {
     let mut event = Event::new(GATEWAY_BONDING_EVENT_TYPE)
         .add_attribute(OWNER_KEY, owner)
@@ -131,7 +131,7 @@ pub fn new_gateway_unbonding_event(
     owner: &Addr,
     proxy: &Option<Addr>,
     amount: &Coin,
-    identity: IdentityKeyRef,
+    identity: IdentityKeyRef<'_>,
 ) -> Event {
     let mut event = Event::new(GATEWAY_UNBONDING_EVENT_TYPE)
         .add_attribute(OWNER_KEY, owner)
@@ -149,7 +149,7 @@ pub fn new_mixnode_bonding_event(
     owner: &Addr,
     proxy: &Option<Addr>,
     amount: &Coin,
-    identity: IdentityKeyRef,
+    identity: IdentityKeyRef<'_>,
     assigned_layer: Layer,
 ) -> Event {
     let mut event = Event::new(MIXNODE_BONDING_EVENT_TYPE)
@@ -170,7 +170,7 @@ pub fn new_mixnode_unbonding_event(
     owner: &Addr,
     proxy: &Option<Addr>,
     amount: &Coin,
-    identity: IdentityKeyRef,
+    identity: IdentityKeyRef<'_>,
 ) -> Event {
     let mut event = Event::new(MIXNODE_UNBONDING_EVENT_TYPE)
         .add_attribute(OWNER_KEY, owner)
@@ -243,7 +243,7 @@ pub fn new_settings_update_event(
 
 pub fn new_not_found_mix_operator_rewarding_event(
     interval_id: u32,
-    identity: IdentityKeyRef,
+    identity: IdentityKeyRef<'_>,
 ) -> Event {
     Event::new(OPERATOR_REWARDING_EVENT_TYPE)
         .add_attribute(INTERVAL_ID_KEY, interval_id.to_string())
@@ -253,7 +253,7 @@ pub fn new_not_found_mix_operator_rewarding_event(
 
 pub fn new_too_fresh_bond_mix_operator_rewarding_event(
     interval_id: u32,
-    identity: IdentityKeyRef,
+    identity: IdentityKeyRef<'_>,
 ) -> Event {
     Event::new(OPERATOR_REWARDING_EVENT_TYPE)
         .add_attribute(INTERVAL_ID_KEY, interval_id.to_string())
@@ -263,7 +263,7 @@ pub fn new_too_fresh_bond_mix_operator_rewarding_event(
 
 pub fn new_zero_uptime_mix_operator_rewarding_event(
     interval_id: u32,
-    identity: IdentityKeyRef,
+    identity: IdentityKeyRef<'_>,
 ) -> Event {
     Event::new(OPERATOR_REWARDING_EVENT_TYPE)
         .add_attribute(INTERVAL_ID_KEY, interval_id.to_string())
@@ -273,7 +273,7 @@ pub fn new_zero_uptime_mix_operator_rewarding_event(
 
 pub fn new_mix_operator_rewarding_event(
     interval_id: u32,
-    identity: IdentityKeyRef,
+    identity: IdentityKeyRef<'_>,
     node_reward_result: NodeRewardResult,
     operator_reward: Uint128,
     delegation_rewards_distributed: Uint128,
@@ -301,7 +301,7 @@ pub fn new_mix_operator_rewarding_event(
 
 pub fn new_mix_delegators_rewarding_event(
     interval_id: u32,
-    identity: IdentityKeyRef,
+    identity: IdentityKeyRef<'_>,
     delegation_rewards_distributed: Uint128,
     further_delegations: bool,
 ) -> Event {

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/gateway.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/gateway.rs
@@ -98,7 +98,7 @@ impl PartialOrd for GatewayBond {
 }
 
 impl Display for GatewayBond {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "amount: {} {}, owner: {}, identity: {}",

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
@@ -25,7 +25,7 @@ pub(crate) mod string_rfc3339_offset_date_time {
     impl<'de> Visitor<'de> for Rfc3339OffsetDateTimeVisitor {
         type Value = OffsetDateTime;
 
-        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        fn expecting(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
             formatter.write_str("an rfc3339 `OffsetDateTime`")
         }
 
@@ -218,7 +218,7 @@ impl Interval {
 }
 
 impl Display for Interval {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let length = self.length().as_secs();
         let full_hours = length / 3600;
         let rem = length % 3600;

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/mixnode.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/mixnode.rs
@@ -508,7 +508,7 @@ impl PartialOrd for MixNodeBond {
 }
 
 impl Display for MixNodeBond {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "amount: {} {}, owner: {}, identity: {}",

--- a/common/nymcoconut/src/impls/serde.rs
+++ b/common/nymcoconut/src/impls/serde.rs
@@ -23,7 +23,7 @@ macro_rules! impl_serde {
         impl<'de> Visitor<'de> for $visitor {
             type Value = $struct;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(formatter, "A base58 encoded struct")
             }
 

--- a/common/topology/src/gateway.rs
+++ b/common/topology/src/gateway.rs
@@ -33,7 +33,7 @@ impl From<identity::Ed25519RecoveryError> for GatewayConversionError {
 }
 
 impl Display for GatewayConversionError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             GatewayConversionError::InvalidIdentityKey(err) => write!(
                 f,

--- a/common/topology/src/mix.rs
+++ b/common/topology/src/mix.rs
@@ -33,7 +33,7 @@ impl From<identity::Ed25519RecoveryError> for MixnodeConversionError {
 }
 
 impl Display for MixnodeConversionError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             MixnodeConversionError::InvalidIdentityKey(err) => write!(
                 f,

--- a/contracts/bandwidth-claim/src/lib.rs
+++ b/contracts/bandwidth-claim/src/lib.rs
@@ -21,7 +21,7 @@ use bandwidth_claim_contract::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, Quer
 /// `msg` is the contract initialization message, sort of like a constructor call.
 #[entry_point]
 pub fn instantiate(
-    _deps: DepsMut,
+    _deps: DepsMut<'_>,
     _env: Env,
     _info: MessageInfo,
     _msg: InstantiateMsg,
@@ -32,7 +32,7 @@ pub fn instantiate(
 /// Handle an incoming message
 #[entry_point]
 pub fn execute(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -43,7 +43,7 @@ pub fn execute(
 }
 
 #[entry_point]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, ContractError> {
+pub fn query(deps: Deps<'_>, _env: Env, msg: QueryMsg) -> Result<QueryResponse, ContractError> {
     let query_res = match msg {
         QueryMsg::GetPayments { start_after, limit } => {
             to_binary(&queries::query_payments_paged(deps, start_after, limit)?)
@@ -54,7 +54,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
 }
 
 #[entry_point]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(_deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     Ok(Default::default())
 }
 

--- a/contracts/bandwidth-claim/src/queries.rs
+++ b/contracts/bandwidth-claim/src/queries.rs
@@ -24,7 +24,7 @@ fn calculate_start_value<B: AsRef<[u8]>>(start_after: Option<B>) -> Option<Vec<u
 }
 
 pub fn query_payments_paged(
-    deps: Deps,
+    deps: Deps<'_>,
     start_after: Option<PublicKey>,
     limit: Option<u32>,
 ) -> StdResult<PagedPaymentResponse> {

--- a/contracts/bandwidth-claim/src/storage.rs
+++ b/contracts/bandwidth-claim/src/storage.rs
@@ -19,15 +19,15 @@ pub enum Status {
     Spent,
 }
 
-pub fn payments(storage: &mut dyn Storage) -> Bucket<Payment> {
+pub fn payments(storage: &mut dyn Storage) -> Bucket<'_, Payment> {
     bucket(storage, PREFIX_PAYMENTS)
 }
 
-pub fn payments_read(storage: &dyn Storage) -> ReadonlyBucket<Payment> {
+pub fn payments_read(storage: &dyn Storage) -> ReadonlyBucket<'_, Payment> {
     bucket_read(storage, PREFIX_PAYMENTS)
 }
 
-pub fn status(storage: &mut dyn Storage) -> Bucket<Status> {
+pub fn status(storage: &mut dyn Storage) -> Bucket<'_, Status> {
     bucket(storage, PREFIX_STATUS)
 }
 

--- a/contracts/bandwidth-claim/src/transactions.rs
+++ b/contracts/bandwidth-claim/src/transactions.rs
@@ -8,7 +8,7 @@ use crate::storage::{payments, status, Status};
 use bandwidth_claim_contract::payment::{LinkPaymentData, Payment};
 
 pub(crate) fn link_payment(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     _env: Env,
     _info: MessageInfo,
     data: LinkPaymentData,

--- a/contracts/mixnet/examples/schema.rs
+++ b/contracts/mixnet/examples/schema.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-extern crate mixnet_contract;
-
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 use mixnet_contract_common::{ExecuteMsg, InstantiateMsg, MixNodeBond, QueryMsg};
 use std::env::current_dir;

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -73,7 +73,7 @@ fn default_initial_state(owner: Addr, rewarding_validator_address: Addr) -> Cont
 /// `msg` is the contract initialization message, sort of like a constructor call.
 #[entry_point]
 pub fn instantiate(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     msg: InstantiateMsg,
@@ -95,7 +95,7 @@ pub fn instantiate(
 /// Handle an incoming message
 #[entry_point]
 pub fn execute(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -237,7 +237,7 @@ pub fn execute(
 }
 
 #[entry_point]
-pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<QueryResponse, ContractError> {
+pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> Result<QueryResponse, ContractError> {
     let query_res = match msg {
         QueryMsg::GetContractVersion {} => to_binary(&query_contract_version()),
         QueryMsg::GetMixNodes { start_after, limit } => {
@@ -316,7 +316,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<QueryResponse, Contr
     Ok(query_res?)
 }
 #[entry_point]
-pub fn migrate(deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(deps: DepsMut<'_>, env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     use cw_storage_plus::Item;
     use serde::{Deserialize, Serialize};
 
@@ -349,7 +349,7 @@ pub fn migrate(deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, Co
         pub rewarding_in_progress: bool,
     }
 
-    let old_contract_state: Item<OldContractState> = Item::new("config");
+    let old_contract_state: Item<'_, OldContractState> = Item::new("config");
 
     let old_state = old_contract_state.load(deps.storage)?;
 

--- a/contracts/mixnet/src/delegations/queries.rs
+++ b/contracts/mixnet/src/delegations/queries.rs
@@ -13,7 +13,7 @@ use mixnet_contract_common::{
 };
 
 pub(crate) fn query_all_network_delegations_paged(
-    deps: Deps,
+    deps: Deps<'_>,
     start_after: Option<(IdentityKey, String)>,
     limit: Option<u32>,
 ) -> StdResult<PagedAllDelegationsResponse> {
@@ -42,7 +42,7 @@ pub(crate) fn query_all_network_delegations_paged(
 }
 
 pub(crate) fn query_delegator_delegations_paged(
-    deps: Deps,
+    deps: Deps<'_>,
     delegation_owner: String,
     start_after: Option<IdentityKey>,
     limit: Option<u32>,
@@ -76,7 +76,7 @@ pub(crate) fn query_delegator_delegations_paged(
 
 // queries for delegation value of given address for particular node
 pub(crate) fn query_mixnode_delegation(
-    deps: Deps,
+    deps: Deps<'_>,
     mix_identity: IdentityKey,
     delegator: String,
 ) -> Result<Delegation, ContractError> {
@@ -92,7 +92,7 @@ pub(crate) fn query_mixnode_delegation(
 }
 
 pub(crate) fn query_mixnode_delegations_paged(
-    deps: Deps,
+    deps: Deps<'_>,
     mix_identity: IdentityKey,
     start_after: Option<String>,
     limit: Option<u32>,

--- a/contracts/mixnet/src/delegations/transactions.rs
+++ b/contracts/mixnet/src/delegations/transactions.rs
@@ -36,7 +36,7 @@ fn validate_delegation_stake(mut delegation: Vec<Coin>) -> Result<Coin, Contract
 }
 
 pub(crate) fn try_delegate_to_mixnode(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     mix_identity: IdentityKey,
@@ -48,7 +48,7 @@ pub(crate) fn try_delegate_to_mixnode(
 }
 
 pub(crate) fn try_delegate_to_mixnode_on_behalf(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     mix_identity: IdentityKey,
@@ -68,7 +68,7 @@ pub(crate) fn try_delegate_to_mixnode_on_behalf(
 }
 
 pub(crate) fn _try_delegate_to_mixnode(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     mix_identity: IdentityKey,
     delegate: &str,
@@ -132,7 +132,7 @@ pub(crate) fn _try_delegate_to_mixnode(
 }
 
 pub(crate) fn try_remove_delegation_from_mixnode(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     info: MessageInfo,
     mix_identity: IdentityKey,
 ) -> Result<Response, ContractError> {
@@ -140,7 +140,7 @@ pub(crate) fn try_remove_delegation_from_mixnode(
 }
 
 pub(crate) fn try_remove_delegation_from_mixnode_on_behalf(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     info: MessageInfo,
     mix_identity: IdentityKey,
     delegate: String,
@@ -149,7 +149,7 @@ pub(crate) fn try_remove_delegation_from_mixnode_on_behalf(
 }
 
 pub(crate) fn _try_remove_delegation_from_mixnode(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     mix_identity: IdentityKey,
     delegate: &str,
     proxy: Option<Addr>,

--- a/contracts/mixnet/src/gateways/queries.rs
+++ b/contracts/mixnet/src/gateways/queries.rs
@@ -10,7 +10,7 @@ use mixnet_contract_common::{
 };
 
 pub(crate) fn query_gateways_paged(
-    deps: Deps,
+    deps: Deps<'_>,
     start_after: Option<IdentityKey>,
     limit: Option<u32>,
 ) -> StdResult<PagedGatewayResponse> {
@@ -31,7 +31,7 @@ pub(crate) fn query_gateways_paged(
 }
 
 pub(crate) fn query_owns_gateway(
-    deps: Deps,
+    deps: Deps<'_>,
     address: String,
 ) -> StdResult<GatewayOwnershipResponse> {
     let validated_addr = deps.api.addr_validate(&address)?;

--- a/contracts/mixnet/src/gateways/storage.rs
+++ b/contracts/mixnet/src/gateways/storage.rs
@@ -46,7 +46,7 @@ mod tests {
     // currently this is only used in tests but may become useful later on
     pub(crate) fn read_gateway_pledge_amount(
         storage: &dyn Storage,
-        identity: IdentityKeyRef,
+        identity: IdentityKeyRef<'_>,
     ) -> StdResult<cosmwasm_std::Uint128> {
         let node = storage::gateways().load(storage, identity)?;
         Ok(node.pledge_amount.amount)

--- a/contracts/mixnet/src/gateways/transactions.rs
+++ b/contracts/mixnet/src/gateways/transactions.rs
@@ -15,7 +15,7 @@ use vesting_contract_common::messages::ExecuteMsg as VestingContractExecuteMsg;
 use vesting_contract_common::one_unym;
 
 pub fn try_add_gateway(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     gateway: Gateway,
@@ -40,7 +40,7 @@ pub fn try_add_gateway(
 }
 
 pub fn try_add_gateway_on_behalf(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     gateway: Gateway,
@@ -67,7 +67,7 @@ pub fn try_add_gateway_on_behalf(
 }
 
 pub(crate) fn _try_add_gateway(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     gateway: Gateway,
     pledge: Coin,
@@ -120,7 +120,7 @@ pub(crate) fn _try_add_gateway(
 }
 
 pub fn try_remove_gateway_on_behalf(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     info: MessageInfo,
     owner: String,
 ) -> Result<Response, ContractError> {
@@ -128,12 +128,12 @@ pub fn try_remove_gateway_on_behalf(
     _try_remove_gateway(deps, &owner, Some(proxy))
 }
 
-pub fn try_remove_gateway(deps: DepsMut, info: MessageInfo) -> Result<Response, ContractError> {
+pub fn try_remove_gateway(deps: DepsMut<'_>, info: MessageInfo) -> Result<Response, ContractError> {
     _try_remove_gateway(deps, info.sender.as_ref(), None)
 }
 
 pub(crate) fn _try_remove_gateway(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     owner: &str,
     proxy: Option<Addr>,
 ) -> Result<Response, ContractError> {

--- a/contracts/mixnet/src/interval/storage.rs
+++ b/contracts/mixnet/src/interval/storage.rs
@@ -14,16 +14,16 @@ type IntervalId = u32;
 pub(crate) const REWARDED_NODE_DEFAULT_PAGE_LIMIT: u32 = 1000;
 pub(crate) const REWARDED_NODE_MAX_PAGE_LIMIT: u32 = 1500;
 
-pub(crate) const CURRENT_INTERVAL: Item<Interval> = Item::new("cep");
-pub(crate) const CURRENT_REWARDED_SET_HEIGHT: Item<BlockHeight> = Item::new("crh");
+pub(crate) const CURRENT_INTERVAL: Item<'_, Interval> = Item::new("cep");
+pub(crate) const CURRENT_REWARDED_SET_HEIGHT: Item<'_, BlockHeight> = Item::new("crh");
 
 // I've changed the `()` data to an `u8` as after serializing `()` is represented as "null",
 // taking more space than a single digit u8. If we don't care about what's there, why not go with more efficient approach? : )
-pub(crate) const REWARDED_SET_HEIGHTS_FOR_INTERVAL: Map<(IntervalId, BlockHeight), u8> =
+pub(crate) const REWARDED_SET_HEIGHTS_FOR_INTERVAL: Map<'_, (IntervalId, BlockHeight), u8> =
     Map::new("rsh");
 
 // pub(crate) const REWARDED_SET: Map<(u64, IdentityKey), NodeStatus> = Map::new("rs");
-pub(crate) const REWARDED_SET: Map<(BlockHeight, IdentityKey), RewardedSetNodeStatus> =
+pub(crate) const REWARDED_SET: Map<'_, (BlockHeight, IdentityKey), RewardedSetNodeStatus> =
     Map::new("rs");
 
 pub(crate) fn save_rewarded_set(

--- a/contracts/mixnet/src/interval/transactions.rs
+++ b/contracts/mixnet/src/interval/transactions.rs
@@ -10,7 +10,7 @@ use mixnet_contract_common::events::{new_advance_interval_event, new_change_rewa
 use mixnet_contract_common::IdentityKey;
 
 pub fn try_write_rewarded_set(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     rewarded_set: Vec<IdentityKey>,

--- a/contracts/mixnet/src/mixnet_contract_settings/queries.rs
+++ b/contracts/mixnet/src/mixnet_contract_settings/queries.rs
@@ -5,7 +5,7 @@ use super::storage;
 use cosmwasm_std::{Deps, StdResult};
 use mixnet_contract_common::{ContractStateParams, MixnetContractVersion};
 
-pub(crate) fn query_contract_settings_params(deps: Deps) -> StdResult<ContractStateParams> {
+pub(crate) fn query_contract_settings_params(deps: Deps<'_>) -> StdResult<ContractStateParams> {
     storage::CONTRACT_STATE
         .load(deps.storage)
         .map(|settings| settings.params)

--- a/contracts/mixnet/src/mixnet_contract_settings/storage.rs
+++ b/contracts/mixnet/src/mixnet_contract_settings/storage.rs
@@ -7,8 +7,8 @@ use cosmwasm_std::Storage;
 use cw_storage_plus::Item;
 use mixnet_contract_common::{Layer, LayerDistribution};
 
-pub(crate) const CONTRACT_STATE: Item<ContractState> = Item::new("config");
-pub(crate) const LAYERS: Item<LayerDistribution> = Item::new("layers");
+pub(crate) const CONTRACT_STATE: Item<'_, ContractState> = Item::new("config");
+pub(crate) const LAYERS: Item<'_, LayerDistribution> = Item::new("layers");
 
 pub fn increment_layer_count(storage: &mut dyn Storage, layer: Layer) -> StdResult<()> {
     LAYERS

--- a/contracts/mixnet/src/mixnet_contract_settings/transactions.rs
+++ b/contracts/mixnet/src/mixnet_contract_settings/transactions.rs
@@ -10,7 +10,7 @@ use mixnet_contract_common::events::new_settings_update_event;
 use mixnet_contract_common::ContractStateParams;
 
 pub(crate) fn try_update_contract_settings(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     info: MessageInfo,
     params: ContractStateParams,
 ) -> Result<Response, ContractError> {

--- a/contracts/mixnet/src/mixnodes/bonding_queries.rs
+++ b/contracts/mixnet/src/mixnodes/bonding_queries.rs
@@ -9,7 +9,7 @@ use mixnet_contract_common::{
 };
 
 pub fn query_mixnodes_paged(
-    deps: Deps,
+    deps: Deps<'_>,
     start_after: Option<IdentityKey>,
     limit: Option<u32>,
 ) -> StdResult<PagedMixnodeResponse> {
@@ -39,7 +39,7 @@ pub fn query_mixnodes_paged(
     Ok(PagedMixnodeResponse::new(nodes, limit, start_next_after))
 }
 
-pub fn query_owns_mixnode(deps: Deps, address: String) -> StdResult<MixOwnershipResponse> {
+pub fn query_owns_mixnode(deps: Deps<'_>, address: String) -> StdResult<MixOwnershipResponse> {
     let validated_addr = deps.api.addr_validate(&address)?;
     let stored_bond = storage::mixnodes()
         .idx

--- a/contracts/mixnet/src/mixnodes/layer_queries.rs
+++ b/contracts/mixnet/src/mixnodes/layer_queries.rs
@@ -5,6 +5,6 @@ use crate::mixnet_contract_settings::storage as mixnet_params_storage;
 use cosmwasm_std::{Deps, StdResult};
 use mixnet_contract_common::LayerDistribution;
 
-pub(crate) fn query_layer_distribution(deps: Deps) -> StdResult<LayerDistribution> {
+pub(crate) fn query_layer_distribution(deps: Deps<'_>) -> StdResult<LayerDistribution> {
     mixnet_params_storage::LAYERS.load(deps.storage)
 }

--- a/contracts/mixnet/src/mixnodes/storage.rs
+++ b/contracts/mixnet/src/mixnodes/storage.rs
@@ -17,7 +17,7 @@ const MIXNODES_OWNER_IDX_NAMESPACE: &str = "mno";
 pub(crate) const BOND_PAGE_MAX_LIMIT: u32 = 75;
 pub(crate) const BOND_PAGE_DEFAULT_LIMIT: u32 = 50;
 
-pub(crate) const TOTAL_DELEGATION: Map<IdentityKeyRef, Uint128> =
+pub(crate) const TOTAL_DELEGATION: Map<'_, IdentityKeyRef<'_>, Uint128> =
     Map::new(TOTAL_DELEGATION_NAMESPACE);
 
 pub(crate) struct MixnodeBondIndex<'a> {
@@ -96,7 +96,7 @@ impl StoredMixnodeBond {
 }
 
 impl Display for StoredMixnodeBond {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "amount: {}, owner: {}, identity: {}",
@@ -107,7 +107,7 @@ impl Display for StoredMixnodeBond {
 
 pub(crate) fn read_full_mixnode_bond(
     storage: &dyn Storage,
-    mix_identity: IdentityKeyRef,
+    mix_identity: IdentityKeyRef<'_>,
 ) -> StdResult<Option<MixNodeBond>> {
     let stored_bond = mixnodes().may_load(storage, mix_identity)?;
     match stored_bond {

--- a/contracts/mixnet/src/mixnodes/transactions.rs
+++ b/contracts/mixnet/src/mixnodes/transactions.rs
@@ -17,7 +17,7 @@ use vesting_contract_common::messages::ExecuteMsg as VestingContractExecuteMsg;
 use vesting_contract_common::one_unym;
 
 pub fn try_add_mixnode(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     mix_node: MixNode,
@@ -42,7 +42,7 @@ pub fn try_add_mixnode(
 }
 
 pub fn try_add_mixnode_on_behalf(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     mix_node: MixNode,
@@ -69,7 +69,7 @@ pub fn try_add_mixnode_on_behalf(
 }
 
 fn _try_add_mixnode(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     mix_node: MixNode,
     pledge_amount: Coin,
@@ -144,7 +144,7 @@ fn _try_add_mixnode(
 }
 
 pub fn try_remove_mixnode_on_behalf(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     info: MessageInfo,
     owner: String,
 ) -> Result<Response, ContractError> {
@@ -152,12 +152,12 @@ pub fn try_remove_mixnode_on_behalf(
     _try_remove_mixnode(deps, &owner, Some(proxy))
 }
 
-pub fn try_remove_mixnode(deps: DepsMut, info: MessageInfo) -> Result<Response, ContractError> {
+pub fn try_remove_mixnode(deps: DepsMut<'_>, info: MessageInfo) -> Result<Response, ContractError> {
     _try_remove_mixnode(deps, info.sender.as_ref(), None)
 }
 
 pub(crate) fn _try_remove_mixnode(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     owner: &str,
     proxy: Option<Addr>,
 ) -> Result<Response, ContractError> {
@@ -216,7 +216,7 @@ pub(crate) fn _try_remove_mixnode(
 }
 
 pub(crate) fn try_update_mixnode_config(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     profit_margin_percent: u8,

--- a/contracts/mixnet/src/rewards/helpers.rs
+++ b/contracts/mixnet/src/rewards/helpers.rs
@@ -12,7 +12,7 @@ use mixnet_contract_common::{
 
 pub(crate) fn update_post_rewarding_storage(
     storage: &mut dyn Storage,
-    mix_identity: IdentityKeyRef,
+    mix_identity: IdentityKeyRef<'_>,
     operator_reward: Uint128,
     delegators_reward: Uint128,
 ) -> Result<(), ContractError> {

--- a/contracts/mixnet/src/rewards/queries.rs
+++ b/contracts/mixnet/src/rewards/queries.rs
@@ -6,16 +6,16 @@ use cosmwasm_std::Uint128;
 use cosmwasm_std::{Deps, StdResult};
 use mixnet_contract_common::{IdentityKey, MixnodeRewardingStatusResponse};
 
-pub(crate) fn query_reward_pool(deps: Deps) -> StdResult<Uint128> {
+pub(crate) fn query_reward_pool(deps: Deps<'_>) -> StdResult<Uint128> {
     storage::REWARD_POOL.load(deps.storage)
 }
 
-pub(crate) fn query_circulating_supply(deps: Deps) -> StdResult<Uint128> {
+pub(crate) fn query_circulating_supply(deps: Deps<'_>) -> StdResult<Uint128> {
     storage::circulating_supply(deps.storage)
 }
 
 pub(crate) fn query_rewarding_status(
-    deps: Deps,
+    deps: Deps<'_>,
     mix_identity: IdentityKey,
     interval_id: u32,
 ) -> StdResult<MixnodeRewardingStatusResponse> {

--- a/contracts/mixnet/src/rewards/storage.rs
+++ b/contracts/mixnet/src/rewards/storage.rs
@@ -7,9 +7,9 @@ use cosmwasm_std::{StdResult, Storage, Uint128};
 use cw_storage_plus::{Item, Map};
 use mixnet_contract_common::{IdentityKey, RewardingStatus};
 
-pub(crate) const REWARD_POOL: Item<Uint128> = Item::new("pool");
+pub(crate) const REWARD_POOL: Item<'_, Uint128> = Item::new("pool");
 // TODO: Do we need a migration for this?
-pub(crate) const REWARDING_STATUS: Map<(u32, IdentityKey), RewardingStatus> = Map::new("rm");
+pub(crate) const REWARDING_STATUS: Map<'_, (u32, IdentityKey), RewardingStatus> = Map::new("rm");
 
 #[allow(dead_code)]
 pub fn incr_reward_pool(

--- a/contracts/mixnet/src/rewards/transactions.rs
+++ b/contracts/mixnet/src/rewards/transactions.rs
@@ -142,7 +142,7 @@ fn reward_mix_delegators(
 }
 
 pub(crate) fn try_reward_next_mixnode_delegators(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     info: MessageInfo,
     mix_identity: IdentityKey,
     interval_id: u32,
@@ -206,7 +206,7 @@ pub(crate) fn try_reward_next_mixnode_delegators(
 }
 
 pub(crate) fn try_reward_mixnode(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     mix_identity: IdentityKey,

--- a/contracts/mixnet/src/support/helpers.rs
+++ b/contracts/mixnet/src/support/helpers.rs
@@ -48,10 +48,10 @@ pub(crate) fn ensure_no_existing_bond(
 }
 
 pub(crate) fn validate_node_identity_signature(
-    deps: Deps,
+    deps: Deps<'_>,
     owner: &Addr,
     signature: String,
-    identity: IdentityKeyRef,
+    identity: IdentityKeyRef<'_>,
 ) -> Result<(), ContractError> {
     let owner_bytes = owner.as_bytes();
 

--- a/contracts/mixnet/src/support/tests/mod.rs
+++ b/contracts/mixnet/src/support/tests/mod.rs
@@ -33,7 +33,7 @@ pub mod test_helpers {
     use mixnet_contract_common::{Delegation, Gateway, IdentityKeyRef, InstantiateMsg, MixNode};
     use rand::thread_rng;
 
-    pub fn add_mixnode(sender: &str, stake: Vec<Coin>, deps: DepsMut) -> String {
+    pub fn add_mixnode(sender: &str, stake: Vec<Coin>, deps: DepsMut<'_>) -> String {
         let keypair = crypto::asymmetric::identity::KeyPair::new(&mut thread_rng());
         let owner_signature = keypair
             .private_key()
@@ -57,7 +57,7 @@ pub mod test_helpers {
         key
     }
 
-    pub fn add_gateway(sender: &str, stake: Vec<Coin>, deps: DepsMut) -> String {
+    pub fn add_gateway(sender: &str, stake: Vec<Coin>, deps: DepsMut<'_>) -> String {
         let keypair = crypto::asymmetric::identity::KeyPair::new(&mut thread_rng());
         let owner_signature = keypair
             .private_key()
@@ -94,7 +94,7 @@ pub mod test_helpers {
     // currently not used outside tests
     pub(crate) fn read_mixnode_pledge_amount(
         storage: &dyn Storage,
-        identity: IdentityKeyRef,
+        identity: IdentityKeyRef<'_>,
     ) -> StdResult<cosmwasm_std::Uint128> {
         let node = mixnodes_storage::mixnodes().load(storage, identity)?;
         Ok(node.pledge_amount.amount)

--- a/contracts/vesting/src/contract.rs
+++ b/contracts/vesting/src/contract.rs
@@ -21,7 +21,7 @@ use vesting_contract_common::messages::{
 
 #[entry_point]
 pub fn instantiate(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     _env: Env,
     info: MessageInfo,
     msg: InitMsg,
@@ -33,13 +33,13 @@ pub fn instantiate(
 }
 
 #[entry_point]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(_deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     Ok(Response::default())
 }
 
 #[entry_point]
 pub fn execute(
-    deps: DepsMut,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -106,7 +106,7 @@ pub fn execute(
 pub fn try_update_mixnet_address(
     address: String,
     info: MessageInfo,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     if info.sender != ADMIN.load(deps.storage)? {
         return Err(ContractError::NotAdmin(info.sender.as_str().to_string()));
@@ -120,7 +120,7 @@ pub fn try_withdraw_vested_coins(
     amount: Coin,
     env: Env,
     info: MessageInfo,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     if amount.denom != DENOM {
         return Err(ContractError::WrongDenom(amount.denom, DENOM.to_string()));
@@ -162,7 +162,7 @@ pub fn try_withdraw_vested_coins(
 fn try_transfer_ownership(
     to_address: String,
     info: MessageInfo,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     let address = info.sender.clone();
     let to_address = deps.api.addr_validate(&to_address)?;
@@ -178,7 +178,7 @@ fn try_transfer_ownership(
 fn try_update_staking_address(
     to_address: Option<String>,
     info: MessageInfo,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     let address = info.sender.clone();
     let to_address = to_address.and_then(|x| deps.api.addr_validate(&x).ok());
@@ -199,14 +199,14 @@ pub fn try_bond_gateway(
     amount: Coin,
     info: MessageInfo,
     env: Env,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     let pledge = validate_funds(&[amount])?;
     let account = account_from_address(info.sender.as_str(), deps.storage, deps.api)?;
     account.try_bond_gateway(gateway, owner_signature, pledge, &env, deps.storage)
 }
 
-pub fn try_unbond_gateway(info: MessageInfo, deps: DepsMut) -> Result<Response, ContractError> {
+pub fn try_unbond_gateway(info: MessageInfo, deps: DepsMut<'_>) -> Result<Response, ContractError> {
     let account = account_from_address(info.sender.as_str(), deps.storage, deps.api)?;
     account.try_unbond_gateway(deps.storage)
 }
@@ -215,7 +215,7 @@ pub fn try_track_unbond_gateway(
     owner: &str,
     amount: Coin,
     info: MessageInfo,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     if info.sender != MIXNET_CONTRACT_ADDRESS.load(deps.storage)? {
         return Err(ContractError::NotMixnetContract(info.sender));
@@ -231,14 +231,14 @@ pub fn try_bond_mixnode(
     amount: Coin,
     info: MessageInfo,
     env: Env,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     let pledge = validate_funds(&[amount])?;
     let account = account_from_address(info.sender.as_str(), deps.storage, deps.api)?;
     account.try_bond_mixnode(mix_node, owner_signature, pledge, &env, deps.storage)
 }
 
-pub fn try_unbond_mixnode(info: MessageInfo, deps: DepsMut) -> Result<Response, ContractError> {
+pub fn try_unbond_mixnode(info: MessageInfo, deps: DepsMut<'_>) -> Result<Response, ContractError> {
     let account = account_from_address(info.sender.as_str(), deps.storage, deps.api)?;
     account.try_unbond_mixnode(deps.storage)
 }
@@ -247,7 +247,7 @@ pub fn try_track_unbond_mixnode(
     owner: &str,
     amount: Coin,
     info: MessageInfo,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     if info.sender != MIXNET_CONTRACT_ADDRESS.load(deps.storage)? {
         return Err(ContractError::NotMixnetContract(info.sender));
@@ -262,7 +262,7 @@ fn try_track_undelegation(
     mix_identity: IdentityKey,
     amount: Coin,
     info: MessageInfo,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     if info.sender != MIXNET_CONTRACT_ADDRESS.load(deps.storage)? {
         return Err(ContractError::NotMixnetContract(info.sender));
@@ -277,7 +277,7 @@ fn try_delegate_to_mixnode(
     amount: Coin,
     info: MessageInfo,
     env: Env,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     let amount = validate_funds(&[amount])?;
     let account = account_from_address(info.sender.as_str(), deps.storage, deps.api)?;
@@ -287,7 +287,7 @@ fn try_delegate_to_mixnode(
 fn try_undelegate_from_mixnode(
     mix_identity: IdentityKey,
     info: MessageInfo,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     let account = account_from_address(info.sender.as_str(), deps.storage, deps.api)?;
     account.try_undelegate_from_mixnode(mix_identity, deps.storage)
@@ -299,7 +299,7 @@ fn try_create_periodic_vesting_account(
     vesting_spec: Option<VestingSpecification>,
     info: MessageInfo,
     env: Env,
-    deps: DepsMut,
+    deps: DepsMut<'_>,
 ) -> Result<Response, ContractError> {
     if info.sender != ADMIN.load(deps.storage)? {
         return Err(ContractError::NotAdmin(info.sender.as_str().to_string()));
@@ -357,7 +357,7 @@ fn try_create_periodic_vesting_account(
 }
 
 #[entry_point]
-pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<QueryResponse, ContractError> {
+pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> Result<QueryResponse, ContractError> {
     let query_res = match msg {
         QueryMsg::LockedCoins {
             vesting_account_address,
@@ -430,17 +430,17 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<QueryResponse, Contr
     Ok(query_res?)
 }
 
-pub fn try_get_mixnode(address: &str, deps: Deps) -> Result<Option<PledgeData>, ContractError> {
+pub fn try_get_mixnode(address: &str, deps: Deps<'_>) -> Result<Option<PledgeData>, ContractError> {
     let account = account_from_address(address, deps.storage, deps.api)?;
     account.load_mixnode_pledge(deps.storage)
 }
 
-pub fn try_get_gateway(address: &str, deps: Deps) -> Result<Option<PledgeData>, ContractError> {
+pub fn try_get_gateway(address: &str, deps: Deps<'_>) -> Result<Option<PledgeData>, ContractError> {
     let account = account_from_address(address, deps.storage, deps.api)?;
     account.load_gateway_pledge(deps.storage)
 }
 
-pub fn try_get_account(address: &str, deps: Deps) -> Result<Account, ContractError> {
+pub fn try_get_account(address: &str, deps: Deps<'_>) -> Result<Account, ContractError> {
     account_from_address(address, deps.storage, deps.api)
 }
 
@@ -448,7 +448,7 @@ pub fn try_get_locked_coins(
     vesting_account_address: &str,
     block_time: Option<Timestamp>,
     env: Env,
-    deps: Deps,
+    deps: Deps<'_>,
 ) -> Result<Coin, ContractError> {
     let account = account_from_address(vesting_account_address, deps.storage, deps.api)?;
     account.locked_coins(block_time, &env, deps.storage)
@@ -458,7 +458,7 @@ pub fn try_get_spendable_coins(
     vesting_account_address: &str,
     block_time: Option<Timestamp>,
     env: Env,
-    deps: Deps,
+    deps: Deps<'_>,
 ) -> Result<Coin, ContractError> {
     let account = account_from_address(vesting_account_address, deps.storage, deps.api)?;
     account.spendable_coins(block_time, &env, deps.storage)
@@ -468,7 +468,7 @@ pub fn try_get_vested_coins(
     vesting_account_address: &str,
     block_time: Option<Timestamp>,
     env: Env,
-    deps: Deps,
+    deps: Deps<'_>,
 ) -> Result<Coin, ContractError> {
     let account = account_from_address(vesting_account_address, deps.storage, deps.api)?;
     account.get_vested_coins(block_time, &env)
@@ -478,7 +478,7 @@ pub fn try_get_vesting_coins(
     vesting_account_address: &str,
     block_time: Option<Timestamp>,
     env: Env,
-    deps: Deps,
+    deps: Deps<'_>,
 ) -> Result<Coin, ContractError> {
     let account = account_from_address(vesting_account_address, deps.storage, deps.api)?;
     account.get_vesting_coins(block_time, &env)
@@ -486,7 +486,7 @@ pub fn try_get_vesting_coins(
 
 pub fn try_get_start_time(
     vesting_account_address: &str,
-    deps: Deps,
+    deps: Deps<'_>,
 ) -> Result<Timestamp, ContractError> {
     let account = account_from_address(vesting_account_address, deps.storage, deps.api)?;
     Ok(account.get_start_time())
@@ -494,7 +494,7 @@ pub fn try_get_start_time(
 
 pub fn try_get_end_time(
     vesting_account_address: &str,
-    deps: Deps,
+    deps: Deps<'_>,
 ) -> Result<Timestamp, ContractError> {
     let account = account_from_address(vesting_account_address, deps.storage, deps.api)?;
     Ok(account.get_end_time())
@@ -502,7 +502,7 @@ pub fn try_get_end_time(
 
 pub fn try_get_original_vesting(
     vesting_account_address: &str,
-    deps: Deps,
+    deps: Deps<'_>,
 ) -> Result<Coin, ContractError> {
     let account = account_from_address(vesting_account_address, deps.storage, deps.api)?;
     Ok(account.get_original_vesting())
@@ -512,7 +512,7 @@ pub fn try_get_delegated_free(
     block_time: Option<Timestamp>,
     vesting_account_address: &str,
     env: Env,
-    deps: Deps,
+    deps: Deps<'_>,
 ) -> Result<Coin, ContractError> {
     let account = account_from_address(vesting_account_address, deps.storage, deps.api)?;
     account.get_delegated_free(block_time, &env, deps.storage)
@@ -522,7 +522,7 @@ pub fn try_get_delegated_vesting(
     block_time: Option<Timestamp>,
     vesting_account_address: &str,
     env: Env,
-    deps: Deps,
+    deps: Deps<'_>,
 ) -> Result<Coin, ContractError> {
     let account = account_from_address(vesting_account_address, deps.storage, deps.api)?;
     account.get_delegated_vesting(block_time, &env, deps.storage)

--- a/contracts/vesting/src/storage.rs
+++ b/contracts/vesting/src/storage.rs
@@ -7,15 +7,15 @@ use mixnet_contract_common::IdentityKey;
 
 type BlockHeight = u64;
 
-pub const KEY: Item<u32> = Item::new("key");
-const ACCOUNTS: Map<String, Account> = Map::new("acc");
+pub const KEY: Item<'_, u32> = Item::new("key");
+const ACCOUNTS: Map<'_, String, Account> = Map::new("acc");
 // Holds data related to individual accounts
-const BALANCES: Map<u32, Uint128> = Map::new("blc");
-const BOND_PLEDGES: Map<u32, PledgeData> = Map::new("bnd");
-const GATEWAY_PLEDGES: Map<u32, PledgeData> = Map::new("gtw");
-pub const DELEGATIONS: Map<(u32, IdentityKey, BlockHeight), Uint128> = Map::new("dlg");
-pub const ADMIN: Item<String> = Item::new("adm");
-pub const MIXNET_CONTRACT_ADDRESS: Item<String> = Item::new("mix");
+const BALANCES: Map<'_, u32, Uint128> = Map::new("blc");
+const BOND_PLEDGES: Map<'_, u32, PledgeData> = Map::new("bnd");
+const GATEWAY_PLEDGES: Map<'_, u32, PledgeData> = Map::new("gtw");
+pub const DELEGATIONS: Map<'_, (u32, IdentityKey, BlockHeight), Uint128> = Map::new("dlg");
+pub const ADMIN: Item<'_, String> = Item::new("adm");
+pub const MIXNET_CONTRACT_ADDRESS: Item<'_, String> = Item::new("mix");
 
 pub fn save_delegation(
     key: (u32, IdentityKey, BlockHeight),

--- a/explorer-api/src/http/mod.rs
+++ b/explorer-api/src/http/mod.rs
@@ -66,7 +66,7 @@ fn configure_rocket(state: ExplorerApiStateContext) -> Rocket<Build> {
 }
 
 #[catch(404)]
-pub(crate) fn not_found(req: &Request) -> String {
+pub(crate) fn not_found(req: &Request<'_>) -> String {
     format!("I couldn't find '{}'. Try something else?", req.uri())
 }
 

--- a/gateway/src/commands/mod.rs
+++ b/gateway/src/commands/mod.rs
@@ -50,7 +50,7 @@ fn parse_validators(raw: &str) -> Vec<Url> {
         .collect()
 }
 
-pub(crate) fn override_config(mut config: Config, matches: &ArgMatches) -> Config {
+pub(crate) fn override_config(mut config: Config, matches: &ArgMatches<'_>) -> Config {
     let mut was_host_overridden = false;
     if let Some(host) = matches.value_of(HOST_ARG_NAME) {
         config = config.with_listening_address(host);

--- a/gateway/src/commands/sign.rs
+++ b/gateway/src/commands/sign.rs
@@ -80,7 +80,7 @@ fn print_signed_text(private_key: &identity::PrivateKey, text: &str) {
     )
 }
 
-pub fn execute(matches: &ArgMatches) {
+pub fn execute(matches: &ArgMatches<'_>) {
     let id = matches.value_of(ID_ARG_NAME).unwrap();
 
     let config = match Config::load_from_file(Some(id)) {

--- a/gateway/src/commands/upgrade.rs
+++ b/gateway/src/commands/upgrade.rs
@@ -96,7 +96,7 @@ fn parse_package_version() -> Version {
 
 fn minor_0_12_upgrade(
     config: Config,
-    _matches: &ArgMatches,
+    _matches: &ArgMatches<'_>,
     config_version: &Version,
     package_version: &Version,
 ) -> Config {
@@ -128,7 +128,7 @@ fn minor_0_12_upgrade(
     upgraded_config
 }
 
-fn do_upgrade(mut config: Config, matches: &ArgMatches, package_version: Version) {
+fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: Version) {
     loop {
         let config_version = parse_config_version(&config);
 

--- a/mixnode/src/node/http/mod.rs
+++ b/mixnode/src/node/http/mod.rs
@@ -5,6 +5,6 @@ pub(crate) mod verloc;
 use rocket::Request;
 
 #[catch(404)]
-pub(crate) fn not_found(req: &Request) -> String {
+pub(crate) fn not_found(req: &Request<'_>) -> String {
     format!("I couldn't find '{}'. Try something else?", req.uri())
 }

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -233,7 +233,7 @@ fn setup_logging() {
         .init();
 }
 
-fn override_config(mut config: Config, matches: &ArgMatches) -> Config {
+fn override_config(mut config: Config, matches: &ArgMatches<'_>) -> Config {
     if matches.is_present(MONITORING_ENABLED) {
         config = config.with_network_monitor_enabled(true)
     }

--- a/validator-api/src/network_monitor/test_route/mod.rs
+++ b/validator-api/src/network_monitor/test_route/mod.rs
@@ -98,7 +98,7 @@ impl TestRoute {
 }
 
 impl Debug for TestRoute {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "[v{}] Route {}: [G] {} => [M1] {} => [M2] {} => [M3] {}",

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -61,7 +61,7 @@ pub struct InclusionProbabilityResponse {
 }
 
 impl fmt::Display for InclusionProbabilityResponse {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "in_active: {:.5}, in_reserve: {:.5}",


### PR DESCRIPTION
Enabling `-Wrust-2018-idioms` generates `-Welided-lifetimes-in-paths` warnings about hidden lifetime parameters in types being deprecated