### PR TITLE
Wallet signing on MacOS

### DIFF
--- a/.github/workflows/nym-wallet-publish-macos.yml
+++ b/.github/workflows/nym-wallet-publish-macos.yml
@@ -1,0 +1,70 @@
+name: Publish Nym Wallet (MacOS)
+on:
+  push:
+    tags:
+      - nym-wallet-*
+
+defaults:
+  run:
+    working-directory: nym-wallet
+
+jobs:
+  publish-tauri:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Node v16
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: Install Rust stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install the Apple developer certificate for code signing
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          # import certificate and provisioning profile from secrets
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode --output $CERTIFICATE_PATH
+
+          # create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+      - name: Install app dependencies and build it
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_IDENTITY_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+        run: yarn && yarn build
+
+      - name: Upload to release based on tag name
+        uses: softprops/action-gh-release@v1
+        with:
+          files: nym-wallet/target/release/bundle/dmg/*.dmg
+
+      - name: Clean up keychain
+        if: ${{ always() }}
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db

--- a/.github/workflows/nym-wallet-publish.yml
+++ b/.github/workflows/nym-wallet-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Nym Wallet
+name: Publish Nym Wallet (create release based on tag name)
 on:
   push:
     tags:
@@ -8,5 +8,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Run a one-line script
-        run: echo Hello, world!
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          draft: true
+          body: This is a pre-release of the Nym Wallet.
+

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "nym_wallet"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "bip39",
  "coconut-interface",

--- a/nym-wallet/src-tauri/Cargo.toml
+++ b/nym-wallet/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym_wallet"
-version = "0.1.0"
+version = "1.0.0"
 description = "Nym Native Wallet"
 authors = ["you"]
 license = ""

--- a/nym-wallet/src-tauri/tauri.conf.json
+++ b/nym-wallet/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       "copyright": "Copyright © 2021-2022 Nym Technologies SA",
       "category": "Business",
       "shortDescription": "Nym desktop wallet allows you to manage your Nym tokens",
-      "longDescription": "The Nym wallet allows you to manage your Nym tokens and to stake on mixnodes, gateways and validators.",
+      "longDescription": "",
       "deb": {
         "depends": [],
         "useBootstrapper": false

--- a/nym-wallet/src-tauri/tauri.conf.json
+++ b/nym-wallet/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "package": {
     "productName": "nym-wallet",
-    "version": "0.12.1"
+    "version": "1.0.0"
   },
   "build": {
     "distDir": "../dist",
@@ -13,7 +13,7 @@
     "bundle": {
       "active": true,
       "targets": "all",
-      "identifier": "com.nymwallet.nymtech",
+      "identifier": "net.nymtech.wallet",
       "icon": [
         "icons/32x32.png",
         "icons/128x128.png",
@@ -23,10 +23,10 @@
       ],
       "resources": [],
       "externalBin": [],
-      "copyright": "",
-      "category": "DeveloperTool",
-      "shortDescription": "",
-      "longDescription": "",
+      "copyright": "Copyright © 2021-2022 Nym Technologies SA",
+      "category": "Business",
+      "shortDescription": "Nym desktop wallet allows you to manage your Nym tokens",
+      "longDescription": "The Nym wallet allows you to manage your Nym tokens and to stake on mixnodes, gateways and validators.",
       "deb": {
         "depends": [],
         "useBootstrapper": false
@@ -36,7 +36,7 @@
         "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": "",
-        "signingIdentity": null,
+        "signingIdentity": "Developer ID Application: Nym Technologies SA (VW5DZLFHM5)",
         "entitlements": null
       },
       "windows": {
@@ -55,7 +55,7 @@
     },
     "windows": [
       {
-        "title": "nym-wallet",
+        "title": "Nym Wallet",
         "width": 1268,
         "height": 768,
         "resizable": true


### PR DESCRIPTION
Adds two GitHub Actions:

1. Create a release when pushing to a tag `nym-wallet-*`
2. Builds, signs and uploads the wallet `dmg` to the release

Once merged into develop, the process of triggering these actions is as follows:

- write code, create PR, approve and merge PR to `develop`
- create a new release and name tag `nym-wallet-v1.0.0`
- this triggers the GH Action to mark the release as `draft` and in parallel starts building on MacOS

Soon, we can add GH Actions to do the same for Windows and Linux