### PR TITLE
Emit original bond as part of rewarding event

### DIFF
--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/events.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/events.rs
@@ -52,6 +52,8 @@ pub const NEW_MIXNODE_ACTIVE_SET_SIZE_KEY: &str = "new_mixnode_active_set_size";
 pub const INTERVAL_ID_KEY: &str = "interval_id";
 pub const TOTAL_MIXNODE_REWARD_KEY: &str = "total_node_reward";
 pub const OPERATOR_REWARD_KEY: &str = "operator_reward";
+pub const TOTAL_PLEDGE_KEY: &str = "pledge";
+pub const TOTAL_DELEGATIONS_KEY: &str = "delegated";
 pub const LAMBDA_KEY: &str = "lambda";
 pub const SIGMA_KEY: &str = "sigma";
 pub const DISTRIBUTED_DELEGATION_REWARDS_KEY: &str = "distributed_delegation_rewards";
@@ -271,10 +273,13 @@ pub fn new_zero_uptime_mix_operator_rewarding_event(
         .add_attribute(NO_REWARD_REASON_KEY, ZERO_UPTIME_VALUE)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn new_mix_operator_rewarding_event(
     interval_id: u32,
     identity: IdentityKeyRef<'_>,
     node_reward_result: NodeRewardResult,
+    node_pledge: Uint128,
+    node_delegation: Uint128,
     operator_reward: Uint128,
     delegation_rewards_distributed: Uint128,
     further_delegations: bool,
@@ -282,6 +287,8 @@ pub fn new_mix_operator_rewarding_event(
     Event::new(OPERATOR_REWARDING_EVENT_TYPE)
         .add_attribute(INTERVAL_ID_KEY, interval_id.to_string())
         .add_attribute(NODE_IDENTITY_KEY, identity)
+        .add_attribute(TOTAL_PLEDGE_KEY, node_pledge)
+        .add_attribute(TOTAL_DELEGATIONS_KEY, node_delegation)
         .add_attribute(
             TOTAL_MIXNODE_REWARD_KEY,
             node_reward_result.reward().to_string(),

--- a/contracts/mixnet/src/rewards/transactions.rs
+++ b/contracts/mixnet/src/rewards/transactions.rs
@@ -260,6 +260,9 @@ pub(crate) fn try_reward_mixnode(
         );
     }
 
+    let node_pledge = current_bond.pledge_amount.amount;
+    let node_delegation = current_bond.total_delegation.amount;
+
     // check if it has non-zero uptime
     if params.uptime() == 0 {
         storage::REWARDING_STATUS.save(
@@ -315,6 +318,8 @@ pub(crate) fn try_reward_mixnode(
         interval_id,
         &mix_identity,
         node_reward_result,
+        node_pledge,
+        node_delegation,
         operator_reward,
         total_delegator_reward,
         further_delegations,


### PR DESCRIPTION
This should make it easier to validate whether calculated rewards were correct.

The only possible worry I have is that we begin to bloat the chain by emitting so many of attributes with the events. But then again, rewarding only happens monthly so maybe it's not so bad after all.