### PR TITLE
nym-gateway: upgrade clap and use declarative cli argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "app"
@@ -3845,10 +3845,11 @@ dependencies = [
 name = "nym-gateway"
 version = "0.12.1"
 dependencies = [
+ "anyhow",
  "bandwidth-claim-contract",
  "bip39",
  "bs58",
- "clap 2.33.3",
+ "clap 3.0.10",
  "coconut-interface",
  "colored",
  "config",
@@ -3866,6 +3867,7 @@ dependencies = [
  "mixnode-common",
  "network-defaults",
  "nymsphinx",
+ "once_cell",
  "pemstore",
  "pretty_env_logger",
  "rand 0.7.3",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -5,33 +5,36 @@
 name = "nym-gateway"
 version = "0.12.1"
 authors = ["Dave Hrycyszyn <futurechimp@users.noreply.github.com>", "Jędrzej Stuczyński <andrew@nymtech.net>"]
+description = "Implementation of the Nym Mixnet Gateway"
 edition = "2021"
 rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bs58 = "0.4.0"
+anyhow = "1.0.53"
 bip39 = "1.0.1"
-clap = "2.33.0"
+bs58 = "0.4.0"
+clap = { version = "3.0.10", features = ["cargo", "derive"] }
 colored = "2.0"
-dirs = "3.0"
 dashmap = "4.0"
+dirs = "3.0"
 dotenv = "0.15.0"
 futures = "0.3"
 humantime-serde = "1.0.1"
 log = "0.4"
+once_cell = "1.7.2"
 pretty_env_logger = "0.4"
 rand = "0.7"
 serde = { version = "1.0.104", features = ["derive"] }
+sqlx = { version = "0.5", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate"] }
 subtle-encoding = { version = "0.5", features =  ["bech32-preview"]}
 thiserror = "1"
 tokio = { version = "1.4", features = [ "rt-multi-thread", "net", "signal", "fs" ] }
-tokio-util = { version = "0.6", features = [ "codec" ] }
 tokio-stream = { version = "0.1", features = [ "fs" ] }
 tokio-tungstenite = "0.14"
+tokio-util = { version = "0.6", features = [ "codec" ] }
 url = { version = "2.2", features = [ "serde" ] }
-sqlx = { version = "0.5", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate"] }
 web3 = "0.17.0"
 
 # internal

--- a/gateway/src/commands/init.rs
+++ b/gateway/src/commands/init.rs
@@ -1,97 +1,100 @@
 // Copyright 2020 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::commands::*;
-use crate::config::persistence::pathfinder::GatewayPathfinder;
-use crate::config::Config;
-use crate::node::Gateway;
-use clap::{App, Arg, ArgMatches};
+use crate::{
+    commands::{override_config, OverrideConfig},
+    config::{persistence::pathfinder::GatewayPathfinder, Config},
+    node::Gateway,
+};
+use clap::Args;
 use config::NymConfig;
 use crypto::asymmetric::{encryption, identity};
 
-pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
-    let app = App::new("init")
-        .about("Initialise the gateway")
-        .arg(
-            Arg::with_name(ID_ARG_NAME)
-                .long(ID_ARG_NAME)
-                .help("Id of the gateway we want to create config for.")
-                .takes_value(true)
-                .required(true),
-        )
-        .arg(
-            Arg::with_name(HOST_ARG_NAME)
-                .long(HOST_ARG_NAME)
-                .help("The custom host on which the gateway will be running for receiving sphinx packets")
-                .takes_value(true)
-                .required(true),
-        )
-        .arg(
-            Arg::with_name(MIX_PORT_ARG_NAME)
-                .long(MIX_PORT_ARG_NAME)
-                .help("The port on which the gateway will be listening for sphinx packets")
-                .takes_value(true)
-        )
-        .arg(
-            Arg::with_name(CLIENTS_PORT_ARG_NAME)
-                .long(CLIENTS_PORT_ARG_NAME)
-                .help("The port on which the gateway will be listening for clients gateway-requests")
-                .takes_value(true)
-        )
-        .arg(
-            Arg::with_name(ANNOUNCE_HOST_ARG_NAME)
-                .long(ANNOUNCE_HOST_ARG_NAME)
-                .help("The host that will be reported to the directory server")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name(DATASTORE_PATH)
-                .long(DATASTORE_PATH)
-                .help("Path to sqlite database containing all gateway persistent data")
-                .takes_value(true)
-        )
-        .arg(
-            Arg::with_name(VALIDATOR_APIS_ARG_NAME)
-                .long(VALIDATOR_APIS_ARG_NAME)
-                .help("Comma separated list of endpoints of the validators APIs")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name(WALLET_ADDRESS)
-            .long(WALLET_ADDRESS)
-            .help("The wallet address you will use to bond this gateway, e.g. nymt1z9egw0knv47nmur0p8vk4rcx59h9gg4zuxrrr9")
-            .takes_value(true)
-            .required(true)
-        );
+#[derive(Args, Clone)]
+pub struct Init {
+    /// Id of the gateway we want to create config for
+    #[clap(long)]
+    id: String,
 
-    #[cfg(feature = "eth")]
-    #[cfg(not(feature = "coconut"))]
-    let app = app
-        .arg(
-            Arg::with_name(TESTNET_MODE_ARG_NAME)
-                .long(TESTNET_MODE_ARG_NAME)
-                .help("Set this gateway to work in a testnet mode that would allow clients to bypass bandwidth credential requirement")
-        )
-        .arg(Arg::with_name(ETH_ENDPOINT)
-            .long(ETH_ENDPOINT)
-            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens")
-            .takes_value(true)
-            .required(true))
-        .arg(Arg::with_name(VALIDATORS_ARG_NAME)
-            .long(VALIDATORS_ARG_NAME)
-            .help("Comma separated list of endpoints of the validator")
-            .takes_value(true))
-        .arg(Arg::with_name(COSMOS_MNEMONIC)
-            .long(COSMOS_MNEMONIC)
-            .help("Cosmos wallet mnemonic")
-            .takes_value(true)
-            .required(true));
+    /// The custom host on which the gateway will be running for receiving sphinx packets
+    #[clap(long)]
+    host: String,
 
-    app
+    /// The wallet address you will use to bond this gateway, e.g. nymt1z9egw0knv47nmur0p8vk4rcx59h9gg4zuxrrr9
+    #[clap(long)]
+    wallet_address: String,
+
+    /// The port on which the gateway will be listening for sphinx packets
+    #[clap(long)]
+    mix_port: Option<u16>,
+
+    /// The port on which the gateway will be listening for clients gateway-requests
+    #[clap(long)]
+    clients_port: Option<u16>,
+
+    /// The host that will be reported to the directory server
+    #[clap(long)]
+    announce_host: Option<String>,
+
+    /// Path to sqlite database containing all gateway persistent data
+    #[clap(long)]
+    datastore: Option<String>,
+
+    /// Comma separated list of endpoints of the validators APIs
+    #[clap(long)]
+    validator_apis: Option<String>,
+
+    /// Set this gateway to work in a testnet mode that would allow clients to bypass bandwidth credential requirement
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long)]
+    testnet_mode: bool,
+
+    /// URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long)]
+    eth_endpoint: String,
+
+    /// Comma separated list of endpoints of the validator
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long)]
+    validators: Option<String>,
+
+    /// Cosmos wallet mnemonic
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long)]
+    mnemonic: String,
 }
 
-pub async fn execute(matches: ArgMatches<'static>) {
-    let id = matches.value_of(ID_ARG_NAME).unwrap();
+impl From<Init> for OverrideConfig {
+    fn from(init_config: Init) -> Self {
+        OverrideConfig {
+            id: init_config.id,
+            host: Some(init_config.host),
+            wallet_address: Some(init_config.wallet_address),
+            mix_port: init_config.mix_port,
+            clients_port: init_config.clients_port,
+            datastore: init_config.datastore,
+            announce_host: init_config.announce_host,
+            validator_apis: init_config.validator_apis,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            testnet_mode: init_config.testnet_mode,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            eth_endpoint: Some(init_config.eth_endpoint),
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            validators: init_config.validators,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            mnemonic: Some(init_config.mnemonic),
+        }
+    }
+}
+
+pub async fn execute(args: &Init) {
+    let override_config_fields = OverrideConfig::from(args.clone());
+    let id = &override_config_fields.id;
     println!("Initialising gateway {}...", id);
 
     let already_init = if Config::default_config_file_path(Some(id)).exists() {
@@ -103,7 +106,7 @@ pub async fn execute(matches: ArgMatches<'static>) {
 
     let mut config = Config::new(id);
 
-    config = override_config(config, &matches);
+    config = override_config(config, override_config_fields);
 
     // if gateway was already initialised, don't generate new keys
     if !already_init {
@@ -140,5 +143,5 @@ pub async fn execute(matches: ArgMatches<'static>) {
     println!("Saved configuration file to {:?}", config_save_location);
     println!("Gateway configuration completed.\n\n\n");
 
-    Gateway::new(config).await.print_node_details()
+    Gateway::new(config).await.print_node_details();
 }

--- a/gateway/src/commands/mod.rs
+++ b/gateway/src/commands/mod.rs
@@ -3,8 +3,8 @@
 
 use std::process;
 
-use crate::config::Config;
-use clap::ArgMatches;
+use crate::{config::Config, Cli};
+use clap::Subcommand;
 use colored::Colorize;
 use crypto::bech32_address_validation;
 use url::Url;
@@ -15,29 +15,65 @@ pub(crate) mod run;
 pub(crate) mod sign;
 pub(crate) mod upgrade;
 
-pub(crate) const ID_ARG_NAME: &str = "id";
-pub(crate) const HOST_ARG_NAME: &str = "host";
-pub(crate) const MIX_PORT_ARG_NAME: &str = "mix-port";
-pub(crate) const CLIENTS_PORT_ARG_NAME: &str = "clients-port";
-pub(crate) const VALIDATOR_APIS_ARG_NAME: &str = "validator-apis";
-#[cfg(not(feature = "coconut"))]
-pub(crate) const VALIDATORS_ARG_NAME: &str = "validators";
-#[cfg(not(feature = "coconut"))]
-pub(crate) const COSMOS_MNEMONIC: &str = "mnemonic";
-#[cfg(not(feature = "coconut"))]
-pub(crate) const ETH_ENDPOINT: &str = "eth_endpoint";
-pub(crate) const ANNOUNCE_HOST_ARG_NAME: &str = "announce-host";
-pub(crate) const DATASTORE_PATH: &str = "datastore";
-pub(crate) const TESTNET_MODE_ARG_NAME: &str = "testnet-mode";
-pub(crate) const WALLET_ADDRESS: &str = "wallet-address";
-
-#[cfg(not(feature = "coconut"))]
+#[cfg(all(feature = "eth", not(feature = "coconut")))]
 const DEFAULT_ETH_ENDPOINT: &str = "https://rinkeby.infura.io/v3/00000000000000000000000000000000";
-#[cfg(not(feature = "coconut"))]
+#[cfg(all(feature = "eth", not(feature = "coconut")))]
 const DEFAULT_VALIDATOR_ENDPOINT: &str = "http://localhost:26657";
 // A dummy mnemonic
-#[cfg(not(feature = "coconut"))]
+#[cfg(all(feature = "eth", not(feature = "coconut")))]
 const DEFAULT_MNEMONIC: &str = "typical regret aware used tennis noise resource crisp defy join donate orient army item immense clean emerge globe gift chronic loan flat enter egg";
+
+#[derive(Subcommand)]
+pub(crate) enum Commands {
+    /// Initialise the gateway
+    Init(init::Init),
+
+    /// Show details of this gateway
+    NodeDetails(node_details::NodeDetails),
+
+    /// Starts the gateway
+    Run(run::Run),
+
+    /// Sign text to prove ownership of this mixnode
+    Sign(sign::Sign),
+
+    /// Try to upgrade the gateway
+    Upgrade(upgrade::Upgrade),
+}
+
+// Configuration that can be overridden.
+pub(crate) struct OverrideConfig {
+    id: String,
+    host: Option<String>,
+    wallet_address: Option<String>,
+    mix_port: Option<u16>,
+    clients_port: Option<u16>,
+    datastore: Option<String>,
+    announce_host: Option<String>,
+    validator_apis: Option<String>,
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    testnet_mode: bool,
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    eth_endpoint: Option<String>,
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    validators: Option<String>,
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    mnemonic: Option<String>,
+}
+
+pub(crate) async fn execute(args: Cli) {
+    match &args.command {
+        Commands::Init(m) => init::execute(m).await,
+        Commands::NodeDetails(m) => node_details::execute(m).await,
+        Commands::Run(m) => run::execute(m).await,
+        Commands::Sign(m) => sign::execute(m),
+        Commands::Upgrade(m) => upgrade::execute(m).await,
+    }
+}
 
 fn parse_validators(raw: &str) -> Vec<Url> {
     raw.split(',')
@@ -50,82 +86,72 @@ fn parse_validators(raw: &str) -> Vec<Url> {
         .collect()
 }
 
-pub(crate) fn override_config(mut config: Config, matches: &ArgMatches<'_>) -> Config {
+pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Config {
     let mut was_host_overridden = false;
-    if let Some(host) = matches.value_of(HOST_ARG_NAME) {
+    if let Some(host) = args.host {
         config = config.with_listening_address(host);
         was_host_overridden = true;
     }
 
-    if let Some(mix_port) = matches
-        .value_of(MIX_PORT_ARG_NAME)
-        .map(|port| port.parse::<u16>())
-    {
-        if let Err(err) = mix_port {
-            // if port was overridden, it must be parsable
-            panic!("Invalid port value provided - {:?}", err);
-        }
-        config = config.with_mix_port(mix_port.unwrap());
+    if let Some(mix_port) = args.mix_port {
+        config = config.with_mix_port(mix_port);
     }
 
-    if let Some(clients_port) = matches
-        .value_of(CLIENTS_PORT_ARG_NAME)
-        .map(|port| port.parse::<u16>())
-    {
-        if let Err(err) = clients_port {
-            // if port was overridden, it must be parsable
-            panic!("Invalid port value provided - {:?}", err);
-        }
-        config = config.with_clients_port(clients_port.unwrap());
+    if let Some(clients_port) = args.clients_port {
+        config = config.with_clients_port(clients_port);
     }
 
-    if let Some(announce_host) = matches.value_of(ANNOUNCE_HOST_ARG_NAME) {
+    if let Some(announce_host) = args.announce_host {
         config = config.with_announce_address(announce_host);
     } else if was_host_overridden {
         // make sure our 'mix-announce-host' always defaults to 'mix-host'
-        config = config.announce_host_from_listening_host()
+        config = config.announce_host_from_listening_host();
     }
 
-    if let Some(raw_validators) = matches.value_of(VALIDATOR_APIS_ARG_NAME) {
-        config = config.with_custom_validator_apis(parse_validators(raw_validators));
+    if let Some(raw_validators) = args.validator_apis {
+        config = config.with_custom_validator_apis(parse_validators(&raw_validators));
     }
 
-    #[cfg(not(feature = "coconut"))]
-    if let Some(raw_validators) = matches.value_of(VALIDATORS_ARG_NAME) {
-        config = config.with_custom_validator_nymd(parse_validators(raw_validators));
-    } else {
-        config = config.with_custom_validator_nymd(parse_validators(DEFAULT_VALIDATOR_ENDPOINT));
-    }
-
-    #[cfg(not(feature = "coconut"))]
-    if let Some(cosmos_mnemonic) = matches.value_of(COSMOS_MNEMONIC) {
-        config = config.with_cosmos_mnemonic(String::from(cosmos_mnemonic));
-    } else {
-        config = config.with_cosmos_mnemonic(String::from(DEFAULT_MNEMONIC));
-    }
-
-    if let Some(datastore_path) = matches.value_of(DATASTORE_PATH) {
-        config = config.with_custom_persistent_store(datastore_path);
-    }
-
-    #[cfg(not(feature = "coconut"))]
-    if let Some(eth_endpoint) = matches.value_of(ETH_ENDPOINT) {
-        config = config.with_eth_endpoint(String::from(eth_endpoint));
-    } else {
-        config = config.with_eth_endpoint(String::from(DEFAULT_ETH_ENDPOINT));
-    }
-
-    if let Some(wallet_address) = matches.value_of(WALLET_ADDRESS) {
+    if let Some(wallet_address) = args.wallet_address {
         let trimmed = wallet_address.trim();
         validate_bech32_address_or_exit(trimmed);
         config = config.with_wallet_address(trimmed);
     }
 
-    if !cfg!(feature = "eth") || matches.is_present(TESTNET_MODE_ARG_NAME) {
-        config.with_testnet_mode(true)
-    } else {
-        config
+    if let Some(datastore_path) = args.datastore {
+        config = config.with_custom_persistent_store(datastore_path);
     }
+
+    // Set the test mode to always on, except if build with `feature = eth`, then we check the flag
+    config = config.with_testnet_mode(true);
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    {
+        if args.testnet_mode {
+            config = config.with_testnet_mode(true);
+        }
+
+        if let Some(raw_validators) = args.validators {
+            config = config.with_custom_validator_nymd(parse_validators(&raw_validators));
+        } else {
+            config =
+                config.with_custom_validator_nymd(parse_validators(DEFAULT_VALIDATOR_ENDPOINT));
+        }
+
+        if let Some(cosmos_mnemonic) = args.mnemonic {
+            config = config.with_cosmos_mnemonic(String::from(cosmos_mnemonic));
+        } else {
+            config = config.with_cosmos_mnemonic(String::from(DEFAULT_MNEMONIC));
+        }
+
+        if let Some(eth_endpoint) = args.eth_endpoint {
+            config = config.with_eth_endpoint(eth_endpoint);
+        } else {
+            config = config.with_eth_endpoint(String::from(DEFAULT_ETH_ENDPOINT));
+        }
+    }
+
+    config
 }
 
 /// Ensures that a given bech32 address is valid, or exits

--- a/gateway/src/commands/node_details.rs
+++ b/gateway/src/commands/node_details.rs
@@ -1,35 +1,30 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::commands::*;
-use crate::config::Config;
-use crate::node::Gateway;
-use clap::{App, Arg, ArgMatches};
+use crate::{config::Config, node::Gateway};
+use clap::Args;
 use config::NymConfig;
 use log::error;
 
-pub fn command_args<'a, 'b>() -> App<'a, 'b> {
-    App::new("node-details")
-        .about("Show details of this gateway")
-        .arg(
-            Arg::with_name(ID_ARG_NAME)
-                .long(ID_ARG_NAME)
-                .help("The id of the gateway you want to show details for")
-                .takes_value(true)
-                .required(true),
-        )
+#[derive(Args, Clone)]
+pub struct NodeDetails {
+    /// The id of the gateway you want to show details for
+    #[clap(long)]
+    id: String,
 }
 
-pub async fn execute(matches: ArgMatches<'static>) {
-    let id = matches.value_of(ID_ARG_NAME).unwrap();
-
-    let config = match Config::load_from_file(Some(id)) {
+pub async fn execute(args: &NodeDetails) {
+    let config = match Config::load_from_file(Some(&args.id)) {
         Ok(cfg) => cfg,
         Err(err) => {
-            error!("Failed to load config for {}. Are you sure you have run `init` before? (Error was: {})", id, err);
+            error!(
+                "Failed to load config for {}. Are you sure you have run `init` before? (Error was: {})",
+                args.id,
+                err,
+            );
             return;
         }
     };
 
-    Gateway::new(config).await.print_node_details()
+    Gateway::new(config).await.print_node_details();
 }

--- a/gateway/src/commands/run.rs
+++ b/gateway/src/commands/run.rs
@@ -45,21 +45,22 @@ pub struct Run {
     validator_apis: Option<String>,
 
     /// Set this gateway to work in a testnet mode that would allow clients to bypass bandwidth credential requirement
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
     #[clap(long)]
     testnet_mode: bool,
 
     /// URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens
-    #[cfg(not(feature = "coconut"))]
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
     #[clap(long)]
     eth_endpoint: Option<String>,
 
     /// Comma separated list of endpoints of the validator
-    #[cfg(not(feature = "coconut"))]
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
     #[clap(long)]
     validators: Option<String>,
 
     /// Cosmos wallet mnemonic
-    #[cfg(not(feature = "coconut"))]
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
     #[clap(long)]
     mnemonic: Option<String>,
 }

--- a/gateway/src/commands/upgrade.rs
+++ b/gateway/src/commands/upgrade.rs
@@ -1,14 +1,20 @@
 // Copyright 2020 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::commands::*;
 use crate::config::{Config, MISSING_VALUE};
-use clap::{App, Arg, ArgMatches};
+use clap::Args;
 use config::defaults::default_api_endpoints;
 use config::NymConfig;
 use std::fmt::Display;
 use std::process;
 use version_checker::Version;
+
+#[derive(Args, Clone)]
+pub struct Upgrade {
+    /// Id of the nym-gateway we want to upgrade
+    #[clap(long)]
+    id: String,
+}
 
 #[allow(dead_code)]
 fn fail_upgrade<D1: Display, D2: Display>(from_version: D1, to_version: D2) -> ! {
@@ -50,16 +56,6 @@ fn unsupported_upgrade(current_version: &Version, config_version: &Version) -> !
     process::exit(1)
 }
 
-pub fn command_args<'a, 'b>() -> App<'a, 'b> {
-    App::new("upgrade").about("Try to upgrade the gateway").arg(
-        Arg::with_name("id")
-            .long("id")
-            .help("Id of the nym-gateway we want to upgrade")
-            .takes_value(true)
-            .required(true),
-    )
-}
-
 fn parse_config_version(config: &Config) -> Version {
     let version = Version::parse(config.get_version()).unwrap_or_else(|err| {
         eprintln!("failed to parse client version! - {:?}", err);
@@ -96,7 +92,7 @@ fn parse_package_version() -> Version {
 
 fn minor_0_12_upgrade(
     config: Config,
-    _matches: &ArgMatches<'_>,
+    _args: &Upgrade,
     config_version: &Version,
     package_version: &Version,
 ) -> Config {
@@ -128,7 +124,7 @@ fn minor_0_12_upgrade(
     upgraded_config
 }
 
-fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: Version) {
+fn do_upgrade(mut config: Config, args: &Upgrade, package_version: Version) {
     loop {
         let config_version = parse_config_version(&config);
 
@@ -140,7 +136,7 @@ fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: Ver
         config = match config_version.major {
             0 => match config_version.minor {
                 9 | 10 => outdated_upgrade(&config_version, &package_version),
-                11 => minor_0_12_upgrade(config, matches, &config_version, &package_version),
+                11 => minor_0_12_upgrade(config, args, &config_version, &package_version),
                 _ => unsupported_upgrade(&config_version, &package_version),
             },
             _ => unsupported_upgrade(&config_version, &package_version),
@@ -148,12 +144,10 @@ fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: Ver
     }
 }
 
-pub async fn execute(matches: ArgMatches<'static>) {
+pub async fn execute(args: &Upgrade) {
     let package_version = parse_package_version();
 
-    let id = matches.value_of(ID_ARG_NAME).unwrap();
-
-    let existing_config = Config::load_from_file(Some(id)).unwrap_or_else(|err| {
+    let existing_config = Config::load_from_file(Some(&args.id)).unwrap_or_else(|err| {
         eprintln!("failed to load existing config file! - {:?}", err);
         process::exit(1)
     });
@@ -163,5 +157,5 @@ pub async fn execute(matches: ArgMatches<'static>) {
         process::exit(1);
     }
 
-    do_upgrade(existing_config, &matches, package_version)
+    do_upgrade(existing_config, args, package_version)
 }

--- a/gateway/src/config/mod.rs
+++ b/gateway/src/config/mod.rs
@@ -132,19 +132,19 @@ impl Config {
         self
     }
 
-    #[cfg(not(feature = "coconut"))]
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
     pub fn with_custom_validator_nymd(mut self, validator_nymd_urls: Vec<Url>) -> Self {
         self.gateway.validator_nymd_urls = validator_nymd_urls;
         self
     }
 
-    #[cfg(not(feature = "coconut"))]
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
     pub fn with_cosmos_mnemonic(mut self, cosmos_mnemonic: String) -> Self {
         self.gateway.cosmos_mnemonic = cosmos_mnemonic;
         self
     }
 
-    #[cfg(not(feature = "coconut"))]
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
     pub fn with_eth_endpoint(mut self, eth_endpoint: String) -> Self {
         self.gateway.eth_endpoint = eth_endpoint;
         self

--- a/mixnode/src/commands/init.rs
+++ b/mixnode/src/commands/init.rs
@@ -12,7 +12,7 @@ use super::OverrideConfig;
 
 #[derive(Args, Clone)]
 pub(crate) struct Init {
-    /// Initialise the mixnode
+    /// Id of the nym-mixnode we want to create config for
     #[clap(long)]
     id: String,
 


### PR DESCRIPTION
Upgrade clap to latest and revamp command line parsing for `nym-gateway`

Changes in behaviour:

- Changed `--eth_endpoint` to `--eth-endpoint` for consistency
- Flags related to `eth` feature flag not available for `run`, consistent with `init` (`--testnet-mode`, `--eth-endpoint`, `--validators`, `--mnemonic`)