### PR TITLE
Extract out storage in gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3847,6 +3847,7 @@ name = "nym-gateway"
 version = "0.12.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bandwidth-claim-contract",
  "bip39",
  "bs58",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.56"
 
 [dependencies]
 anyhow = "1.0.53"
+async-trait = { version = "0.1.51" }
 bip39 = "1.0.1"
 bs58 = "0.4.0"
 clap = { version = "3.0.10", features = ["cargo", "derive"] }

--- a/gateway/src/commands/init.rs
+++ b/gateway/src/commands/init.rs
@@ -4,7 +4,7 @@
 use crate::{
     commands::{override_config, OverrideConfig},
     config::{persistence::pathfinder::GatewayPathfinder, Config},
-    node::Gateway,
+    node::{storage::PersistentStorage, Gateway},
 };
 use clap::Args;
 use config::NymConfig;
@@ -68,7 +68,6 @@ pub struct Init {
 impl From<Init> for OverrideConfig {
     fn from(init_config: Init) -> Self {
         OverrideConfig {
-            id: init_config.id,
             host: Some(init_config.host),
             wallet_address: Some(init_config.wallet_address),
             mix_port: init_config.mix_port,
@@ -93,20 +92,23 @@ impl From<Init> for OverrideConfig {
 }
 
 pub async fn execute(args: &Init) {
-    let override_config_fields = OverrideConfig::from(args.clone());
-    let id = &override_config_fields.id;
-    println!("Initialising gateway {}...", id);
+    println!("Initialising gateway {}...", args.id);
 
-    let already_init = if Config::default_config_file_path(Some(id)).exists() {
-        println!("Gateway \"{}\" was already initialised before! Config information will be overwritten (but keys will be kept)!", id);
+    let already_init = if Config::default_config_file_path(Some(&args.id)).exists() {
+        println!(
+            "Gateway \"{}\" was already initialised before! Config information will be \
+            overwritten (but keys will be kept)!",
+            args.id
+        );
         true
     } else {
         false
     };
 
-    let mut config = Config::new(id);
+    let override_config_fields = OverrideConfig::from(args.clone());
 
-    config = override_config(config, override_config_fields);
+    // Initialising the config structure is just overriding a default constructed one
+    let config = override_config(Config::new(&args.id), override_config_fields);
 
     // if gateway was already initialised, don't generate new keys
     if !already_init {
@@ -143,5 +145,44 @@ pub async fn execute(args: &Init) {
     println!("Saved configuration file to {:?}", config_save_location);
     println!("Gateway configuration completed.\n\n\n");
 
-    Gateway::new(config).await.print_node_details();
+    Gateway::<PersistentStorage>::new(config)
+        .await
+        .print_node_details();
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::node::storage::InMemStorage;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn create_gateway_with_in_mem_storage() {
+        let args = Init {
+            id: "foo-id".to_string(),
+            host: "foo-host".to_string(),
+            wallet_address: "nymt1z9egw0knv47nmur0p8vk4rcx59h9gg4zuxrrr9".to_string(),
+            mix_port: Some(42),
+            clients_port: Some(43),
+            announce_host: Some("foo-announce-host".to_string()),
+            datastore: Some("foo-datastore".to_string()),
+            validator_apis: None,
+        };
+
+        let config = Config::new(&args.id);
+        let config = override_config(config, OverrideConfig::from(args.clone()));
+
+        let (identity_keys, sphinx_keys) = {
+            let mut rng = rand::rngs::OsRng;
+            (
+                identity::KeyPair::new(&mut rng),
+                encryption::KeyPair::new(&mut rng),
+            )
+        };
+
+        // The test is really if this instantiates with InMemStorage without panics
+        let _gateway =
+            Gateway::new_from_keys_and_storage(config, identity_keys, sphinx_keys, InMemStorage)
+                .await;
+    }
 }

--- a/gateway/src/commands/init.rs
+++ b/gateway/src/commands/init.rs
@@ -4,7 +4,6 @@
 use crate::{
     commands::{override_config, OverrideConfig},
     config::{persistence::pathfinder::GatewayPathfinder, Config},
-    node::{storage::PersistentStorage, Gateway},
 };
 use clap::Args;
 use config::NymConfig;
@@ -145,14 +144,14 @@ pub async fn execute(args: &Init) {
     println!("Saved configuration file to {:?}", config_save_location);
     println!("Gateway configuration completed.\n\n\n");
 
-    Gateway::<PersistentStorage>::new(config)
+    crate::node::create_gateway(config)
         .await
         .print_node_details();
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::node::storage::InMemStorage;
+    use crate::node::{storage::InMemStorage, Gateway};
 
     use super::*;
 

--- a/gateway/src/commands/mod.rs
+++ b/gateway/src/commands/mod.rs
@@ -43,7 +43,6 @@ pub(crate) enum Commands {
 
 // Configuration that can be overridden.
 pub(crate) struct OverrideConfig {
-    id: String,
     host: Option<String>,
     wallet_address: Option<String>,
     mix_port: Option<u16>,

--- a/gateway/src/commands/node_details.rs
+++ b/gateway/src/commands/node_details.rs
@@ -1,10 +1,7 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    config::Config,
-    node::{storage::PersistentStorage, Gateway},
-};
+use crate::config::Config;
 use clap::Args;
 use config::NymConfig;
 use log::error;
@@ -29,7 +26,7 @@ pub async fn execute(args: &NodeDetails) {
         }
     };
 
-    Gateway::<PersistentStorage>::new(config)
+    crate::node::create_gateway(config)
         .await
         .print_node_details();
 }

--- a/gateway/src/commands/node_details.rs
+++ b/gateway/src/commands/node_details.rs
@@ -1,7 +1,10 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{config::Config, node::Gateway};
+use crate::{
+    config::Config,
+    node::{storage::PersistentStorage, Gateway},
+};
 use clap::Args;
 use config::NymConfig;
 use log::error;
@@ -26,5 +29,7 @@ pub async fn execute(args: &NodeDetails) {
         }
     };
 
-    Gateway::new(config).await.print_node_details();
+    Gateway::<PersistentStorage>::new(config)
+        .await
+        .print_node_details();
 }

--- a/gateway/src/commands/run.rs
+++ b/gateway/src/commands/run.rs
@@ -4,7 +4,7 @@
 use crate::{
     commands::{override_config, version_check, OverrideConfig},
     config::Config,
-    node::Gateway,
+    node::{storage::PersistentStorage, Gateway},
 };
 use clap::Args;
 use config::NymConfig;
@@ -68,7 +68,6 @@ pub struct Run {
 impl From<Run> for OverrideConfig {
     fn from(run_config: Run) -> Self {
         OverrideConfig {
-            id: run_config.id,
             host: run_config.host,
             wallet_address: run_config.wallet_address,
             mix_port: run_config.mix_port,
@@ -133,7 +132,7 @@ pub async fn execute(args: &Run) {
         show_binding_warning(config.get_listening_address().to_string());
     }
 
-    let mut gateway = Gateway::new(config).await;
+    let mut gateway = Gateway::<PersistentStorage>::new(config).await;
     println!(
         "\nTo bond your gateway you will need to install the Nym wallet, go to https://nymtech.net/get-involved and select the Download button.\n\
          Select the correct version and install it to your machine. You will need to provide the following: \n ");

--- a/gateway/src/commands/run.rs
+++ b/gateway/src/commands/run.rs
@@ -4,7 +4,6 @@
 use crate::{
     commands::{override_config, version_check, OverrideConfig},
     config::Config,
-    node::{storage::PersistentStorage, Gateway},
 };
 use clap::Args;
 use config::NymConfig;
@@ -132,7 +131,7 @@ pub async fn execute(args: &Run) {
         show_binding_warning(config.get_listening_address().to_string());
     }
 
-    let mut gateway = Gateway::<PersistentStorage>::new(config).await;
+    let mut gateway = crate::node::create_gateway(config).await;
     println!(
         "\nTo bond your gateway you will need to install the Nym wallet, go to https://nymtech.net/get-involved and select the Download button.\n\
          Select the correct version and install it to your machine. You will need to provide the following: \n ");

--- a/gateway/src/config/mod.rs
+++ b/gateway/src/config/mod.rs
@@ -416,11 +416,11 @@ impl Default for Gateway {
 
 #[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct Logging {}
+struct Logging {}
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default)]
-pub struct Debug {
+struct Debug {
     /// Initial value of an exponential backoff to reconnect to dropped TCP connection when
     /// forwarding sphinx packets.
     #[serde(with = "humantime_serde")]

--- a/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
@@ -6,7 +6,7 @@ use crate::node::client_handling::websocket::connection_handler::{
     AuthenticatedHandler, ClientDetails, InitialAuthResult, SocketStream,
 };
 use crate::node::storage::error::StorageError;
-use crate::node::storage::PersistentStorage;
+use crate::node::storage::Storage;
 use crypto::asymmetric::identity;
 use futures::{channel::mpsc, SinkExt, StreamExt};
 use gateway_requests::authentication::encrypted_address::{
@@ -68,14 +68,14 @@ impl InitialAuthenticationError {
     }
 }
 
-pub(crate) struct FreshHandler<R, S> {
+pub(crate) struct FreshHandler<R, S, St> {
     rng: R,
     local_identity: Arc<identity::KeyPair>,
     pub(crate) testnet_mode: bool,
     pub(crate) active_clients_store: ActiveClientsStore,
     pub(crate) outbound_mix_sender: MixForwardingSender,
     pub(crate) socket_connection: SocketStream<S>,
-    pub(crate) storage: PersistentStorage,
+    pub(crate) storage: St,
 
     #[cfg(feature = "coconut")]
     pub(crate) aggregated_verification_key: VerificationKey,
@@ -84,9 +84,10 @@ pub(crate) struct FreshHandler<R, S> {
     pub(crate) erc20_bridge: Arc<ERC20Bridge>,
 }
 
-impl<R, S> FreshHandler<R, S>
+impl<R, S, St> FreshHandler<R, S, St>
 where
     R: Rng + CryptoRng,
+    St: Storage,
 {
     // for time being we assume handle is always constructed from raw socket.
     // if we decide we want to change it, that's not too difficult
@@ -99,7 +100,7 @@ where
         testnet_mode: bool,
         outbound_mix_sender: MixForwardingSender,
         local_identity: Arc<identity::KeyPair>,
-        storage: PersistentStorage,
+        storage: St,
         active_clients_store: ActiveClientsStore,
         #[cfg(feature = "coconut")] aggregated_verification_key: VerificationKey,
         #[cfg(not(feature = "coconut"))] erc20_bridge: Arc<ERC20Bridge>,
@@ -543,7 +544,7 @@ where
     // TODO: somehow cleanup this method
     pub(crate) async fn perform_initial_authentication(
         mut self,
-    ) -> Option<AuthenticatedHandler<R, S>>
+    ) -> Option<AuthenticatedHandler<R, S, St>>
     where
         S: AsyncRead + AsyncWrite + Unpin + Send,
     {

--- a/gateway/src/node/client_handling/websocket/connection_handler/mod.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/mod.rs
@@ -9,6 +9,8 @@ use rand::{CryptoRng, Rng};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_tungstenite::WebSocketStream;
 
+use crate::node::storage::Storage;
+
 pub(crate) use self::authenticated::AuthenticatedHandler;
 pub(crate) use self::fresh::FreshHandler;
 
@@ -64,10 +66,11 @@ impl InitialAuthResult {
     }
 }
 
-pub(crate) async fn handle_connection<R, S>(mut handle: FreshHandler<R, S>)
+pub(crate) async fn handle_connection<R, S, St>(mut handle: FreshHandler<R, S, St>)
 where
     R: Rng + CryptoRng,
     S: AsyncRead + AsyncWrite + Unpin + Send,
+    St: Storage,
 {
     if let Err(err) = handle.perform_websocket_handshake().await {
         warn!(

--- a/gateway/src/node/client_handling/websocket/listener.rs
+++ b/gateway/src/node/client_handling/websocket/listener.rs
@@ -52,13 +52,13 @@ impl Listener {
 
     // TODO: change the signature to pub(crate) async fn run(&self, handler: Handler)
 
-    pub(crate) async fn run<S>(
+    pub(crate) async fn run<St>(
         &mut self,
         outbound_mix_sender: MixForwardingSender,
-        storage: S,
+        storage: St,
         active_clients_store: ActiveClientsStore,
     ) where
-        S: Storage + 'static,
+        St: Storage + 'static,
     {
         info!("Starting websocket listener at {}", self.address);
         let tcp_listener = match tokio::net::TcpListener::bind(self.address).await {
@@ -95,14 +95,14 @@ impl Listener {
         }
     }
 
-    pub(crate) fn start<S>(
+    pub(crate) fn start<St>(
         mut self,
         outbound_mix_sender: MixForwardingSender,
-        storage: S,
+        storage: St,
         active_clients_store: ActiveClientsStore,
     ) -> JoinHandle<()>
     where
-        S: Storage + 'static,
+        St: Storage + 'static,
     {
         tokio::spawn(async move {
             self.run(outbound_mix_sender, storage, active_clients_store)

--- a/gateway/src/node/client_handling/websocket/listener.rs
+++ b/gateway/src/node/client_handling/websocket/listener.rs
@@ -58,7 +58,7 @@ impl Listener {
         storage: St,
         active_clients_store: ActiveClientsStore,
     ) where
-        St: Storage + 'static,
+        St: Storage + Clone + 'static,
     {
         info!("Starting websocket listener at {}", self.address);
         let tcp_listener = match tokio::net::TcpListener::bind(self.address).await {
@@ -102,7 +102,7 @@ impl Listener {
         active_clients_store: ActiveClientsStore,
     ) -> JoinHandle<()>
     where
-        St: Storage + 'static,
+        St: Storage + Clone + 'static,
     {
         tokio::spawn(async move {
             self.run(outbound_mix_sender, storage, active_clients_store)

--- a/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
+++ b/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
@@ -32,7 +32,7 @@ pub(crate) struct ConnectionHandler<St: Storage> {
     ack_sender: MixForwardingSender,
 }
 
-impl<St: Storage> Clone for ConnectionHandler<St> {
+impl<St: Storage + Clone> Clone for ConnectionHandler<St> {
     fn clone(&self) -> Self {
         // remove stale entries from the cache while cloning
         let mut clients_store_cache = HashMap::with_capacity(self.clients_store_cache.capacity());

--- a/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
+++ b/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
@@ -19,7 +19,7 @@ use std::net::SocketAddr;
 use tokio::net::TcpStream;
 use tokio_util::codec::Framed;
 
-pub(crate) struct ConnectionHandler<S: Storage> {
+pub(crate) struct ConnectionHandler<St: Storage> {
     packet_processor: PacketProcessor,
 
     // TODO: investigate performance trade-offs for whether this cache even makes sense
@@ -28,12 +28,11 @@ pub(crate) struct ConnectionHandler<S: Storage> {
     // and each `get` internally copies the channel, however, is it really that expensive?
     clients_store_cache: HashMap<DestinationAddressBytes, MixMessageSender>,
     active_clients_store: ActiveClientsStore,
-    //storage: PersistentStorage,
-    storage: S,
+    storage: St,
     ack_sender: MixForwardingSender,
 }
 
-impl<S: Storage> Clone for ConnectionHandler<S> {
+impl<St: Storage> Clone for ConnectionHandler<St> {
     fn clone(&self) -> Self {
         // remove stale entries from the cache while cloning
         let mut clients_store_cache = HashMap::with_capacity(self.clients_store_cache.capacity());
@@ -53,10 +52,10 @@ impl<S: Storage> Clone for ConnectionHandler<S> {
     }
 }
 
-impl<S: Storage> ConnectionHandler<S> {
+impl<St: Storage> ConnectionHandler<St> {
     pub(crate) fn new(
         packet_processor: PacketProcessor,
-        storage: S,
+        storage: St,
         ack_sender: MixForwardingSender,
         active_clients_store: ActiveClientsStore,
     ) -> Self {

--- a/gateway/src/node/mixnet_handling/receiver/listener.rs
+++ b/gateway/src/node/mixnet_handling/receiver/listener.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::node::mixnet_handling::receiver::connection_handler::ConnectionHandler;
+use crate::node::storage::Storage;
 use log::*;
 use std::net::SocketAddr;
 use std::process;
@@ -17,7 +18,10 @@ impl Listener {
         Listener { address }
     }
 
-    pub(crate) async fn run(&mut self, connection_handler: ConnectionHandler) {
+    pub(crate) async fn run<S>(&mut self, connection_handler: ConnectionHandler<S>)
+    where
+        S: Storage + 'static,
+    {
         info!("Starting mixnet listener at {}", self.address);
         let tcp_listener = match tokio::net::TcpListener::bind(self.address).await {
             Ok(listener) => listener,
@@ -38,7 +42,10 @@ impl Listener {
         }
     }
 
-    pub(crate) fn start(mut self, connection_handler: ConnectionHandler) -> JoinHandle<()> {
+    pub(crate) fn start<S>(mut self, connection_handler: ConnectionHandler<S>) -> JoinHandle<()>
+    where
+        S: Storage + 'static,
+    {
         info!("Running mix listener on {:?}", self.address.to_string());
 
         tokio::spawn(async move { self.run(connection_handler).await })

--- a/gateway/src/node/mixnet_handling/receiver/listener.rs
+++ b/gateway/src/node/mixnet_handling/receiver/listener.rs
@@ -18,9 +18,9 @@ impl Listener {
         Listener { address }
     }
 
-    pub(crate) async fn run<S>(&mut self, connection_handler: ConnectionHandler<S>)
+    pub(crate) async fn run<St>(&mut self, connection_handler: ConnectionHandler<St>)
     where
-        S: Storage + 'static,
+        St: Storage + 'static,
     {
         info!("Starting mixnet listener at {}", self.address);
         let tcp_listener = match tokio::net::TcpListener::bind(self.address).await {
@@ -42,9 +42,9 @@ impl Listener {
         }
     }
 
-    pub(crate) fn start<S>(mut self, connection_handler: ConnectionHandler<S>) -> JoinHandle<()>
+    pub(crate) fn start<St>(mut self, connection_handler: ConnectionHandler<St>) -> JoinHandle<()>
     where
-        S: Storage + 'static,
+        St: Storage + 'static,
     {
         info!("Running mix listener on {:?}", self.address.to_string());
 

--- a/gateway/src/node/mixnet_handling/receiver/listener.rs
+++ b/gateway/src/node/mixnet_handling/receiver/listener.rs
@@ -20,7 +20,7 @@ impl Listener {
 
     pub(crate) async fn run<St>(&mut self, connection_handler: ConnectionHandler<St>)
     where
-        St: Storage + 'static,
+        St: Storage + Clone + 'static,
     {
         info!("Starting mixnet listener at {}", self.address);
         let tcp_listener = match tokio::net::TcpListener::bind(self.address).await {
@@ -44,7 +44,7 @@ impl Listener {
 
     pub(crate) fn start<St>(mut self, connection_handler: ConnectionHandler<St>) -> JoinHandle<()>
     where
-        St: Storage + 'static,
+        St: Storage + Clone + 'static,
     {
         info!("Running mix listener on {:?}", self.address.to_string());
 

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -7,7 +7,7 @@ use crate::config::Config;
 use crate::node::client_handling::active_clients::ActiveClientsStore;
 use crate::node::client_handling::websocket;
 use crate::node::mixnet_handling::receiver::connection_handler::ConnectionHandler;
-use crate::node::storage::PersistentStorage;
+use crate::node::storage::Storage;
 use crypto::asymmetric::{encryption, identity};
 use log::*;
 use mixnet_client::forwarder::{MixForwardingSender, PacketForwarder};
@@ -29,19 +29,25 @@ pub(crate) mod client_handling;
 pub(crate) mod mixnet_handling;
 pub(crate) mod storage;
 
-pub struct Gateway {
+pub(crate) struct Gateway<S: Storage> {
     config: Config,
     /// ed25519 keypair used to assert one's identity.
     identity_keypair: Arc<identity::KeyPair>,
     /// x25519 keypair used for Diffie-Hellman. Currently only used for sphinx key derivation.
     sphinx_keypair: Arc<encryption::KeyPair>,
-    storage: PersistentStorage,
+    storage: S,
 }
 
-impl Gateway {
+impl<S> Gateway<S>
+where
+    S: Storage + 'static,
+{
+    /// Construct from the given `Config` instance.
+    // TODO: consider extracting out the storage construction from `Gateway` to uncouple further.
+    // That would probably also mean removing the `init` function from the `Storage` trait.
     pub async fn new(config: Config) -> Self {
-        let storage = Self::initialise_storage(&config).await;
         let pathfinder = GatewayPathfinder::new_from_config(&config);
+        let storage = Self::initialise_storage(&config).await;
 
         Gateway {
             config,
@@ -51,10 +57,25 @@ impl Gateway {
         }
     }
 
-    async fn initialise_storage(config: &Config) -> PersistentStorage {
+    #[cfg(test)]
+    pub async fn new_from_keys_and_storage(
+        config: Config,
+        identity_keypair: identity::KeyPair,
+        sphinx_keypair: encryption::KeyPair,
+        storage: S,
+    ) -> Self {
+        Gateway {
+            config,
+            identity_keypair: Arc::new(identity_keypair),
+            sphinx_keypair: Arc::new(sphinx_keypair),
+            storage,
+        }
+    }
+
+    async fn initialise_storage(config: &Config) -> S {
         let path = config.get_persistent_store_path();
         let retrieval_limit = config.get_message_retrieval_limit();
-        match PersistentStorage::init(path, retrieval_limit).await {
+        match S::init(path, retrieval_limit).await {
             Err(err) => panic!("failed to initialise gateway storage - {}", err),
             Ok(storage) => storage,
         }

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -57,7 +57,7 @@ pub(crate) struct Gateway<St: Storage> {
 
 impl<St> Gateway<St>
 where
-    St: Storage + 'static,
+    St: Storage + Clone + 'static,
 {
     /// Construct from the given `Config` instance.
     pub async fn new(config: Config, storage: St) -> Self {

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -29,18 +29,18 @@ pub(crate) mod client_handling;
 pub(crate) mod mixnet_handling;
 pub(crate) mod storage;
 
-pub(crate) struct Gateway<S: Storage> {
+pub(crate) struct Gateway<St: Storage> {
     config: Config,
     /// ed25519 keypair used to assert one's identity.
     identity_keypair: Arc<identity::KeyPair>,
     /// x25519 keypair used for Diffie-Hellman. Currently only used for sphinx key derivation.
     sphinx_keypair: Arc<encryption::KeyPair>,
-    storage: S,
+    storage: St,
 }
 
-impl<S> Gateway<S>
+impl<St> Gateway<St>
 where
-    S: Storage + 'static,
+    St: Storage + 'static,
 {
     /// Construct from the given `Config` instance.
     // TODO: consider extracting out the storage construction from `Gateway` to uncouple further.
@@ -62,7 +62,7 @@ where
         config: Config,
         identity_keypair: identity::KeyPair,
         sphinx_keypair: encryption::KeyPair,
-        storage: S,
+        storage: St,
     ) -> Self {
         Gateway {
             config,
@@ -72,10 +72,10 @@ where
         }
     }
 
-    async fn initialise_storage(config: &Config) -> S {
+    async fn initialise_storage(config: &Config) -> St {
         let path = config.get_persistent_store_path();
         let retrieval_limit = config.get_message_retrieval_limit();
-        match S::init(path, retrieval_limit).await {
+        match St::init(path, retrieval_limit).await {
             Err(err) => panic!("failed to initialise gateway storage - {}", err),
             Ok(storage) => storage,
         }

--- a/gateway/src/node/storage/mod.rs
+++ b/gateway/src/node/storage/mod.rs
@@ -20,7 +20,7 @@ mod models;
 mod shared_keys;
 
 #[async_trait]
-pub(crate) trait Storage: Clone + Send + Sync {
+pub(crate) trait Storage: Send + Sync {
     /// Inserts provided derived shared keys into the database.
     /// If keys previously existed for the provided client, they are overwritten with the new data.
     ///


### PR DESCRIPTION
Move gateway `PersistentStorage` behind a trait to make it easier to swap in alternative in-memory storage backends in tests