### PR TITLE
wallet: config backend for validator selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,7 @@ version = "0.1.0"
 dependencies = [
  "handlebars",
  "humantime-serde",
+ "log",
  "network-defaults",
  "serde",
  "toml",

--- a/common/client-libs/validator-client/src/connection_tester.rs
+++ b/common/client-libs/validator-client/src/connection_tester.rs
@@ -93,7 +93,11 @@ async fn test_nymd_connection(
     {
         Ok(Err(NymdError::TendermintError(e))) => {
             // If we get a tendermint-rpc error, we classify the node as not contactable
-            log::debug!("Checking: nymd_url: {network}: {url}: failed: {}", e);
+            log::debug!(
+                "Checking: nymd_url: {network}: {url}: {}: {}",
+                "failed".red(),
+                e
+            );
             false
         }
         Ok(Err(NymdError::AbciError(code, log))) => {

--- a/common/config/Cargo.toml
+++ b/common/config/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 handlebars = "3.0.1"
 humantime-serde = "1.0"
+log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5.6"
 url = "2.2"

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -13,6 +13,7 @@ pub trait NymConfig: Default + Serialize + DeserializeOwned {
     fn template() -> &'static str;
 
     fn config_file_name() -> String {
+        log::trace!("NymdConfig::config_file_name");
         "config.toml".to_string()
     }
 
@@ -20,6 +21,7 @@ pub trait NymConfig: Default + Serialize + DeserializeOwned {
 
     // default, most probable, implementations; can be easily overridden where required
     fn default_config_directory(id: Option<&str>) -> PathBuf {
+        log::trace!("NymdConfig::default_config_directory");
         if let Some(id) = id {
             Self::default_root_directory().join(id).join("config")
         } else {
@@ -28,6 +30,7 @@ pub trait NymConfig: Default + Serialize + DeserializeOwned {
     }
 
     fn default_data_directory(id: Option<&str>) -> PathBuf {
+        log::trace!("NymdConfig::default_data_path");
         if let Some(id) = id {
             Self::default_root_directory().join(id).join("data")
         } else {
@@ -36,6 +39,7 @@ pub trait NymConfig: Default + Serialize + DeserializeOwned {
     }
 
     fn default_config_file_path(id: Option<&str>) -> PathBuf {
+        log::trace!("NymdConfig::default_config_file_path");
         Self::default_config_directory(id).join(Self::config_file_name())
     }
 
@@ -68,7 +72,9 @@ pub trait NymConfig: Default + Serialize + DeserializeOwned {
     }
 
     fn load_from_file(id: Option<&str>) -> io::Result<Self> {
-        let config_contents = fs::read_to_string(Self::default_config_file_path(id))?;
+        let file = Self::default_config_file_path(id);
+        log::trace!("Loading from file: {:#?}", file);
+        let config_contents = fs::read_to_string(file)?;
 
         toml::from_str(&config_contents)
             .map_err(|toml_err| io::Error::new(io::ErrorKind::Other, toml_err))

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -219,6 +219,7 @@ version = "0.1.0"
 dependencies = [
  "handlebars",
  "humantime-serde",
+ "log",
  "network-defaults",
  "serde",
  "toml",

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -568,6 +568,7 @@ version = "0.1.0"
 dependencies = [
  "handlebars",
  "humantime-serde",
+ "log",
  "network-defaults",
  "serde",
  "toml",

--- a/nym-wallet/src-tauri/src/network.rs
+++ b/nym-wallet/src-tauri/src/network.rs
@@ -21,6 +21,10 @@ pub enum Network {
 }
 
 impl Network {
+  pub fn as_key(&self) -> String {
+    self.to_string().to_lowercase()
+  }
+
   pub fn denom(&self) -> Denom {
     match self {
       // network defaults should be correctly formatted

--- a/nym-wallet/src-tauri/src/platform_constants.rs
+++ b/nym-wallet/src-tauri/src/platform_constants.rs
@@ -6,16 +6,24 @@
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "linux")] {
+        pub const CONFIG_DIR_NAME: &str = "nym-wallet";
+        pub const CONFIG_FILENAME: &str = "config.toml";
         pub const STORAGE_DIR_NAME: &str = "nym-wallet";
         pub const WALLET_INFO_FILENAME: &str = "saved-wallet.json";
     } else if #[cfg(taret_os = "macos")] {
+        pub const CONFIG_DIR_NAME: &str = "nym-wallet";
+        pub const CONFIG_FILENAME: &str = "config.toml";
         pub const STORAGE_DIR_NAME: &str = "nym-wallet";
         pub const WALLET_INFO_FILENAME: &str = "saved-wallet.json";
     } else if #[cfg(taret_os = "windows")] {
+        pub const CONFIG_DIR_NAME: &str = "NymWallet";
+        pub const CONFIG_FILENAME: &str = "Config.toml";
         pub const STORAGE_DIR_NAME: &str = "NymWallet";
         pub const WALLET_INFO_FILENAME: &str = "saved_wallet.json";
     } else {
         // This case is likely to be a unix-y system
+        pub const CONFIG_DIR_NAME: &str = "nym-wallet";
+        pub const CONFIG_FILENAME: &str = "config.toml";
         pub const STORAGE_DIR_NAME: &str = "nym-wallet";
         pub const WALLET_INFO_FILENAME: &str = "saved-wallet.json";
     }

--- a/nym-wallet/src-tauri/src/state.rs
+++ b/nym-wallet/src-tauri/src/state.rs
@@ -1,16 +1,25 @@
-use crate::config::Config;
+use crate::config::{Config, OptionalValidators, ValidatorUrl};
 use crate::error::BackendError;
 use crate::network::Network;
+
+use strum::IntoEnumIterator;
 use validator_client::nymd::SigningNymdClient;
 use validator_client::Client;
 
+use itertools::Itertools;
+use url::Url;
+
 use std::collections::HashMap;
+use std::time::Duration;
 
 #[derive(Default)]
 pub struct State {
   config: Config,
   signing_clients: HashMap<Network, Client<SigningNymdClient>>,
   current_network: Network,
+
+  /// Validators that have been fetched dynamically, probably during startup.
+  fetched_validators: OptionalValidators,
 }
 
 impl State {
@@ -28,8 +37,18 @@ impl State {
       .ok_or(BackendError::ClientNotInitialized)
   }
 
-  pub fn config(&self) -> Config {
-    self.config.clone()
+  pub fn config(&self) -> &Config {
+    &self.config
+  }
+
+  /// Load configuration from files. If unsuccessful we just log it and move on.
+  pub fn load_config_files(&mut self) {
+    self.config = Config::load_from_files();
+  }
+
+  #[allow(unused)]
+  pub fn save_config_files(&self) -> Result<(), BackendError> {
+    Ok(self.config.save_to_files()?)
   }
 
   pub fn add_client(&mut self, network: Network, client: Client<SigningNymdClient>) {
@@ -48,8 +67,91 @@ impl State {
     self.signing_clients = HashMap::new();
   }
 
+  /// Get the available validators in the order
+  /// 1. from the configuration file
+  /// 2. provided remotely
+  /// 3. hardcoded fallback
+  pub fn get_validators(&self, network: Network) -> impl Iterator<Item = ValidatorUrl> + '_ {
+    let validators_in_config = self.config.get_configured_validators(network);
+    let fetched_validators = self.fetched_validators.validators(network).cloned();
+    let default_validators = self.config.get_base_validators(network);
+
+    validators_in_config
+      .chain(fetched_validators)
+      .chain(default_validators)
+      .unique()
+  }
+
+  pub fn get_nymd_urls(&self, network: Network) -> impl Iterator<Item = Url> + '_ {
+    self.get_validators(network).into_iter().map(|v| v.nymd_url)
+  }
+
+  pub fn get_api_urls(&self, network: Network) -> impl Iterator<Item = Url> + '_ {
+    self
+      .get_validators(network)
+      .into_iter()
+      .filter_map(|v| v.api_url)
+  }
+
+  pub fn get_all_nymd_urls(&self) -> HashMap<Network, Vec<Url>> {
+    Network::iter()
+      .flat_map(|network| self.get_nymd_urls(network).map(move |url| (network, url)))
+      .into_group_map()
+  }
+
+  pub fn get_all_api_urls(&self) -> HashMap<Network, Vec<Url>> {
+    Network::iter()
+      .flat_map(|network| self.get_api_urls(network).map(move |url| (network, url)))
+      .into_group_map()
+  }
+
+  /// Fetch validator urls remotely. These are used to in addition to the base ones, and the user
+  /// configured ones.
   pub async fn fetch_updated_validator_urls(&mut self) -> Result<(), BackendError> {
-    self.config.fetch_updated_validator_urls().await
+    let client = reqwest::Client::builder()
+      .timeout(Duration::from_secs(3))
+      .build()?;
+    log::debug!(
+      "Fetching validator urls from: {}",
+      crate::config::REMOTE_SOURCE_OF_VALIDATOR_URLS
+    );
+    let response = client
+      .get(crate::config::REMOTE_SOURCE_OF_VALIDATOR_URLS.to_string())
+      .send()
+      .await?;
+    self.fetched_validators = serde_json::from_str(&response.text().await?)?;
+    log::debug!("Received validator urls: \n{}", self.fetched_validators);
+    Ok(())
+  }
+
+  #[allow(unused)]
+  pub fn select_validator_nymd_url(
+    &mut self,
+    url: &str,
+    network: Network,
+  ) -> Result<(), BackendError> {
+    self.config.select_validator_nymd_url(url.parse()?, network);
+    Ok(())
+  }
+
+  #[allow(unused)]
+  pub fn select_validator_api_url(
+    &mut self,
+    url: &str,
+    network: Network,
+  ) -> Result<(), BackendError> {
+    self.config.select_validator_api_url(url.parse()?, network);
+    Ok(())
+  }
+
+  #[allow(unused)]
+  pub fn add_validator_url(&mut self, url: ValidatorUrl, network: Network) {
+    self.config.add_validator_url(url, network);
+  }
+
+  #[allow(unused)]
+  pub fn remove_validator_url(&mut self, url: ValidatorUrl, network: Network) {
+    self.config.remove_validator_url(url, network)
   }
 }
 
@@ -72,4 +174,69 @@ macro_rules! api_client {
   ($state:ident) => {
     $state.read().await.current_client()?.validator_api
   };
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn adding_validators_urls_prepends() {
+    let mut state = State::default();
+    let _api_urls = state.get_api_urls(Network::MAINNET).collect::<Vec<_>>();
+
+    state.add_validator_url(
+      ValidatorUrl {
+        nymd_url: "http://nymd_url.com".parse().unwrap(),
+        api_url: Some("http://nymd_url.com/api".parse().unwrap()),
+      },
+      Network::MAINNET,
+    );
+
+    state.add_validator_url(
+      ValidatorUrl {
+        nymd_url: "http://foo.com".parse().unwrap(),
+        api_url: None,
+      },
+      Network::MAINNET,
+    );
+
+    state.add_validator_url(
+      ValidatorUrl {
+        nymd_url: "http://bar.com".parse().unwrap(),
+        api_url: None,
+      },
+      Network::MAINNET,
+    );
+
+    assert_eq!(
+      state.get_nymd_urls(Network::MAINNET).collect::<Vec<_>>(),
+      vec![
+        "http://nymd_url.com/".parse().unwrap(),
+        "http://foo.com".parse().unwrap(),
+        "http://bar.com".parse().unwrap(),
+        "https://rpc.nyx.nodes.guru".parse().unwrap(),
+      ],
+    );
+    assert_eq!(
+      state.get_api_urls(Network::MAINNET).collect::<Vec<_>>(),
+      vec![
+        "http://nymd_url.com/api".parse().unwrap(),
+        "https://api.nyx.nodes.guru".parse().unwrap(),
+      ],
+    );
+    assert_eq!(
+      state
+        .get_all_nymd_urls()
+        .get(&Network::MAINNET)
+        .unwrap()
+        .clone(),
+      vec![
+        "http://nymd_url.com/".parse().unwrap(),
+        "http://foo.com".parse().unwrap(),
+        "http://bar.com".parse().unwrap(),
+        "https://rpc.nyx.nodes.guru".parse().unwrap(),
+      ],
+    )
+  }
 }


### PR DESCRIPTION
Wallet backend support for selecting nymd and validator-api urls, as well as adding additional validator urls.
There is a one global config file, and one config file per network.

Part of: https://github.com/nymtech/nym/issues/2489