### PR TITLE
Running CI tests with debug assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ overflow-checks = true
 panic = "abort"
 
 [profile.test]
-opt-level = 2
+# equivalent of running in `--release` (but since we're in test profile we're keeping overflow checks and all of those by default)
+opt-level = 3
 
 [workspace]
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clippy-all-wallet:
 	cargo clippy --workspace --manifest-path nym-wallet/Cargo.toml --all-features -- -D warnings
 
 test-main:
-	cargo test --all-features --workspace --release
+	cargo test --all-features --workspace
 
 test-contracts:
 	cargo test --manifest-path contracts/Cargo.toml --all-features


### PR DESCRIPTION
# Description

Our `test-main` directive was using `cargo test` in `--release` mode and thus was optimising away `debug-assertions ` (and other things like `overflow-checks`) . This change instead makes it run under normal `test` profile, but `test` profile has been adjusted to run with `opt-level` 3 ( so same as if it was in `release` mode)

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
