### PR TITLE
Added network information to --version (or --help) command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
 - validator-api: add Swagger to document the REST API ([#1249]).
+- all: added network compilation target to `--help` (or `--version`) commands ([#1256]).
 
 [#1249]: https://github.com/nymtech/nym/pull/1249
+[#1256]: https://github.com/nymtech/nym/pull/1256
 
 ## [nym-wallet-v1.0.4](https://github.com/nymtech/nym/tree/nym-wallet-v1.0.4) (2022-05-04)
 

--- a/clients/native/src/main.rs
+++ b/clients/native/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{crate_version, App, ArgMatches};
+use network_defaults::DEFAULT_NETWORK;
 
 pub mod client;
 pub mod commands;
@@ -67,6 +68,7 @@ fn long_version() -> String {
 {:<20}{}
 {:<20}{}
 {:<20}{}
+{:<20}{}
 "#,
         "Build Timestamp:",
         env!("VERGEN_BUILD_TIMESTAMP"),
@@ -84,6 +86,8 @@ fn long_version() -> String {
         env!("VERGEN_RUSTC_CHANNEL"),
         "cargo Profile:",
         env!("VERGEN_CARGO_PROFILE"),
+        "Network:",
+        DEFAULT_NETWORK
     )
 }
 

--- a/clients/socks5/src/main.rs
+++ b/clients/socks5/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{crate_version, App, ArgMatches};
+use network_defaults::DEFAULT_NETWORK;
 
 pub mod client;
 mod commands;
@@ -67,6 +68,7 @@ fn long_version() -> String {
 {:<20}{}
 {:<20}{}
 {:<20}{}
+{:<20}{}
 "#,
         "Build Timestamp:",
         env!("VERGEN_BUILD_TIMESTAMP"),
@@ -84,6 +86,8 @@ fn long_version() -> String {
         env!("VERGEN_RUSTC_CHANNEL"),
         "cargo Profile:",
         env!("VERGEN_CARGO_PROFILE"),
+        "Network:",
+        DEFAULT_NETWORK
     )
 }
 

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{crate_version, Parser};
+use network_defaults::DEFAULT_NETWORK;
 use once_cell::sync::OnceCell;
 
 mod commands;
@@ -63,6 +64,7 @@ fn long_version() -> String {
 {:<20}{}
 {:<20}{}
 {:<20}{}
+{:<20}{}
 "#,
         "Build Timestamp:",
         env!("VERGEN_BUILD_TIMESTAMP"),
@@ -80,6 +82,8 @@ fn long_version() -> String {
         env!("VERGEN_RUSTC_CHANNEL"),
         "cargo Profile:",
         env!("VERGEN_CARGO_PROFILE"),
+        "Network:",
+        DEFAULT_NETWORK
     )
 }
 

--- a/mixnode/src/main.rs
+++ b/mixnode/src/main.rs
@@ -4,6 +4,7 @@ extern crate rocket;
 // Copyright 2020 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use ::config::defaults::DEFAULT_NETWORK;
 use clap::{crate_version, Parser};
 use lazy_static::lazy_static;
 
@@ -65,6 +66,7 @@ fn long_version() -> String {
 {:<20}{}
 {:<20}{}
 {:<20}{}
+{:<20}{}
 "#,
         "Build Timestamp:",
         env!("VERGEN_BUILD_TIMESTAMP"),
@@ -82,6 +84,8 @@ fn long_version() -> String {
         env!("VERGEN_RUSTC_CHANNEL"),
         "cargo Profile:",
         env!("VERGEN_CARGO_PROFILE"),
+        "Network:",
+        DEFAULT_NETWORK
     )
 }
 

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -10,6 +10,7 @@ use crate::network_monitor::NetworkMonitorBuilder;
 use crate::node_status_api::uptime_updater::HistoricalUptimeUpdater;
 use crate::nymd_client::Client;
 use crate::storage::ValidatorApiStorage;
+use ::config::defaults::DEFAULT_NETWORK;
 use ::config::NymConfig;
 use anyhow::Result;
 use clap::{crate_version, App, Arg, ArgMatches};
@@ -94,6 +95,7 @@ fn long_version() -> String {
 {:<20}{}
 {:<20}{}
 {:<20}{}
+{:<20}{}
 "#,
         "Build Timestamp:",
         env!("VERGEN_BUILD_TIMESTAMP"),
@@ -111,6 +113,8 @@ fn long_version() -> String {
         env!("VERGEN_RUSTC_CHANNEL"),
         "cargo Profile:",
         env!("VERGEN_CARGO_PROFILE"),
+        "Network:",
+        DEFAULT_NETWORK
     )
 }
 


### PR DESCRIPTION
# Description

When running `--help` (or `--version` in case of validator-api), it will now also display the network target against which the binary has been compiled, for example:
```
Build Timestamp:    2022-05-06T09:33:43.367153727+00:00
Build Version:      1.0.1
Commit SHA:         4b95e71adbd426fb6953505a0a8738413e0fea1f
Commit Date:        2022-05-06T08:39:30+00:00
Commit Branch:      feature/network-info-in-version
rustc Version:      1.59.0
rustc Channel:      stable
cargo Profile:      debug
Network:            Mainnet
```

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
