### PR TITLE
Removed an 'expect' in mixnet contract query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@
 - validator-api: add Swagger to document the REST API ([#1249]).
 - all: added network compilation target to `--help` (or `--version`) commands ([#1256]).
 
+### Fixed
+
+- mixnet-contract: removed `expect` in `query_delegator_reward` and queries containing invalid proxy address should now return a more human-readable error ([#1257])
+
 [#1249]: https://github.com/nymtech/nym/pull/1249
 [#1256]: https://github.com/nymtech/nym/pull/1256
+[#1257]: https://github.com/nymtech/nym/pull/1257
 
 ## [nym-wallet-v1.0.4](https://github.com/nymtech/nym/tree/nym-wallet-v1.0.4) (2022-05-04)
 

--- a/contracts/mixnet/src/rewards/queries.rs
+++ b/contracts/mixnet/src/rewards/queries.rs
@@ -48,12 +48,15 @@ pub fn query_delegator_reward(
     mix_identity: IdentityKey,
     proxy: Option<String>,
 ) -> Result<Uint128, ContractError> {
-    let proxy = proxy.map(|p| {
-        deps.api
-            .addr_validate(&p)
-            .map_err(|_| ContractError::InvalidAddress(p))
-            .expect("proxy address is invalid")
-    });
+    let proxy = match proxy {
+        Some(proxy) => Some(
+            deps.api
+                .addr_validate(&proxy)
+                .map_err(|_| ContractError::InvalidAddress(proxy))?,
+        ),
+        None => None,
+    };
+
     let key = mixnet_contract_common::delegation::generate_storage_key(
         &deps.api.addr_validate(&owner)?,
         proxy.as_ref(),


### PR DESCRIPTION
# Description

`query_delegator_reward` was unwrapping  (well, technically via `expect`) an error if provided proxy address was invalid thus  rather than returning user-readable error, the contract would have returned `unreachable` due to the panic

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
