### PR TITLE
Use saturating_sub for extra safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@
 
 ### Added
 
+- mixnet-contract: Replace all naked `-` with `saturating_sub`.
 - validator-api: add Swagger to document the REST API ([#1249]).
 - all: added network compilation target to `--help` (or `--version`) commands ([#1256]).
 
 ### Fixed
 
 - mixnet-contract: removed `expect` in `query_delegator_reward` and queries containing invalid proxy address should now return a more human-readable error ([#1257])
+- mixnet-contract: Under certain circumstances nodes could not be unbonded ([#1255](https://github.com/nymtech/nym/issues/1255)) ([#1258])
 
+[#1258]: https://github.com/nymtech/nym/pull/1258
 [#1249]: https://github.com/nymtech/nym/pull/1249
 [#1256]: https://github.com/nymtech/nym/pull/1256
 [#1257]: https://github.com/nymtech/nym/pull/1257

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/reward_params.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/reward_params.rs
@@ -47,11 +47,8 @@ impl NodeEpochRewards {
 
     pub fn node_profit(&self) -> U128 {
         let reward = U128::from_num(self.reward().u128());
-        if reward < self.operator_cost() {
-            U128::from_num(0u128)
-        } else {
-            reward - self.operator_cost()
-        }
+        // if operating cost is higher then the reward node profit is 0
+        reward.saturating_sub(self.operator_cost())
     }
 
     pub fn operator_reward(&self, profit_margin: U128) -> Result<Uint128, MixnetContractError> {

--- a/contracts/mixnet/src/rewards/storage.rs
+++ b/contracts/mixnet/src/rewards/storage.rs
@@ -60,5 +60,5 @@ pub fn decr_reward_pool(
 
 pub fn circulating_supply(storage: &dyn Storage) -> StdResult<Uint128> {
     let reward_pool = REWARD_POOL.load(storage)?;
-    Ok(Uint128::new(TOTAL_SUPPLY) - reward_pool)
+    Ok(Uint128::new(TOTAL_SUPPLY).saturating_sub(reward_pool))
 }

--- a/contracts/mixnet/src/rewards/transactions.rs
+++ b/contracts/mixnet/src/rewards/transactions.rs
@@ -255,7 +255,7 @@ pub fn _try_compound_delegator_reward(
 
     {
         if let Some(mut bond) = mixnodes().may_load(deps.storage, mix_identity)? {
-            bond.accumulated_rewards = Some(bond.accumulated_rewards() - reward);
+            bond.accumulated_rewards = Some(bond.accumulated_rewards().saturating_sub(reward));
             mixnodes().save(deps.storage, mix_identity, &bond, block_height)?;
         }
     }

--- a/contracts/mixnet/src/rewards/transactions.rs
+++ b/contracts/mixnet/src/rewards/transactions.rs
@@ -81,7 +81,8 @@ pub fn _try_compound_operator_reward(
 
     let mut updated_bond = bond.clone();
     let reward = calculate_operator_reward(storage, api, owner, &bond)?;
-    updated_bond.accumulated_rewards = Some(updated_bond.accumulated_rewards() - reward);
+    updated_bond.accumulated_rewards =
+        Some(updated_bond.accumulated_rewards().saturating_sub(reward));
     updated_bond.pledge_amount.amount += reward;
     mixnodes().replace(
         storage,


### PR DESCRIPTION
# Description

Might fix #1255

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
