### PR TITLE
Fixed overflow in determining reconnection backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@
 
 - mixnet-contract: removed `expect` in `query_delegator_reward` and queries containing invalid proxy address should now return a more human-readable error ([#1257])
 - mixnet-contract: Under certain circumstances nodes could not be unbonded ([#1255](https://github.com/nymtech/nym/issues/1255)) ([#1258])
+- mixnode, gateway: attempting to determine reconnection backoff to persistently failing mixnode could result in a crash ([#1260])
 
 [#1258]: https://github.com/nymtech/nym/pull/1258
 [#1249]: https://github.com/nymtech/nym/pull/1249
 [#1256]: https://github.com/nymtech/nym/pull/1256
 [#1257]: https://github.com/nymtech/nym/pull/1257
+[#1260]: https://github.com/nymtech/nym/pull/1260
 
 ## [nym-wallet-v1.0.4](https://github.com/nymtech/nym/tree/nym-wallet-v1.0.4) (2022-05-04)
 


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1123

Even though we were performing `checked_mul` to ensure we couldn't overflow by attempting to determine backoff for reconnecting to a dead mixnode, we didn't do the exponentiation. This PR fixes it.

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
