### PR TITLE
Replace checked with saturating sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- vesting-contract: replaced `checked_sub` with `saturating_sub` to fix the underflow in `get_vesting_tokens` ([#1275])
 - mixnet-contract: removed `expect` in `query_delegator_reward` and queries containing invalid proxy address should now return a more human-readable error ([#1257])
 - mixnet-contract: Under certain circumstances nodes could not be unbonded ([#1255](https://github.com/nymtech/nym/issues/1255)) ([#1258])
 - mixnode, gateway: attempting to determine reconnection backoff to persistently failing mixnode could result in a crash ([#1260])
@@ -24,6 +25,7 @@
 [#1260]: https://github.com/nymtech/nym/pull/1260
 [#1265]: https://github.com/nymtech/nym/pull/1265
 [#1267]: https://github.com/nymtech/nym/pull/1267
+[#1275]: https://github.com/nymtech/nym/pull/1275
 
 ## [nym-wallet-v1.0.4](https://github.com/nymtech/nym/tree/nym-wallet-v1.0.4) (2022-05-04)
 

--- a/contracts/vesting/src/vesting/account/vesting_account.rs
+++ b/contracts/vesting/src/vesting/account/vesting_account.rs
@@ -14,24 +14,22 @@ impl VestingAccount for Account {
         env: &Env,
         storage: &dyn Storage,
     ) -> Result<Coin, ContractError> {
-        // Returns 0 in case of underflow.
+        // Returns 0 in case of underflow. Which is fine, as the amount of pledged and delegated tokens can be larger then vesting_coins due to rewards and vesting periods expiring
         Ok(Coin {
             amount: Uint128::new(
                 self.get_vesting_coins(block_time, env)?
                     .amount
                     .u128()
-                    .checked_sub(
+                    .saturating_sub(
                         self.get_delegated_vesting(block_time, env, storage)?
                             .amount
                             .u128(),
                     )
-                    .ok_or(ContractError::Underflow)?
-                    .checked_sub(
+                    .saturating_sub(
                         self.get_pledged_vesting(block_time, env, storage)?
                             .amount
                             .u128(),
-                    )
-                    .ok_or(ContractError::Underflow)?,
+                    ),
             ),
             denom: DENOM.to_string(),
         })


### PR DESCRIPTION
# Description

Fixes underflow when there are more tokens delegated/pledge then there are tokens vesting

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
