### PR TITLE
wallet: check against importing same mnemonic twice

### DIFF
--- a/nym-wallet/src-tauri/src/error.rs
+++ b/nym-wallet/src-tauri/src/error.rs
@@ -91,6 +91,8 @@ pub enum BackendError {
   WalletLoginIdAlreadyExists,
   #[error("Account ID already found in wallet login")]
   WalletAccountIdAlreadyExistsInWalletLogin,
+  #[error("Mnemonic already found in wallet login, was it already imported?")]
+  WalletMnemonicAlreadyExistsInWalletLogin,
   #[error("Adding a different password to the wallet not currently supported")]
   WalletDifferentPasswordDetected,
   #[error("Unexpted mnemonic account for login")]

--- a/nym-wallet/src-tauri/src/wallet_storage/account_data.rs
+++ b/nym-wallet/src-tauri/src/wallet_storage/account_data.rs
@@ -204,6 +204,15 @@ impl MultipleAccounts {
     self.accounts.iter().find(|account| &account.id == id)
   }
 
+  pub(crate) fn get_account_with_mnemonic(
+    &self,
+    mnemonic: &bip39::Mnemonic,
+  ) -> Option<&WalletAccount> {
+    self
+      .get_accounts()
+      .find(|account| account.mnemonic() == mnemonic)
+  }
+
   pub(crate) fn into_accounts(self) -> impl Iterator<Item = WalletAccount> {
     self.accounts.into_iter()
   }
@@ -225,6 +234,8 @@ impl MultipleAccounts {
   ) -> Result<(), BackendError> {
     if self.get_account(&id).is_some() {
       Err(BackendError::WalletAccountIdAlreadyExistsInWalletLogin)
+    } else if self.get_account_with_mnemonic(&mnemonic).is_some() {
+      Err(BackendError::WalletMnemonicAlreadyExistsInWalletLogin)
     } else {
       self.accounts.push(WalletAccount::new(
         id,

--- a/nym-wallet/src-tauri/src/wallet_storage/mod.rs
+++ b/nym-wallet/src-tauri/src/wallet_storage/mod.rs
@@ -1069,6 +1069,31 @@ mod tests {
   }
 
   #[test]
+  fn append_the_same_mnemonic_twice_fails() {
+    let store_dir = tempdir().unwrap();
+    let wallet_file = store_dir.path().join(WALLET_INFO_FILENAME);
+    let account1 = bip39::Mnemonic::generate(24).unwrap();
+    let hd_path: DerivationPath = COSMOS_DERIVATION_PATH.parse().unwrap();
+    let password = UserPassword::new("password".to_string());
+    let id1 = LoginId::new("first".to_string());
+    let id2 = AccountId::new("second".to_string());
+
+    store_login_with_multiple_accounts_at_file(
+      &wallet_file,
+      account1.clone(),
+      hd_path.clone(),
+      id1.clone(),
+      &password,
+    )
+    .unwrap();
+
+    assert!(matches!(
+      append_account_to_login_at_file(&wallet_file, account1, hd_path, id1, id2, &password,),
+      Err(BackendError::WalletMnemonicAlreadyExistsInWalletLogin),
+    ))
+  }
+
+  #[test]
   fn delete_the_same_account_twice_for_a_login_fails() {
     let store_dir = tempdir().unwrap();
     let wallet = store_dir.path().join(WALLET_INFO_FILENAME);


### PR DESCRIPTION
Add a check in the wallet against importing the same mnemonic twice under the same encrypted login.
