### PR TITLE
validator-api: add detailed mixnode bond endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- validator-api: add detailed mixnode bond endpoints, and explorer-api makes use of that data to append stake saturation.
 - wallet: require password to switch accounts
 - wallet: add simple CLI tool for decrypting and recovering the wallet file.
 - wallet: added support for multiple accounts ([#1265])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3213,6 +3213,7 @@ dependencies = [
  "coconut-interface",
  "config",
  "console-subscriber",
+ "cosmwasm-std",
  "credential-storage",
  "credentials",
  "crypto",

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -9,7 +9,7 @@ use url::Url;
 #[cfg(feature = "nymd-client")]
 use validator_api_requests::models::UptimeResponse;
 use validator_api_requests::models::{
-    CoreNodeStatusResponse, MixnodeStatusResponse, RewardEstimationResponse,
+    CoreNodeStatusResponse, MixNodeBondDetailed, MixnodeStatusResponse, RewardEstimationResponse,
     StakeSaturationResponse,
 };
 
@@ -233,10 +233,22 @@ impl<C> Client<C> {
         Ok(self.validator_api.get_mixnodes().await?)
     }
 
+    pub async fn get_cached_mixnodes_detailed(
+        &self,
+    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorClientError> {
+        Ok(self.validator_api.get_mixnodes_detailed().await?)
+    }
+
     pub async fn get_cached_rewarded_mixnodes(
         &self,
     ) -> Result<Vec<MixNodeBond>, ValidatorClientError> {
         Ok(self.validator_api.get_rewarded_mixnodes().await?)
+    }
+
+    pub async fn get_cached_rewarded_mixnodes_detailed(
+        &self,
+    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorClientError> {
+        Ok(self.validator_api.get_rewarded_mixnodes_detailed().await?)
     }
 
     pub async fn get_cached_active_mixnodes(
@@ -244,6 +256,13 @@ impl<C> Client<C> {
     ) -> Result<Vec<MixNodeBond>, ValidatorClientError> {
         Ok(self.validator_api.get_active_mixnodes().await?)
     }
+
+    pub async fn get_cached_active_mixnodes_detailed(
+        &self,
+    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorClientError> {
+        Ok(self.validator_api.get_active_mixnodes_detailed().await?)
+    }
+
 
     pub async fn get_cached_gateways(&self) -> Result<Vec<GatewayBond>, ValidatorClientError> {
         Ok(self.validator_api.get_gateways().await?)

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -263,7 +263,6 @@ impl<C> Client<C> {
         Ok(self.validator_api.get_active_mixnodes_detailed().await?)
     }
 
-
     pub async fn get_cached_gateways(&self) -> Result<Vec<GatewayBond>, ValidatorClientError> {
         Ok(self.validator_api.get_gateways().await?)
     }

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -9,7 +9,7 @@ use url::Url;
 #[cfg(feature = "nymd-client")]
 use validator_api_requests::models::UptimeResponse;
 use validator_api_requests::models::{
-    CoreNodeStatusResponse, MixNodeBondResponse, MixnodeStatusResponse, RewardEstimationResponse,
+    CoreNodeStatusResponse, MixNodeBondAnnotated, MixnodeStatusResponse, RewardEstimationResponse,
     StakeSaturationResponse,
 };
 
@@ -235,7 +235,7 @@ impl<C> Client<C> {
 
     pub async fn get_cached_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondResponse>, ValidatorClientError> {
+    ) -> Result<Vec<MixNodeBondAnnotated>, ValidatorClientError> {
         Ok(self.validator_api.get_mixnodes_detailed().await?)
     }
 
@@ -247,7 +247,7 @@ impl<C> Client<C> {
 
     pub async fn get_cached_rewarded_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondResponse>, ValidatorClientError> {
+    ) -> Result<Vec<MixNodeBondAnnotated>, ValidatorClientError> {
         Ok(self.validator_api.get_rewarded_mixnodes_detailed().await?)
     }
 
@@ -259,7 +259,7 @@ impl<C> Client<C> {
 
     pub async fn get_cached_active_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondResponse>, ValidatorClientError> {
+    ) -> Result<Vec<MixNodeBondAnnotated>, ValidatorClientError> {
         Ok(self.validator_api.get_active_mixnodes_detailed().await?)
     }
 

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -6,12 +6,12 @@ use coconut_interface::{BlindSignRequestBody, BlindedSignatureResponse, Verifica
 use mixnet_contract_common::{GatewayBond, IdentityKeyRef, MixNodeBond};
 use url::Url;
 
-#[cfg(feature = "nymd-client")]
-use validator_api_requests::models::UptimeResponse;
 use validator_api_requests::models::{
-    CoreNodeStatusResponse, MixNodeBondAnnotated, MixnodeStatusResponse, RewardEstimationResponse,
+    CoreNodeStatusResponse, MixnodeStatusResponse, RewardEstimationResponse,
     StakeSaturationResponse,
 };
+#[cfg(feature = "nymd-client")]
+use validator_api_requests::models::{MixNodeBondAnnotated, UptimeResponse};
 
 #[cfg(feature = "nymd-client")]
 use network_defaults::DEFAULT_NETWORK;

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -9,7 +9,7 @@ use url::Url;
 #[cfg(feature = "nymd-client")]
 use validator_api_requests::models::UptimeResponse;
 use validator_api_requests::models::{
-    CoreNodeStatusResponse, MixNodeBondDetailed, MixnodeStatusResponse, RewardEstimationResponse,
+    CoreNodeStatusResponse, MixNodeBondResponse, MixnodeStatusResponse, RewardEstimationResponse,
     StakeSaturationResponse,
 };
 
@@ -235,7 +235,7 @@ impl<C> Client<C> {
 
     pub async fn get_cached_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorClientError> {
+    ) -> Result<Vec<MixNodeBondResponse>, ValidatorClientError> {
         Ok(self.validator_api.get_mixnodes_detailed().await?)
     }
 
@@ -247,7 +247,7 @@ impl<C> Client<C> {
 
     pub async fn get_cached_rewarded_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorClientError> {
+    ) -> Result<Vec<MixNodeBondResponse>, ValidatorClientError> {
         Ok(self.validator_api.get_rewarded_mixnodes_detailed().await?)
     }
 
@@ -259,7 +259,7 @@ impl<C> Client<C> {
 
     pub async fn get_cached_active_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorClientError> {
+    ) -> Result<Vec<MixNodeBondResponse>, ValidatorClientError> {
         Ok(self.validator_api.get_active_mixnodes_detailed().await?)
     }
 

--- a/common/client-libs/validator-client/src/validator_api/mod.rs
+++ b/common/client-libs/validator-client/src/validator_api/mod.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use url::Url;
 use validator_api_requests::models::{
-    CoreNodeStatusResponse, InclusionProbabilityResponse, MixNodeBondResponse,
+    CoreNodeStatusResponse, InclusionProbabilityResponse, MixNodeBondAnnotated,
     MixnodeStatusResponse, RewardEstimationResponse, StakeSaturationResponse, UptimeResponse,
 };
 
@@ -87,7 +87,7 @@ impl Client {
 
     pub async fn get_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondResponse>, ValidatorAPIError> {
+    ) -> Result<Vec<MixNodeBondAnnotated>, ValidatorAPIError> {
         self.query_validator_api(
             &[routes::API_VERSION, routes::MIXNODES, routes::DETAILED],
             NO_PARAMS,
@@ -110,7 +110,7 @@ impl Client {
 
     pub async fn get_active_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondResponse>, ValidatorAPIError> {
+    ) -> Result<Vec<MixNodeBondAnnotated>, ValidatorAPIError> {
         self.query_validator_api(
             &[
                 routes::API_VERSION,
@@ -133,7 +133,7 @@ impl Client {
 
     pub async fn get_rewarded_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondResponse>, ValidatorAPIError> {
+    ) -> Result<Vec<MixNodeBondAnnotated>, ValidatorAPIError> {
         self.query_validator_api(
             &[
                 routes::API_VERSION,

--- a/common/client-libs/validator-client/src/validator_api/mod.rs
+++ b/common/client-libs/validator-client/src/validator_api/mod.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use url::Url;
 use validator_api_requests::models::{
-    CoreNodeStatusResponse, InclusionProbabilityResponse, MixnodeStatusResponse,
-    RewardEstimationResponse, StakeSaturationResponse, UptimeResponse,
+    CoreNodeStatusResponse, InclusionProbabilityResponse, MixNodeBondDetailed,
+    MixnodeStatusResponse, RewardEstimationResponse, StakeSaturationResponse, UptimeResponse,
 };
 
 pub mod error;
@@ -85,6 +85,16 @@ impl Client {
             .await
     }
 
+    pub async fn get_mixnodes_detailed(
+        &self,
+    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorAPIError> {
+        self.query_validator_api(
+            &[routes::API_VERSION, routes::MIXNODES, routes::DETAILED],
+            NO_PARAMS,
+        )
+        .await
+    }
+
     pub async fn get_gateways(&self) -> Result<Vec<GatewayBond>, ValidatorAPIError> {
         self.query_validator_api(&[routes::API_VERSION, routes::GATEWAYS], NO_PARAMS)
             .await
@@ -98,9 +108,39 @@ impl Client {
         .await
     }
 
+    pub async fn get_active_mixnodes_detailed(
+        &self,
+    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorAPIError> {
+        self.query_validator_api(
+            &[
+                routes::API_VERSION,
+                routes::MIXNODES,
+                routes::ACTIVE,
+                routes::DETAILED,
+            ],
+            NO_PARAMS,
+        )
+        .await
+    }
+
     pub async fn get_rewarded_mixnodes(&self) -> Result<Vec<MixNodeBond>, ValidatorAPIError> {
         self.query_validator_api(
             &[routes::API_VERSION, routes::MIXNODES, routes::REWARDED],
+            NO_PARAMS,
+        )
+        .await
+    }
+
+    pub async fn get_rewarded_mixnodes_detailed(
+        &self,
+    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorAPIError> {
+        self.query_validator_api(
+            &[
+                routes::API_VERSION,
+                routes::MIXNODES,
+                routes::REWARDED,
+                routes::DETAILED,
+            ],
             NO_PARAMS,
         )
         .await

--- a/common/client-libs/validator-client/src/validator_api/mod.rs
+++ b/common/client-libs/validator-client/src/validator_api/mod.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use url::Url;
 use validator_api_requests::models::{
-    CoreNodeStatusResponse, InclusionProbabilityResponse, MixNodeBondDetailed,
+    CoreNodeStatusResponse, InclusionProbabilityResponse, MixNodeBondResponse,
     MixnodeStatusResponse, RewardEstimationResponse, StakeSaturationResponse, UptimeResponse,
 };
 
@@ -87,7 +87,7 @@ impl Client {
 
     pub async fn get_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorAPIError> {
+    ) -> Result<Vec<MixNodeBondResponse>, ValidatorAPIError> {
         self.query_validator_api(
             &[routes::API_VERSION, routes::MIXNODES, routes::DETAILED],
             NO_PARAMS,
@@ -110,7 +110,7 @@ impl Client {
 
     pub async fn get_active_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorAPIError> {
+    ) -> Result<Vec<MixNodeBondResponse>, ValidatorAPIError> {
         self.query_validator_api(
             &[
                 routes::API_VERSION,
@@ -133,7 +133,7 @@ impl Client {
 
     pub async fn get_rewarded_mixnodes_detailed(
         &self,
-    ) -> Result<Vec<MixNodeBondDetailed>, ValidatorAPIError> {
+    ) -> Result<Vec<MixNodeBondResponse>, ValidatorAPIError> {
         self.query_validator_api(
             &[
                 routes::API_VERSION,

--- a/common/client-libs/validator-client/src/validator_api/routes.rs
+++ b/common/client-libs/validator-client/src/validator_api/routes.rs
@@ -7,6 +7,7 @@ pub const API_VERSION: &str = VALIDATOR_API_VERSION;
 pub const MIXNODES: &str = "mixnodes";
 pub const GATEWAYS: &str = "gateways";
 
+pub const DETAILED: &str = "detailed";
 pub const ACTIVE: &str = "active";
 pub const REWARDED: &str = "rewarded";
 

--- a/explorer-api/src/country_statistics/geolocate.rs
+++ b/explorer-api/src/country_statistics/geolocate.rs
@@ -51,7 +51,7 @@ impl GeoLocateTask {
                 .state
                 .inner
                 .mixnodes
-                .is_location_valid(&cache_item.mix_node.identity_key)
+                .is_location_valid(&cache_item.mix_node().identity_key)
                 .await
             {
                 // when the cached location is valid, don't locate and continue to next mix node
@@ -59,14 +59,14 @@ impl GeoLocateTask {
             }
 
             // the mix node has not been located or is the cache time has expired
-            match locate(&cache_item.mix_node.host).await {
+            match locate(&cache_item.mix_node().host).await {
                 Ok(geo_location) => {
                     let location = Location::new(geo_location);
 
                     trace!(
                         "{} mix nodes already located. Ip {} is located in {:#?}",
                         i,
-                        cache_item.mix_node.host,
+                        cache_item.mix_node().host,
                         location.three_letter_iso_country_code,
                     );
 
@@ -80,7 +80,7 @@ impl GeoLocateTask {
                     self.state
                         .inner
                         .mixnodes
-                        .set_location(&cache_item.mix_node.identity_key, Some(location))
+                        .set_location(&cache_item.mix_node().identity_key, Some(location))
                         .await;
 
                     // one node has been located, so return out of the loop
@@ -89,22 +89,22 @@ impl GeoLocateTask {
                 Err(e) => match e {
                     LocateError::ReqwestError(e) => warn!(
                         "❌ Oh no! Location for {} failed {}",
-                        cache_item.mix_node.host, e
+                        cache_item.mix_node().host, e
                     ),
                     LocateError::NotFound(e) => {
                             warn!(
                             "❌ Location for {} not found. Response body: {}",
-                            cache_item.mix_node.host, e
+                            cache_item.mix_node().host, e
                         );
                         self.state
                             .inner
                             .mixnodes
-                            .set_location(&cache_item.mix_node.identity_key, None)
+                            .set_location(&cache_item.mix_node().identity_key, None)
                             .await;
                     },
                     LocateError::RateLimited(e) => warn!(
                         "❌ Oh no, we've been rate limited! Location for {} failed. Response body: {}",
-                        cache_item.mix_node.host, e
+                        cache_item.mix_node().host, e
                     ),
                 },
             }

--- a/explorer-api/src/mix_node/http.rs
+++ b/explorer-api/src/mix_node/http.rs
@@ -70,8 +70,8 @@ pub(crate) async fn get_description(
             match state.inner.get_mix_node(pubkey).await {
                 Some(bond) => {
                     match get_mix_node_description(
-                        &bond.mix_node.host,
-                        &bond.mix_node.http_api_port,
+                        &bond.mix_node().host,
+                        &bond.mix_node().http_api_port,
                     )
                     .await
                     {
@@ -87,7 +87,10 @@ pub(crate) async fn get_description(
                         Err(e) => {
                             error!(
                                 "Unable to get description for {} on {}:{} -> {}",
-                                pubkey, bond.mix_node.host, bond.mix_node.http_api_port, e
+                                pubkey,
+                                bond.mix_node().host,
+                                bond.mix_node().http_api_port,
+                                e
                             );
                             Option::None
                         }
@@ -114,7 +117,7 @@ pub(crate) async fn get_stats(
             trace!("No valid cache value for {}", pubkey);
             match state.inner.get_mix_node(pubkey).await {
                 Some(bond) => {
-                    match get_mix_node_stats(&bond.mix_node.host, &bond.mix_node.http_api_port)
+                    match get_mix_node_stats(&bond.mix_node().host, &bond.mix_node().http_api_port)
                         .await
                     {
                         Ok(response) => {
@@ -129,7 +132,10 @@ pub(crate) async fn get_stats(
                         Err(e) => {
                             error!(
                                 "Unable to get description for {} on {}:{} -> {}",
-                                pubkey, bond.mix_node.host, bond.mix_node.http_api_port, e
+                                pubkey,
+                                bond.mix_node().host,
+                                bond.mix_node().http_api_port,
+                                e
                             );
                             Option::None
                         }

--- a/explorer-api/src/mix_node/models.rs
+++ b/explorer-api/src/mix_node/models.rs
@@ -29,6 +29,7 @@ pub(crate) struct PrettyDetailedMixNodeBond {
     pub layer: Layer,
     pub mix_node: MixNode,
     pub avg_uptime: Option<u8>,
+    pub stake_saturation: f32,
 }
 
 pub(crate) struct MixNodeCache {

--- a/explorer-api/src/mix_nodes/models.rs
+++ b/explorer-api/src/mix_nodes/models.rs
@@ -148,19 +148,17 @@ impl ThreadsafeMixNodesCache {
         let health = mixnode_health_guard.get(identity_key);
 
         match bond {
-            Some(bond) => {
-                Some(PrettyDetailedMixNodeBond {
-                    location: location.and_then(|l| l.location.clone()),
-                    status: mixnodes_guard.determine_node_status(&bond.mix_node().identity_key),
-                    pledge_amount: bond.mixnode_bond.pledge_amount,
-                    total_delegation: bond.mixnode_bond.total_delegation,
-                    owner: bond.mixnode_bond.owner,
-                    layer: bond.mixnode_bond.layer,
-                    mix_node: bond.mixnode_bond.mix_node,
-                    avg_uptime: health.map(|m| m.avg_uptime),
-                    stake_saturation: bond.stake_saturation,
-                })
-            }
+            Some(bond) => Some(PrettyDetailedMixNodeBond {
+                location: location.and_then(|l| l.location.clone()),
+                status: mixnodes_guard.determine_node_status(&bond.mix_node().identity_key),
+                pledge_amount: bond.mixnode_bond.pledge_amount,
+                total_delegation: bond.mixnode_bond.total_delegation,
+                owner: bond.mixnode_bond.owner,
+                layer: bond.mixnode_bond.layer,
+                mix_node: bond.mixnode_bond.mix_node,
+                avg_uptime: health.map(|m| m.avg_uptime),
+                stake_saturation: bond.stake_saturation,
+            }),
             None => None,
         }
     }

--- a/explorer-api/src/mix_nodes/models.rs
+++ b/explorer-api/src/mix_nodes/models.rs
@@ -8,8 +8,7 @@ use std::time::{Duration, SystemTime};
 use serde::Serialize;
 use tokio::sync::RwLock;
 
-use mixnet_contract_common::MixNodeBond;
-use validator_client::models::UptimeResponse;
+use validator_client::models::{MixNodeBondDetailed, UptimeResponse};
 
 use crate::cache::Cache;
 use crate::mix_node::models::{MixnodeStatus, PrettyDetailedMixNodeBond};
@@ -32,7 +31,7 @@ pub(crate) struct MixNodeSummary {
 #[derive(Clone, Debug)]
 pub(crate) struct MixNodesResult {
     pub(crate) valid_until: SystemTime,
-    pub(crate) all_mixnodes: HashMap<String, MixNodeBond>,
+    pub(crate) all_mixnodes: HashMap<String, MixNodeBondDetailed>,
     active_mixnodes: HashSet<String>,
     rewarded_mixnodes: HashSet<String>,
 }
@@ -61,7 +60,7 @@ impl MixNodesResult {
         self.valid_until >= SystemTime::now()
     }
 
-    fn get_mixnode(&self, pubkey: &str) -> Option<MixNodeBond> {
+    fn get_mixnode(&self, pubkey: &str) -> Option<MixNodeBondDetailed> {
         if self.is_valid() {
             self.all_mixnodes.get(pubkey).cloned()
         } else {
@@ -69,7 +68,7 @@ impl MixNodesResult {
         }
     }
 
-    fn get_mixnodes(&self) -> Option<HashMap<String, MixNodeBond>> {
+    fn get_mixnodes(&self) -> Option<HashMap<String, MixNodeBondDetailed>> {
         if self.is_valid() {
             Some(self.all_mixnodes.clone())
         } else {
@@ -128,11 +127,11 @@ impl ThreadsafeMixNodesCache {
         );
     }
 
-    pub(crate) async fn get_mixnode(&self, pubkey: &str) -> Option<MixNodeBond> {
+    pub(crate) async fn get_mixnode(&self, pubkey: &str) -> Option<MixNodeBondDetailed> {
         self.mixnodes.read().await.get_mixnode(pubkey)
     }
 
-    pub(crate) async fn get_mixnodes(&self) -> Option<HashMap<String, MixNodeBond>> {
+    pub(crate) async fn get_mixnodes(&self) -> Option<HashMap<String, MixNodeBondDetailed>> {
         self.mixnodes.read().await.get_mixnodes()
     }
 
@@ -149,16 +148,19 @@ impl ThreadsafeMixNodesCache {
         let health = mixnode_health_guard.get(identity_key);
 
         match bond {
-            Some(bond) => Some(PrettyDetailedMixNodeBond {
-                location: location.and_then(|l| l.location.clone()),
-                status: mixnodes_guard.determine_node_status(&bond.mix_node.identity_key),
-                pledge_amount: bond.pledge_amount,
-                total_delegation: bond.total_delegation,
-                owner: bond.owner,
-                layer: bond.layer,
-                mix_node: bond.mix_node,
-                avg_uptime: health.map(|m| m.avg_uptime),
-            }),
+            Some(bond) => {
+                let mix_node = bond.mix_node().clone();
+                Some(PrettyDetailedMixNodeBond {
+                    location: location.and_then(|l| l.location.clone()),
+                    status: mixnodes_guard.determine_node_status(&bond.mix_node().identity_key),
+                    pledge_amount: bond.mixnode_bond.pledge_amount,
+                    total_delegation: bond.mixnode_bond.total_delegation,
+                    owner: bond.mixnode_bond.owner,
+                    layer: bond.mixnode_bond.layer,
+                    mix_node,
+                    avg_uptime: health.map(|m| m.avg_uptime),
+                })
+            }
             None => None,
         }
     }
@@ -172,12 +174,12 @@ impl ThreadsafeMixNodesCache {
             .all_mixnodes
             .values()
             .map(|bond| {
-                let location = location_guard.get(&bond.mix_node.identity_key);
-                let copy = bond.clone();
-                let health = mixnode_health_guard.get(&bond.mix_node.identity_key);
+                let location = location_guard.get(&bond.mix_node().identity_key);
+                let copy = bond.mixnode_bond.clone();
+                let health = mixnode_health_guard.get(&bond.mix_node().identity_key);
                 PrettyDetailedMixNodeBond {
                     location: location.and_then(|l| l.location.clone()),
-                    status: mixnodes_guard.determine_node_status(&bond.mix_node.identity_key),
+                    status: mixnodes_guard.determine_node_status(&bond.mix_node().identity_key),
                     pledge_amount: copy.pledge_amount,
                     total_delegation: copy.total_delegation,
                     owner: copy.owner,
@@ -191,14 +193,14 @@ impl ThreadsafeMixNodesCache {
 
     pub(crate) async fn update_cache(
         &self,
-        all_bonds: Vec<MixNodeBond>,
+        all_bonds: Vec<MixNodeBondDetailed>,
         rewarded_nodes: HashSet<String>,
         active_nodes: HashSet<String>,
     ) {
         let mut guard = self.mixnodes.write().await;
         guard.all_mixnodes = all_bonds
             .into_iter()
-            .map(|bond| (bond.mix_node.identity_key.to_string(), bond))
+            .map(|bond| (bond.mix_node().identity_key.to_string(), bond))
             .collect();
         guard.rewarded_mixnodes = rewarded_nodes;
         guard.active_mixnodes = active_nodes;

--- a/explorer-api/src/mix_nodes/models.rs
+++ b/explorer-api/src/mix_nodes/models.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime};
 use serde::Serialize;
 use tokio::sync::RwLock;
 
-use validator_client::models::{MixNodeBondResponse, UptimeResponse};
+use validator_client::models::{MixNodeBondAnnotated, UptimeResponse};
 
 use crate::cache::Cache;
 use crate::mix_node::models::{MixnodeStatus, PrettyDetailedMixNodeBond};
@@ -31,7 +31,7 @@ pub(crate) struct MixNodeSummary {
 #[derive(Clone, Debug)]
 pub(crate) struct MixNodesResult {
     pub(crate) valid_until: SystemTime,
-    pub(crate) all_mixnodes: HashMap<String, MixNodeBondResponse>,
+    pub(crate) all_mixnodes: HashMap<String, MixNodeBondAnnotated>,
     active_mixnodes: HashSet<String>,
     rewarded_mixnodes: HashSet<String>,
 }
@@ -60,7 +60,7 @@ impl MixNodesResult {
         self.valid_until >= SystemTime::now()
     }
 
-    fn get_mixnode(&self, pubkey: &str) -> Option<MixNodeBondResponse> {
+    fn get_mixnode(&self, pubkey: &str) -> Option<MixNodeBondAnnotated> {
         if self.is_valid() {
             self.all_mixnodes.get(pubkey).cloned()
         } else {
@@ -68,7 +68,7 @@ impl MixNodesResult {
         }
     }
 
-    fn get_mixnodes(&self) -> Option<HashMap<String, MixNodeBondResponse>> {
+    fn get_mixnodes(&self) -> Option<HashMap<String, MixNodeBondAnnotated>> {
         if self.is_valid() {
             Some(self.all_mixnodes.clone())
         } else {
@@ -127,11 +127,11 @@ impl ThreadsafeMixNodesCache {
         );
     }
 
-    pub(crate) async fn get_mixnode(&self, pubkey: &str) -> Option<MixNodeBondResponse> {
+    pub(crate) async fn get_mixnode(&self, pubkey: &str) -> Option<MixNodeBondAnnotated> {
         self.mixnodes.read().await.get_mixnode(pubkey)
     }
 
-    pub(crate) async fn get_mixnodes(&self) -> Option<HashMap<String, MixNodeBondResponse>> {
+    pub(crate) async fn get_mixnodes(&self) -> Option<HashMap<String, MixNodeBondAnnotated>> {
         self.mixnodes.read().await.get_mixnodes()
     }
 
@@ -195,7 +195,7 @@ impl ThreadsafeMixNodesCache {
 
     pub(crate) async fn update_cache(
         &self,
-        all_bonds: Vec<MixNodeBondResponse>,
+        all_bonds: Vec<MixNodeBondAnnotated>,
         rewarded_nodes: HashSet<String>,
         active_nodes: HashSet<String>,
     ) {

--- a/explorer-api/src/mix_nodes/models.rs
+++ b/explorer-api/src/mix_nodes/models.rs
@@ -159,6 +159,7 @@ impl ThreadsafeMixNodesCache {
                     layer: bond.mixnode_bond.layer,
                     mix_node,
                     avg_uptime: health.map(|m| m.avg_uptime),
+                    stake_saturation: bond.stake_saturation.saturation,
                 })
             }
             None => None,
@@ -186,6 +187,7 @@ impl ThreadsafeMixNodesCache {
                     layer: copy.layer,
                     mix_node: copy.mix_node,
                     avg_uptime: health.map(|m| m.avg_uptime),
+                    stake_saturation: bond.stake_saturation.saturation,
                 }
             })
             .collect()

--- a/explorer-api/src/mix_nodes/models.rs
+++ b/explorer-api/src/mix_nodes/models.rs
@@ -149,7 +149,6 @@ impl ThreadsafeMixNodesCache {
 
         match bond {
             Some(bond) => {
-                let mix_node = bond.mix_node().clone();
                 Some(PrettyDetailedMixNodeBond {
                     location: location.and_then(|l| l.location.clone()),
                     status: mixnodes_guard.determine_node_status(&bond.mix_node().identity_key),
@@ -157,7 +156,7 @@ impl ThreadsafeMixNodesCache {
                     total_delegation: bond.mixnode_bond.total_delegation,
                     owner: bond.mixnode_bond.owner,
                     layer: bond.mixnode_bond.layer,
-                    mix_node,
+                    mix_node: bond.mixnode_bond.mix_node,
                     avg_uptime: health.map(|m| m.avg_uptime),
                     stake_saturation: bond.stake_saturation,
                 })

--- a/explorer-api/src/ping/http.rs
+++ b/explorer-api/src/ping/http.rs
@@ -42,7 +42,7 @@ pub(crate) async fn index(
                     state.inner.ping.set_pending(pubkey).await;
 
                     // do the check
-                    let ports = Some(port_check(&bond).await);
+                    let ports = Some(port_check(&bond.mixnode_bond).await);
                     trace!("Tested mix node {}: {:?}", pubkey, ports);
                     let response = PingResponse {
                         ports,

--- a/explorer-api/src/state.rs
+++ b/explorer-api/src/state.rs
@@ -6,7 +6,7 @@ use log::info;
 use serde::{Deserialize, Serialize};
 
 use crate::client::ThreadsafeValidatorClient;
-use mixnet_contract_common::MixNodeBond;
+use validator_client::models::MixNodeBondDetailed;
 
 use crate::country_statistics::country_nodes_distribution::{
     CountryNodesDistribution, ThreadsafeCountryNodesDistribution,
@@ -35,7 +35,7 @@ pub struct ExplorerApiState {
 }
 
 impl ExplorerApiState {
-    pub(crate) async fn get_mix_node(&self, pubkey: &str) -> Option<MixNodeBond> {
+    pub(crate) async fn get_mix_node(&self, pubkey: &str) -> Option<MixNodeBondDetailed> {
         self.mixnodes.get_mixnode(pubkey).await
     }
 }

--- a/explorer-api/src/state.rs
+++ b/explorer-api/src/state.rs
@@ -6,7 +6,7 @@ use log::info;
 use serde::{Deserialize, Serialize};
 
 use crate::client::ThreadsafeValidatorClient;
-use validator_client::models::MixNodeBondResponse;
+use validator_client::models::MixNodeBondAnnotated;
 
 use crate::country_statistics::country_nodes_distribution::{
     CountryNodesDistribution, ThreadsafeCountryNodesDistribution,
@@ -35,7 +35,7 @@ pub struct ExplorerApiState {
 }
 
 impl ExplorerApiState {
-    pub(crate) async fn get_mix_node(&self, pubkey: &str) -> Option<MixNodeBondResponse> {
+    pub(crate) async fn get_mix_node(&self, pubkey: &str) -> Option<MixNodeBondAnnotated> {
         self.mixnodes.get_mixnode(pubkey).await
     }
 }

--- a/explorer-api/src/state.rs
+++ b/explorer-api/src/state.rs
@@ -6,7 +6,7 @@ use log::info;
 use serde::{Deserialize, Serialize};
 
 use crate::client::ThreadsafeValidatorClient;
-use validator_client::models::MixNodeBondDetailed;
+use validator_client::models::MixNodeBondResponse;
 
 use crate::country_statistics::country_nodes_distribution::{
     CountryNodesDistribution, ThreadsafeCountryNodesDistribution,
@@ -35,7 +35,7 @@ pub struct ExplorerApiState {
 }
 
 impl ExplorerApiState {
-    pub(crate) async fn get_mix_node(&self, pubkey: &str) -> Option<MixNodeBondDetailed> {
+    pub(crate) async fn get_mix_node(&self, pubkey: &str) -> Option<MixNodeBondResponse> {
         self.mixnodes.get_mixnode(pubkey).await
     }
 }

--- a/explorer-api/src/tasks.rs
+++ b/explorer-api/src/tasks.rs
@@ -4,7 +4,7 @@
 use std::future::Future;
 
 use mixnet_contract_common::GatewayBond;
-use validator_client::models::{MixNodeBondDetailed, UptimeResponse};
+use validator_client::models::{MixNodeBondResponse, UptimeResponse};
 use validator_client::nymd::error::NymdError;
 use validator_client::nymd::{Paging, QueryNymdClient, ValidatorResponse};
 use validator_client::ValidatorClientError;
@@ -22,10 +22,10 @@ impl ExplorerApiTasks {
     }
 
     // a helper to remove duplicate code when grabbing active/rewarded/all mixnodes
-    async fn retrieve_mixnodes<'a, F, Fut>(&'a self, f: F) -> Vec<MixNodeBondDetailed>
+    async fn retrieve_mixnodes<'a, F, Fut>(&'a self, f: F) -> Vec<MixNodeBondResponse>
     where
         F: FnOnce(&'a validator_client::Client<QueryNymdClient>) -> Fut,
-        Fut: Future<Output = Result<Vec<MixNodeBondDetailed>, ValidatorClientError>>,
+        Fut: Future<Output = Result<Vec<MixNodeBondResponse>, ValidatorClientError>>,
     {
         let bonds = match f(&self.state.inner.validator_client.0).await {
             Ok(result) => result,
@@ -39,7 +39,7 @@ impl ExplorerApiTasks {
         bonds
     }
 
-    async fn retrieve_all_mixnodes(&self) -> Vec<MixNodeBondDetailed> {
+    async fn retrieve_all_mixnodes(&self) -> Vec<MixNodeBondResponse> {
         info!("About to retrieve all mixnode bonds...");
         self.retrieve_mixnodes(validator_client::Client::get_cached_mixnodes_detailed)
             .await
@@ -77,13 +77,13 @@ impl ExplorerApiTasks {
         Ok(response)
     }
 
-    async fn retrieve_rewarded_mixnodes(&self) -> Vec<MixNodeBondDetailed> {
+    async fn retrieve_rewarded_mixnodes(&self) -> Vec<MixNodeBondResponse> {
         info!("About to retrieve rewarded mixnode bonds...");
         self.retrieve_mixnodes(validator_client::Client::get_cached_rewarded_mixnodes_detailed)
             .await
     }
 
-    async fn retrieve_active_mixnodes(&self) -> Vec<MixNodeBondDetailed> {
+    async fn retrieve_active_mixnodes(&self) -> Vec<MixNodeBondResponse> {
         info!("About to retrieve active mixnode bonds...");
         self.retrieve_mixnodes(validator_client::Client::get_cached_active_mixnodes_detailed)
             .await

--- a/explorer-api/src/tasks.rs
+++ b/explorer-api/src/tasks.rs
@@ -4,7 +4,7 @@
 use std::future::Future;
 
 use mixnet_contract_common::GatewayBond;
-use validator_client::models::{MixNodeBondResponse, UptimeResponse};
+use validator_client::models::{MixNodeBondAnnotated, UptimeResponse};
 use validator_client::nymd::error::NymdError;
 use validator_client::nymd::{Paging, QueryNymdClient, ValidatorResponse};
 use validator_client::ValidatorClientError;
@@ -22,10 +22,10 @@ impl ExplorerApiTasks {
     }
 
     // a helper to remove duplicate code when grabbing active/rewarded/all mixnodes
-    async fn retrieve_mixnodes<'a, F, Fut>(&'a self, f: F) -> Vec<MixNodeBondResponse>
+    async fn retrieve_mixnodes<'a, F, Fut>(&'a self, f: F) -> Vec<MixNodeBondAnnotated>
     where
         F: FnOnce(&'a validator_client::Client<QueryNymdClient>) -> Fut,
-        Fut: Future<Output = Result<Vec<MixNodeBondResponse>, ValidatorClientError>>,
+        Fut: Future<Output = Result<Vec<MixNodeBondAnnotated>, ValidatorClientError>>,
     {
         let bonds = match f(&self.state.inner.validator_client.0).await {
             Ok(result) => result,
@@ -39,7 +39,7 @@ impl ExplorerApiTasks {
         bonds
     }
 
-    async fn retrieve_all_mixnodes(&self) -> Vec<MixNodeBondResponse> {
+    async fn retrieve_all_mixnodes(&self) -> Vec<MixNodeBondAnnotated> {
         info!("About to retrieve all mixnode bonds...");
         self.retrieve_mixnodes(validator_client::Client::get_cached_mixnodes_detailed)
             .await
@@ -77,13 +77,13 @@ impl ExplorerApiTasks {
         Ok(response)
     }
 
-    async fn retrieve_rewarded_mixnodes(&self) -> Vec<MixNodeBondResponse> {
+    async fn retrieve_rewarded_mixnodes(&self) -> Vec<MixNodeBondAnnotated> {
         info!("About to retrieve rewarded mixnode bonds...");
         self.retrieve_mixnodes(validator_client::Client::get_cached_rewarded_mixnodes_detailed)
             .await
     }
 
-    async fn retrieve_active_mixnodes(&self) -> Vec<MixNodeBondResponse> {
+    async fn retrieve_active_mixnodes(&self) -> Vec<MixNodeBondAnnotated> {
         info!("About to retrieve active mixnode bonds...");
         self.retrieve_mixnodes(validator_client::Client::get_cached_active_mixnodes_detailed)
             .await

--- a/explorer-api/src/tasks.rs
+++ b/explorer-api/src/tasks.rs
@@ -3,8 +3,8 @@
 
 use std::future::Future;
 
-use mixnet_contract_common::{GatewayBond, MixNodeBond};
-use validator_client::models::UptimeResponse;
+use mixnet_contract_common::GatewayBond;
+use validator_client::models::{MixNodeBondDetailed, UptimeResponse};
 use validator_client::nymd::error::NymdError;
 use validator_client::nymd::{Paging, QueryNymdClient, ValidatorResponse};
 use validator_client::ValidatorClientError;
@@ -22,10 +22,10 @@ impl ExplorerApiTasks {
     }
 
     // a helper to remove duplicate code when grabbing active/rewarded/all mixnodes
-    async fn retrieve_mixnodes<'a, F, Fut>(&'a self, f: F) -> Vec<MixNodeBond>
+    async fn retrieve_mixnodes<'a, F, Fut>(&'a self, f: F) -> Vec<MixNodeBondDetailed>
     where
         F: FnOnce(&'a validator_client::Client<QueryNymdClient>) -> Fut,
-        Fut: Future<Output = Result<Vec<MixNodeBond>, ValidatorClientError>>,
+        Fut: Future<Output = Result<Vec<MixNodeBondDetailed>, ValidatorClientError>>,
     {
         let bonds = match f(&self.state.inner.validator_client.0).await {
             Ok(result) => result,
@@ -39,9 +39,9 @@ impl ExplorerApiTasks {
         bonds
     }
 
-    async fn retrieve_all_mixnodes(&self) -> Vec<MixNodeBond> {
+    async fn retrieve_all_mixnodes(&self) -> Vec<MixNodeBondDetailed> {
         info!("About to retrieve all mixnode bonds...");
-        self.retrieve_mixnodes(validator_client::Client::get_cached_mixnodes)
+        self.retrieve_mixnodes(validator_client::Client::get_cached_mixnodes_detailed)
             .await
     }
 
@@ -77,15 +77,15 @@ impl ExplorerApiTasks {
         Ok(response)
     }
 
-    async fn retrieve_rewarded_mixnodes(&self) -> Vec<MixNodeBond> {
+    async fn retrieve_rewarded_mixnodes(&self) -> Vec<MixNodeBondDetailed> {
         info!("About to retrieve rewarded mixnode bonds...");
-        self.retrieve_mixnodes(validator_client::Client::get_cached_rewarded_mixnodes)
+        self.retrieve_mixnodes(validator_client::Client::get_cached_rewarded_mixnodes_detailed)
             .await
     }
 
-    async fn retrieve_active_mixnodes(&self) -> Vec<MixNodeBond> {
+    async fn retrieve_active_mixnodes(&self) -> Vec<MixNodeBondDetailed> {
         info!("About to retrieve active mixnode bonds...");
-        self.retrieve_mixnodes(validator_client::Client::get_cached_active_mixnodes)
+        self.retrieve_mixnodes(validator_client::Client::get_cached_active_mixnodes_detailed)
             .await
     }
 
@@ -106,13 +106,13 @@ impl ExplorerApiTasks {
             .retrieve_rewarded_mixnodes()
             .await
             .into_iter()
-            .map(|bond| bond.mix_node.identity_key)
+            .map(|bond| bond.mix_node().identity_key.clone())
             .collect();
         let active_nodes = self
             .retrieve_active_mixnodes()
             .await
             .into_iter()
-            .map(|bond| bond.mix_node.identity_key)
+            .map(|bond| bond.mix_node().identity_key.clone())
             .collect();
         self.state
             .inner

--- a/validator-api/Cargo.toml
+++ b/validator-api/Cargo.toml
@@ -50,6 +50,7 @@ schemars = { version = "0.8", features = ["preserve_order"] }
 ## internal
 coconut-bandwidth-contract-common = { path = "../common/cosmwasm-smart-contracts/coconut-bandwidth-contract" }
 config = { path = "../common/config" }
+cosmwasm-std = "1.0.0-beta8"
 crypto = { path="../common/crypto" }
 gateway-client = { path="../common/client-libs/gateway-client" }
 mixnet-contract-common = { path= "../common/cosmwasm-smart-contracts/mixnet-contract" }

--- a/validator-api/src/contract_cache/mod.rs
+++ b/validator-api/src/contract_cache/mod.rs
@@ -40,14 +40,14 @@ pub struct ValidatorCache {
 }
 
 struct ValidatorCacheInner {
-    mixnodes: Cache<Vec<MixNodeBond>>,
+    mixnodes: Cache<Vec<MixNodeBondResponse>>,
     gateways: Cache<Vec<GatewayBond>>,
 
     mixnodes_blacklist: Cache<HashSet<IdentityKey>>,
     gateways_blacklist: Cache<HashSet<IdentityKey>>,
 
-    rewarded_set: Cache<Vec<MixNodeBond>>,
-    active_set: Cache<Vec<MixNodeBond>>,
+    rewarded_set: Cache<Vec<MixNodeBondResponse>>,
+    active_set: Cache<Vec<MixNodeBondResponse>>,
 
     current_reward_params: Cache<EpochRewardParams>,
     current_epoch: Cache<Option<Interval>>,
@@ -99,11 +99,32 @@ impl<C> ValidatorCacheRefresher<C> {
         }
     }
 
+    fn annotate_bond_with_details(
+        mixnodes: Vec<MixNodeBond>,
+        interval_reward_params: EpochRewardParams,
+    ) -> Vec<MixNodeBondResponse> {
+        mixnodes
+            .into_iter()
+            .map(|mixnode_bond| {
+                let stake_saturation = mixnode_bond
+                    .stake_saturation(
+                        interval_reward_params.circulating_supply(),
+                        interval_reward_params.rewarded_set_size() as u32,
+                    )
+                    .to_num();
+                MixNodeBondResponse {
+                    mixnode_bond,
+                    stake_saturation,
+                }
+            })
+            .collect()
+    }
+
     fn collect_rewarded_and_active_set_details(
         &self,
-        all_mixnodes: &[MixNodeBond],
+        all_mixnodes: &[MixNodeBondResponse],
         rewarded_set_identities: Vec<(IdentityKey, RewardedSetNodeStatus)>,
-    ) -> (Vec<MixNodeBond>, Vec<MixNodeBond>) {
+    ) -> (Vec<MixNodeBondResponse>, Vec<MixNodeBondResponse>) {
         let mut active_set = Vec::new();
         let mut rewarded_set = Vec::new();
         let rewarded_set_identities = rewarded_set_identities
@@ -111,7 +132,7 @@ impl<C> ValidatorCacheRefresher<C> {
             .collect::<HashMap<_, _>>();
 
         for mix in all_mixnodes {
-            if let Some(status) = rewarded_set_identities.get(mix.identity()) {
+            if let Some(status) = rewarded_set_identities.get(mix.mixnode_bond.identity()) {
                 rewarded_set.push(mix.clone());
                 if status.is_active() {
                     active_set.push(mix.clone())
@@ -126,10 +147,15 @@ impl<C> ValidatorCacheRefresher<C> {
     where
         C: CosmWasmClient + Sync,
     {
+        let epoch_rewarding_params = self.nymd_client.get_current_epoch_reward_params().await?;
+        let current_epoch = self.nymd_client.get_current_epoch().await?;
+
         let (mixnodes, gateways) = tokio::try_join!(
             self.nymd_client.get_mixnodes(),
             self.nymd_client.get_gateways(),
         )?;
+
+        let mixnodes = Self::annotate_bond_with_details(mixnodes, epoch_rewarding_params);
 
         let (rewarded_set, active_set) = if let Ok(rewarded_set_identities) =
             self.nymd_client.get_rewarded_set_identities().await
@@ -138,9 +164,6 @@ impl<C> ValidatorCacheRefresher<C> {
         } else {
             (Vec::new(), Vec::new())
         };
-
-        let epoch_rewarding_params = self.nymd_client.get_current_epoch_reward_params().await?;
-        let current_epoch = self.nymd_client.get_current_epoch().await?;
 
         info!(
             "Updating validator cache. There are {} mixnodes and {} gateways",
@@ -213,10 +236,10 @@ impl ValidatorCache {
 
     async fn update_cache(
         &self,
-        mixnodes: Vec<MixNodeBond>,
+        mixnodes: Vec<MixNodeBondResponse>,
         gateways: Vec<GatewayBond>,
-        rewarded_set: Vec<MixNodeBond>,
-        active_set: Vec<MixNodeBond>,
+        rewarded_set: Vec<MixNodeBondResponse>,
+        active_set: Vec<MixNodeBondResponse>,
         epoch_rewarding_params: EpochRewardParams,
         current_epoch: Interval,
     ) {
@@ -233,27 +256,6 @@ impl ValidatorCache {
                 error!("{}", e);
             }
         }
-    }
-
-    async fn annotate_with_details(&self, mixnodes: Vec<MixNodeBond>) -> Vec<MixNodeBondResponse> {
-        let interval_reward_params = self.epoch_reward_params().await;
-        let interval_reward_params = interval_reward_params.into_inner();
-
-        let mut mixnodes_detailed = Vec::new();
-        for mixnode_bond in mixnodes {
-            let stake_saturation = mixnode_bond
-                .stake_saturation(
-                    interval_reward_params.circulating_supply(),
-                    interval_reward_params.rewarded_set_size() as u32,
-                )
-                .to_num();
-            mixnodes_detailed.push(MixNodeBondResponse {
-                mixnode_bond,
-                stake_saturation,
-            });
-        }
-
-        mixnodes_detailed
     }
 
     pub async fn mixnodes_blacklist(&self) -> Option<Cache<HashSet<IdentityKey>>> {
@@ -336,7 +338,7 @@ impl ValidatorCache {
         error!("Failed to update gateways blacklist");
     }
 
-    pub async fn mixnodes(&self) -> Vec<MixNodeBond> {
+    pub async fn mixnodes_detailed(&self) -> Vec<MixNodeBondResponse> {
         let blacklist = self.mixnodes_blacklist().await;
         let mixnodes = match time::timeout(Duration::from_millis(100), self.inner.read()).await {
             Ok(cache) => cache.mixnodes.clone(),
@@ -350,7 +352,7 @@ impl ValidatorCache {
             mixnodes
                 .value
                 .iter()
-                .filter(|mix| !blacklist.value.contains(mix.identity()))
+                .filter(|mix| !blacklist.value.contains(mix.mixnode_bond.identity()))
                 .cloned()
                 .collect()
         } else {
@@ -358,14 +360,23 @@ impl ValidatorCache {
         }
     }
 
-    pub async fn mixnodes_detailed(&self) -> Vec<MixNodeBondResponse> {
-        let mixnodes = self.mixnodes().await;
-        self.annotate_with_details(mixnodes).await
+    pub async fn mixnodes(&self) -> Vec<MixNodeBond> {
+        self.mixnodes_detailed()
+            .await
+            .into_iter()
+            .map(|bond| bond.mixnode_bond)
+            .collect()
     }
 
     pub async fn mixnodes_all(&self) -> Vec<MixNodeBond> {
         match time::timeout(Duration::from_millis(100), self.inner.read()).await {
-            Ok(cache) => cache.mixnodes.clone().into_inner(),
+            Ok(cache) => cache
+                .mixnodes
+                .clone()
+                .into_inner()
+                .into_iter()
+                .map(|bond| bond.mixnode_bond)
+                .collect(),
             Err(e) => {
                 error!("{}", e);
                 Vec::new()
@@ -405,7 +416,7 @@ impl ValidatorCache {
         }
     }
 
-    pub async fn rewarded_set(&self) -> Cache<Vec<MixNodeBond>> {
+    pub async fn rewarded_set_detailed(&self) -> Cache<Vec<MixNodeBondResponse>> {
         match time::timeout(Duration::from_millis(100), self.inner.read()).await {
             Ok(cache) => cache.rewarded_set.clone(),
             Err(e) => {
@@ -415,12 +426,16 @@ impl ValidatorCache {
         }
     }
 
-    pub async fn rewarded_set_detailed(&self) -> Vec<MixNodeBondResponse> {
-        let rewarded_set = self.rewarded_set().await.value;
-        self.annotate_with_details(rewarded_set).await
+    pub async fn rewarded_set(&self) -> Vec<MixNodeBond> {
+        self.rewarded_set_detailed()
+            .await
+            .value
+            .into_iter()
+            .map(|bond| bond.mixnode_bond)
+            .collect()
     }
 
-    pub async fn active_set(&self) -> Cache<Vec<MixNodeBond>> {
+    pub async fn active_set_detailed(&self) -> Cache<Vec<MixNodeBondResponse>> {
         match time::timeout(Duration::from_millis(100), self.inner.read()).await {
             Ok(cache) => cache.active_set.clone(),
             Err(e) => {
@@ -430,9 +445,13 @@ impl ValidatorCache {
         }
     }
 
-    pub async fn active_set_detailed(&self) -> Vec<MixNodeBondResponse> {
-        let active_set = self.active_set().await.value;
-        self.annotate_with_details(active_set).await
+    pub async fn active_set(&self) -> Vec<MixNodeBond> {
+        self.active_set_detailed()
+            .await
+            .value
+            .into_iter()
+            .map(|bond| bond.mixnode_bond)
+            .collect()
     }
 
     pub(crate) async fn epoch_reward_params(&self) -> Cache<EpochRewardParams> {
@@ -458,30 +477,30 @@ impl ValidatorCache {
     pub async fn mixnode_details(
         &self,
         identity: IdentityKeyRef<'_>,
-    ) -> (Option<MixNodeBond>, MixnodeStatus) {
+    ) -> (Option<MixNodeBondResponse>, MixnodeStatus) {
         // it might not be the most optimal to possibly iterate the entire vector to find (or not)
         // the relevant value. However, the vectors are relatively small (< 10_000 elements, < 1000 for active set)
 
-        let active_set = &self.active_set().await.value;
+        let active_set = &self.active_set_detailed().await.value;
         if let Some(bond) = active_set
             .iter()
-            .find(|mix| mix.mix_node.identity_key == identity)
+            .find(|mix| mix.mix_node().identity_key == identity)
         {
             return (Some(bond.clone()), MixnodeStatus::Active);
         }
 
-        let rewarded_set = &self.rewarded_set().await.value;
+        let rewarded_set = &self.rewarded_set_detailed().await.value;
         if let Some(bond) = rewarded_set
             .iter()
-            .find(|mix| mix.mix_node.identity_key == identity)
+            .find(|mix| mix.mix_node().identity_key == identity)
         {
             return (Some(bond.clone()), MixnodeStatus::Standby);
         }
 
-        let all_bonded = &self.mixnodes().await;
+        let all_bonded = &self.mixnodes_detailed().await;
         if let Some(bond) = all_bonded
             .iter()
-            .find(|mix| mix.mix_node.identity_key == identity)
+            .find(|mix| mix.mix_node().identity_key == identity)
         {
             (Some(bond.clone()), MixnodeStatus::Inactive)
         } else {

--- a/validator-api/src/contract_cache/routes.rs
+++ b/validator-api/src/contract_cache/routes.rs
@@ -8,7 +8,7 @@ use rocket::serde::json::Json;
 use rocket::State;
 use rocket_okapi::openapi;
 use std::collections::HashSet;
-use validator_api_requests::models::MixNodeBondResponse;
+use validator_api_requests::models::MixNodeBondAnnotated;
 
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes")]
@@ -20,7 +20,7 @@ pub async fn get_mixnodes(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBond
 #[get("/mixnodes/detailed")]
 pub async fn get_mixnodes_detailed(
     cache: &State<ValidatorCache>,
-) -> Json<Vec<MixNodeBondResponse>> {
+) -> Json<Vec<MixNodeBondAnnotated>> {
     Json(cache.mixnodes_detailed().await)
 }
 
@@ -40,7 +40,7 @@ pub async fn get_rewarded_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNode
 #[get("/mixnodes/rewarded/detailed")]
 pub async fn get_rewarded_set_detailed(
     cache: &State<ValidatorCache>,
-) -> Json<Vec<MixNodeBondResponse>> {
+) -> Json<Vec<MixNodeBondAnnotated>> {
     Json(cache.rewarded_set_detailed().await.value)
 }
 
@@ -54,7 +54,7 @@ pub async fn get_active_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBo
 #[get("/mixnodes/active/detailed")]
 pub async fn get_active_set_detailed(
     cache: &State<ValidatorCache>,
-) -> Json<Vec<MixNodeBondResponse>> {
+) -> Json<Vec<MixNodeBondAnnotated>> {
     Json(cache.active_set_detailed().await.value)
 }
 

--- a/validator-api/src/contract_cache/routes.rs
+++ b/validator-api/src/contract_cache/routes.rs
@@ -38,7 +38,9 @@ pub async fn get_rewarded_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNode
 
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/rewarded/detailed")]
-pub async fn get_rewarded_set_detailed(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBondDetailed>> {
+pub async fn get_rewarded_set_detailed(
+    cache: &State<ValidatorCache>,
+) -> Json<Vec<MixNodeBondDetailed>> {
     Json(cache.rewarded_set_detailed().await)
 }
 
@@ -50,7 +52,9 @@ pub async fn get_active_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBo
 
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/active/detailed")]
-pub async fn get_active_set_detailed(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBondDetailed>> {
+pub async fn get_active_set_detailed(
+    cache: &State<ValidatorCache>,
+) -> Json<Vec<MixNodeBondDetailed>> {
     Json(cache.active_set_detailed().await)
 }
 

--- a/validator-api/src/contract_cache/routes.rs
+++ b/validator-api/src/contract_cache/routes.rs
@@ -33,7 +33,7 @@ pub async fn get_gateways(cache: &State<ValidatorCache>) -> Json<Vec<GatewayBond
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/rewarded")]
 pub async fn get_rewarded_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBond>> {
-    Json(cache.rewarded_set().await.value)
+    Json(cache.rewarded_set().await)
 }
 
 #[openapi(tag = "contract-cache")]
@@ -41,13 +41,13 @@ pub async fn get_rewarded_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNode
 pub async fn get_rewarded_set_detailed(
     cache: &State<ValidatorCache>,
 ) -> Json<Vec<MixNodeBondResponse>> {
-    Json(cache.rewarded_set_detailed().await)
+    Json(cache.rewarded_set_detailed().await.value)
 }
 
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/active")]
 pub async fn get_active_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBond>> {
-    Json(cache.active_set().await.value)
+    Json(cache.active_set().await)
 }
 
 #[openapi(tag = "contract-cache")]
@@ -55,7 +55,7 @@ pub async fn get_active_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBo
 pub async fn get_active_set_detailed(
     cache: &State<ValidatorCache>,
 ) -> Json<Vec<MixNodeBondResponse>> {
-    Json(cache.active_set_detailed().await)
+    Json(cache.active_set_detailed().await.value)
 }
 
 #[openapi(tag = "contract-cache")]

--- a/validator-api/src/contract_cache/routes.rs
+++ b/validator-api/src/contract_cache/routes.rs
@@ -8,11 +8,20 @@ use rocket::serde::json::Json;
 use rocket::State;
 use rocket_okapi::openapi;
 use std::collections::HashSet;
+use validator_api_requests::models::MixNodeBondDetailed;
 
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes")]
 pub async fn get_mixnodes(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBond>> {
     Json(cache.mixnodes().await)
+}
+
+#[openapi(tag = "contract-cache")]
+#[get("/mixnodes-detailed")]
+pub async fn get_mixnodes_detailed(
+    cache: &State<ValidatorCache>,
+) -> Json<Vec<MixNodeBondDetailed>> {
+    Json(cache.mixnodes_detailed().await)
 }
 
 #[openapi(tag = "contract-cache")]

--- a/validator-api/src/contract_cache/routes.rs
+++ b/validator-api/src/contract_cache/routes.rs
@@ -17,7 +17,7 @@ pub async fn get_mixnodes(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBond
 }
 
 #[openapi(tag = "contract-cache")]
-#[get("/mixnodes-detailed")]
+#[get("/mixnodes/detailed")]
 pub async fn get_mixnodes_detailed(
     cache: &State<ValidatorCache>,
 ) -> Json<Vec<MixNodeBondDetailed>> {
@@ -37,9 +37,21 @@ pub async fn get_rewarded_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNode
 }
 
 #[openapi(tag = "contract-cache")]
+#[get("/mixnodes/rewarded/detailed")]
+pub async fn get_rewarded_set_detailed(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBondDetailed>> {
+    Json(cache.rewarded_set_detailed().await)
+}
+
+#[openapi(tag = "contract-cache")]
 #[get("/mixnodes/active")]
 pub async fn get_active_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBond>> {
     Json(cache.active_set().await.value)
+}
+
+#[openapi(tag = "contract-cache")]
+#[get("/mixnodes/active/detailed")]
+pub async fn get_active_set_detailed(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBondDetailed>> {
+    Json(cache.active_set_detailed().await)
 }
 
 #[openapi(tag = "contract-cache")]

--- a/validator-api/src/contract_cache/routes.rs
+++ b/validator-api/src/contract_cache/routes.rs
@@ -8,7 +8,7 @@ use rocket::serde::json::Json;
 use rocket::State;
 use rocket_okapi::openapi;
 use std::collections::HashSet;
-use validator_api_requests::models::MixNodeBondDetailed;
+use validator_api_requests::models::MixNodeBondResponse;
 
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes")]
@@ -20,7 +20,7 @@ pub async fn get_mixnodes(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBond
 #[get("/mixnodes/detailed")]
 pub async fn get_mixnodes_detailed(
     cache: &State<ValidatorCache>,
-) -> Json<Vec<MixNodeBondDetailed>> {
+) -> Json<Vec<MixNodeBondResponse>> {
     Json(cache.mixnodes_detailed().await)
 }
 
@@ -40,7 +40,7 @@ pub async fn get_rewarded_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNode
 #[get("/mixnodes/rewarded/detailed")]
 pub async fn get_rewarded_set_detailed(
     cache: &State<ValidatorCache>,
-) -> Json<Vec<MixNodeBondDetailed>> {
+) -> Json<Vec<MixNodeBondResponse>> {
     Json(cache.rewarded_set_detailed().await)
 }
 
@@ -54,7 +54,7 @@ pub async fn get_active_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeBo
 #[get("/mixnodes/active/detailed")]
 pub async fn get_active_set_detailed(
     cache: &State<ValidatorCache>,
-) -> Json<Vec<MixNodeBondDetailed>> {
+) -> Json<Vec<MixNodeBondResponse>> {
     Json(cache.active_set_detailed().await)
 }
 

--- a/validator-api/src/node_status_api/routes.rs
+++ b/validator-api/src/node_status_api/routes.rs
@@ -147,7 +147,7 @@ pub(crate) async fn get_mixnode_reward_estimation(
         let node_reward_params = NodeRewardParams::new(0, uptime.u8() as u128, status.is_active());
         let reward_params = RewardParams::new(reward_params, node_reward_params);
 
-        match bond.estimate_reward(&reward_params) {
+        match bond.mixnode_bond.estimate_reward(&reward_params) {
             Ok((
                 estimated_total_node_reward,
                 estimated_operator_reward,
@@ -183,11 +183,13 @@ pub(crate) async fn get_mixnode_stake_saturation(
 ) -> Result<Json<StakeSaturationResponse>, ErrorResponse> {
     let (bond, _) = cache.mixnode_details(&identity).await;
     if let Some(bond) = bond {
+        // Recompute the stake saturation just so that we can confidentaly state that the `as_at`
+        // field is consistent and correct. Luckily this is very cheap.
         let interval_reward_params = cache.epoch_reward_params().await;
         let as_at = interval_reward_params.timestamp();
         let interval_reward_params = interval_reward_params.into_inner();
 
-        let saturation = bond.stake_saturation(
+        let saturation = bond.mixnode_bond.stake_saturation(
             interval_reward_params.circulating_supply(),
             interval_reward_params.rewarded_set_size() as u32,
         );

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use mixnet_contract_common::reward_params::RewardParams;
+use mixnet_contract_common::{reward_params::RewardParams, MixNodeBond};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -51,6 +51,12 @@ pub struct CoreNodeStatusResponse {
 )]
 pub struct MixnodeStatusResponse {
     pub status: MixnodeStatus,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct MixNodeBondDetailed {
+    pub mixnode_bond: MixNodeBond,
+    pub stake_saturation: StakeSaturationResponse,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -54,12 +54,12 @@ pub struct MixnodeStatusResponse {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct MixNodeBondResponse {
+pub struct MixNodeBondAnnotated {
     pub mixnode_bond: MixNodeBond,
     pub stake_saturation: StakeSaturation,
 }
 
-impl MixNodeBondResponse {
+impl MixNodeBondAnnotated {
     pub fn mix_node(&self) -> &MixNode {
         &self.mixnode_bond.mix_node
     }

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use mixnet_contract_common::{reward_params::RewardParams, MixNodeBond};
+use mixnet_contract_common::{reward_params::RewardParams, MixNodeBond, MixNode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -57,6 +57,12 @@ pub struct MixnodeStatusResponse {
 pub struct MixNodeBondDetailed {
     pub mixnode_bond: MixNodeBond,
     pub stake_saturation: StakeSaturationResponse,
+}
+
+impl MixNodeBondDetailed {
+    pub fn mix_node(&self) -> &MixNode {
+        &self.mixnode_bond.mix_node
+    }
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -54,12 +54,12 @@ pub struct MixnodeStatusResponse {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct MixNodeBondDetailed {
+pub struct MixNodeBondResponse {
     pub mixnode_bond: MixNodeBond,
-    pub stake_saturation: StakeSaturationResponse,
+    pub stake_saturation: StakeSaturation,
 }
 
-impl MixNodeBondDetailed {
+impl MixNodeBondResponse {
     pub fn mix_node(&self) -> &MixNode {
         &self.mixnode_bond.mix_node
     }
@@ -91,9 +91,11 @@ pub struct UptimeResponse {
     )
 )]
 pub struct StakeSaturationResponse {
-    pub saturation: f32,
+    pub saturation: StakeSaturation,
     pub as_at: i64,
 }
+
+pub type StakeSaturation = f32;
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[cfg_attr(test, derive(ts_rs::TS))]

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use mixnet_contract_common::{reward_params::RewardParams, MixNodeBond, MixNode};
+use mixnet_contract_common::{reward_params::RewardParams, MixNode, MixNodeBond};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;


### PR DESCRIPTION
Second attempt at adding stake saturation data to mixnode bond endpoints.
Supersedes https://github.com/nymtech/nym/pull/1289

Fixes: https://github.com/nymtech/nym/issues/2450
