### PR TITLE
Allow .env not to be present

### DIFF
--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -590,7 +590,7 @@ async fn run_validator_api(matches: ArgMatches<'static>) -> Result<()> {
 async fn main() -> Result<()> {
     println!("Starting validator api...");
 
-    dotenv::dotenv()?;
+    dotenv::dotenv();
 
     cfg_if::cfg_if! {if #[cfg(feature = "console-subscriber")] {
         // instriment tokio console subscriber needs RUSTFLAGS="--cfg tokio_unstable" at build time


### PR DESCRIPTION
# Fixes issues when deploying validator api without .env

Closes: #NA

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
