### PR TITLE
explorer-api: add endpoint for summed delegations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- explorer-api: learned how to sum the delegations by owner in a new endpoint.
 - validator-api: add detailed mixnode bond endpoints, and explorer-api makes use of that data to append stake saturation.
 - wallet: require password to switch accounts
 - wallet: add simple CLI tool for decrypting and recovering the wallet file.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,6 +1574,7 @@ dependencies = [
  "chrono",
  "humantime-serde",
  "isocountry",
+ "itertools",
  "log",
  "mixnet-contract-common",
  "network-defaults",

--- a/explorer-api/Cargo.toml
+++ b/explorer-api/Cargo.toml
@@ -6,21 +6,22 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = { version = "0.4.19", features = ["serde"] }
+humantime-serde = "1.0"
 isocountry = "0.3.2"
+itertools = "0.10.3"
+log = "0.4.0"
+okapi = { version = "0.7.0-rc.1", features = ["impl_json_schema"] }
+pretty_env_logger = "0.4.0"
 reqwest = "0.11.4"
 rocket = {version = "0.5.0-rc.1", features=["json"] }
 rocket_cors = { git="https://github.com/lawliet89/rocket_cors", rev="dfd3662c49e2f6fc37df35091cb94d82f7fb5915" }
-serde = "1.0.126"
-humantime-serde = "1.0"
-serde_json = "1.0.66"
-tokio = {version = "1.9.0", features = ["full"] }
-chrono = { version = "0.4.19", features = ["serde"] }
-schemars = { version = "0.8", features = ["preserve_order"] }
-okapi = { version = "0.7.0-rc.1", features = ["impl_json_schema"] }
 rocket_okapi = { version = "0.8.0-rc.1", features = ["swagger"] }
-log = "0.4.0"
-pretty_env_logger = "0.4.0"
+schemars = { version = "0.8", features = ["preserve_order"] }
+serde = "1.0.126"
+serde_json = "1.0.66"
 thiserror = "1.0.29"
+tokio = {version = "1.9.0", features = ["full"] }
 
 mixnet-contract-common = { path = "../common/cosmwasm-smart-contracts/mixnet-contract" }
 network-defaults = { path = "../common/network-defaults" }

--- a/explorer-api/src/mix_node/delegations.rs
+++ b/explorer-api/src/mix_node/delegations.rs
@@ -1,8 +1,12 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use itertools::Itertools;
+
 use crate::client::ThreadsafeValidatorClient;
 use mixnet_contract_common::Delegation;
+
+use super::models::SummedDelegations;
 
 pub(crate) async fn get_single_mixnode_delegations(
     client: &ThreadsafeValidatorClient,
@@ -20,4 +24,19 @@ pub(crate) async fn get_single_mixnode_delegations(
         }
     };
     delegates
+}
+
+pub(crate) async fn get_single_mixnode_delegations_summed(
+    client: &ThreadsafeValidatorClient,
+    pubkey: &str,
+) -> Vec<SummedDelegations> {
+    let delegations_by_owner = get_single_mixnode_delegations(client, pubkey)
+        .await
+        .into_iter()
+        .into_group_map_by(|delegation| delegation.owner.clone());
+
+    delegations_by_owner
+        .iter()
+        .filter_map(|(_, delegations)| SummedDelegations::from(delegations))
+        .collect()
 }

--- a/explorer-api/src/mix_node/http.rs
+++ b/explorer-api/src/mix_node/http.rs
@@ -11,16 +11,19 @@ use rocket_okapi::settings::OpenApiSettings;
 
 use mixnet_contract_common::Delegation;
 
-use crate::mix_node::delegations::get_single_mixnode_delegations;
+use crate::mix_node::delegations::{
+    get_single_mixnode_delegations, get_single_mixnode_delegations_summed,
+};
 use crate::mix_node::econ_stats::retrieve_mixnode_econ_stats;
 use crate::mix_node::models::{
-    EconomicDynamicsStats, NodeDescription, NodeStats, PrettyDetailedMixNodeBond,
+    EconomicDynamicsStats, NodeDescription, NodeStats, PrettyDetailedMixNodeBond, SummedDelegations,
 };
 use crate::state::ExplorerApiStateContext;
 
 pub fn mix_node_make_default_routes(settings: &OpenApiSettings) -> (Vec<Route>, OpenApi) {
     openapi_get_routes_spec![
         settings: get_delegations,
+        get_delegations_summed,
         get_by_id,
         get_description,
         get_stats,
@@ -52,6 +55,15 @@ pub(crate) async fn get_delegations(
     state: &State<ExplorerApiStateContext>,
 ) -> Json<Vec<Delegation>> {
     Json(get_single_mixnode_delegations(&state.inner.validator_client, pubkey).await)
+}
+
+#[openapi(tag = "mix_node")]
+#[get("/<pubkey>/delegations/summed")]
+pub(crate) async fn get_delegations_summed(
+    pubkey: &str,
+    state: &State<ExplorerApiStateContext>,
+) -> Json<Vec<SummedDelegations>> {
+    Json(get_single_mixnode_delegations_summed(&state.inner.validator_client, pubkey).await)
 }
 
 #[openapi(tag = "mix_node")]

--- a/explorer-api/src/mix_node/models.rs
+++ b/explorer-api/src/mix_node/models.rs
@@ -4,6 +4,7 @@
 use crate::cache::Cache;
 use crate::mix_nodes::location::Location;
 use mixnet_contract_common::{Addr, Coin, Layer, MixNode};
+use mixnet_contract_common::{Delegation, IdentityKey};
 use serde::Deserialize;
 use serde::Serialize;
 use std::sync::Arc;
@@ -30,6 +31,34 @@ pub(crate) struct PrettyDetailedMixNodeBond {
     pub mix_node: MixNode,
     pub avg_uptime: Option<u8>,
     pub stake_saturation: f32,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+pub struct SummedDelegations {
+    pub owner: Addr,
+    pub node_identity: IdentityKey,
+    pub amount: Coin,
+}
+
+impl SummedDelegations {
+    pub fn from(delegations: &[Delegation]) -> Option<Self> {
+        let owner = get_common_owner(delegations)?;
+        let node_identity = get_common_node_identity(delegations)?;
+        let denom = get_common_denom(delegations)?;
+
+        let sum = delegations
+            .iter()
+            .map(|delegation| delegation.amount.amount)
+            .sum();
+
+        let amount = Coin { denom, amount: sum };
+
+        Some(SummedDelegations {
+            owner,
+            node_identity,
+            amount,
+        })
+    }
 }
 
 pub(crate) struct MixNodeCache {
@@ -137,4 +166,40 @@ pub(crate) struct EconomicDynamicsStats {
     pub(crate) estimated_delegators_reward: u64,
 
     pub(crate) current_interval_uptime: u8,
+}
+
+fn get_common_owner(delegations: &[Delegation]) -> Option<Addr> {
+    let owner = delegations.iter().next()?.owner();
+    if delegations
+        .iter()
+        .any(|delegation| delegation.owner() != owner)
+    {
+        log::warn!("Unexpected different owners when summing delegations");
+        return None;
+    }
+    Some(owner)
+}
+
+fn get_common_node_identity(delegations: &[Delegation]) -> Option<String> {
+    let node_identity = delegations.iter().next()?.node_identity();
+    if delegations
+        .iter()
+        .any(|delegation| delegation.node_identity() != node_identity)
+    {
+        log::warn!("Unexpected different node identities when summing delegations");
+        return None;
+    }
+    Some(node_identity)
+}
+
+fn get_common_denom(delegations: &[Delegation]) -> Option<String> {
+    let denom = delegations.iter().next()?.amount.denom.clone();
+    if delegations
+        .iter()
+        .any(|delegation| delegation.amount.denom != denom)
+    {
+        log::warn!("Unexpected different coin denom when summing delegations");
+        return None;
+    }
+    Some(denom)
 }


### PR DESCRIPTION
# Description

Add endpoint for getting the number of delegations summed by owner.

Part of: https://github.com/nymtech/nym/issues/2449

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
