### PR TITLE
Set probability to 1 if less nodes then the limit

### DIFF
--- a/validator-api/src/node_status_api/routes.rs
+++ b/validator-api/src/node_status_api/routes.rs
@@ -211,6 +211,14 @@ pub(crate) async fn get_mixnode_inclusion_probability(
     identity: String,
 ) -> Json<Option<InclusionProbabilityResponse>> {
     let mixnodes = cache.mixnodes().await;
+    let rewarding_params = cache.epoch_reward_params().await.into_inner();
+
+    if mixnodes.len() <= rewarding_params.rewarded_set_size() as usize {
+        return Json(Some(InclusionProbabilityResponse {
+            in_active: 1.0.into(),
+            in_reserve: 1.0.into(),
+        }));
+    }
 
     if let Some(target_mixnode) = mixnodes.iter().find(|x| x.identity() == &identity) {
         let total_bonded_tokens = mixnodes
@@ -218,7 +226,6 @@ pub(crate) async fn get_mixnode_inclusion_probability(
             .fold(0u128, |acc, x| acc + x.total_bond().unwrap_or_default())
             as f64;
 
-        let rewarding_params = cache.epoch_reward_params().await.into_inner();
         let rewarded_set_size = rewarding_params.rewarded_set_size() as f64;
         let active_set_size = rewarding_params.active_set_size() as f64;
 
@@ -228,7 +235,6 @@ pub(crate) async fn get_mixnode_inclusion_probability(
         let prob_active_set = active_set_size * prob_one_draw;
         // This is likely slightly too high, as we're not correcting form them not being selected in active, should be chance to be selected, minus the chance for being not selected in reserve
         let prob_reserve_set = (rewarded_set_size - active_set_size) * prob_one_draw;
-        // (rewarded_set_size - active_set_size) * prob_one_draw * (1. - prob_active_set);
 
         Json(Some(InclusionProbabilityResponse {
             in_active: prob_active_set.into(),


### PR DESCRIPTION
# Description

Set probability of nodes to be included in the rewarded and active sets to 1. if there are less node then the rewarded_set limit.

Closes: [#226](https://github.com/nymtech/nym/issues/2448)

<!-- If appropriate, insert relevant description here -->
