### PR TITLE
Panic early if re-init with new gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - mixnode, gateway: attempting to determine reconnection backoff to persistently failing mixnode could result in a crash ([#1260])
 - mixnode: the mixnode learned how to shutdown gracefully.
 - vesting-contract: replaced `checked_sub` with `saturating_sub` to fix the underflow in `get_vesting_tokens` ([#1275])
+- native & socks5 clients: fail early when clients try to re-init with a different gateway, which is not supported yet ([#1322])
 
 ### Changed
 
@@ -54,6 +55,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1295]: https://github.com/nymtech/nym/pull/1295
 [#1302]: https://github.com/nymtech/nym/pull/1302
 [#1318]: https://github.com/nymtech/nym/pull/1318
+[#1322]: https://github.com/nymtech/nym/pull/1322
 
 ## [nym-wallet-v1.0.4](https://github.com/nymtech/nym/tree/nym-wallet-v1.0.4) (2022-05-04)
 

--- a/clients/native/src/commands/init.rs
+++ b/clients/native/src/commands/init.rs
@@ -186,6 +186,9 @@ pub async fn execute(matches: ArgMatches<'static>) {
     let id = matches.value_of("id").unwrap(); // required for now
 
     let already_init = if Config::default_config_file_path(Some(id)).exists() {
+        if matches.is_present("gateway") {
+            panic!("At the moment, gateway information can't be overwritten. If you want to point to a different gateway, client {}'s directory will need to be manually removed", id);
+        }
         println!("Client \"{}\" was already initialised before! Config information will be overwritten (but keys will be kept)!", id);
         true
     } else {

--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -39,10 +39,6 @@ pub(crate) fn override_config(mut config: Config, matches: &ArgMatches<'_>) -> C
             .set_custom_validator_apis(parse_validators(raw_validators));
     }
 
-    if let Some(gateway_id) = matches.value_of("gateway") {
-        config.get_base_mut().with_gateway_id(gateway_id);
-    }
-
     if matches.is_present("disable-socket") {
         config = config.with_socket(SocketType::None);
     }

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -187,6 +187,9 @@ pub async fn execute(matches: ArgMatches<'static>) {
     let provider_address = matches.value_of("provider").unwrap();
 
     let already_init = if Config::default_config_file_path(Some(id)).exists() {
+        if matches.is_present("gateway") {
+            panic!("At the moment, gateway information can't be overwritten. If you want to point to a different gateway, client {}'s directory will need to be manually removed", id);
+        }
         println!("Socks5 client \"{}\" was already initialised before! Config information will be overwritten (but keys will be kept)!", id);
         true
     } else {

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -39,10 +39,6 @@ pub(crate) fn override_config(mut config: Config, matches: &ArgMatches<'_>) -> C
             .set_custom_validator_apis(parse_validators(raw_validators));
     }
 
-    if let Some(gateway_id) = matches.value_of("gateway") {
-        config.get_base_mut().with_gateway_id(gateway_id);
-    }
-
     if let Some(port) = matches.value_of("port").map(|port| port.parse::<u16>()) {
         if let Err(err) = port {
             // if port was overridden, it must be parsable


### PR DESCRIPTION
# Description

Fixes clients being able to re-init with a different gateway, which is not currently possible and would fail later, after altering the config file

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
