### PR TITLE
Fix validator docker build on other platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - mixnode: the mixnode learned how to shutdown gracefully.
 - vesting-contract: replaced `checked_sub` with `saturating_sub` to fix the underflow in `get_vesting_tokens` ([#1275])
 - native & socks5 clients: fail early when clients try to re-init with a different gateway, which is not supported yet ([#1322])
+- validator: fixed local docker-compose setup to work on Apple M1 ([#1329])
 
 ### Changed
 
@@ -61,6 +62,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1318]: https://github.com/nymtech/nym/pull/1318
 [#1322]: https://github.com/nymtech/nym/pull/1322
 [#1328]: https://github.com/nymtech/nym/pull/1328
+[#1329]: https://github.com/nymtech/nym/pull/1329
 
 ## [nym-wallet-v1.0.4](https://github.com/nymtech/nym/tree/nym-wallet-v1.0.4) (2022-05-04)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-network: &NETWORK
   BECH32_PREFIX: nymt
   DENOM: nymt
   STAKE_DENOM: nyxt
-  WASMD_VERSION: v0.26.0
+  WASMD_VERSION: v0.27.0
 
 services:
   genesis_validator:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ x-network: &NETWORK
   DENOM: nymt
   STAKE_DENOM: nyxt
   WASMD_VERSION: v0.26.0
-  WASMD_COMMIT_HASH: dc5ef6fe84f0a5e3b0894692a18cc48fb5b00adf
 
 services:
   genesis_validator:

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -7,6 +7,6 @@ RUN ./setup.sh
 
 FROM ubuntu:20.04
 COPY --from=go_builder /go/wasmd/build/nymd /root/nymd
-COPY --from=go_builder /go/wasmd/build/libwasmvm.so /root/libwasmvm.so
+COPY --from=go_builder /go/wasmd/build/libwasmvm*.so /root
 COPY init_and_start.sh .
 ENTRYPOINT ["./init_and_start.sh"]

--- a/docker/validator/setup.sh
+++ b/docker/validator/setup.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
+set -ue
+
 git clone https://github.com/CosmWasm/wasmd.git
 cd wasmd
 git checkout "${WASMD_VERSION}"
+WASMD_COMMIT_HASH=$(git rev-parse HEAD)
 mkdir build
 go build \
     -o build/nymd -mod=readonly -tags "netgo,ledger" \

--- a/docker/validator/setup.sh
+++ b/docker/validator/setup.sh
@@ -14,5 +14,4 @@ go build \
     -X github.com/CosmWasm/wasmd/app.Bech32Prefix=${BECH32_PREFIX} \
     -X 'github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger'" \
     -trimpath ./cmd/wasmd
-WASMVM_SO=$(ldd build/nymd | grep libwasmvm.so | awk '{ print $3 }')
-cp "${WASMVM_SO}" build/
+find .. -type f -name 'libwasm*.so' -exec cp {} build \;


### PR DESCRIPTION
# Description

The `Dockerfile` for validator failed to build when run on arm macOS hosts, even when targeting `amd64`. This is because the `setup.sh` script was not accounting for different naming of `libwasmvm` on various architectures and using `ldd` which routinely segfaults under emulation. The solution is simply to use `find` instead of `ldd` and allow for different naming.

This change also makes the build-arg variables required instead of silently building without them set.