### PR TITLE
Show transaction hash in modals when redeeming or compounding rewards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - wallet: new delegation and rewards UI
 - wallet: show version in nav bar
 - wallet: contract admin route put back
-- waller: staking_supply field to StateParams
+- wallet: staking_supply field to StateParams
+- wallet: show transaction hash for redeeming or compounding rewards
 - network-statistics: a new mixnet service that aggregates and exposes anonymized data about mixnet services ([#1328])
 
 ### Fixed

--- a/nym-wallet/src-tauri/src/operations/mixnet/rewards.rs
+++ b/nym-wallet/src-tauri/src/operations/mixnet/rewards.rs
@@ -2,6 +2,7 @@ use crate::error::BackendError;
 use crate::nymd_client;
 use crate::state::State;
 use mixnet_contract_common::IdentityKey;
+use nym_types::transaction::TransactionExecuteResult;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use validator_client::nymd::Fee;
@@ -10,22 +11,36 @@ use validator_client::nymd::Fee;
 pub async fn claim_operator_reward(
     fee: Option<Fee>,
     state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<(), BackendError> {
-    nymd_client!(state)
+) -> Result<TransactionExecuteResult, BackendError> {
+    log::info!(">>> Claim operator reward");
+    let denom_minor = state.read().await.current_network().denom();
+    let res = nymd_client!(state)
         .execute_claim_operator_reward(fee)
         .await?;
-    Ok(())
+    log::info!("<<< tx hash = {}", res.transaction_hash);
+    log::trace!("<<< {:?}", res);
+    Ok(TransactionExecuteResult::from_execute_result(
+        res,
+        denom_minor.as_ref(),
+    )?)
 }
 
 #[tauri::command]
 pub async fn compound_operator_reward(
     fee: Option<Fee>,
     state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<(), BackendError> {
-    nymd_client!(state)
+) -> Result<TransactionExecuteResult, BackendError> {
+    log::info!(">>> Compound operator reward");
+    let denom_minor = state.read().await.current_network().denom();
+    let res = nymd_client!(state)
         .execute_compound_operator_reward(fee)
         .await?;
-    Ok(())
+    log::info!("<<< tx hash = {}", res.transaction_hash);
+    log::trace!("<<< {:?}", res);
+    Ok(TransactionExecuteResult::from_execute_result(
+        res,
+        denom_minor.as_ref(),
+    )?)
 }
 
 #[tauri::command]
@@ -33,11 +48,21 @@ pub async fn claim_delegator_reward(
     mix_identity: IdentityKey,
     fee: Option<Fee>,
     state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<(), BackendError> {
-    nymd_client!(state)
+) -> Result<TransactionExecuteResult, BackendError> {
+    log::info!(
+        ">>> Claim delegator reward: identity_key = {}",
+        mix_identity
+    );
+    let denom_minor = state.read().await.current_network().denom();
+    let res = nymd_client!(state)
         .execute_claim_delegator_reward(mix_identity, fee)
         .await?;
-    Ok(())
+    log::info!("<<< tx hash = {}", res.transaction_hash);
+    log::trace!("<<< {:?}", res);
+    Ok(TransactionExecuteResult::from_execute_result(
+        res,
+        denom_minor.as_ref(),
+    )?)
 }
 
 #[tauri::command]
@@ -45,9 +70,19 @@ pub async fn compound_delegator_reward(
     mix_identity: IdentityKey,
     fee: Option<Fee>,
     state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<(), BackendError> {
-    nymd_client!(state)
+) -> Result<TransactionExecuteResult, BackendError> {
+    log::info!(
+        ">>> Compound delegator reward: identity_key = {}",
+        mix_identity
+    );
+    let denom_minor = state.read().await.current_network().denom();
+    let res = nymd_client!(state)
         .execute_compound_delegator_reward(mix_identity, fee)
         .await?;
-    Ok(())
+    log::info!("<<< tx hash = {}", res.transaction_hash);
+    log::trace!("<<< {:?}", res);
+    Ok(TransactionExecuteResult::from_execute_result(
+        res,
+        denom_minor.as_ref(),
+    )?)
 }

--- a/nym-wallet/src-tauri/src/operations/vesting/rewards.rs
+++ b/nym-wallet/src-tauri/src/operations/vesting/rewards.rs
@@ -2,6 +2,7 @@ use crate::error::BackendError;
 use crate::nymd_client;
 use crate::state::State;
 use mixnet_contract_common::IdentityKey;
+use nym_types::transaction::TransactionExecuteResult;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use validator_client::nymd::Fee;
@@ -9,22 +10,36 @@ use validator_client::nymd::Fee;
 #[tauri::command]
 pub async fn vesting_claim_operator_reward(
     state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<(), BackendError> {
-    nymd_client!(state)
+) -> Result<TransactionExecuteResult, BackendError> {
+    log::info!(">>> Vesting account: claim operator reward");
+    let denom_minor = state.read().await.current_network().denom();
+    let res = nymd_client!(state)
         .execute_vesting_claim_operator_reward(None)
         .await?;
-    Ok(())
+    log::info!("<<< tx hash = {}", res.transaction_hash);
+    log::trace!("<<< {:?}", res);
+    Ok(TransactionExecuteResult::from_execute_result(
+        res,
+        denom_minor.as_ref(),
+    )?)
 }
 
 #[tauri::command]
 pub async fn vesting_compound_operator_reward(
     fee: Option<Fee>,
     state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<(), BackendError> {
-    nymd_client!(state)
+) -> Result<TransactionExecuteResult, BackendError> {
+    log::info!(">>> Vesting account: compound operator reward");
+    let denom_minor = state.read().await.current_network().denom();
+    let res = nymd_client!(state)
         .execute_vesting_compound_operator_reward(fee)
         .await?;
-    Ok(())
+    log::info!("<<< tx hash = {}", res.transaction_hash);
+    log::trace!("<<< {:?}", res);
+    Ok(TransactionExecuteResult::from_execute_result(
+        res,
+        denom_minor.as_ref(),
+    )?)
 }
 
 #[tauri::command]
@@ -32,11 +47,21 @@ pub async fn vesting_claim_delegator_reward(
     mix_identity: IdentityKey,
     fee: Option<Fee>,
     state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<(), BackendError> {
-    nymd_client!(state)
+) -> Result<TransactionExecuteResult, BackendError> {
+    log::info!(
+        ">>> Vesting account: claim delegator reward: identity_key = {}",
+        mix_identity
+    );
+    let denom_minor = state.read().await.current_network().denom();
+    let res = nymd_client!(state)
         .execute_vesting_claim_delegator_reward(mix_identity, fee)
         .await?;
-    Ok(())
+    log::info!("<<< tx hash = {}", res.transaction_hash);
+    log::trace!("<<< {:?}", res);
+    Ok(TransactionExecuteResult::from_execute_result(
+        res,
+        denom_minor.as_ref(),
+    )?)
 }
 
 #[tauri::command]
@@ -44,9 +69,19 @@ pub async fn vesting_compound_delegator_reward(
     mix_identity: IdentityKey,
     fee: Option<Fee>,
     state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<(), BackendError> {
-    nymd_client!(state)
+) -> Result<TransactionExecuteResult, BackendError> {
+    log::info!(
+        ">>> Vesting account: compound delegator reward: identity_key = {}",
+        mix_identity
+    );
+    let denom_minor = state.read().await.current_network().denom();
+    let res = nymd_client!(state)
         .execute_vesting_compound_delegator_reward(mix_identity, fee)
         .await?;
-    Ok(())
+    log::info!("<<< tx hash = {}", res.transaction_hash);
+    log::trace!("<<< {:?}", res);
+    Ok(TransactionExecuteResult::from_execute_result(
+        res,
+        denom_minor.as_ref(),
+    )?)
 }

--- a/nym-wallet/src/context/delegations.tsx
+++ b/nym-wallet/src/context/delegations.tsx
@@ -32,8 +32,8 @@ export type TDelegationContext = {
     tokenPool: TPoolOption,
   ) => Promise<TransactionExecuteResult>;
   undelegate: (identity: string, proxy: string | null) => Promise<TransactionExecuteResult>;
-  redeemRewards: (identity: string, proxy: string | null) => Promise<void>;
-  compoundRewards: (identity: string, proxy: string | null) => Promise<void>;
+  redeemRewards: (identity: string, proxy: string | null) => Promise<TransactionExecuteResult>;
+  compoundRewards: (identity: string, proxy: string | null) => Promise<TransactionExecuteResult>;
 };
 
 export type TDelegationTransaction = {
@@ -100,10 +100,10 @@ export const DelegationContextProvider: FC<{
     try {
       if ((proxy || '').trim().length === 0) {
         // the owner of the delegation is main account (the owner of the vesting account), so it is delegation with unlocked tokens
-        await claimDelegatorRewards(identity);
+        return claimDelegatorRewards(identity);
       } else {
         // the delegation is with locked tokens, so use the vesting contract
-        await vestingClaimDelegatorRewards(identity);
+        return vestingClaimDelegatorRewards(identity);
       }
     } catch (e) {
       throw new Error(e as string);
@@ -114,10 +114,10 @@ export const DelegationContextProvider: FC<{
     try {
       if ((proxy || '').trim().length === 0) {
         // the owner of the delegation is main account (the owner of the vesting account), so it is delegation with unlocked tokens
-        await compoundDelegatorRewards(identity);
+        return compoundDelegatorRewards(identity);
       } else {
         // the delegation is with locked tokens, so use the vesting contract
-        await vestingCompoundDelegatorRewards(identity);
+        return vestingCompoundDelegatorRewards(identity);
       }
     } catch (e) {
       throw new Error(e as string);

--- a/nym-wallet/src/pages/delegation/index.tsx
+++ b/nym-wallet/src/pages/delegation/index.tsx
@@ -196,12 +196,13 @@ export const Delegation: FC = () => {
     setCurrentDelegationListActionItem(undefined);
 
     try {
-      await redeemRewards(identityKey, proxy);
+      const tx = await redeemRewards(identityKey, proxy);
       const bal = await userBalance();
       setConfirmationModalProps({
         status: 'success',
         action: 'redeem',
         balance: bal?.printable_balance || '-',
+        transactionUrl: `${urls(network).blockExplorer}/transaction/${tx.transaction_hash}`,
       });
     } catch (e) {
       setConfirmationModalProps({
@@ -221,12 +222,13 @@ export const Delegation: FC = () => {
     setCurrentDelegationListActionItem(undefined);
 
     try {
-      await compoundRewards(identityKey, proxy);
+      const tx = await compoundRewards(identityKey, proxy);
       const bal = await userBalance();
       setConfirmationModalProps({
         status: 'success',
         action: 'compound',
         balance: bal?.printable_balance || '-',
+        transactionUrl: `${urls(network).blockExplorer}/transaction/${tx.transaction_hash}`,
       });
     } catch (e) {
       setConfirmationModalProps({

--- a/nym-wallet/src/requests/rewards.ts
+++ b/nym-wallet/src/requests/rewards.ts
@@ -1,7 +1,14 @@
 import { invokeWrapper } from './wrapper';
+import { TransactionExecuteResult } from '@nymproject/types';
 
-export const claimDelegatorRewards = async (mixIdentity: string): Promise<void> =>
-  invokeWrapper('claim_delegator_reward', { mixIdentity });
+export const claimOperatorRewards = async () =>
+  invokeWrapper<TransactionExecuteResult>('claim_operator_reward');
 
-export const compoundDelegatorRewards = async (mixIdentity: String): Promise<void> =>
-  invokeWrapper('compound_delegator_reward', { mixIdentity });
+export const compoundOperatorRewards = async () =>
+  invokeWrapper<TransactionExecuteResult>('compound_operator_reward');
+
+export const claimDelegatorRewards = async (mixIdentity: string) =>
+  invokeWrapper<TransactionExecuteResult>('claim_delegator_reward', { mixIdentity });
+
+export const compoundDelegatorRewards = async (mixIdentity: String) =>
+  invokeWrapper<TransactionExecuteResult>('compound_delegator_reward', { mixIdentity });

--- a/nym-wallet/src/requests/vesting.ts
+++ b/nym-wallet/src/requests/vesting.ts
@@ -104,8 +104,14 @@ export const vestingBond = async (args: { type: EnumNodeType } & (TBondMixNodeAr
   return vestingBondGateway(other as TBondGatewayArgs);
 };
 
-export const vestingClaimDelegatorRewards = async (mixIdentity: string): Promise<void> =>
-  invokeWrapper('vesting_claim_delegator_reward', { mixIdentity });
+export const vestingClaimOperatorRewards = async () =>
+  invokeWrapper<TransactionExecuteResult>('vesting_claim_operator_reward');
 
-export const vestingCompoundDelegatorRewards = async (mixIdentity: string): Promise<void> =>
-  invokeWrapper('vesting_compound_delegator_reward', { mixIdentity });
+export const vestingCompoundOperatorRewards = async () =>
+  invokeWrapper<TransactionExecuteResult>('vesting_compound_operator_reward');
+
+export const vestingClaimDelegatorRewards = async (mixIdentity: string) =>
+  invokeWrapper<TransactionExecuteResult>('vesting_claim_delegator_reward', { mixIdentity });
+
+export const vestingCompoundDelegatorRewards = async (mixIdentity: string) =>
+  invokeWrapper<TransactionExecuteResult>('vesting_compound_delegator_reward', { mixIdentity });


### PR DESCRIPTION
# Description

Shows the transaction hash when compounding or redeeming rewards

Closes: https://github.com/nymtech/nym/issues/2429, https://github.com/nymtech/nym/issues/2428

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
