### PR TITLE
Ignored most of expensive dkg tests and made them run only on PRs to develop/master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,13 @@ jobs:
           command: test
           args: --workspace --all-features
 
+      - name: Run expensive tests
+        if: github.ref == 'refs/heads/develop' || github.event.pull_request.base.ref == 'develop' || github.event.pull_request.base.ref == 'master'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --all-features -- --ignored
+
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -50,6 +50,13 @@ jobs:
           command: test
           args: --workspace
 
+      - name: Run expensive tests
+        if: github.ref == 'refs/heads/develop' || github.event.pull_request.base.ref == 'develop' || github.event.pull_request.base.ref == 'master'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --all-features -- --ignored
+
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
+test-all: test cargo-test-expensive
 test: build clippy-all cargo-test wasm fmt
 no-clippy: build cargo-test wasm fmt
 happy: fmt clippy-happy test
 clippy-all: clippy-all-main clippy-all-contracts clippy-all-wallet clippy-all-connect
 clippy-happy: clippy-happy-main clippy-happy-contracts clippy-happy-wallet clippy-happy-connect
 cargo-test: test-main test-contracts test-wallet test-connect
+cargo-test-expensive: test-main-expensive test-contracts-expensive test-wallet-expensive test-connect-expensive
 build: build-contracts build-wallet build-main build-connect
 fmt: fmt-main fmt-contracts fmt-wallet fmt-connect
 
@@ -34,14 +36,26 @@ clippy-all-connect:
 test-main:
 	cargo test --all-features --workspace
 
+test-main-expensive:
+	cargo test --all-features --workspace -- --ignored
+
 test-contracts:
 	cargo test --manifest-path contracts/Cargo.toml --all-features
+
+test-contracts-expensive:
+	cargo test --manifest-path contracts/Cargo.toml --all-features -- --ignored
 
 test-wallet:
 	cargo test --manifest-path nym-wallet/Cargo.toml --all-features
 
+test-wallet-expensive:
+	cargo test --manifest-path nym-wallet/Cargo.toml --all-features -- --ignored
+
 test-connect:
 	cargo test --manifest-path nym-connect/Cargo.toml --all-features
+
+test-connect-expensive:
+	cargo test --manifest-path nym-connect/Cargo.toml --all-features -- --ignored
 
 build-main:
 	cargo build --workspace

--- a/common/crypto/dkg/src/bte/encryption.rs
+++ b/common/crypto/dkg/src/bte/encryption.rs
@@ -458,6 +458,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn share_decryption_20() {
         let dummy_seed = [1u8; 32];
         let mut rng = rand_chacha::ChaCha20Rng::from_seed(dummy_seed);
@@ -487,6 +488,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn share_encryption_under_nonzero_epoch() {
         let dummy_seed = [1u8; 32];
         let mut rng = rand_chacha::ChaCha20Rng::from_seed(dummy_seed);
@@ -557,6 +559,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn update_and_decrypt_10() {
         let dummy_seed = [1u8; 32];
         let mut rng = rand_chacha::ChaCha20Rng::from_seed(dummy_seed);
@@ -581,6 +584,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn reblinding_node_doesnt_affect_decryption() {
         let dummy_seed = [1u8; 32];
         let mut rng = rand_chacha::ChaCha20Rng::from_seed(dummy_seed);
@@ -623,6 +627,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn ciphertext_integrity_check_passes_for_valid_data() {
         let params = setup();
 
@@ -640,6 +645,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn ciphertext_integrity_check_passes_fails_for_malformed_data() {
         let params = setup();
 
@@ -668,6 +674,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn ciphertext_integrity_check_passes_fails_for_wrong_epoch() {
         let params = setup();
 

--- a/common/crypto/dkg/src/bte/keys.rs
+++ b/common/crypto/dkg/src/bte/keys.rs
@@ -651,6 +651,7 @@ mod tests {
     use rand_core::SeedableRng;
 
     #[test]
+    #[ignore] // expensive test
     fn basic_coverage_nodes() {
         // it's some basic test I've been performing when writing the update function, but figured
         // might as well put it into a unit test. note that it doesn't check the entire structure,
@@ -761,6 +762,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn updating_to_next_epoch() {
         let params = setup();
 
@@ -816,6 +818,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn bte_node_roundtrip() {
         let params = setup();
 
@@ -839,6 +842,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn decryption_key_node_roundtrip() {
         let params = setup();
 

--- a/common/crypto/dkg/src/bte/proof_chunking.rs
+++ b/common/crypto/dkg/src/bte/proof_chunking.rs
@@ -761,6 +761,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn should_verify_a_valid_proof() {
         let dummy_seed = [1u8; 32];
         let mut rng = rand_chacha::ChaCha20Rng::from_seed(dummy_seed);

--- a/common/crypto/dkg/src/dealing.rs
+++ b/common/crypto/dkg/src/dealing.rs
@@ -351,6 +351,7 @@ mod tests {
     use rand_core::SeedableRng;
 
     #[test]
+    #[ignore] // expensive test
     fn recovering_partial_verification_keys() {
         // START OF SETUP
         let dummy_seed = [42u8; 32];
@@ -419,6 +420,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn verifying_partial_verification_keys() {
         let dummy_seed = [42u8; 32];
         let mut rng = rand_chacha::ChaCha20Rng::from_seed(dummy_seed);
@@ -467,6 +469,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // expensive test
     fn dealing_roundtrip() {
         let dummy_seed = [1u8; 32];
         let mut rng = rand_chacha::ChaCha20Rng::from_seed(dummy_seed);

--- a/common/crypto/dkg/tests/integration.rs
+++ b/common/crypto/dkg/tests/integration.rs
@@ -9,6 +9,7 @@ use rand_core::SeedableRng;
 use std::collections::BTreeMap;
 
 #[test]
+#[ignore] // expensive test
 fn single_sender() {
     // makes it easier to understand than `full_threshold_secret_sharing`
     // and is a good stepping stone, because its everything each node will have to perform (from one point of view)
@@ -66,6 +67,7 @@ fn single_sender() {
 }
 
 #[test]
+#[ignore] // expensive test
 fn full_threshold_secret_sharing() {
     let dummy_seed = [42u8; 32];
     let mut rng = rand_chacha::ChaCha20Rng::from_seed(dummy_seed);
@@ -161,6 +163,7 @@ fn full_threshold_secret_sharing() {
 }
 
 #[test]
+#[ignore] // expensive test
 fn full_threshold_secret_resharing() {
     let dummy_seed = [42u8; 32];
     let mut rng = rand_chacha::ChaCha20Rng::from_seed(dummy_seed);


### PR DESCRIPTION
# Description

In a way suggested in the [rust book](https://doc.rust-lang.org/book/ch11-02-running-tests.html), I'm ignoring expensive DKG tests and instead I have a separate `Run Expensive tests` step in our CI that would (in theory) only run on PRs to develop/master that would run those.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
