### PR TITLE
Wallet: Sending again the NodeId to fetch the saturation

### DIFF
--- a/nym-wallet/src/components/Delegation/DelegateModal.tsx
+++ b/nym-wallet/src/components/Delegation/DelegateModal.tsx
@@ -68,6 +68,7 @@ export const DelegateModal: React.FC<{
 
   const handleCheckStakeSaturation = async (identity: string) => {
     setErrorNodeSaturation(undefined);
+
     try {
       const newSaturation = await getMixnodeStakeSaturation(identity);
       if (newSaturation && newSaturation.saturation > 1) {
@@ -109,7 +110,7 @@ export const DelegateModal: React.FC<{
 
   const handleIdentityKeyChanged = (newIdentityKey: string) => {
     setIdentityKey(newIdentityKey);
-    handleCheckStakeSaturation(newIdentityKey!);
+    handleCheckStakeSaturation(newIdentityKey);
 
     if (onIdentityKeyChanged) {
       onIdentityKeyChanged(newIdentityKey);

--- a/nym-wallet/src/components/Delegation/DelegateModal.tsx
+++ b/nym-wallet/src/components/Delegation/DelegateModal.tsx
@@ -68,7 +68,6 @@ export const DelegateModal: React.FC<{
 
   const handleCheckStakeSaturation = async (identity: string) => {
     setErrorNodeSaturation(undefined);
-
     try {
       const newSaturation = await getMixnodeStakeSaturation(identity);
       if (newSaturation && newSaturation.saturation > 1) {
@@ -81,13 +80,12 @@ export const DelegateModal: React.FC<{
     }
   };
 
-  const validateIdentityKey = async (isValid: boolean) => {
+  const validateIdentityKey = (isValid: boolean) => {
     if (!isValid) {
       setErrorIdentityKey('Identity key is invalid');
       setErrorNodeSaturation(undefined);
     } else {
       setErrorIdentityKey(undefined);
-      await handleCheckStakeSaturation(identityKey!);
     }
   };
 
@@ -109,8 +107,9 @@ export const DelegateModal: React.FC<{
     }
   };
 
-  const handleIdentityKeyChanged = async (newIdentityKey: string) => {
+  const handleIdentityKeyChanged = (newIdentityKey: string) => {
     setIdentityKey(newIdentityKey);
+    handleCheckStakeSaturation(newIdentityKey!);
 
     if (onIdentityKeyChanged) {
       onIdentityKeyChanged(newIdentityKey);


### PR DESCRIPTION
In some ulterior refactor, was moved - by mistake - the function `handleCheckStakeSaturation(nodeId)`, and at this place the `nodeId` wasn't set yet. Then, the saturation fetch fails (because we make the call without the needed parameter, `nodeId`), and the field doesn't properly check.

Closes: (https://github.com/nymtech/nym/issues/1374)

