### PR TITLE
wallet: remove broken platform constants

### DIFF
--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -5581,7 +5581,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vesting-contract"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "config",
  "cosmwasm-std",

--- a/nym-wallet/src-tauri/src/platform_constants.rs
+++ b/nym-wallet/src-tauri/src/platform_constants.rs
@@ -4,27 +4,7 @@
 // Specify filenames and other platform specific constants to respect platform conventions, or at
 // least, something popular on each respective platform.
 
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "linux")] {
-        pub const CONFIG_DIR_NAME: &str = "nym-wallet";
-        pub const CONFIG_FILENAME: &str = "config.toml";
-        pub const STORAGE_DIR_NAME: &str = "nym-wallet";
-        pub const WALLET_INFO_FILENAME: &str = "saved-wallet.json";
-    } else if #[cfg(taret_os = "macos")] {
-        pub const CONFIG_DIR_NAME: &str = "nym-wallet";
-        pub const CONFIG_FILENAME: &str = "config.toml";
-        pub const STORAGE_DIR_NAME: &str = "nym-wallet";
-        pub const WALLET_INFO_FILENAME: &str = "saved-wallet.json";
-    } else if #[cfg(taret_os = "windows")] {
-        pub const CONFIG_DIR_NAME: &str = "NymWallet";
-        pub const CONFIG_FILENAME: &str = "Config.toml";
-        pub const STORAGE_DIR_NAME: &str = "NymWallet";
-        pub const WALLET_INFO_FILENAME: &str = "saved_wallet.json";
-    } else {
-        // This case is likely to be a unix-y system
-        pub const CONFIG_DIR_NAME: &str = "nym-wallet";
-        pub const CONFIG_FILENAME: &str = "config.toml";
-        pub const STORAGE_DIR_NAME: &str = "nym-wallet";
-        pub const WALLET_INFO_FILENAME: &str = "saved-wallet.json";
-    }
-}
+pub const CONFIG_DIR_NAME: &str = "nym-wallet";
+pub const CONFIG_FILENAME: &str = "config.toml";
+pub const STORAGE_DIR_NAME: &str = "nym-wallet";
+pub const WALLET_INFO_FILENAME: &str = "saved-wallet.json";


### PR DESCRIPTION
Due to a bug (typo) these constants were actually never used, and at this point we can't fix it without breaking backwards compatibility.