### PR TITLE
client: consolidate and de-duplicate initialization between clients and nym-connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - mixnode: the mixnode learned how to shutdown gracefully
 - native & socks5 clients: fail early when clients try to re-init with a different gateway, which is not supported yet ([#1322])
 - native & socks5 clients: rerun init will now reuse previous gateway configuration instead of failing ([#1353])
+- native & socks5 clients: deduplicate big chunks of init logic
 - validator: fixed local docker-compose setup to work on Apple M1 ([#1329])
 
 ### Changed

--- a/clients/client-core/src/init.rs
+++ b/clients/client-core/src/init.rs
@@ -1,0 +1,137 @@
+// Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Collection of initialization steps used by client implementations
+
+use std::{sync::Arc, time::Duration};
+
+use config::NymConfig;
+use crypto::asymmetric::{encryption, identity};
+use gateway_client::GatewayClient;
+use gateway_requests::registration::handshake::SharedKeys;
+use nymsphinx::addressing::clients::Recipient;
+use nymsphinx::addressing::nodes::NodeIdentity;
+use rand::rngs::OsRng;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use topology::{filter::VersionFilterable, gateway};
+use url::Url;
+
+use crate::{
+    client::key_manager::KeyManager,
+    config::{persistence::key_pathfinder::ClientKeyPathfinder, Config},
+};
+
+pub async fn query_gateway_details(
+    validator_servers: Vec<Url>,
+    chosen_gateway_id: Option<&str>,
+) -> gateway::Node {
+    let validator_api = validator_servers
+        .choose(&mut thread_rng())
+        .expect("The list of validator apis is empty");
+    let validator_client = validator_client::ApiClient::new(validator_api.clone());
+
+    log::trace!("Fetching list of gateways from: {}", validator_api);
+    let gateways = validator_client.get_cached_gateways().await.unwrap();
+    let valid_gateways = gateways
+        .into_iter()
+        .filter_map(|gateway| gateway.try_into().ok())
+        .collect::<Vec<gateway::Node>>();
+
+    let filtered_gateways = valid_gateways.filter_by_version(env!("CARGO_PKG_VERSION"));
+
+    // if we have chosen particular gateway - use it, otherwise choose a random one.
+    // (remember that in active topology all gateways have at least 100 reputation so should
+    // be working correctly)
+    if let Some(gateway_id) = chosen_gateway_id {
+        filtered_gateways
+            .iter()
+            .find(|gateway| gateway.identity_key.to_base58_string() == gateway_id)
+            .expect(&*format!("no gateway with id {} exists!", gateway_id))
+            .clone()
+    } else {
+        filtered_gateways
+            .choose(&mut rand::thread_rng())
+            .expect("there are no gateways on the network!")
+            .clone()
+    }
+}
+
+pub async fn register_with_gateway_and_store_keys<T>(
+    gateway_details: gateway::Node,
+    config: &Config<T>,
+) where
+    T: NymConfig,
+{
+    let mut rng = OsRng;
+    let mut key_manager = KeyManager::new(&mut rng);
+
+    let shared_keys = register_with_gateway(&gateway_details, key_manager.identity_keypair()).await;
+    key_manager.insert_gateway_shared_key(shared_keys);
+
+    let pathfinder = ClientKeyPathfinder::new_from_config(config);
+    key_manager
+        .store_keys(&pathfinder)
+        .expect("Failed to generated keys");
+}
+
+async fn register_with_gateway(
+    gateway: &gateway::Node,
+    our_identity: Arc<identity::KeyPair>,
+) -> Arc<SharedKeys> {
+    let timeout = Duration::from_millis(1500);
+    let mut gateway_client = GatewayClient::new_init(
+        gateway.clients_address(),
+        gateway.identity_key,
+        gateway.owner.clone(),
+        our_identity.clone(),
+        timeout,
+    );
+    gateway_client
+        .establish_connection()
+        .await
+        .expect("failed to establish connection with the gateway!");
+    gateway_client
+        .perform_initial_authentication()
+        .await
+        .expect("failed to register with the gateway!")
+}
+
+pub fn show_address<T>(config: &Config<T>)
+where
+    T: config::NymConfig,
+{
+    fn load_identity_keys(pathfinder: &ClientKeyPathfinder) -> identity::KeyPair {
+        let identity_keypair: identity::KeyPair =
+            pemstore::load_keypair(&pemstore::KeyPairPath::new(
+                pathfinder.private_identity_key().to_owned(),
+                pathfinder.public_identity_key().to_owned(),
+            ))
+            .expect("Failed to read stored identity key files");
+        identity_keypair
+    }
+
+    fn load_sphinx_keys(pathfinder: &ClientKeyPathfinder) -> encryption::KeyPair {
+        let sphinx_keypair: encryption::KeyPair =
+            pemstore::load_keypair(&pemstore::KeyPairPath::new(
+                pathfinder.private_encryption_key().to_owned(),
+                pathfinder.public_encryption_key().to_owned(),
+            ))
+            .expect("Failed to read stored sphinx key files");
+        sphinx_keypair
+    }
+
+    let pathfinder = ClientKeyPathfinder::new_from_config(config);
+    let identity_keypair = load_identity_keys(&pathfinder);
+    let sphinx_keypair = load_sphinx_keys(&pathfinder);
+
+    let client_recipient = Recipient::new(
+        *identity_keypair.public_key(),
+        *sphinx_keypair.public_key(),
+        // TODO: below only works under assumption that gateway address == gateway id
+        // (which currently is true)
+        NodeIdentity::from_base58_string(config.get_gateway_id()).unwrap(),
+    );
+
+    println!("\nThe address of this client is: {}", client_recipient);
+}

--- a/clients/client-core/src/lib.rs
+++ b/clients/client-core/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod client;
 pub mod config;
+pub mod init;

--- a/clients/native/src/commands/init.rs
+++ b/clients/native/src/commands/init.rs
@@ -2,22 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{App, Arg, ArgMatches};
-use client_core::client::key_manager::KeyManager;
-use client_core::config::persistence::key_pathfinder::ClientKeyPathfinder;
+use client_core::config::GatewayEndpoint;
 use config::NymConfig;
-use crypto::asymmetric::{encryption, identity};
-use gateway_client::GatewayClient;
-use gateway_requests::registration::handshake::SharedKeys;
-use nymsphinx::addressing::clients::Recipient;
-use nymsphinx::addressing::nodes::NodeIdentity;
-use rand::rngs::OsRng;
-use rand::seq::SliceRandom;
-use rand::thread_rng;
-use std::convert::TryInto;
-use std::sync::Arc;
-use std::time::Duration;
-use topology::{filter::VersionFilterable, gateway};
-use url::Url;
 
 use crate::client::config::Config;
 use crate::commands::override_config;
@@ -93,133 +79,6 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
     app
 }
 
-async fn register_with_gateway(
-    gateway: &gateway::Node,
-    our_identity: Arc<identity::KeyPair>,
-) -> Arc<SharedKeys> {
-    let timeout = Duration::from_millis(1500);
-    let mut gateway_client = GatewayClient::new_init(
-        gateway.clients_address(),
-        gateway.identity_key,
-        gateway.owner.clone(),
-        our_identity.clone(),
-        timeout,
-    );
-    gateway_client
-        .establish_connection()
-        .await
-        .expect("failed to establish connection with the gateway!");
-    gateway_client
-        .perform_initial_authentication()
-        .await
-        .expect("failed to register with the gateway!")
-}
-
-async fn gateway_details(
-    validator_servers: Vec<Url>,
-    chosen_gateway_id: Option<&str>,
-) -> gateway::Node {
-    let validator_api = validator_servers
-        .choose(&mut thread_rng())
-        .expect("The list of validator apis is empty");
-    let validator_client = validator_client::ApiClient::new(validator_api.clone());
-
-    log::trace!("Fetching list of gateways from: {}", validator_api);
-    let gateways = validator_client.get_cached_gateways().await.unwrap();
-    let valid_gateways = gateways
-        .into_iter()
-        .filter_map(|gateway| gateway.try_into().ok())
-        .collect::<Vec<gateway::Node>>();
-
-    let filtered_gateways = valid_gateways.filter_by_version(env!("CARGO_PKG_VERSION"));
-
-    // if we have chosen particular gateway - use it, otherwise choose a random one.
-    // (remember that in active topology all gateways have at least 100 reputation so should
-    // be working correctly)
-    if let Some(gateway_id) = chosen_gateway_id {
-        filtered_gateways
-            .iter()
-            .find(|gateway| gateway.identity_key.to_base58_string() == gateway_id)
-            .expect(&*format!("no gateway with id {} exists!", gateway_id))
-            .clone()
-    } else {
-        filtered_gateways
-            .choose(&mut rand::thread_rng())
-            .expect("there are no gateways on the network!")
-            .clone()
-    }
-}
-
-fn show_address(config: &Config) {
-    fn load_identity_keys(pathfinder: &ClientKeyPathfinder) -> identity::KeyPair {
-        let identity_keypair: identity::KeyPair =
-            pemstore::load_keypair(&pemstore::KeyPairPath::new(
-                pathfinder.private_identity_key().to_owned(),
-                pathfinder.public_identity_key().to_owned(),
-            ))
-            .expect("Failed to read stored identity key files");
-        identity_keypair
-    }
-
-    fn load_sphinx_keys(pathfinder: &ClientKeyPathfinder) -> encryption::KeyPair {
-        let sphinx_keypair: encryption::KeyPair =
-            pemstore::load_keypair(&pemstore::KeyPairPath::new(
-                pathfinder.private_encryption_key().to_owned(),
-                pathfinder.public_encryption_key().to_owned(),
-            ))
-            .expect("Failed to read stored sphinx key files");
-        sphinx_keypair
-    }
-
-    let pathfinder = ClientKeyPathfinder::new_from_config(config.get_base());
-    let identity_keypair = load_identity_keys(&pathfinder);
-    let sphinx_keypair = load_sphinx_keys(&pathfinder);
-
-    let client_recipient = Recipient::new(
-        *identity_keypair.public_key(),
-        *sphinx_keypair.public_key(),
-        // TODO: below only works under assumption that gateway address == gateway id
-        // (which currently is true)
-        NodeIdentity::from_base58_string(config.get_base().get_gateway_id()).unwrap(),
-    );
-
-    println!("\nThe address of this client is: {}", client_recipient);
-}
-
-async fn set_gateway_config(config: &mut Config, chosen_gateway_id: Option<&str>) -> gateway::Node {
-    println!("Setting gateway config");
-    log::trace!("Chosen gateway: {:?}", chosen_gateway_id);
-
-    // Get the gateway details by querying the validator-api, and using the chosen one if it's
-    // among the available ones.
-    let gateway_details = gateway_details(
-        config.get_base().get_validator_api_endpoints(),
-        chosen_gateway_id,
-    )
-    .await;
-    log::trace!("Used gateway: {}", gateway_details);
-
-    config
-        .get_base_mut()
-        .with_gateway_endpoint(gateway_details.clone().into());
-    gateway_details
-}
-
-async fn register_and_store_gateway_keys(gateway_details: gateway::Node, config: &Config) {
-    println!("Registering gateway");
-
-    let mut rng = OsRng;
-    let mut key_manager = KeyManager::new(&mut rng);
-    let shared_keys = register_with_gateway(&gateway_details, key_manager.identity_keypair()).await;
-    key_manager.insert_gateway_shared_key(shared_keys);
-
-    let pathfinder = ClientKeyPathfinder::new_from_config(config.get_base());
-    key_manager
-        .store_keys(&pathfinder)
-        .expect("Failed to generated keys");
-    println!("Saved all generated keys");
-}
-
 pub async fn execute(matches: ArgMatches<'static>) {
     println!("Initialising client...");
 
@@ -236,51 +95,31 @@ pub async fn execute(matches: ArgMatches<'static>) {
 
     // Usually you only register with the gateway on the first init, however you can force
     // re-registering if wanted.
-    let should_force_register = matches.is_present("force-register-gateway");
+    let user_wants_force_register = matches.is_present("force-register-gateway");
 
     // If the client was already initialized, don't generate new keys and don't re-register with
     // the gateway (because this would create a new shared key).
     // Unless the user really wants to.
-    let will_register_gateway = !already_init || should_force_register;
+    let register_gateway = !already_init || user_wants_force_register;
 
     // Attempt to use a user-provided gateway, if possible
-    let is_gateway_provided = matches.value_of("gateway").is_some();
+    let user_chosen_gateway_id = matches.value_of("gateway");
 
     let mut config = Config::new(id);
 
-    // TODO: ideally that should be the last thing that's being done to config.
-    // However, we are later further overriding it with gateway id
     config = override_config(config, &matches);
     if matches.is_present("fastmode") {
         config.get_base_mut().set_high_default_traffic_volume();
     }
 
-    if will_register_gateway {
-        // Create identity, encryption and ack keys.
-        let gateway_details = set_gateway_config(&mut config, matches.value_of("gateway")).await;
-        register_and_store_gateway_keys(gateway_details, &config).await;
-    } else if is_gateway_provided {
-        // Just set the config, don't register or create any keys
-        set_gateway_config(&mut config, matches.value_of("gateway")).await;
-    } else {
-        // Read the existing config to reuse the gateway configuration
-        println!("Not registering gateway, will reuse existing config and keys");
-        if let Ok(existing_config) = Config::load_from_file(Some(id)) {
-            config
-                .get_base_mut()
-                .with_gateway_endpoint(existing_config.get_base().get_gateway_endpoint().clone());
-        } else {
-            log::warn!(
-                "Existing configuration found, but enable to load gateway details. \
-                Proceeding anyway."
-            );
-        };
-    }
+    let gateway = setup_gateway(id, register_gateway, user_chosen_gateway_id, &config).await;
+    config.get_base_mut().with_gateway_endpoint(gateway);
 
     let config_save_location = config.get_config_file_save_location();
     config
         .save_to_file(None)
         .expect("Failed to save the config file");
+
     println!("Saved configuration file to {:?}", config_save_location);
     println!("Using gateway: {}", config.get_base().get_gateway_id());
     log::debug!("Gateway id: {}", config.get_base().get_gateway_id());
@@ -291,5 +130,58 @@ pub async fn execute(matches: ArgMatches<'static>) {
     );
     println!("Client configuration completed.");
 
-    show_address(&config);
+    client_core::init::show_address(config.get_base());
+}
+
+async fn setup_gateway(
+    id: &str,
+    register: bool,
+    user_chosen_gateway_id: Option<&str>,
+    config: &Config,
+) -> GatewayEndpoint {
+    if register {
+        // Get the gateway details by querying the validator-api. Either pick one at random or use
+        // the chosen one if it's among the available ones.
+        println!("Configuring gateway");
+        let gateway = client_core::init::query_gateway_details(
+            config.get_base().get_validator_api_endpoints(),
+            user_chosen_gateway_id,
+        )
+        .await;
+        log::debug!("Querying gateway gives: {}", gateway);
+
+        // Registering with gateway by setting up and writing shared keys to disk
+        log::trace!("Registering gateway");
+        client_core::init::register_with_gateway_and_store_keys(gateway.clone(), config.get_base())
+            .await;
+        println!("Saved all generated keys");
+
+        gateway.into()
+    } else if user_chosen_gateway_id.is_some() {
+        // Just set the config, don't register or create any keys
+        // This assumes that the user knows what they are doing, and that the existing keys are
+        // valid for the gateway being used
+        println!("Using gateway provided by user, keeping existing keys");
+        let gateway = client_core::init::query_gateway_details(
+            config.get_base().get_validator_api_endpoints(),
+            user_chosen_gateway_id,
+        )
+        .await;
+        log::debug!("Querying gateway gives: {}", gateway);
+        gateway.into()
+    } else {
+        println!("Not registering gateway, will reuse existing config and keys");
+        match Config::load_from_file(Some(id)) {
+            Ok(existing_config) => existing_config.get_base().get_gateway_endpoint().clone(),
+            Err(err) => {
+                panic!(
+                    "Unable to configure gateway: {err}. \n
+                    Seems like the client was already initialized but it was not possible to read \
+                    the existing configuration file. \n
+                    CAUTION: Consider backing up your gateway keys and try force gateway registration, or \
+                    removing the existing configuration and starting over."
+                )
+            }
+        }
+    }
 }

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -2,20 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{App, Arg, ArgMatches};
-use client_core::client::key_manager::KeyManager;
-use client_core::config::persistence::key_pathfinder::ClientKeyPathfinder;
+use client_core::config::GatewayEndpoint;
 use config::NymConfig;
-use crypto::asymmetric::{encryption, identity};
-use gateway_client::GatewayClient;
-use gateway_requests::registration::handshake::SharedKeys;
-use nymsphinx::addressing::clients::Recipient;
-use nymsphinx::addressing::nodes::NodeIdentity;
-use rand::{prelude::SliceRandom, rngs::OsRng, thread_rng};
-use std::convert::TryInto;
-use std::sync::Arc;
-use std::time::Duration;
-use topology::{filter::VersionFilterable, gateway};
-use url::Url;
 
 use crate::client::config::Config;
 use crate::commands::override_config;
@@ -93,137 +81,6 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
     app
 }
 
-// TODO: make this private again after refactoring the config setup
-pub async fn register_with_gateway(
-    gateway: &gateway::Node,
-    our_identity: Arc<identity::KeyPair>,
-) -> Arc<SharedKeys> {
-    let timeout = Duration::from_millis(1500);
-    let mut gateway_client = GatewayClient::new_init(
-        gateway.clients_address(),
-        gateway.identity_key,
-        gateway.owner.clone(),
-        our_identity.clone(),
-        timeout,
-    );
-    gateway_client
-        .establish_connection()
-        .await
-        .expect("failed to establish connection with the gateway!");
-    gateway_client
-        .perform_initial_authentication()
-        .await
-        .expect("failed to register with the gateway!")
-}
-
-// TODO: make this private again after refactoring the config setup
-pub async fn gateway_details(
-    validator_servers: Vec<Url>,
-    chosen_gateway_id: Option<&str>,
-) -> gateway::Node {
-    let validator_api = validator_servers
-        .choose(&mut thread_rng())
-        .expect("The list of validator apis is empty");
-    let validator_client = validator_client::ApiClient::new(validator_api.clone());
-
-    log::trace!("Fetching list of gateways from: {}", validator_api);
-    let gateways = validator_client.get_cached_gateways().await.unwrap();
-    let valid_gateways = gateways
-        .into_iter()
-        .filter_map(|gateway| gateway.try_into().ok())
-        .collect::<Vec<gateway::Node>>();
-
-    let filtered_gateways = valid_gateways.filter_by_version(env!("CARGO_PKG_VERSION"));
-
-    // if we have chosen particular gateway - use it, otherwise choose a random one.
-    // (remember that in active topology all gateways have at least 100 reputation so should
-    // be working correctly)
-    if let Some(gateway_id) = chosen_gateway_id {
-        filtered_gateways
-            .iter()
-            .find(|gateway| gateway.identity_key.to_base58_string() == gateway_id)
-            .expect(&*format!("no gateway with id {} exists!", gateway_id))
-            .clone()
-    } else {
-        filtered_gateways
-            .choose(&mut rand::thread_rng())
-            .expect("there are no gateways on the network!")
-            .clone()
-    }
-}
-
-// TODO: make this private again after refactoring the config setup
-pub fn show_address(config: &Config) {
-    fn load_identity_keys(pathfinder: &ClientKeyPathfinder) -> identity::KeyPair {
-        let identity_keypair: identity::KeyPair =
-            pemstore::load_keypair(&pemstore::KeyPairPath::new(
-                pathfinder.private_identity_key().to_owned(),
-                pathfinder.public_identity_key().to_owned(),
-            ))
-            .expect("Failed to read stored identity key files");
-        identity_keypair
-    }
-
-    fn load_sphinx_keys(pathfinder: &ClientKeyPathfinder) -> encryption::KeyPair {
-        let sphinx_keypair: encryption::KeyPair =
-            pemstore::load_keypair(&pemstore::KeyPairPath::new(
-                pathfinder.private_encryption_key().to_owned(),
-                pathfinder.public_encryption_key().to_owned(),
-            ))
-            .expect("Failed to read stored sphinx key files");
-        sphinx_keypair
-    }
-
-    let pathfinder = ClientKeyPathfinder::new_from_config(config.get_base());
-    let identity_keypair = load_identity_keys(&pathfinder);
-    let sphinx_keypair = load_sphinx_keys(&pathfinder);
-
-    let client_recipient = Recipient::new(
-        *identity_keypair.public_key(),
-        *sphinx_keypair.public_key(),
-        // TODO: below only works under assumption that gateway address == gateway id
-        // (which currently is true)
-        NodeIdentity::from_base58_string(config.get_base().get_gateway_id()).unwrap(),
-    );
-
-    println!("\nThe address of this client is: {}", client_recipient);
-}
-
-async fn set_gateway_config(config: &mut Config, chosen_gateway_id: Option<&str>) -> gateway::Node {
-    println!("Setting gateway config");
-    log::trace!("Chosen gateway: {:?}", chosen_gateway_id);
-
-    // Get the gateway details by querying the validator-api, and using the chosen one if it's
-    // among the available ones.
-    let gateway_details = gateway_details(
-        config.get_base().get_validator_api_endpoints(),
-        chosen_gateway_id,
-    )
-    .await;
-
-    log::trace!("Used gateway: {}", gateway_details);
-
-    config
-        .get_base_mut()
-        .with_gateway_endpoint(gateway_details.clone().into());
-    gateway_details
-}
-
-async fn register_and_store_gateway_keys(gateway_details: gateway::Node, config: &Config) {
-    println!("Registering gateway");
-
-    let mut rng = OsRng;
-    let mut key_manager = KeyManager::new(&mut rng);
-    let shared_keys = register_with_gateway(&gateway_details, key_manager.identity_keypair()).await;
-    key_manager.insert_gateway_shared_key(shared_keys);
-
-    let pathfinder = ClientKeyPathfinder::new_from_config(config.get_base());
-    key_manager
-        .store_keys(&pathfinder)
-        .expect("Failed to generated keys");
-    println!("Saved all generated keys");
-}
-
 pub async fn execute(matches: ArgMatches<'static>) {
     println!("Initialising client...");
 
@@ -241,51 +98,31 @@ pub async fn execute(matches: ArgMatches<'static>) {
 
     // Usually you only register with the gateway on the first init, however you can force
     // re-registering if wanted.
-    let should_force_register = matches.is_present("force-register-gateway");
+    let user_wants_force_register = matches.is_present("force-register-gateway");
 
     // If the client was already initialized, don't generate new keys and don't re-register with
     // the gateway (because this would create a new shared key).
     // Unless the user really wants to.
-    let will_register_gateway = !already_init || should_force_register;
+    let register_gateway = !already_init || user_wants_force_register;
 
     // Attempt to use a user-provided gateway, if possible
-    let is_gateway_provided = matches.value_of("gateway").is_some();
+    let user_chosen_gateway_id = matches.value_of("gateway");
 
     let mut config = Config::new(id, provider_address);
 
-    // TODO: ideally that should be the last thing that's being done to config.
-    // However, we are later further overriding it with gateway id
     config = override_config(config, &matches);
     if matches.is_present("fastmode") {
         config.get_base_mut().set_high_default_traffic_volume();
     }
 
-    if will_register_gateway {
-        // Create identity, encryption and ack keys.
-        let gateway_details = set_gateway_config(&mut config, matches.value_of("gateway")).await;
-        register_and_store_gateway_keys(gateway_details, &config).await;
-    } else if is_gateway_provided {
-        // Just set the config, don't register or create any keys
-        set_gateway_config(&mut config, matches.value_of("gateway")).await;
-    } else {
-        // Read the existing config to reuse the gateway configuration
-        println!("Not registering gateway, will reuse existing config and keys");
-        if let Ok(existing_config) = Config::load_from_file(Some(id)) {
-            config
-                .get_base_mut()
-                .with_gateway_endpoint(existing_config.get_base().get_gateway_endpoint().clone());
-        } else {
-            log::warn!(
-                "Existing configuration found, but enable to load gateway details. \
-                Proceeding anyway."
-            );
-        };
-    }
+    let gateway = setup_gateway(id, register_gateway, user_chosen_gateway_id, &config).await;
+    config.get_base_mut().with_gateway_endpoint(gateway);
 
     let config_save_location = config.get_config_file_save_location();
     config
         .save_to_file(None)
         .expect("Failed to save the config file");
+
     println!("Saved configuration file to {:?}", config_save_location);
     println!("Using gateway: {}", config.get_base().get_gateway_id());
     log::debug!("Gateway id: {}", config.get_base().get_gateway_id());
@@ -296,5 +133,58 @@ pub async fn execute(matches: ArgMatches<'static>) {
     );
     println!("Client configuration completed.");
 
-    show_address(&config);
+    client_core::init::show_address(config.get_base());
+}
+
+async fn setup_gateway(
+    id: &str,
+    register: bool,
+    user_chosen_gateway_id: Option<&str>,
+    config: &Config,
+) -> GatewayEndpoint {
+    if register {
+        // Get the gateway details by querying the validator-api. Either pick one at random or use
+        // the chosen one if it's among the available ones.
+        println!("Configuring gateway");
+        let gateway = client_core::init::query_gateway_details(
+            config.get_base().get_validator_api_endpoints(),
+            user_chosen_gateway_id,
+        )
+        .await;
+        log::debug!("Querying gateway gives: {}", gateway);
+
+        // Registering with gateway by setting up and writing shared keys to disk
+        log::trace!("Registering gateway");
+        client_core::init::register_with_gateway_and_store_keys(gateway.clone(), config.get_base())
+            .await;
+        println!("Saved all generated keys");
+
+        gateway.into()
+    } else if user_chosen_gateway_id.is_some() {
+        // Just set the config, don't register or create any keys
+        // This assumes that the user knows what they are doing, and that the existing keys are
+        // valid for the gateway being used
+        println!("Using gateway provided by user, keeping existing keys");
+        let gateway = client_core::init::query_gateway_details(
+            config.get_base().get_validator_api_endpoints(),
+            user_chosen_gateway_id,
+        )
+        .await;
+        log::debug!("Querying gateway gives: {}", gateway);
+        gateway.into()
+    } else {
+        println!("Not registering gateway, will reuse existing config and keys");
+        match Config::load_from_file(Some(id)) {
+            Ok(existing_config) => existing_config.get_base().get_gateway_endpoint().clone(),
+            Err(err) => {
+                panic!(
+                    "Unable to configure gateway: {err}. \n
+                    Seems like the client was already initialized but it was not possible to read \
+                    the existing configuration file. \n
+                    CAUTION: Consider backing up your gateway keys and try force gateway registration, or \
+                    removing the existing configuration and starting over."
+                )
+            }
+        }
+    }
 }

--- a/nym-connect/Cargo.lock
+++ b/nym-connect/Cargo.lock
@@ -3404,6 +3404,7 @@ dependencies = [
  "tendermint-rpc",
  "thiserror",
  "tokio",
+ "topology",
  "ts-rs",
  "url",
 ]

--- a/nym-connect/src-tauri/Cargo.toml
+++ b/nym-connect/src-tauri/Cargo.toml
@@ -38,8 +38,9 @@ pretty_env_logger = "0.4.0"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", branch = "release"}
 
 client-core = { path = "../../clients/client-core" }
-nym-socks5-client = { path = "../../clients/socks5" }
 config = { path = "../../common/config" }
+nym-socks5-client = { path = "../../clients/socks5" }
+topology = { path = "../../common/topology" }
 
 [dev-dependencies]
 ts-rs = "6.1.2"

--- a/nym-connect/src-tauri/src/config/mod.rs
+++ b/nym-connect/src-tauri/src/config/mod.rs
@@ -84,7 +84,7 @@ pub async fn init_socks5(provider_address: &str, chosen_gateway_id: Option<&str>
         "Using gateway: {}",
         config.get_socks5().get_base().get_gateway_id(),
     );
-    info!("Client configuration completed.\n\n\n");
+    info!("Client configuration completed.");
 
     client_core::init::show_address(config.get_base());
 }

--- a/nym-connect/src-tauri/src/config/mod.rs
+++ b/nym-connect/src-tauri/src/config/mod.rs
@@ -1,11 +1,11 @@
+use client_core::config::GatewayEndpoint;
 use log::info;
 use once_cell::sync::Lazy;
-use rand::rngs::OsRng;
 use rand::Rng;
 
-use client_core::client::key_manager::KeyManager;
-use client_core::config::persistence::key_pathfinder::ClientKeyPathfinder;
+use client_core::config::Config as BaseConfig;
 use config::NymConfig;
+use nym_socks5::client::config::Config as Socks5Config;
 
 // Generate a random id used for the config, since we need to init a new configuration each time
 // due to not being able to reuse gateway registration. This is probably something we should
@@ -22,9 +22,34 @@ const DEFAULT_ETH_ENDPOINT: &str = "https://rinkeby.infura.io/v3/000000000000000
 const DEFAULT_ETH_PRIVATE_KEY: &str =
     "0000000000000000000000000000000000000000000000000000000000000001";
 
-pub struct Config {}
+pub struct Config {
+    socks5: Socks5Config,
+}
 
 impl Config {
+    pub fn new<S: Into<String>>(id: S, provider_mix_address: S) -> Self {
+        Config {
+            socks5: Socks5Config::new(id, provider_mix_address),
+        }
+    }
+
+    pub fn get_socks5(&self) -> &Socks5Config {
+        &self.socks5
+    }
+
+    #[allow(unused)]
+    pub fn get_socks5_mut(&mut self) -> &mut Socks5Config {
+        &mut self.socks5
+    }
+
+    pub fn get_base(&self) -> &BaseConfig<Socks5Config> {
+        self.socks5.get_base()
+    }
+
+    pub fn get_base_mut(&mut self) -> &mut BaseConfig<Socks5Config> {
+        self.socks5.get_base_mut()
+    }
+
     pub async fn init() {
         info!("Initialising...");
         init_socks5(PROVIDER_ADDRESS, None).await;
@@ -35,40 +60,10 @@ impl Config {
 pub async fn init_socks5(provider_address: &str, chosen_gateway_id: Option<&str>) {
     let id: &str = &SOCKS5_CONFIG_ID;
     log::trace!("Creating config for id: {}", id);
-    let mut config = nym_socks5::client::config::Config::new(id, provider_address);
+    let mut config = Config::new(id, provider_address);
 
-    // create identity, encryption and ack keys.
-    let mut rng = OsRng;
-    let mut key_manager = KeyManager::new(&mut rng);
-
-    info!("Getting gateway details");
-    let gateway_details = nym_socks5::commands::init::gateway_details(
-        config.get_base().get_validator_api_endpoints(),
-        chosen_gateway_id,
-    )
-    .await;
-
-    info!("Registering with gateway");
-    let shared_keys = nym_socks5::commands::init::register_with_gateway(
-        &gateway_details,
-        key_manager.identity_keypair(),
-    )
-    .await;
-
-    info!("Setting gateway endpoint");
-    config
-        .get_base_mut()
-        .with_gateway_endpoint(gateway_details.into());
-
-    info!("Insert gateway shared key");
-    key_manager.insert_gateway_shared_key(shared_keys);
-
-    info!("Creating client key path finder");
-    let pathfinder = ClientKeyPathfinder::new_from_config(config.get_base());
-    key_manager
-        .store_keys(&pathfinder)
-        .expect("Failed to generated keys");
-    info!("Saved all generated keys");
+    let gateway = setup_gateway(chosen_gateway_id, config.get_socks5()).await;
+    config.get_base_mut().with_gateway_endpoint(gateway);
 
     // As far as I'm aware, these two are not used, they are only set because the socks5 init code
     // requires them for initialising the bandwidth controller.
@@ -79,13 +74,40 @@ pub async fn init_socks5(provider_address: &str, chosen_gateway_id: Option<&str>
         .get_base_mut()
         .with_eth_private_key(DEFAULT_ETH_PRIVATE_KEY);
 
-    let config_save_location = config.get_config_file_save_location();
+    let config_save_location = config.get_socks5().get_config_file_save_location();
     config
+        .get_socks5()
         .save_to_file(None)
         .expect("Failed to save the config file");
     info!("Saved configuration file to {:?}", config_save_location);
-    info!("Using gateway: {}", config.get_base().get_gateway_id(),);
+    info!(
+        "Using gateway: {}",
+        config.get_socks5().get_base().get_gateway_id(),
+    );
     info!("Client configuration completed.\n\n\n");
 
-    nym_socks5::commands::init::show_address(&config);
+    client_core::init::show_address(config.get_base());
+}
+
+async fn setup_gateway(
+    user_chosen_gateway_id: Option<&str>,
+    config: &nym_socks5::client::config::Config,
+) -> GatewayEndpoint {
+    // Get the gateway details by querying the validator-api. Either pick one at random or use
+    // the chosen one if it's among the available ones.
+    log::info!("Configuring gateway");
+    let gateway = client_core::init::query_gateway_details(
+        config.get_base().get_validator_api_endpoints(),
+        user_chosen_gateway_id,
+    )
+    .await;
+    log::debug!("Querying gateway gives: {}", gateway);
+
+    // Registering with gateway by setting up and writing shared keys to disk
+    log::trace!("Registering gateway");
+    client_core::init::register_with_gateway_and_store_keys(gateway.clone(), config.get_base())
+        .await;
+    log::info!("Saved all generated keys");
+
+    gateway.into()
 }


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/2416
Part of: https://github.com/nymtech/nym/issues/2013

Remove (some) duplication between the native and socks5 client initialization routines, and as a consequence allow nym-connect to share the same init logic as well.

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
