### PR TITLE
connect: add tauri methods to get and set provider

### DIFF
--- a/nym-connect/Cargo.lock
+++ b/nym-connect/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
  "network-defaults",
  "thiserror",
  "url",
+ "validator-api-requests",
  "validator-client",
 ]
 
@@ -6298,6 +6299,10 @@ dependencies = [
 name = "validator-api-requests"
 version = "0.1.0"
 dependencies = [
+ "bs58",
+ "coconut-interface",
+ "cosmrs",
+ "getset",
  "mixnet-contract-common",
  "schemars",
  "serde",
@@ -6401,7 +6406,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vesting-contract"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "config",
  "cosmwasm-std",

--- a/nym-connect/src-tauri/src/config/mod.rs
+++ b/nym-connect/src-tauri/src/config/mod.rs
@@ -16,6 +16,8 @@ pub static SOCKS5_CONFIG_ID: Lazy<String> = Lazy::new(|| {
 });
 
 // TODO: make this configurable from the UI
+// TODO: once we can set this is the UI, consider just removing it, and put in guards to halt if
+// user hasn't chosen the provider
 pub static PROVIDER_ADDRESS: &str = "EWa8DgePKfuWSjqPo6NEdavBK6gpnK4TKb2npi2HWuC2.6PGVT9y83UMGbFrPKDnCvTP2jJjpXYpD87ZpiRsLo1YR@CgQrYP8etksSBf4nALNqp93SHPpgFwEUyTsjBNNLj5WM";
 
 const DEFAULT_ETH_ENDPOINT: &str = "https://rinkeby.infura.io/v3/00000000000000000000000000000000";
@@ -50,9 +52,10 @@ impl Config {
         self.socks5.get_base_mut()
     }
 
-    pub async fn init() {
+    pub async fn init(service_provider: Option<&String>) {
+        let service_provider = service_provider.map_or(PROVIDER_ADDRESS, String::as_str);
         info!("Initialising...");
-        init_socks5(PROVIDER_ADDRESS, None).await;
+        init_socks5(service_provider, None).await;
         info!("Configuration saved 🚀");
     }
 }

--- a/nym-connect/src-tauri/src/error.rs
+++ b/nym-connect/src-tauri/src/error.rs
@@ -10,6 +10,8 @@ pub enum BackendError {
     CouldNotConnect,
     #[error("Could not disconnect")]
     CouldNotDisconnect,
+    #[error("No serverice provider set")]
+    NoServiceProviderSet,
 }
 
 impl Serialize for BackendError {

--- a/nym-connect/src-tauri/src/main.rs
+++ b/nym-connect/src-tauri/src/main.rs
@@ -34,6 +34,8 @@ fn main() {
     tauri::Builder::default()
         .manage(Arc::new(RwLock::new(State::new())))
         .invoke_handler(tauri::generate_handler![
+            crate::operations::connection::connect::get_service_provider,
+            crate::operations::connection::connect::set_service_provider,
             crate::operations::connection::connect::start_connecting,
             crate::operations::connection::disconnect::start_disconnecting,
             crate::operations::window::hide_window,

--- a/nym-connect/src-tauri/src/operations/connection/connect.rs
+++ b/nym-connect/src-tauri/src/operations/connection/connect.rs
@@ -18,3 +18,24 @@ pub async fn start_connecting(
         address: "Test".to_string(),
     })
 }
+
+#[tauri::command]
+pub async fn get_service_provider(
+    state: tauri::State<'_, Arc<RwLock<State>>>,
+) -> Result<String, BackendError> {
+    let guard = state.read().await;
+    guard
+        .get_service_provider()
+        .clone()
+        .ok_or(BackendError::NoServiceProviderSet)
+}
+
+#[tauri::command]
+pub async fn set_service_provider(
+    service_provider: String,
+    state: tauri::State<'_, Arc<RwLock<State>>>,
+) -> Result<(), BackendError> {
+    let mut guard = state.write().await;
+    guard.set_service_provider(service_provider);
+    Ok(())
+}


### PR DESCRIPTION
# Description

Part of: https://github.com/nymtech/nym/issues/2392

Expost tauri methods for setting and getting the service provider in nym-connect

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
