### PR TITLE
connect: reuse the same id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 ### Changed
 
+- nym-connect: reuse config id instead of creating a new id on each connection.
 - validator-client: created internal `Coin` type that replaces coins from `cosmrs` and `cosmwasm` for API entrypoints [[#1295]]
 - all: updated all `cosmwasm`-related dependencies to `1.0.0` and `cw-storage-plus` to `0.13.4` [[#1318]]
 - all: updated `rocket` to `0.5.0-rc.2`.

--- a/nym-connect/Cargo.lock
+++ b/nym-connect/Cargo.lock
@@ -3392,7 +3392,6 @@ dependencies = [
  "futures",
  "log",
  "nym-socks5-client",
- "once_cell",
  "pretty_env_logger",
  "rand 0.7.3",
  "serde",

--- a/nym-connect/src-tauri/Cargo.toml
+++ b/nym-connect/src-tauri/Cargo.toml
@@ -24,7 +24,6 @@ bip39 = "1.0"
 dirs = "4.0"
 eyre = "0.6.5"
 futures = "0.3"
-once_cell = "1.12"
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/nym-connect/src-tauri/src/config/mod.rs
+++ b/nym-connect/src-tauri/src/config/mod.rs
@@ -101,8 +101,14 @@ pub async fn init_socks5(provider_address: &str, chosen_gateway_id: Option<&str>
         config.get_base().get_gateway_listener()
     );
 
-    log::info!("Service provider address: {}", config.get_socks5().get_provider_mix_address());
-    log::info!("Service provider port: {}", config.get_socks5().get_listening_port());
+    log::info!(
+        "Service provider address: {}",
+        config.get_socks5().get_provider_mix_address()
+    );
+    log::info!(
+        "Service provider port: {}",
+        config.get_socks5().get_listening_port()
+    );
     info!("Client configuration completed.");
 
     client_core::init::show_address(config.get_base());

--- a/nym-connect/src-tauri/src/state.rs
+++ b/nym-connect/src-tauri/src/state.rs
@@ -88,7 +88,7 @@ impl State {
 }
 
 fn start_nym_socks5_client() -> Socks5ControlMessageSender {
-    let id: &str = &SOCKS5_CONFIG_ID;
+    let id: &str = SOCKS5_CONFIG_ID;
 
     info!("Loading config from file");
     let config = nym_socks5::client::config::Config::load_from_file(Some(id)).unwrap();


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/2417

With https://github.com/nymtech/nym/issues/2017 now resolved, we can let `nym-connect` reuse the same `id`, so we don't pollute the config directory. This means we reuse keys.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
