### PR TITLE
nym-connect: catch panics during init

### DIFF
--- a/nym-connect/src-tauri/Cargo.toml
+++ b/nym-connect/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0"
 tauri = { version = "=1.0.0-rc.8", features = ["ayatana-tray", "shell-open", "system-tray"] }
 tendermint-rpc = "0.23.0"
 thiserror = "1.0"
-tokio = { version = "1.19.1", features = ["sync"] }
+tokio = { version = "1.19.1", features = ["sync", "time"] }
 url = "2.2"
 log = "0.4"
 pretty_env_logger = "0.4.0"

--- a/nym-connect/src-tauri/src/error.rs
+++ b/nym-connect/src-tauri/src/error.rs
@@ -19,6 +19,8 @@ pub enum BackendError {
         #[from]
         source: reqwest::Error,
     },
+    #[error("Initialization failed with a panic")]
+    InitializationPanic,
 }
 
 impl Serialize for BackendError {

--- a/nym-connect/src-tauri/src/main.rs
+++ b/nym-connect/src-tauri/src/main.rs
@@ -68,5 +68,6 @@ fn setup_logging() {
         .filter_module("sled", log::LevelFilter::Warn)
         .filter_module("tokio_tungstenite", log::LevelFilter::Warn)
         .filter_module("tungstenite", log::LevelFilter::Warn)
+        .filter_module("want", log::LevelFilter::Warn)
         .init();
 }

--- a/nym-connect/src-tauri/src/operations/connection/connect.rs
+++ b/nym-connect/src-tauri/src/operations/connection/connect.rs
@@ -13,7 +13,7 @@ pub async fn start_connecting(
         log::trace!("Start connecting with:");
         log::trace!("  service_provider: {:?}", guard.get_service_provider());
         log::trace!("  gateway: {:?}", guard.get_gateway());
-        guard.start_connecting(&window).await
+        guard.start_connecting(&window).await?
     };
 
     // Setup task for checking status


### PR DESCRIPTION
# Description

Client initialization was not originally written to be called from elsewhere, so it can panic it all sorts of ways. Wrap initialization in `catch_unwind` until we have proper error handling in socks5 client initialization

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
