### PR TITLE
feat(wallet): add confirmation modal component

### DIFF
--- a/nym-wallet/src/components/Modals/ConfirmationModal.stories.tsx
+++ b/nym-wallet/src/components/Modals/ConfirmationModal.stories.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Button } from '@mui/material';
+import ConfirmationModal from './ConfirmationModal';
+
+export default {
+  title: 'Modals/ConfirmationModal',
+  component: ConfirmationModal,
+} as ComponentMeta<typeof ConfirmationModal>;
+
+const Template: ComponentStory<typeof ConfirmationModal> = (args) => {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <Button variant="outlined" onClick={() => setOpen(true)}>
+        Open confirmation dialog
+      </Button>
+      <ConfirmationModal {...args} open={open} onClose={() => setOpen(false)} onConfirm={() => setOpen(false)}>
+        Dialog content.
+      </ConfirmationModal>
+    </>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  title: 'Confirmation Modal',
+  subTitle: '',
+  fullWidth: true,
+  confirmButton: 'Confirm',
+  maxWidth: 'xs',
+  disabled: false,
+};

--- a/nym-wallet/src/components/Modals/ConfirmationModal.stories.tsx
+++ b/nym-wallet/src/components/Modals/ConfirmationModal.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useState } from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Button } from '@mui/material';
-import ConfirmationModal from './ConfirmationModal';
+import { ConfirmationModal } from './ConfirmationModal';
 
 export default {
   title: 'Modals/ConfirmationModal',

--- a/nym-wallet/src/components/Modals/ConfirmationModal.tsx
+++ b/nym-wallet/src/components/Modals/ConfirmationModal.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import {
+  Breakpoint,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  SxProps,
+  Typography,
+} from '@mui/material';
+
+export interface Props {
+  open: boolean;
+  onConfirm: () => void;
+  onClose?: () => void;
+  children?: React.ReactNode;
+  title: React.ReactNode | string;
+  subTitle?: React.ReactNode | string;
+  confirmButton: React.ReactNode | string;
+  disabled?: boolean;
+  sx?: SxProps;
+  fullWidth?: boolean;
+  maxWidth?: Breakpoint;
+}
+
+const ConfirmationModal = ({
+  open,
+  onConfirm,
+  onClose,
+  children,
+  title,
+  subTitle,
+  confirmButton,
+  disabled,
+  sx,
+  fullWidth,
+  maxWidth,
+}: Props) => {
+  const titleComp = (
+    <DialogTitle id="responsive-dialog-title" sx={{ py: 3, pb: 2, fontWeight: 600 }} color="black">
+      {title}
+      {subTitle &&
+        (typeof subTitle === 'string' ? (
+          <Typography fontWeight={400} variant="subtitle1" fontSize={12} color={(t) => t.palette.nym.text.muted}>
+            {subTitle}
+          </Typography>
+        ) : (
+          subTitle
+        ))}
+    </DialogTitle>
+  );
+  const confirmButtonComp =
+    typeof confirmButton === 'string' ? (
+      <Button onClick={onConfirm} variant="contained" fullWidth disabled={disabled} sx={{ py: 1.6 }}>
+        <Typography variant="button" fontSize="large">
+          {confirmButton}
+        </Typography>
+      </Button>
+    ) : (
+      confirmButton
+    );
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="responsive-dialog-title"
+      maxWidth={maxWidth || 'sm'}
+      sx={{ textAlign: 'center', ...sx }}
+      fullWidth={fullWidth}
+    >
+      {titleComp}
+      <DialogContent>{children}</DialogContent>
+      <DialogActions sx={{ px: 3, pb: 3 }}>{confirmButtonComp}</DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmationModal;

--- a/nym-wallet/src/components/Modals/ConfirmationModal.tsx
+++ b/nym-wallet/src/components/Modals/ConfirmationModal.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
 } from '@mui/material';
 
-export interface Props {
+export interface ConfirmationModalProps {
   open: boolean;
   onConfirm: () => void;
   onClose?: () => void;
@@ -24,7 +24,7 @@ export interface Props {
   maxWidth?: Breakpoint;
 }
 
-const ConfirmationModal = ({
+export const ConfirmationModal = ({
   open,
   onConfirm,
   onClose,
@@ -36,8 +36,8 @@ const ConfirmationModal = ({
   sx,
   fullWidth,
   maxWidth,
-}: Props) => {
-  const titleComp = (
+}: ConfirmationModalProps) => {
+  const Title = (
     <DialogTitle id="responsive-dialog-title" sx={{ py: 3, pb: 2, fontWeight: 600 }} color="black">
       {title}
       {subTitle &&
@@ -50,7 +50,7 @@ const ConfirmationModal = ({
         ))}
     </DialogTitle>
   );
-  const confirmButtonComp =
+  const ConfirmButton =
     typeof confirmButton === 'string' ? (
       <Button onClick={onConfirm} variant="contained" fullWidth disabled={disabled} sx={{ py: 1.6 }}>
         <Typography variant="button" fontSize="large">
@@ -69,11 +69,9 @@ const ConfirmationModal = ({
       sx={{ textAlign: 'center', ...sx }}
       fullWidth={fullWidth}
     >
-      {titleComp}
+      {Title}
       <DialogContent>{children}</DialogContent>
-      <DialogActions sx={{ px: 3, pb: 3 }}>{confirmButtonComp}</DialogActions>
+      <DialogActions sx={{ px: 3, pb: 3 }}>{ConfirmButton}</DialogActions>
     </Dialog>
   );
 };
-
-export default ConfirmationModal;

--- a/nym-wallet/src/components/index.ts
+++ b/nym-wallet/src/components/index.ts
@@ -20,4 +20,4 @@ export * from './Title';
 export * from './TokenPoolSelector';
 export * from './TransactionDetails';
 export * from './Warning';
-export { default as ConfirmationModal } from './Modals/ConfirmationModal';
+export * from './Modals/ConfirmationModal';

--- a/nym-wallet/src/components/index.ts
+++ b/nym-wallet/src/components/index.ts
@@ -20,3 +20,4 @@ export * from './Title';
 export * from './TokenPoolSelector';
 export * from './TransactionDetails';
 export * from './Warning';
+export { default as ConfirmationModal } from './Modals/ConfirmationModal';


### PR DESCRIPTION
# ConfirmationModal

Add a new component to render confirmation Modals.

![image](https://user-images.githubusercontent.com/6359431/177305894-1f071f08-1a66-4e59-b4cb-8e8614be5ac2.png)

