### PR TITLE
nym-connect: error handling and get rid of big bunch of sources for panics

### DIFF
--- a/nym-connect/Cargo.lock
+++ b/nym-connect/Cargo.lock
@@ -3388,6 +3388,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tap",
  "tauri",
  "tauri-build",
  "tauri-codegen",

--- a/nym-connect/src-tauri/Cargo.toml
+++ b/nym-connect/src-tauri/Cargo.toml
@@ -23,19 +23,20 @@ tauri-macros = "=1.0.0-rc.5"
 bip39 = "1.0"
 dirs = "4.0"
 eyre = "0.6.5"
+fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", branch = "release"}
 futures = "0.3"
+log = "0.4"
+pretty_env_logger = "0.4.0"
 rand = "0.7"
+reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tap = "1.0.1"
 tauri = { version = "=1.0.0-rc.8", features = ["ayatana-tray", "shell-open", "system-tray"] }
 tendermint-rpc = "0.23.0"
 thiserror = "1.0"
 tokio = { version = "1.19.1", features = ["sync", "time"] }
 url = "2.2"
-log = "0.4"
-pretty_env_logger = "0.4.0"
-fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", branch = "release"}
-reqwest = { version = "0.11", features = ["json"] }
 
 client-core = { path = "../../clients/client-core" }
 config = { path = "../../common/config" }

--- a/nym-connect/src-tauri/src/build.rs
+++ b/nym-connect/src-tauri/src/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    tauri_build::build()
+    tauri_build::build();
 }

--- a/nym-connect/src-tauri/src/config/mod.rs
+++ b/nym-connect/src-tauri/src/config/mod.rs
@@ -3,13 +3,17 @@ use std::path::PathBuf;
 use client_core::config::GatewayEndpoint;
 use log::info;
 use std::sync::Arc;
+use tap::TapFallible;
 use tokio::sync::RwLock;
 
 use client_core::config::Config as BaseConfig;
 use config::NymConfig;
 use nym_socks5::client::config::Config as Socks5Config;
 
-use crate::{error::BackendError, state::State};
+use crate::{
+    error::{BackendError, Result},
+    state::State,
+};
 
 pub static SOCKS5_CONFIG_ID: &str = "nym-connect";
 
@@ -17,30 +21,22 @@ const DEFAULT_ETH_ENDPOINT: &str = "https://rinkeby.infura.io/v3/000000000000000
 const DEFAULT_ETH_PRIVATE_KEY: &str =
     "0000000000000000000000000000000000000000000000000000000000000001";
 
-pub fn append_config_id(gateway_id: &str) -> String {
+pub fn socks5_config_id_appended_with(gateway_id: &str) -> Result<String> {
     use std::fmt::Write as _;
     let mut id = SOCKS5_CONFIG_ID.to_string();
-    write!(id, "-{}", gateway_id).expect("Failed to set config id");
-    id
+    write!(id, "-{}", gateway_id)?;
+    Ok(id)
 }
 
 #[tauri::command]
-pub async fn get_config_id(
-    state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<String, BackendError> {
-    let guard = state.read().await;
-    // TODO: return error instead
-    let gateway_id = guard
-        .get_gateway()
-        .as_ref()
-        .expect("The config id can not be determined before setting the gateway");
-    Ok(append_config_id(gateway_id))
+pub async fn get_config_id(state: tauri::State<'_, Arc<RwLock<State>>>) -> Result<String> {
+    state.read().await.get_config_id()
 }
 
 #[tauri::command]
 pub async fn get_config_file_location(
     state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<String, BackendError> {
+) -> Result<String> {
     let id = get_config_id(state).await?;
     Ok(Config::config_file_location(&id)
         .to_string_lossy()
@@ -76,7 +72,7 @@ impl Config {
         self.socks5.get_base_mut()
     }
 
-    pub async fn init(service_provider: &str, chosen_gateway_id: &str) -> Result<(), BackendError> {
+    pub async fn init(service_provider: &str, chosen_gateway_id: &str) -> Result<()> {
         info!("Initialising...");
 
         let service_provider = service_provider.to_owned();
@@ -88,10 +84,12 @@ impl Config {
         std::thread::spawn(move || {
             tokio::runtime::Runtime::new()
                 .expect("Failed to create tokio runtime")
-                .block_on(async move { init_socks5(service_provider, chosen_gateway_id).await })
+                .block_on(
+                    async move { init_socks5_config(service_provider, chosen_gateway_id).await },
+                )
         })
         .join()
-        .map_err(|_| BackendError::InitializationPanic)?;
+        .map_err(|_| BackendError::InitializationPanic)??;
 
         info!("Configuration saved 🚀");
         Ok(())
@@ -102,11 +100,11 @@ impl Config {
     }
 }
 
-pub async fn init_socks5(provider_address: String, chosen_gateway_id: String) {
+pub async fn init_socks5_config(provider_address: String, chosen_gateway_id: String) -> Result<()> {
     log::info!("Initialising client...");
 
     // Append the gateway id to the name id that we store the config under
-    let id = append_config_id(&chosen_gateway_id);
+    let id = socks5_config_id_appended_with(&chosen_gateway_id)?;
 
     log::debug!(
         "Attempting to use config file location: {}",
@@ -148,10 +146,9 @@ pub async fn init_socks5(provider_address: String, chosen_gateway_id: String) {
     config.get_base_mut().with_gateway_endpoint(gateway);
 
     let config_save_location = config.get_socks5().get_config_file_save_location();
-    config
-        .get_socks5()
-        .save_to_file(None)
-        .expect("Failed to save the config file");
+    config.get_socks5().save_to_file(None).tap_err(|_| {
+        log::warn!("Failed to save the config file");
+    })?;
 
     log::info!("Saved configuration file to {:?}", config_save_location);
     log::info!("Gateway id: {}", config.get_base().get_gateway_id());
@@ -172,6 +169,7 @@ pub async fn init_socks5(provider_address: String, chosen_gateway_id: String) {
     info!("Client configuration completed.");
 
     client_core::init::show_address(config.get_base());
+    Ok(())
 }
 
 // TODO: deduplicate with same functions in other client

--- a/nym-connect/src-tauri/src/error.rs
+++ b/nym-connect/src-tauri/src/error.rs
@@ -4,30 +4,57 @@ use thiserror::Error;
 #[allow(unused)]
 #[derive(Error, Debug)]
 pub enum BackendError {
+    #[error("{source}")]
+    ReqwestError {
+        #[from]
+        source: reqwest::Error,
+    },
+    #[error("I/O error: {source}")]
+    IoError {
+        #[from]
+        source: std::io::Error,
+    },
+    #[error("String formatting error: {source}")]
+    FmtError {
+        #[from]
+        source: std::fmt::Error,
+    },
+    #[error("Tauri error: {source}")]
+    TauriError {
+        #[from]
+        source: tauri::Error,
+    },
+
     #[error("State error")]
     StateError,
     #[error("Could not connect")]
     CouldNotConnect,
     #[error("Could not disconnect")]
     CouldNotDisconnect,
+    #[error("Could not send disconnect signal to the SOCKS5 client")]
+    CoundNotSendDisconnectSignal,
     #[error("No service provider set")]
     NoServiceProviderSet,
     #[error("No gateway provider set")]
     NoGatewaySet,
-    #[error("{source}")]
-    ReqwestError {
-        #[from]
-        source: reqwest::Error,
-    },
     #[error("Initialization failed with a panic")]
     InitializationPanic,
+    #[error("Could not get config id before gateway is set")]
+    CouldNotGetIdWithoutGateway,
+    #[error("Could initialize without gateway set")]
+    CouldNotInitWithoutGateway,
+    #[error("Could initialize without service provider set")]
+    CouldNotInitWithoutServiceProvider,
 }
 
 impl Serialize for BackendError {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         serializer.collect_str(self)
     }
 }
+
+// Local crate level Result alias
+pub(crate) type Result<T, E = BackendError> = std::result::Result<T, E>;

--- a/nym-connect/src-tauri/src/models/mod.rs
+++ b/nym-connect/src-tauri/src/models/mod.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(test, derive(ts_rs::TS))]
@@ -21,6 +23,17 @@ pub enum ConnectionStatusKind {
     Disconnecting,
     Connected,
     Connecting,
+}
+
+impl fmt::Display for ConnectionStatusKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            ConnectionStatusKind::Disconnected => write!(f, "Disconnected"),
+            ConnectionStatusKind::Disconnecting => write!(f, "Disconnecting"),
+            ConnectionStatusKind::Connected => write!(f, "Connected"),
+            ConnectionStatusKind::Connecting => write!(f, "Connecting"),
+        }
+    }
 }
 
 pub const APP_EVENT_CONNECTION_STATUS_CHANGED: &str = "app:connection-status-changed";

--- a/nym-connect/src-tauri/src/operations/connection/connect.rs
+++ b/nym-connect/src-tauri/src/operations/connection/connect.rs
@@ -1,4 +1,8 @@
-use crate::{error::BackendError, models::ConnectResult, tasks::start_disconnect_listener, State};
+use crate::{
+    error::{BackendError, Result},
+    models::ConnectResult,
+    tasks, State,
+};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -6,30 +10,23 @@ use tokio::sync::RwLock;
 pub async fn start_connecting(
     state: tauri::State<'_, Arc<RwLock<State>>>,
     window: tauri::Window<tauri::Wry>,
-) -> Result<ConnectResult, BackendError> {
+) -> Result<ConnectResult> {
     let status_receiver = {
-        let mut guard = state.write().await;
-
-        log::trace!("Start connecting with:");
-        log::trace!("  service_provider: {:?}", guard.get_service_provider());
-        log::trace!("  gateway: {:?}", guard.get_gateway());
-        guard.start_connecting(&window).await?
+        let mut state_w = state.write().await;
+        state_w.start_connecting(&window).await?
     };
 
     // Setup task for checking status
     let state = state.inner().clone();
-    start_disconnect_listener(state, window, status_receiver);
+    tasks::start_disconnect_listener(state, window, status_receiver);
 
     Ok(ConnectResult {
-        // WIP(JON): fixme
-        address: "Test".to_string(),
+        address: "PLACEHOLDER".to_string(),
     })
 }
 
 #[tauri::command]
-pub async fn get_service_provider(
-    state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<String, BackendError> {
+pub async fn get_service_provider(state: tauri::State<'_, Arc<RwLock<State>>>) -> Result<String> {
     let guard = state.read().await;
     guard
         .get_service_provider()
@@ -41,7 +38,7 @@ pub async fn get_service_provider(
 pub async fn set_service_provider(
     service_provider: String,
     state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<(), BackendError> {
+) -> Result<()> {
     log::trace!("Setting service_provider: {service_provider}");
     let mut guard = state.write().await;
     guard.set_service_provider(service_provider);
@@ -49,9 +46,7 @@ pub async fn set_service_provider(
 }
 
 #[tauri::command]
-pub async fn get_gateway(
-    state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<String, BackendError> {
+pub async fn get_gateway(state: tauri::State<'_, Arc<RwLock<State>>>) -> Result<String> {
     let guard = state.read().await;
     guard
         .get_gateway()
@@ -63,7 +58,7 @@ pub async fn get_gateway(
 pub async fn set_gateway(
     gateway: String,
     state: tauri::State<'_, Arc<RwLock<State>>>,
-) -> Result<(), BackendError> {
+) -> Result<()> {
     log::trace!("Setting gateway: {gateway}");
     let mut guard = state.write().await;
     guard.set_gateway(gateway);

--- a/nym-connect/src-tauri/src/operations/connection/disconnect.rs
+++ b/nym-connect/src-tauri/src/operations/connection/disconnect.rs
@@ -1,4 +1,4 @@
-use crate::error::BackendError;
+use crate::error::Result;
 use crate::models::ConnectResult;
 use crate::State;
 use std::sync::Arc;
@@ -8,13 +8,12 @@ use tokio::sync::RwLock;
 pub async fn start_disconnecting(
     state: tauri::State<'_, Arc<RwLock<State>>>,
     window: tauri::Window<tauri::Wry>,
-) -> Result<ConnectResult, BackendError> {
+) -> Result<ConnectResult> {
     let mut guard = state.write().await;
 
-    guard.start_disconnecting(&window).await;
+    guard.start_disconnecting(&window).await?;
 
     Ok(ConnectResult {
-        // WIP(JON): fixme
-        address: "Test".to_string(),
+        address: "PLACEHOLDER".to_string(),
     })
 }

--- a/nym-connect/src-tauri/src/operations/directory/mod.rs
+++ b/nym-connect/src-tauri/src/operations/directory/mod.rs
@@ -1,11 +1,11 @@
-use crate::error::BackendError;
+use crate::error::Result;
 use crate::models::DirectoryService;
 
 static SERVICE_PROVIDER_WELLKNOWN_URL: &str =
     "https://nymtech.net/.wellknown/connect/service-providers.json";
 
 #[tauri::command]
-pub async fn get_services() -> Result<Vec<DirectoryService>, BackendError> {
+pub async fn get_services() -> Result<Vec<DirectoryService>> {
     let res = reqwest::get(SERVICE_PROVIDER_WELLKNOWN_URL)
         .await?
         .json::<Vec<DirectoryService>>()


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/2374

Remove all sorts of sources of panics and instead try to return errors to the frontend.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
