### PR TITLE
using a tag instead of link component for external link

### DIFF
--- a/explorer/src/components/Nav.tsx
+++ b/explorer/src/components/Nav.tsx
@@ -18,9 +18,6 @@ import { NymLogo } from '@nymproject/react/logo/NymLogo';
 import { NYM_WEBSITE } from '../api/constants';
 import { useMainContext } from '../context/main';
 import { MobileDrawerClose } from '../icons/MobileDrawerClose';
-import { OverviewSVG } from '../icons/OverviewSVG';
-import { NetworkComponentsSVG } from '../icons/NetworksSVG';
-import { NodemapSVG } from '../icons/NodemapSVG';
 import { Socials } from './Socials';
 import { Footer } from './Footer';
 import { DarkLightSwitchDesktop } from './Switch';
@@ -155,19 +152,17 @@ export const ExpandableButton: React.FC<ExpandableButtonType> = ({
 
   const linkProps = isExternal
     ? {
+        component: 'a',
         href: url,
         target: '_blank',
       }
-    : {
-        to: url,
-      };
+    : { component: !nested ? Link : 'div', to: url };
 
   return (
     <>
       <ListItem
         disablePadding
         disableGutters
-        component={!nested ? (isExternal ? 'a' : Link) : 'div'}
         {...linkProps}
         sx={{
           borderBottom: isChild ? 'none' : '1px solid rgba(255, 255, 255, 0.1)',

--- a/explorer/src/components/Nav.tsx
+++ b/explorer/src/components/Nav.tsx
@@ -15,7 +15,7 @@ import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { NymLogo } from '@nymproject/react/logo/NymLogo';
-import { BIG_DIPPER, NYM_WEBSITE } from '../api/constants';
+import { NYM_WEBSITE } from '../api/constants';
 import { useMainContext } from '../context/main';
 import { MobileDrawerClose } from '../icons/MobileDrawerClose';
 import { OverviewSVG } from '../icons/OverviewSVG';
@@ -24,6 +24,7 @@ import { NodemapSVG } from '../icons/NodemapSVG';
 import { Socials } from './Socials';
 import { Footer } from './Footer';
 import { DarkLightSwitchDesktop } from './Switch';
+import { NavOptionType } from '../context/nav';
 
 const drawerWidth = 300;
 
@@ -69,57 +70,6 @@ const Drawer = styled(MuiDrawer, {
     '& .MuiDrawer-paper': closedMixin(theme),
   }),
 }));
-
-type NavOptionType = {
-  id: number;
-  isActive?: boolean;
-  url: string;
-  title: string;
-  Icon?: React.ReactNode;
-  nested?: NavOptionType[];
-  isExpandedChild?: boolean;
-};
-
-export const originalNavOptions: NavOptionType[] = [
-  {
-    id: 0,
-    isActive: false,
-    url: '/',
-    title: 'Overview',
-    Icon: <OverviewSVG />,
-  },
-  {
-    id: 1,
-    isActive: false,
-    url: '/network-components',
-    title: 'Network Components',
-    Icon: <NetworkComponentsSVG />,
-    nested: [
-      {
-        id: 3,
-        url: '/network-components/mixnodes',
-        title: 'Mixnodes',
-      },
-      {
-        id: 4,
-        url: '/network-components/gateways',
-        title: 'Gateways',
-      },
-      {
-        id: 5,
-        url: `${BIG_DIPPER}/validators`,
-        title: 'Validators',
-      },
-    ],
-  },
-  {
-    id: 2,
-    isActive: false,
-    url: '/nodemap',
-    title: 'Nodemap',
-    Icon: <NodemapSVG />,
-  },
-];
 
 type ExpandableButtonType = {
   id: number;
@@ -203,14 +153,22 @@ export const ExpandableButton: React.FC<ExpandableButtonType> = ({
     }
   }, [drawIsTempOpen]);
 
+  const linkProps = isExternal
+    ? {
+        href: url,
+        target: '_blank',
+      }
+    : {
+        to: url,
+      };
+
   return (
     <>
       <ListItem
         disablePadding
         disableGutters
-        component={!nested ? Link : 'div'}
-        to={isExternal ? { pathname: url } : url}
-        target={isExternal ? '_blank' : ''}
+        component={!nested ? (isExternal ? 'a' : Link) : 'div'}
+        {...linkProps}
         sx={{
           borderBottom: isChild ? 'none' : '1px solid rgba(255, 255, 255, 0.1)',
           ...(isActive


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/2371

I've been trying to make the `Link` component, work well with external link, without success, for this reason, finally I use the `a` tag instead for them.

On the other hand, we have the `originalNavOptions` exported from `explorer/src/context/nav.tsx`, I think, we can removed the exported one from `explorer/src/components/Nav.tsx`