### PR TITLE
client: upgrade clap to latest and use declarative form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - all: updated `rocket` to `0.5.0-rc.2`.
 - network-requester: allow to voluntarily store and send statistical data about the number of bytes the proxied server serves ([#1328])
 - gateway: allow to voluntarily send statistical data about the number of active inboxes served by a gateway ([#1376])
+- socks5 client/websocket client: upgrade to latest clap and switched to declarative commandline parsing.
 
 [#1249]: https://github.com/nymtech/nym/pull/1249
 [#1256]: https://github.com/nymtech/nym/pull/1256

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,16 +568,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
@@ -585,15 +585,24 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -884,7 +893,7 @@ dependencies = [
  "async-trait",
  "bip39",
  "cfg-if 0.1.10",
- "clap 3.1.8",
+ "clap 3.2.8",
  "coconut-interface",
  "credential-storage",
  "credentials",
@@ -3089,7 +3098,7 @@ dependencies = [
  "bandwidth-claim-contract",
  "bip39",
  "bs58",
- "clap 3.1.8",
+ "clap 3.2.8",
  "coconut-interface",
  "colored",
  "config",
@@ -3134,7 +3143,7 @@ version = "1.0.1"
 dependencies = [
  "anyhow",
  "bs58",
- "clap 3.1.8",
+ "clap 3.2.8",
  "colored",
  "config",
  "crypto",
@@ -3216,7 +3225,7 @@ dependencies = [
 name = "nym-socks5-client"
 version = "1.0.1"
 dependencies = [
- "clap 2.34.0",
+ "clap 3.2.8",
  "client-core",
  "coconut-interface",
  "config",
@@ -3500,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "oorandom"
@@ -3567,9 +3576,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "pairing"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,7 +3058,7 @@ dependencies = [
 name = "nym-client"
 version = "1.0.1"
 dependencies = [
- "clap 2.34.0",
+ "clap 3.2.8",
  "client-core",
  "coconut-interface",
  "config",

--- a/clients/native/Cargo.toml
+++ b/clients/native/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nym-client"
 version = "1.0.1"
 authors = ["Dave Hrycyszyn <futurechimp@users.noreply.github.com>", "Jędrzej Stuczyński <andrew@nymtech.net>"]
+description = "Implementation of the Nym Client"
 edition = "2021"
 rust-version = "1.56"
 
@@ -19,7 +20,7 @@ futures = "0.3" # bunch of futures stuff, however, now that I think about it, it
 # and the single instance of abortable we have should really be refactored anyway
 url = "2.2"
 
-clap = "2.33.0" # for the command line arguments
+clap = { version = "3.2.8", features = ["cargo", "derive"] }
 dirs = "4.0"
 dotenv = "0.15.0" # for obtaining environmental variables (only used for RUST_LOG for time being)
 log = "0.4" # self explanatory

--- a/clients/native/src/commands/init.rs
+++ b/clients/native/src/commands/init.rs
@@ -1,88 +1,100 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::{App, Arg, ArgMatches};
+use clap::Args;
 use client_core::config::GatewayEndpoint;
 use config::NymConfig;
 
-use crate::client::config::Config;
-use crate::commands::override_config;
-#[cfg(feature = "eth")]
-#[cfg(not(feature = "coconut"))]
-use crate::commands::{
-    DEFAULT_ETH_ENDPOINT, DEFAULT_ETH_PRIVATE_KEY, ENABLED_CREDENTIALS_MODE_ARG_NAME,
-    ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME,
+use crate::{
+    client::config::Config,
+    commands::{override_config, OverrideConfig},
 };
 
-pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
-    let app = App::new("init")
-        .about("Initialise a Nym client. Do this first!")
-        .arg(Arg::with_name("id")
-            .long("id")
-            .help("Id of the nym-mixnet-client we want to create config for.")
-            .takes_value(true)
-            .required(true)
-        )
-        .arg(Arg::with_name("gateway")
-            .long("gateway")
-            .help("Id of the gateway we are going to connect to.")
-            .takes_value(true)
-        )
-        .arg(Arg::with_name("force-register-gateway")
-            .long("force-register-gateway")
-            .help("Force register gateway. WARNING: this will overwrite any existing keys for the given id, potentially causing loss of access.")
-            .takes_value(false)
-        )
-        .arg(Arg::with_name("validators")
-                 .long("validators")
-                 .help("Comma separated list of rest endpoints of the validators")
-                 .takes_value(true),
-        )
-        .arg(Arg::with_name("disable-socket")
-            .long("disable-socket")
-            .help("Whether to not start the websocket")
-        )
-        .arg(Arg::with_name("port")
-            .short("p")
-            .long("port")
-            .help("Port for the socket (if applicable) to listen on in all subsequent runs")
-            .takes_value(true)
-        )
-        .arg(Arg::with_name("fastmode")
-            .long("fastmode")
-            .hidden(true) // this will prevent this flag from being displayed in `--help`
-            .help("Mostly debug-related option to increase default traffic rate so that you would not need to modify config post init")
-        );
-    #[cfg(feature = "eth")]
-    #[cfg(not(feature = "coconut"))]
-        let app = app
-        .arg(
-            Arg::with_name(ENABLED_CREDENTIALS_MODE_ARG_NAME)
-                .long(ENABLED_CREDENTIALS_MODE_ARG_NAME)
-                .help("Set this client to work in a disabled credentials mode that would attempt to use gateway without bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
-                .conflicts_with_all(&[ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME])
-        )
-        .arg(Arg::with_name(ETH_ENDPOINT_ARG_NAME)
-            .long(ETH_ENDPOINT_ARG_NAME)
-            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
-            .takes_value(true)
-            .default_value_if(ENABLED_CREDENTIALS_MODE_ARG_NAME, None, DEFAULT_ETH_ENDPOINT)
-            .required(true))
-        .arg(Arg::with_name(ETH_PRIVATE_KEY_ARG_NAME)
-            .long(ETH_PRIVATE_KEY_ARG_NAME)
-            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
-            .takes_value(true)
-            .default_value_if(ENABLED_CREDENTIALS_MODE_ARG_NAME, None, DEFAULT_ETH_PRIVATE_KEY)
-            .required(true)
-        );
+#[cfg(all(feature = "eth", not(feature = "coconut")))]
+use crate::commands::{DEFAULT_ETH_ENDPOINT, DEFAULT_ETH_PRIVATE_KEY};
 
-    app
+#[derive(Args, Clone)]
+pub(crate) struct Init {
+    /// Id of the nym-mixnet-client we want to create config for.
+    #[clap(long)]
+    id: String,
+
+    /// Id of the gateway we are going to connect to.
+    #[clap(long)]
+    gateway: Option<String>,
+
+    /// Force register gateway. WARNING: this will overwrite any existing keys for the given id,
+    /// potentially causing loss of access.
+    #[clap(long)]
+    force_register_gateway: bool,
+
+    /// Comma separated list of rest endpoints of the validators
+    #[clap(long)]
+    validators: Option<String>,
+
+    /// Whether to not start the websocket
+    #[clap(long)]
+    disable_socket: bool,
+
+    /// Port for the socket (if applicable) to listen on in all subsequent runs
+    #[clap(short, long)]
+    port: Option<u16>,
+
+    /// Mostly debug-related option to increase default traffic rate so that you would not need to
+    /// modify config post init
+    #[clap(long, hidden = true)]
+    fastmode: bool,
+
+    /// Set this client to work in a enabled credentials mode that would attempt to use gateway
+    /// with bandwidth credential requirement. If this value is set, --eth-endpoint and
+    /// --eth-private_key don't need to be set.
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long, conflicts_with_all = &["eth-endpoint", "eth-private-key"])]
+    enabled_credentials_mode: bool,
+
+    /// URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20
+    /// tokens. If you don't want to set this value, use --enabled-credentials-mode instead
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(
+        long,
+        default_value_if("enabled-credentials-mode", None, Some(DEFAULT_ETH_ENDPOINT))
+    )]
+    eth_endpoint: String,
+
+    /// Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't
+    /// want to set this value, use --enabled-credentials-mode instead")
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(
+        long,
+        default_value_if("enabled-credentials-mode", None, Some(DEFAULT_ETH_PRIVATE_KEY))
+    )]
+    eth_private_key: String,
 }
 
-pub async fn execute(matches: ArgMatches<'static>) {
+impl From<Init> for OverrideConfig {
+    fn from(init_config: Init) -> Self {
+        OverrideConfig {
+            validators: init_config.validators,
+            disable_socket: init_config.disable_socket,
+            port: init_config.port,
+            fastmode: init_config.fastmode,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            enabled_credentials_mode: init_config.enabled_credentials_mode,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            eth_private_key: Some(init_config.eth_private_key),
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            eth_endpoint: Some(init_config.eth_endpoint),
+        }
+    }
+}
+
+pub(crate) async fn execute(args: &Init) {
     println!("Initialising client...");
 
-    let id = matches.value_of("id").unwrap(); // required for now
+    let id = &args.id;
 
     let already_init = Config::default_config_file_path(Some(id)).exists();
     if already_init {
@@ -95,7 +107,7 @@ pub async fn execute(matches: ArgMatches<'static>) {
 
     // Usually you only register with the gateway on the first init, however you can force
     // re-registering if wanted.
-    let user_wants_force_register = matches.is_present("force-register-gateway");
+    let user_wants_force_register = args.force_register_gateway;
 
     // If the client was already initialized, don't generate new keys and don't re-register with
     // the gateway (because this would create a new shared key).
@@ -103,14 +115,11 @@ pub async fn execute(matches: ArgMatches<'static>) {
     let register_gateway = !already_init || user_wants_force_register;
 
     // Attempt to use a user-provided gateway, if possible
-    let user_chosen_gateway_id = matches.value_of("gateway");
+    let user_chosen_gateway_id = args.gateway.as_deref();
 
     let mut config = Config::new(id);
-
-    config = override_config(config, &matches);
-    if matches.is_present("fastmode") {
-        config.get_base_mut().set_high_default_traffic_volume();
-    }
+    let override_config_fields = OverrideConfig::from(args.clone());
+    config = override_config(config, override_config_fields);
 
     let gateway = setup_gateway(id, register_gateway, user_chosen_gateway_id, &config).await;
     config.get_base_mut().with_gateway_endpoint(gateway);

--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -2,14 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::client::config::{Config, SocketType};
-use clap::ArgMatches;
+use clap::{Parser, Subcommand};
+use network_defaults::DEFAULT_NETWORK;
 use url::Url;
 
-pub(crate) const ENABLED_CREDENTIALS_MODE_ARG_NAME: &str = "enabled-credentials-mode";
-#[cfg(not(feature = "coconut"))]
-pub(crate) const ETH_ENDPOINT_ARG_NAME: &str = "eth_endpoint";
-#[cfg(not(feature = "coconut"))]
-pub(crate) const ETH_PRIVATE_KEY_ARG_NAME: &str = "eth_private_key";
 #[cfg(not(feature = "coconut"))]
 pub(crate) const DEFAULT_ETH_ENDPOINT: &str =
     "https://rinkeby.infura.io/v3/00000000000000000000000000000000";
@@ -20,6 +16,86 @@ pub(crate) const DEFAULT_ETH_PRIVATE_KEY: &str =
 pub(crate) mod init;
 pub(crate) mod run;
 pub(crate) mod upgrade;
+
+fn long_version() -> String {
+    format!(
+        r#"
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+"#,
+        "Build Timestamp:",
+        env!("VERGEN_BUILD_TIMESTAMP"),
+        "Build Version:",
+        env!("VERGEN_BUILD_SEMVER"),
+        "Commit SHA:",
+        env!("VERGEN_GIT_SHA"),
+        "Commit Date:",
+        env!("VERGEN_GIT_COMMIT_TIMESTAMP"),
+        "Commit Branch:",
+        env!("VERGEN_GIT_BRANCH"),
+        "rustc Version:",
+        env!("VERGEN_RUSTC_SEMVER"),
+        "rustc Channel:",
+        env!("VERGEN_RUSTC_CHANNEL"),
+        "cargo Profile:",
+        env!("VERGEN_CARGO_PROFILE"),
+        "Network:",
+        DEFAULT_NETWORK
+    )
+}
+
+fn long_version_static() -> &'static str {
+    Box::leak(long_version().into_boxed_str())
+}
+
+#[derive(Parser)]
+#[clap(author = "Nymtech", version, long_version = long_version_static(), about)]
+pub(crate) struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum Commands {
+    /// Initialise a Nym client. Do this first!
+    Init(init::Init),
+    /// Run the Nym client with provided configuration client optionally overriding set parameters
+    Run(run::Run),
+    /// Try to upgrade the client
+    Upgrade(upgrade::Upgrade),
+}
+
+// Configuration that can be overridden.
+pub(crate) struct OverrideConfig {
+    validators: Option<String>,
+    disable_socket: bool,
+    port: Option<u16>,
+    fastmode: bool,
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    enabled_credentials_mode: bool,
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    eth_private_key: Option<String>,
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    eth_endpoint: Option<String>,
+}
+
+pub(crate) async fn execute(args: &Cli) {
+    match &args.command {
+        Commands::Init(m) => init::execute(m).await,
+        Commands::Run(m) => run::execute(m).await,
+        Commands::Upgrade(m) => upgrade::execute(m),
+    }
+}
 
 fn parse_validators(raw: &str) -> Vec<Url> {
     raw.split(',')
@@ -32,44 +108,46 @@ fn parse_validators(raw: &str) -> Vec<Url> {
         .collect()
 }
 
-pub(crate) fn override_config(mut config: Config, matches: &ArgMatches<'_>) -> Config {
-    if let Some(raw_validators) = matches.value_of("validators") {
+pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Config {
+    if let Some(raw_validators) = args.validators {
         config
             .get_base_mut()
-            .set_custom_validator_apis(parse_validators(raw_validators));
+            .set_custom_validator_apis(parse_validators(&raw_validators));
     }
 
-    if matches.is_present("disable-socket") {
+    if args.disable_socket {
         config = config.with_socket(SocketType::None);
     }
 
-    if let Some(port) = matches.value_of("port").map(str::parse) {
-        if let Err(err) = port {
-            // if port was overridden, it must be parsable
-            panic!("Invalid port value provided - {:?}", err);
+    if let Some(port) = args.port {
+        config = config.with_port(port);
+    }
+
+    #[cfg(all(not(feature = "eth"), not(feature = "coconut")))]
+    {
+        config
+            .get_base_mut()
+            .with_eth_endpoint(DEFAULT_ETH_ENDPOINT.to_string());
+        config
+            .get_base_mut()
+            .with_eth_private_key(DEFAULT_ETH_PRIVATE_KEY.to_string());
+    }
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    {
+        if args.enabled_credentials_mode {
+            config.get_base_mut().with_disabled_credentials(false)
         }
-        config = config.with_port(port.unwrap());
+        if let Some(eth_endpoint) = args.eth_endpoint {
+            config.get_base_mut().with_eth_endpoint(eth_endpoint);
+        }
+        if let Some(eth_private_key) = args.eth_private_key {
+            config.get_base_mut().with_eth_private_key(eth_private_key);
+        }
     }
 
-    #[cfg(not(feature = "coconut"))]
-    if let Some(eth_endpoint) = matches.value_of(ETH_ENDPOINT_ARG_NAME) {
-        config.get_base_mut().with_eth_endpoint(eth_endpoint);
-    } else if !cfg!(feature = "eth") {
-        config
-            .get_base_mut()
-            .with_eth_endpoint(DEFAULT_ETH_ENDPOINT);
-    }
-    #[cfg(not(feature = "coconut"))]
-    if let Some(eth_private_key) = matches.value_of(ETH_PRIVATE_KEY_ARG_NAME) {
-        config.get_base_mut().with_eth_private_key(eth_private_key);
-    } else if !cfg!(feature = "eth") {
-        config
-            .get_base_mut()
-            .with_eth_private_key(DEFAULT_ETH_PRIVATE_KEY);
-    }
-
-    if matches.is_present(ENABLED_CREDENTIALS_MODE_ARG_NAME) {
-        config.get_base_mut().with_disabled_credentials(false)
+    if args.fastmode {
+        config.get_base_mut().set_high_default_traffic_volume();
     }
 
     config

--- a/clients/native/src/commands/run.rs
+++ b/clients/native/src/commands/run.rs
@@ -1,68 +1,77 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::client::config::Config;
-use crate::client::NymClient;
-use crate::commands::override_config;
-#[cfg(feature = "eth")]
-#[cfg(not(feature = "coconut"))]
-use crate::commands::{
-    ENABLED_CREDENTIALS_MODE_ARG_NAME, ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME,
+use crate::{
+    client::{config::Config, NymClient},
+    commands::{override_config, OverrideConfig},
 };
-use clap::{App, Arg, ArgMatches};
+
+use clap::Args;
 use config::NymConfig;
 use log::*;
 use version_checker::is_minor_version_compatible;
 
-pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
-    let app = App::new("run")
-        .about("Run the Nym client with provided configuration client optionally overriding set parameters")
-        .arg(Arg::with_name("id")
-            .long("id")
-            .help("Id of the nym-mixnet-client we want to run.")
-            .takes_value(true)
-            .required(true)
-        )
-        // the rest of arguments are optional, they are used to override settings in config file
-        .arg(Arg::with_name("validators")
-                .long("validators")
-                .help("Comma separated list rest rest endpoints of the validators")
-                .takes_value(true),
-        )
-        .arg(Arg::with_name("gateway")
-            .long("gateway")
-            .help("Id of the gateway we want to connect to. If overridden, it is user's responsibility to ensure prior registration happened")
-            .takes_value(true)
-        )
-        .arg(Arg::with_name("disable-socket")
-            .long("disable-socket")
-            .help("Whether to not start the websocket")
-        )
-        .arg(Arg::with_name("port")
-            .short("p")
-            .long("port")
-            .help("Port for the socket (if applicable) to listen on")
-            .takes_value(true)
-        );
-    #[cfg(feature = "eth")]
-    #[cfg(not(feature = "coconut"))]
-        let app = app
-        .arg(
-            Arg::with_name(ENABLED_CREDENTIALS_MODE_ARG_NAME)
-                .long(ENABLED_CREDENTIALS_MODE_ARG_NAME)
-                .help("Set this client to work in a enabled credentials mode that would attempt to use gateway with bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
-                .conflicts_with_all(&[ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME])
-        )
-        .arg(Arg::with_name(ETH_ENDPOINT_ARG_NAME)
-            .long(ETH_ENDPOINT_ARG_NAME)
-            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
-            .takes_value(true))
-        .arg(Arg::with_name(ETH_PRIVATE_KEY_ARG_NAME)
-            .long(ETH_PRIVATE_KEY_ARG_NAME)
-            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
-            .takes_value(true));
+#[derive(Args, Clone)]
+pub(crate) struct Run {
+    /// Id of the nym-mixnet-client we want to run.
+    #[clap(long)]
+    id: String,
 
-    app
+    /// Comma separated list of rest endpoints of the validators
+    #[clap(long)]
+    validators: Option<String>,
+
+    /// Id of the gateway we want to connect to. If overridden, it is user's responsibility to
+    /// ensure prior registration happened
+    #[clap(long)]
+    gateway: Option<String>,
+
+    /// Whether to not start the websocket
+    #[clap(long)]
+    disable_socket: bool,
+
+    /// Port for the socket to listen on
+    #[clap(short, long)]
+    port: Option<u16>,
+
+    /// Set this client to work in a enabled credentials mode that would attempt to use gateway
+    /// with bandwidth credential requirement. If this value is set, --eth-endpoint and
+    /// --eth-private-key don't need to be set.
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long, conflicts_with_all = &["eth-endpoint", "eth-private-key"])]
+    enabled_credentials_mode: bool,
+
+    /// URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20
+    /// tokens. If you don't want to set this value, use --enabled-credentials-mode instead
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long)]
+    eth_endpoint: Option<String>,
+
+    /// Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't
+    /// want to set this value, use --enabled-credentials-mode instead")
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long)]
+    eth_private_key: Option<String>,
+}
+
+impl From<Run> for OverrideConfig {
+    fn from(run_config: Run) -> Self {
+        OverrideConfig {
+            validators: run_config.validators,
+            disable_socket: run_config.disable_socket,
+            port: run_config.port,
+            fastmode: false,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            enabled_credentials_mode: run_config.enabled_credentials_mode,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            eth_private_key: run_config.eth_private_key,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            eth_endpoint: run_config.eth_endpoint,
+        }
+    }
 }
 
 // this only checks compatibility between config the binary. It does not take into consideration
@@ -84,8 +93,8 @@ fn version_check(cfg: &Config) -> bool {
     }
 }
 
-pub async fn execute(matches: ArgMatches<'static>) {
-    let id = matches.value_of("id").unwrap();
+pub(crate) async fn execute(args: &Run) {
+    let id = &args.id;
 
     let mut config = match Config::load_from_file(Some(id)) {
         Ok(cfg) => cfg,
@@ -95,7 +104,8 @@ pub async fn execute(matches: ArgMatches<'static>) {
         }
     };
 
-    config = override_config(config, &matches);
+    let override_config_fields = OverrideConfig::from(args.clone());
+    config = override_config(config, override_config_fields);
 
     if !version_check(&config) {
         error!("failed the local version check");

--- a/clients/native/src/commands/upgrade.rs
+++ b/clients/native/src/commands/upgrade.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::client::config::{Config, MISSING_VALUE};
-use clap::{App, Arg, ArgMatches};
-use config::defaults::default_api_endpoints;
-use config::NymConfig;
+
+use config::{defaults::default_api_endpoints, NymConfig};
+use version_checker::Version;
+
+use clap::Args;
 use std::fmt::Display;
 use std::process;
-use version_checker::Version;
 
 #[allow(dead_code)]
 fn fail_upgrade<D1: Display, D2: Display>(from_version: D1, to_version: D2) -> ! {
@@ -49,14 +50,11 @@ fn unsupported_upgrade(current_version: &Version, config_version: &Version) -> !
     process::exit(1)
 }
 
-pub fn command_args<'a, 'b>() -> App<'a, 'b> {
-    App::new("upgrade").about("Try to upgrade the client").arg(
-        Arg::with_name("id")
-            .long("id")
-            .help("Id of the nym-client we want to upgrade")
-            .takes_value(true)
-            .required(true),
-    )
+#[derive(Args, Clone)]
+pub(crate) struct Upgrade {
+    /// Id of the nym-client we want to upgrade
+    #[clap(long)]
+    id: String,
 }
 
 fn parse_config_version(config: &Config) -> Version {
@@ -95,7 +93,7 @@ fn parse_package_version() -> Version {
 
 fn minor_0_12_upgrade(
     mut config: Config,
-    _matches: &ArgMatches<'_>,
+    _matches: &Upgrade,
     config_version: &Version,
     package_version: &Version,
 ) -> Config {
@@ -131,7 +129,7 @@ fn minor_0_12_upgrade(
     config
 }
 
-fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: &Version) {
+fn do_upgrade(mut config: Config, args: &Upgrade, package_version: &Version) {
     loop {
         let config_version = parse_config_version(&config);
 
@@ -143,7 +141,7 @@ fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: &Ve
         config = match config_version.major {
             0 => match config_version.minor {
                 9 | 10 => outdated_upgrade(&config_version, package_version),
-                11 => minor_0_12_upgrade(config, matches, &config_version, package_version),
+                11 => minor_0_12_upgrade(config, args, &config_version, package_version),
                 _ => unsupported_upgrade(&config_version, package_version),
             },
             _ => unsupported_upgrade(&config_version, package_version),
@@ -151,10 +149,10 @@ fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: &Ve
     }
 }
 
-pub fn execute(matches: &ArgMatches<'_>) {
+pub(crate) fn execute(args: &Upgrade) {
     let package_version = parse_package_version();
 
-    let id = matches.value_of("id").unwrap();
+    let id = &args.id;
 
     let existing_config = Config::load_from_file(Some(id)).unwrap_or_else(|err| {
         eprintln!("failed to load existing config file! - {:?}", err);
@@ -167,5 +165,5 @@ pub fn execute(matches: &ArgMatches<'_>) {
     }
 
     // here be upgrade path to 0.9.X and beyond based on version number from config
-    do_upgrade(existing_config, matches, &package_version)
+    do_upgrade(existing_config, args, &package_version)
 }

--- a/clients/native/src/main.rs
+++ b/clients/native/src/main.rs
@@ -1,8 +1,7 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::{crate_version, App, ArgMatches};
-use network_defaults::DEFAULT_NETWORK;
+use clap::{crate_version, Parser};
 
 pub mod client;
 pub mod commands;
@@ -14,30 +13,8 @@ async fn main() {
     setup_logging();
     println!("{}", banner());
 
-    let arg_matches = App::new("Nym Client")
-        .version(crate_version!())
-        .long_version(&*long_version())
-        .author("Nymtech")
-        .about("Implementation of the Nym Client")
-        .subcommand(commands::init::command_args())
-        .subcommand(commands::run::command_args())
-        .subcommand(commands::upgrade::command_args())
-        .get_matches();
-
-    execute(arg_matches).await;
-}
-
-async fn execute(matches: ArgMatches<'static>) {
-    match matches.subcommand() {
-        ("init", Some(m)) => commands::init::execute(m.clone()).await,
-        ("run", Some(m)) => commands::run::execute(m.clone()).await,
-        ("upgrade", Some(m)) => commands::upgrade::execute(m),
-        _ => println!("{}", usage()),
-    }
-}
-
-fn usage() -> &'static str {
-    "usage: --help to see available options.\n\n"
+    let args = commands::Cli::parse();
+    commands::execute(&args).await;
 }
 
 fn banner() -> String {
@@ -54,40 +31,6 @@ fn banner() -> String {
 
     "#,
         crate_version!()
-    )
-}
-
-fn long_version() -> String {
-    format!(
-        r#"
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-"#,
-        "Build Timestamp:",
-        env!("VERGEN_BUILD_TIMESTAMP"),
-        "Build Version:",
-        env!("VERGEN_BUILD_SEMVER"),
-        "Commit SHA:",
-        env!("VERGEN_GIT_SHA"),
-        "Commit Date:",
-        env!("VERGEN_GIT_COMMIT_TIMESTAMP"),
-        "Commit Branch:",
-        env!("VERGEN_GIT_BRANCH"),
-        "rustc Version:",
-        env!("VERGEN_RUSTC_SEMVER"),
-        "rustc Channel:",
-        env!("VERGEN_RUSTC_CHANNEL"),
-        "cargo Profile:",
-        env!("VERGEN_CARGO_PROFILE"),
-        "Network:",
-        DEFAULT_NETWORK
     )
 }
 

--- a/clients/socks5/Cargo.toml
+++ b/clients/socks5/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nym-socks5-client"
 version = "1.0.1"
 authors = ["Dave Hrycyszyn <futurechimp@users.noreply.github.com>"]
+description = "A Socks5 localhost proxy that converts incoming messages to Sphinx and sends them to a Nym address"
 edition = "2021"
 rust-version = "1.56"
 
@@ -10,11 +11,12 @@ name = "nym_socks5"
 path = "src/lib.rs"
 
 [dependencies]
-clap = "2.33.0"
+clap = { version = "3.2.8", features = ["cargo", "derive"] }
 dirs = "4.0"
 dotenv = "0.15.0"
 futures = "0.3"
 log = "0.4"
+#once_cell = "1.13.0"
 pin-project = "1.0"
 pretty_env_logger = "0.4"
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }

--- a/clients/socks5/Cargo.toml
+++ b/clients/socks5/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nym-socks5-client"
 version = "1.0.1"
 authors = ["Dave Hrycyszyn <futurechimp@users.noreply.github.com>"]
-description = "A Socks5 localhost proxy that converts incoming messages to Sphinx and sends them to a Nym address"
+description = "A SOCKS5 localhost proxy that converts incoming messages to Sphinx and sends them to a Nym address"
 edition = "2021"
 rust-version = "1.56"
 
@@ -16,7 +16,6 @@ dirs = "4.0"
 dotenv = "0.15.0"
 futures = "0.3"
 log = "0.4"
-#once_cell = "1.13.0"
 pin-project = "1.0"
 pretty_env_logger = "0.4"
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -5,11 +5,12 @@ use clap::Args;
 use client_core::config::GatewayEndpoint;
 use config::NymConfig;
 
-use crate::commands::override_config;
-use crate::{client::config::Config, commands::OverrideConfig};
+use crate::{
+    client::config::Config,
+    commands::{override_config, OverrideConfig},
+};
 
-#[cfg(feature = "eth")]
-#[cfg(not(feature = "coconut"))]
+#[cfg(all(feature = "eth", not(feature = "coconut")))]
 use crate::commands::{DEFAULT_ETH_ENDPOINT, DEFAULT_ETH_PRIVATE_KEY};
 
 #[derive(Args, Clone)]
@@ -114,13 +115,13 @@ pub(crate) async fn execute(args: &Init) {
     let register_gateway = !already_init || user_wants_force_register;
 
     // Attempt to use a user-provided gateway, if possible
-    let user_chosen_gateway_id = args.gateway.as_ref().map(String::as_str);
+    let user_chosen_gateway_id = args.gateway.as_deref();
 
     let mut config = Config::new(id, provider_address);
     let override_config_fields = OverrideConfig::from(args.clone());
     config = override_config(config, override_config_fields);
 
-    let gateway = setup_gateway(&id, register_gateway, user_chosen_gateway_id, &config).await;
+    let gateway = setup_gateway(id, register_gateway, user_chosen_gateway_id, &config).await;
     config.get_base_mut().with_gateway_endpoint(gateway);
 
     let config_save_location = config.get_config_file_save_location();

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -1,91 +1,99 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::{App, Arg, ArgMatches};
+use clap::Args;
 use client_core::config::GatewayEndpoint;
 use config::NymConfig;
 
-use crate::client::config::Config;
 use crate::commands::override_config;
+use crate::{client::config::Config, commands::OverrideConfig};
+
 #[cfg(feature = "eth")]
 #[cfg(not(feature = "coconut"))]
-use crate::commands::{
-    DEFAULT_ETH_ENDPOINT, DEFAULT_ETH_PRIVATE_KEY, ENABLED_CREDENTIALS_MODE_ARG_NAME,
-    ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME,
-};
+use crate::commands::{DEFAULT_ETH_ENDPOINT, DEFAULT_ETH_PRIVATE_KEY};
 
-pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
-    let app = App::new("init")
-        .about("Initialise a Nym client. Do this first!")
-        .arg(Arg::with_name("id")
-            .long("id")
-            .help("Id of the nym-mixnet-client we want to create config for.")
-            .takes_value(true)
-            .required(true)
-        )
-        .arg(Arg::with_name("provider")
-            .long("provider")
-            .help("Address of the socks5 provider to send messages to.")
-            .takes_value(true)
-            .required(true)
-        )
-        .arg(Arg::with_name("gateway")
-            .long("gateway")
-            .help("Id of the gateway we are going to connect to.")
-            .takes_value(true)
-        )
-        .arg(Arg::with_name("force-register-gateway")
-            .long("force-register-gateway")
-            .help("Force register gateway. WARNING: this will overwrite any existing keys for the given id, potentially causing loss of access.")
-            .takes_value(false)
-        )
-        .arg(Arg::with_name("validators")
-                 .long("validators")
-                 .help("Comma separated list of rest endpoints of the validators")
-                 .takes_value(true),
-        )
-        .arg(Arg::with_name("port")
-            .short("p")
-            .long("port")
-            .help("Port for the socket to listen on in all subsequent runs")
-            .takes_value(true)
-        )
-        .arg(Arg::with_name("fastmode")
-            .long("fastmode")
-            .hidden(true) // this will prevent this flag from being displayed in `--help`
-            .help("Mostly debug-related option to increase default traffic rate so that you would not need to modify config post init")
-        );
-    #[cfg(feature = "eth")]
-    #[cfg(not(feature = "coconut"))]
-        let app = app
-        .arg(
-            Arg::with_name(ENABLED_CREDENTIALS_MODE_ARG_NAME)
-                .long(ENABLED_CREDENTIALS_MODE_ARG_NAME)
-                .help("Set this client to work in a enabled credentials mode that would attempt to use gateway with bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
-                .conflicts_with_all(&[ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME])
-        )
-        .arg(Arg::with_name(ETH_ENDPOINT_ARG_NAME)
-            .long(ETH_ENDPOINT_ARG_NAME)
-            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
-            .takes_value(true)
-            .default_value_if(ENABLED_CREDENTIALS_MODE_ARG_NAME, None, DEFAULT_ETH_ENDPOINT)
-            .required(true))
-        .arg(Arg::with_name(ETH_PRIVATE_KEY_ARG_NAME)
-            .long(ETH_PRIVATE_KEY_ARG_NAME)
-            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
-            .takes_value(true)
-            .default_value_if(ENABLED_CREDENTIALS_MODE_ARG_NAME, None, DEFAULT_ETH_PRIVATE_KEY)
-            .required(true)
-        );
+#[derive(Args, Clone)]
+pub(crate) struct Init {
+    /// Id of the nym-mixnet-client we want to create config for.
+    #[clap(long)]
+    id: String,
 
-    app
+    /// Address of the socks5 provider to send messages to.
+    #[clap(long)]
+    provider: String,
+
+    /// Id of the gateway we are going to connect to.
+    #[clap(long)]
+    gateway: Option<String>,
+
+    /// Force register gateway. WARNING: this will overwrite any existing keys for the given id,
+    /// potentially causing loss of access.
+    #[clap(long)]
+    force_register_gateway: bool,
+
+    /// Comma separated list of rest endpoints of the validators
+    #[clap(long)]
+    validators: Option<String>,
+
+    /// Port for the socket to listen on in all subsequent runs")
+    #[clap(short, long)]
+    port: Option<u16>,
+
+    /// Mostly debug-related option to increase default traffic rate so that you would not need to
+    /// modify config post init
+    #[clap(long, hidden = true)]
+    fastmode: bool,
+
+    /// Set this client to work in a enabled credentials mode that would attempt to use gateway
+    /// with bandwidth credential requirement. If this value is set, --eth-endpoint and
+    /// --eth-private_key don't need to be set.
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long, conflicts_with_all = &["eth-endpoint", "eth-private-key"])]
+    enabled_credentials_mode: bool,
+
+    /// URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20
+    /// tokens. If you don't want to set this value, use --enabled-credentials-mode instead
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(
+        long,
+        default_value = DEFAULT_ETH_ENDPOINT
+    )]
+    eth_endpoint: String,
+
+    /// Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't
+    /// want to set this value, use --enabled-credentials-mode instead")
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(
+        long,
+        default_value = DEFAULT_ETH_PRIVATE_KEY
+    )]
+    eth_private_key: String,
 }
 
-pub async fn execute(matches: ArgMatches<'static>) {
+impl From<Init> for OverrideConfig {
+    fn from(init_config: Init) -> Self {
+        OverrideConfig {
+            validators: init_config.validators,
+            port: init_config.port,
+            fastmode: init_config.fastmode,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            enabled_credentials_mode: init_config.enabled_credentials_mode,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            eth_private_key: Some(init_config.eth_private_key),
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            eth_endpoint: Some(init_config.eth_endpoint),
+        }
+    }
+}
+
+pub(crate) async fn execute(args: &Init) {
     println!("Initialising client...");
 
-    let id = matches.value_of("id").unwrap(); // required for now
-    let provider_address = matches.value_of("provider").unwrap();
+    let id = &args.id;
+    let provider_address = &args.provider;
 
     let already_init = Config::default_config_file_path(Some(id)).exists();
     if already_init {
@@ -98,7 +106,7 @@ pub async fn execute(matches: ArgMatches<'static>) {
 
     // Usually you only register with the gateway on the first init, however you can force
     // re-registering if wanted.
-    let user_wants_force_register = matches.is_present("force-register-gateway");
+    let user_wants_force_register = args.force_register_gateway;
 
     // If the client was already initialized, don't generate new keys and don't re-register with
     // the gateway (because this would create a new shared key).
@@ -106,16 +114,13 @@ pub async fn execute(matches: ArgMatches<'static>) {
     let register_gateway = !already_init || user_wants_force_register;
 
     // Attempt to use a user-provided gateway, if possible
-    let user_chosen_gateway_id = matches.value_of("gateway");
+    let user_chosen_gateway_id = args.gateway.as_ref().map(String::as_str);
 
     let mut config = Config::new(id, provider_address);
+    let override_config_fields = OverrideConfig::from(args.clone());
+    config = override_config(config, override_config_fields);
 
-    config = override_config(config, &matches);
-    if matches.is_present("fastmode") {
-        config.get_base_mut().set_high_default_traffic_volume();
-    }
-
-    let gateway = setup_gateway(id, register_gateway, user_chosen_gateway_id, &config).await;
+    let gateway = setup_gateway(&id, register_gateway, user_chosen_gateway_id, &config).await;
     config.get_base_mut().with_gateway_endpoint(gateway);
 
     let config_save_location = config.get_config_file_save_location();

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -36,7 +36,7 @@ pub(crate) struct Init {
     #[clap(long)]
     validators: Option<String>,
 
-    /// Port for the socket to listen on in all subsequent runs")
+    /// Port for the socket to listen on in all subsequent runs
     #[clap(short, long)]
     port: Option<u16>,
 

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -57,7 +57,7 @@ pub(crate) struct Init {
     #[cfg(all(feature = "eth", not(feature = "coconut")))]
     #[clap(
         long,
-        default_value = DEFAULT_ETH_ENDPOINT
+        default_value_if("enabled-credentials-mode", None, Some(DEFAULT_ETH_ENDPOINT))
     )]
     eth_endpoint: String,
 
@@ -66,7 +66,7 @@ pub(crate) struct Init {
     #[cfg(all(feature = "eth", not(feature = "coconut")))]
     #[clap(
         long,
-        default_value = DEFAULT_ETH_PRIVATE_KEY
+        default_value_if("enabled-credentials-mode", None, Some(DEFAULT_ETH_PRIVATE_KEY))
     )]
     eth_private_key: String,
 }

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -66,9 +66,9 @@ pub(crate) struct Cli {
 pub(crate) enum Commands {
     /// Initialise a Nym client. Do this first!
     Init(init::Init),
-    // Run the Nym client with provided configuration client optionally overriding set parameters
+    /// Run the Nym client with provided configuration client optionally overriding set parameters
     Run(run::Run),
-    // Try to upgrade the client
+    /// Try to upgrade the client
     Upgrade(upgrade::Upgrade),
 }
 

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -130,16 +130,14 @@ pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Confi
 
     #[cfg(all(feature = "eth", not(feature = "coconut")))]
     {
+        if args.enabled_credentials_mode {
+            config.get_base_mut().with_disabled_credentials(false)
+        }
         if let Some(eth_endpoint) = args.eth_endpoint {
             config.get_base_mut().with_eth_endpoint(eth_endpoint);
         }
         if let Some(eth_private_key) = args.eth_private_key {
             config.get_base_mut().with_eth_private_key(eth_private_key);
-        }
-
-        #[cfg(all(feature = "eth", not(feature = "coconut")))]
-        if args.enabled_credentials_mode {
-            config.get_base_mut().with_disabled_credentials(false)
         }
     }
 

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -2,24 +2,99 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::client::config::Config;
-use clap::ArgMatches;
+use clap::{Parser, Subcommand};
+use network_defaults::DEFAULT_NETWORK;
 use url::Url;
 
 pub mod init;
 pub(crate) mod run;
 pub(crate) mod upgrade;
 
-pub(crate) const ENABLED_CREDENTIALS_MODE_ARG_NAME: &str = "enabled-credentials-mode";
-#[cfg(not(feature = "coconut"))]
-pub(crate) const ETH_ENDPOINT_ARG_NAME: &str = "eth_endpoint";
-#[cfg(not(feature = "coconut"))]
-pub(crate) const ETH_PRIVATE_KEY_ARG_NAME: &str = "eth_private_key";
 #[cfg(not(feature = "coconut"))]
 pub(crate) const DEFAULT_ETH_ENDPOINT: &str =
     "https://rinkeby.infura.io/v3/00000000000000000000000000000000";
 #[cfg(not(feature = "coconut"))]
 pub(crate) const DEFAULT_ETH_PRIVATE_KEY: &str =
     "0000000000000000000000000000000000000000000000000000000000000001";
+
+fn long_version() -> String {
+    format!(
+        r#"
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+"#,
+        "Build Timestamp:",
+        env!("VERGEN_BUILD_TIMESTAMP"),
+        "Build Version:",
+        env!("VERGEN_BUILD_SEMVER"),
+        "Commit SHA:",
+        env!("VERGEN_GIT_SHA"),
+        "Commit Date:",
+        env!("VERGEN_GIT_COMMIT_TIMESTAMP"),
+        "Commit Branch:",
+        env!("VERGEN_GIT_BRANCH"),
+        "rustc Version:",
+        env!("VERGEN_RUSTC_SEMVER"),
+        "rustc Channel:",
+        env!("VERGEN_RUSTC_CHANNEL"),
+        "cargo Profile:",
+        env!("VERGEN_CARGO_PROFILE"),
+        "Network:",
+        DEFAULT_NETWORK
+    )
+}
+
+fn long_version_static() -> &'static str {
+    Box::leak(long_version().into_boxed_str())
+}
+
+#[derive(Parser)]
+#[clap(author = "Nymtech", version, long_version = long_version_static(), about)]
+pub(crate) struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum Commands {
+    /// Initialise a Nym client. Do this first!
+    Init(init::Init),
+    // Run the Nym client with provided configuration client optionally overriding set parameters
+    Run(run::Run),
+    // Try to upgrade the client
+    Upgrade(upgrade::Upgrade),
+}
+
+// Configuration that can be overridden.
+pub(crate) struct OverrideConfig {
+    validators: Option<String>,
+    port: Option<u16>,
+    fastmode: bool,
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    enabled_credentials_mode: bool,
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    eth_private_key: Option<String>,
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    eth_endpoint: Option<String>,
+}
+
+pub(crate) async fn execute(args: &Cli) {
+    match &args.command {
+        Commands::Init(m) => init::execute(m).await,
+        Commands::Run(m) => run::execute(m).await,
+        Commands::Upgrade(m) => upgrade::execute(m),
+    }
+}
 
 fn parse_validators(raw: &str) -> Vec<Url> {
     raw.split(',')
@@ -32,40 +107,44 @@ fn parse_validators(raw: &str) -> Vec<Url> {
         .collect()
 }
 
-pub(crate) fn override_config(mut config: Config, matches: &ArgMatches<'_>) -> Config {
-    if let Some(raw_validators) = matches.value_of("validators") {
+pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Config {
+    if let Some(raw_validators) = args.validators {
         config
             .get_base_mut()
-            .set_custom_validator_apis(parse_validators(raw_validators));
+            .set_custom_validator_apis(parse_validators(&raw_validators));
     }
 
-    if let Some(port) = matches.value_of("port").map(|port| port.parse::<u16>()) {
-        if let Err(err) = port {
-            // if port was overridden, it must be parsable
-            panic!("Invalid port value provided - {:?}", err);
+    if let Some(port) = args.port {
+        config = config.with_port(port);
+    }
+
+    #[cfg(all(not(feature = "eth"), not(feature = "coconut")))]
+    {
+        config
+            .get_base_mut()
+            .with_eth_endpoint(DEFAULT_ETH_ENDPOINT.to_string());
+        config
+            .get_base_mut()
+            .with_eth_private_key(DEFAULT_ETH_PRIVATE_KEY.to_string());
+    }
+
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    {
+        if let Some(eth_endpoint) = args.eth_endpoint {
+            config.get_base_mut().with_eth_endpoint(eth_endpoint);
         }
-        config = config.with_port(port.unwrap());
+        if let Some(eth_private_key) = args.eth_private_key {
+            config.get_base_mut().with_eth_private_key(eth_private_key);
+        }
+
+        #[cfg(all(feature = "eth", not(feature = "coconut")))]
+        if args.enabled_credentials_mode {
+            config.get_base_mut().with_disabled_credentials(false)
+        }
     }
 
-    #[cfg(not(feature = "coconut"))]
-    if let Some(eth_endpoint) = matches.value_of(ETH_ENDPOINT_ARG_NAME) {
-        config.get_base_mut().with_eth_endpoint(eth_endpoint);
-    } else if !cfg!(feature = "eth") {
-        config
-            .get_base_mut()
-            .with_eth_endpoint(DEFAULT_ETH_ENDPOINT);
-    }
-    #[cfg(not(feature = "coconut"))]
-    if let Some(eth_private_key) = matches.value_of(ETH_PRIVATE_KEY_ARG_NAME) {
-        config.get_base_mut().with_eth_private_key(eth_private_key);
-    } else if !cfg!(feature = "eth") {
-        config
-            .get_base_mut()
-            .with_eth_private_key(DEFAULT_ETH_PRIVATE_KEY);
-    }
-
-    if matches.is_present(ENABLED_CREDENTIALS_MODE_ARG_NAME) {
-        config.get_base_mut().with_disabled_credentials(false)
+    if args.fastmode {
+        config.get_base_mut().set_high_default_traffic_volume();
     }
 
     config

--- a/clients/socks5/src/commands/run.rs
+++ b/clients/socks5/src/commands/run.rs
@@ -1,74 +1,79 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::client::config::Config;
-use crate::client::NymClient;
-use crate::commands::override_config;
-#[cfg(feature = "eth")]
-#[cfg(not(feature = "coconut"))]
-use crate::commands::{
-    ENABLED_CREDENTIALS_MODE_ARG_NAME, ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME,
+use crate::{
+    client::{config::Config, NymClient},
+    commands::{override_config, OverrideConfig},
 };
-use clap::{App, Arg, ArgMatches};
+
+use clap::Args;
 use config::NymConfig;
 use log::*;
 use version_checker::is_minor_version_compatible;
 
-pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
-    let app = App::new("run")
-        .about("Run the Nym client with provided configuration client optionally overriding set parameters")
-        .arg(Arg::with_name("id")
-            .long("id")
-            .help("Id of the nym-mixnet-client we want to run.")
-            .takes_value(true)
-            .required(true)
-        )
-        // the rest of arguments are optional, they are used to override settings in config file
-        .arg(Arg::with_name("config")
-            .long("config")
-            .help("Custom path to the nym-mixnet-client configuration file")
-            .takes_value(true)
-        )
-        .arg(Arg::with_name("provider")
-            .long("provider")
-            .help("Address of the socks5 provider to send messages to.")
-            .takes_value(true)
-        )
-        .arg(Arg::with_name("gateway")
-            .long("gateway")
-            .help("Id of the gateway we want to connect to. If overridden, it is user's responsibility to ensure prior registration happened")
-            .takes_value(true)
-        )
-        .arg(Arg::with_name("validators")
-                .long("validators")
-                .help("Comma separated list of rest endpoints of the validators")
-                .takes_value(true),
-        )
-        .arg(Arg::with_name("port")
-            .short("p")
-            .long("port")
-            .help("Port for the socket to listen on")
-            .takes_value(true)
-        );
-    #[cfg(feature = "eth")]
-    #[cfg(not(feature = "coconut"))]
-    let app = app
-        .arg(
-            Arg::with_name(ENABLED_CREDENTIALS_MODE_ARG_NAME)
-                .long(ENABLED_CREDENTIALS_MODE_ARG_NAME)
-                .help("Set this client to work in a disabled credentials mode that would attempt to use gateway without bandwidth credential requirement. If this value is set, --eth_endpoint and --eth_private_key don't need to be set.")
-                .conflicts_with_all(&[ETH_ENDPOINT_ARG_NAME, ETH_PRIVATE_KEY_ARG_NAME])
-        )
-        .arg(Arg::with_name(ETH_ENDPOINT_ARG_NAME)
-            .long(ETH_ENDPOINT_ARG_NAME)
-            .help("URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
-            .takes_value(true))
-        .arg(Arg::with_name(ETH_PRIVATE_KEY_ARG_NAME)
-            .long(ETH_PRIVATE_KEY_ARG_NAME)
-            .help("Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't want to set this value, use --testnet-mode instead")
-            .takes_value(true));
+#[derive(Args, Clone)]
+pub(crate) struct Run {
+    /// Id of the nym-mixnet-client we want to run.
+    #[clap(long)]
+    id: String,
 
-    app
+    /// Custom path to the nym-mixnet-client configuration file
+    #[clap(long)]
+    config: Option<String>,
+
+    /// Address of the socks5 provider to send messages to.
+    #[clap(long)]
+    provider: Option<String>,
+
+    /// Id of the gateway we want to connect to. If overridden, it is user's responsibility to ensure prior registration happened
+    #[clap(long)]
+    gateway: Option<String>,
+
+    /// Comma separated list of rest endpoints of the validators
+    #[clap(long)]
+    validators: Option<String>,
+
+    /// Port for the socket to listen on
+    #[clap(short, long)]
+    port: Option<u16>,
+
+    /// Set this client to work in a disabled credentials mode that would attempt to use gateway
+    /// without bandwidth credential requirement. If this value is set, --eth-endpoint and
+    /// --eth-private-key don't need to be set.")
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long, conflicts_with_all = &["eth-endpoint", "eth-private-key"])]
+    enabled_credentials_mode: bool,
+
+    /// URL of an Ethereum full node that we want to use for getting bandwidth tokens from ERC20
+    /// tokens. If you don't want to set this value, use --enabled-credentials-mode instead
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long)]
+    eth_endpoint: Option<String>,
+
+    /// Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't
+    /// want to set this value, use --enabled-credentials-mode instead")
+    #[cfg(all(feature = "eth", not(feature = "coconut")))]
+    #[clap(long)]
+    eth_private_key: Option<String>,
+}
+
+impl From<Run> for OverrideConfig {
+    fn from(run_config: Run) -> Self {
+        OverrideConfig {
+            validators: run_config.validators,
+            port: run_config.port,
+            fastmode: false,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            enabled_credentials_mode: run_config.enabled_credentials_mode,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            eth_private_key: run_config.eth_private_key,
+
+            #[cfg(all(feature = "eth", not(feature = "coconut")))]
+            eth_endpoint: run_config.eth_endpoint,
+        }
+    }
 }
 
 // this only checks compatibility between config the binary. It does not take into consideration
@@ -76,8 +81,13 @@ pub fn command_args<'a, 'b>() -> clap::App<'a, 'b> {
 fn version_check(cfg: &Config) -> bool {
     let binary_version = env!("CARGO_PKG_VERSION");
     let config_version = cfg.get_base().get_version();
-    if binary_version != config_version {
-        warn!("The mixnode binary has different version than what is specified in config file! {} and {}", binary_version, config_version);
+    if binary_version == config_version {
+        true
+    } else {
+        warn!(
+            "The mixnode binary has different version than what is specified in config file! {} and {}",
+            binary_version, config_version
+        );
         if is_minor_version_compatible(binary_version, config_version) {
             info!("but they are still semver compatible. However, consider running the `upgrade` command");
             true
@@ -85,13 +95,11 @@ fn version_check(cfg: &Config) -> bool {
             error!("and they are semver incompatible! - please run the `upgrade` command before attempting `run` again");
             false
         }
-    } else {
-        true
     }
 }
 
-pub async fn execute(matches: ArgMatches<'static>) {
-    let id = matches.value_of("id").unwrap();
+pub(crate) async fn execute(args: &Run) {
+    let id = &args.id;
 
     let mut config = match Config::load_from_file(Some(id)) {
         Ok(cfg) => cfg,
@@ -101,7 +109,8 @@ pub async fn execute(matches: ArgMatches<'static>) {
         }
     };
 
-    config = override_config(config, &matches);
+    let override_config_fields = OverrideConfig::from(args.clone());
+    config = override_config(config, override_config_fields);
 
     if !version_check(&config) {
         error!("failed the local version check");

--- a/clients/socks5/src/commands/run.rs
+++ b/clients/socks5/src/commands/run.rs
@@ -25,7 +25,8 @@ pub(crate) struct Run {
     #[clap(long)]
     provider: Option<String>,
 
-    /// Id of the gateway we want to connect to. If overridden, it is user's responsibility to ensure prior registration happened
+    /// Id of the gateway we want to connect to. If overridden, it is user's responsibility to
+    /// ensure prior registration happened
     #[clap(long)]
     gateway: Option<String>,
 
@@ -37,9 +38,9 @@ pub(crate) struct Run {
     #[clap(short, long)]
     port: Option<u16>,
 
-    /// Set this client to work in a disabled credentials mode that would attempt to use gateway
-    /// without bandwidth credential requirement. If this value is set, --eth-endpoint and
-    /// --eth-private-key don't need to be set.")
+    /// Set this client to work in a enabled credentials mode that would attempt to use gateway
+    /// with bandwidth credential requirement. If this value is set, --eth-endpoint and
+    /// --eth-private-key don't need to be set.
     #[cfg(all(feature = "eth", not(feature = "coconut")))]
     #[clap(long, conflicts_with_all = &["eth-endpoint", "eth-private-key"])]
     enabled_credentials_mode: bool,
@@ -51,7 +52,7 @@ pub(crate) struct Run {
     eth_endpoint: Option<String>,
 
     /// Ethereum private key used for obtaining bandwidth tokens from ERC20 tokens. If you don't
-    /// want to set this value, use --enabled-credentials-mode instead")
+    /// want to set this value, use --enabled-credentials-mode instead
     #[cfg(all(feature = "eth", not(feature = "coconut")))]
     #[clap(long)]
     eth_private_key: Option<String>,

--- a/clients/socks5/src/commands/upgrade.rs
+++ b/clients/socks5/src/commands/upgrade.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::client::config::{Config, MISSING_VALUE};
-use clap::{App, Arg, ArgMatches};
+use clap::{Args};
 use config::defaults::default_api_endpoints;
 use config::NymConfig;
 use std::fmt::Display;
@@ -49,14 +49,11 @@ fn unsupported_upgrade(current_version: &Version, config_version: &Version) -> !
     process::exit(1)
 }
 
-pub fn command_args<'a, 'b>() -> App<'a, 'b> {
-    App::new("upgrade").about("Try to upgrade the client").arg(
-        Arg::with_name("id")
-            .long("id")
-            .help("Id of the nym-client we want to upgrade")
-            .takes_value(true)
-            .required(true),
-    )
+#[derive(Args, Clone)]
+pub(crate) struct Upgrade {
+    /// Id of the nym-client we want to upgrade
+    #[clap(long)]
+    id: String,
 }
 
 fn parse_config_version(config: &Config) -> Version {
@@ -95,7 +92,7 @@ fn parse_package_version() -> Version {
 
 fn minor_0_12_upgrade(
     mut config: Config,
-    _matches: &ArgMatches<'_>,
+    _args: &Upgrade,
     config_version: &Version,
     package_version: &Version,
 ) -> Config {
@@ -131,7 +128,7 @@ fn minor_0_12_upgrade(
     config
 }
 
-fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: Version) {
+fn do_upgrade(mut config: Config, args: &Upgrade, package_version: Version) {
     loop {
         let config_version = parse_config_version(&config);
 
@@ -143,7 +140,7 @@ fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: Ver
         config = match config_version.major {
             0 => match config_version.minor {
                 9 | 10 => outdated_upgrade(&config_version, &package_version),
-                11 => minor_0_12_upgrade(config, matches, &config_version, &package_version),
+                11 => minor_0_12_upgrade(config, args, &config_version, &package_version),
                 _ => unsupported_upgrade(&config_version, &package_version),
             },
             _ => unsupported_upgrade(&config_version, &package_version),
@@ -151,10 +148,10 @@ fn do_upgrade(mut config: Config, matches: &ArgMatches<'_>, package_version: Ver
     }
 }
 
-pub fn execute(matches: &ArgMatches<'_>) {
+pub(crate) fn execute(args: &Upgrade) {
     let package_version = parse_package_version();
 
-    let id = matches.value_of("id").unwrap();
+    let id = &args.id;
 
     let existing_config = Config::load_from_file(Some(id)).unwrap_or_else(|err| {
         eprintln!("failed to load existing config file! - {:?}", err);
@@ -167,5 +164,5 @@ pub fn execute(matches: &ArgMatches<'_>) {
     }
 
     // here be upgrade path to 0.9.X and beyond based on version number from config
-    do_upgrade(existing_config, matches, package_version)
+    do_upgrade(existing_config, args, package_version)
 }

--- a/clients/socks5/src/commands/upgrade.rs
+++ b/clients/socks5/src/commands/upgrade.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::client::config::{Config, MISSING_VALUE};
-use clap::{Args};
-use config::defaults::default_api_endpoints;
-use config::NymConfig;
-use std::fmt::Display;
-use std::process;
+
+use config::{defaults::default_api_endpoints, NymConfig};
 use version_checker::Version;
+
+use clap::Args;
+use std::{fmt::Display, process};
 
 #[allow(dead_code)]
 fn fail_upgrade<D1: Display, D2: Display>(from_version: D1, to_version: D2) -> ! {

--- a/clients/socks5/src/commands/upgrade.rs
+++ b/clients/socks5/src/commands/upgrade.rs
@@ -128,22 +128,22 @@ fn minor_0_12_upgrade(
     config
 }
 
-fn do_upgrade(mut config: Config, args: &Upgrade, package_version: Version) {
+fn do_upgrade(mut config: Config, args: &Upgrade, package_version: &Version) {
     loop {
         let config_version = parse_config_version(&config);
 
-        if config_version == package_version {
+        if &config_version == package_version {
             println!("You're using the most recent version!");
             return;
         }
 
         config = match config_version.major {
             0 => match config_version.minor {
-                9 | 10 => outdated_upgrade(&config_version, &package_version),
-                11 => minor_0_12_upgrade(config, args, &config_version, &package_version),
-                _ => unsupported_upgrade(&config_version, &package_version),
+                9 | 10 => outdated_upgrade(&config_version, package_version),
+                11 => minor_0_12_upgrade(config, args, &config_version, package_version),
+                _ => unsupported_upgrade(&config_version, package_version),
             },
-            _ => unsupported_upgrade(&config_version, &package_version),
+            _ => unsupported_upgrade(&config_version, package_version),
         }
     }
 }
@@ -164,5 +164,5 @@ pub(crate) fn execute(args: &Upgrade) {
     }
 
     // here be upgrade path to 0.9.X and beyond based on version number from config
-    do_upgrade(existing_config, args, package_version)
+    do_upgrade(existing_config, args, &package_version)
 }

--- a/clients/socks5/src/main.rs
+++ b/clients/socks5/src/main.rs
@@ -3,8 +3,8 @@
 
 use clap::{crate_version, Parser};
 
-mod commands;
 pub mod client;
+mod commands;
 pub mod socks;
 
 #[tokio::main]

--- a/clients/socks5/src/main.rs
+++ b/clients/socks5/src/main.rs
@@ -1,11 +1,10 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::{crate_version, App, ArgMatches};
-use network_defaults::DEFAULT_NETWORK;
+use clap::{crate_version, Parser};
 
-pub mod client;
 mod commands;
+pub mod client;
 pub mod socks;
 
 #[tokio::main]
@@ -14,30 +13,8 @@ async fn main() {
     setup_logging();
     println!("{}", banner());
 
-    let arg_matches = App::new("Nym Socks5 Proxy")
-        .version(env!("CARGO_PKG_VERSION"))
-        .author("Nymtech")
-        .long_version(&*long_version())
-        .about("A Socks5 localhost proxy that converts incoming messages to Sphinx and sends them to a Nym address")
-        .subcommand(commands::init::command_args())
-        .subcommand(commands::run::command_args())
-        .subcommand(commands::upgrade::command_args())
-        .get_matches();
-
-    execute(arg_matches).await;
-}
-
-async fn execute(matches: ArgMatches<'static>) {
-    match matches.subcommand() {
-        ("init", Some(m)) => commands::init::execute(m.clone()).await,
-        ("run", Some(m)) => commands::run::execute(m.clone()).await,
-        ("upgrade", Some(m)) => commands::upgrade::execute(m),
-        _ => println!("{}", usage()),
-    }
-}
-
-fn usage() -> &'static str {
-    "usage: --help to see available options.\n\n"
+    let args = commands::Cli::parse();
+    commands::execute(&args).await;
 }
 
 fn banner() -> String {
@@ -54,40 +31,6 @@ fn banner() -> String {
 
     "#,
         crate_version!()
-    )
-}
-
-fn long_version() -> String {
-    format!(
-        r#"
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-"#,
-        "Build Timestamp:",
-        env!("VERGEN_BUILD_TIMESTAMP"),
-        "Build Version:",
-        env!("VERGEN_BUILD_SEMVER"),
-        "Commit SHA:",
-        env!("VERGEN_GIT_SHA"),
-        "Commit Date:",
-        env!("VERGEN_GIT_COMMIT_TIMESTAMP"),
-        "Commit Branch:",
-        env!("VERGEN_GIT_BRANCH"),
-        "rustc Version:",
-        env!("VERGEN_RUSTC_SEMVER"),
-        "rustc Channel:",
-        env!("VERGEN_RUSTC_CHANNEL"),
-        "cargo Profile:",
-        env!("VERGEN_CARGO_PROFILE"),
-        "Network:",
-        DEFAULT_NETWORK
     )
 }
 

--- a/nym-connect/Cargo.lock
+++ b/nym-connect/Cargo.lock
@@ -553,17 +553,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1152,7 +1176,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -3638,6 +3662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
 name = "pairing"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5365,12 +5395,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -5810,12 +5834,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thin-slice"
@@ -6190,12 +6211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6316,12 +6331,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"


### PR DESCRIPTION
# Description

Upgrade the native and socks5 clients to use latest clap, as well as switching to the declarative derive form.

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
