### PR TITLE
mixnode & gateway: move detailed build info back to --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - all: updated `rocket` to `0.5.0-rc.2`.
 - network-requester: allow to voluntarily store and send statistical data about the number of bytes the proxied server serves ([#1328])
 - gateway: allow to voluntarily send statistical data about the number of active inboxes served by a gateway ([#1376])
+- gateway & mixnode: move detailed build info back to `--version` from `--help`.
 - socks5 client/websocket client: upgrade to latest clap and switched to declarative commandline parsing.
 
 [#1249]: https://github.com/nymtech/nym/pull/1249

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -9,15 +9,15 @@ mod commands;
 mod config;
 mod node;
 
-static LONG_ABOUT: OnceCell<String> = OnceCell::new();
+static LONG_VERSION: OnceCell<String> = OnceCell::new();
 
 // Helper for passing LONG_ABOUT to clap
-fn long_about() -> &'static str {
-    LONG_ABOUT.get().expect("Failed to get long about text")
+fn long_version_static() -> &'static str {
+    LONG_VERSION.get().expect("Failed to get long about text")
 }
 
 #[derive(Parser)]
-#[clap(author = "Nymtech", version, about, long_about = Some(long_about()))]
+#[clap(author = "Nymtech", version, about, long_version = long_version_static())]
 struct Cli {
     #[clap(subcommand)]
     command: commands::Commands,
@@ -28,7 +28,7 @@ async fn main() {
     dotenv::dotenv().ok();
     setup_logging();
     println!("{}", banner());
-    LONG_ABOUT
+    LONG_VERSION
         .set(long_version())
         .expect("Failed to set long about text");
 

--- a/mixnode/src/main.rs
+++ b/mixnode/src/main.rs
@@ -13,16 +13,16 @@ mod config;
 mod node;
 
 lazy_static! {
-    pub static ref LONG_ABOUT: String = long_version();
+    pub static ref LONG_VERSION: String = long_version();
 }
 
-// Helper for passing LONG_ABOUT to clap
-fn long_about() -> &'static str {
-    &LONG_ABOUT
+// Helper for passing LONG_VERSION to clap
+fn long_version_static() -> &'static str {
+    &LONG_VERSION
 }
 
 #[derive(Parser)]
-#[clap(author = "Nymtech", version, about, long_about = Some(long_about()))]
+#[clap(author = "Nymtech", version, about, long_version = long_version_static())]
 struct Cli {
     #[clap(subcommand)]
     command: commands::Commands,


### PR DESCRIPTION
# Description

When clap was upgraded to 3.x for the mixnode and gateway, the detailed build info was moved to `--help`. This PR moves the detailed build info back to `--version` where it belongs.

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
