### PR TITLE
all: add clap test asserts

### DIFF
--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -152,3 +152,14 @@ pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Confi
 
     config
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_cli() {
+        Cli::command().debug_assert();
+    }
+}

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -147,3 +147,14 @@ pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Confi
 
     config
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_cli() {
+        Cli::command().debug_assert();
+    }
+}

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -107,3 +107,17 @@ fn setup_logging() {
         .filter_module("tokio_tungstenite", log::LevelFilter::Warn)
         .init();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_cli() {
+        LONG_VERSION
+            .set(long_version())
+            .expect("Failed to set long about text");
+        Cli::command().debug_assert();
+    }
+}

--- a/mixnode/src/main.rs
+++ b/mixnode/src/main.rs
@@ -106,3 +106,14 @@ fn setup_logging() {
         .filter_module("want", log::LevelFilter::Warn)
         .init();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_cli() {
+        Cli::command().debug_assert();
+    }
+}


### PR DESCRIPTION
# Description

Proactively check for bad `Command` configurations by calling `Command::debug_assert` in a test

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
