### PR TITLE
explorer-api: handle SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - native & socks5 clients: rerun init will now reuse previous gateway configuration instead of failing ([#1353])
 - native & socks5 clients: deduplicate big chunks of init logic
 - validator: fixed local docker-compose setup to work on Apple M1 ([#1329])
+- explorer-api: listen out for SIGTERM and SIGQUIT too, making it play nicely as a system service ([#1482]).
 
 ### Changed
 
@@ -73,6 +74,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1457]: https://github.com/nymtech/nym/pull/1457
 [#1463]: https://github.com/nymtech/nym/pull/1463
 [#1478]: https://github.com/nymtech/nym/pull/1478
+[#1482]: https://github.com/nymtech/nym/pull/1482
 
 ## [nym-connect-v1.0.1](https://github.com/nymtech/nym/tree/nym-connect-v1.0.1) (2022-07-22)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "task",
  "thiserror",
  "tokio",
  "validator-client",

--- a/explorer-api/Cargo.toml
+++ b/explorer-api/Cargo.toml
@@ -26,4 +26,5 @@ tokio = {version = "1.19.1", features = ["full"] }
 
 mixnet-contract-common = { path = "../common/cosmwasm-smart-contracts/mixnet-contract" }
 network-defaults = { path = "../common/network-defaults" }
+task = { path = "../common/task" }
 validator-client = { path = "../common/client-libs/validator-client", features=["nymd-client"] }

--- a/explorer-api/src/main.rs
+++ b/explorer-api/src/main.rs
@@ -6,6 +6,7 @@ extern crate rocket_okapi;
 use clap::Parser;
 use log::info;
 use network_defaults::setup_env;
+use task::ShutdownNotifier;
 
 pub(crate) mod cache;
 mod client;
@@ -50,29 +51,63 @@ impl ExplorerApi {
         let validator_api_url = self.state.inner.validator_client.api_endpoint();
         info!("Using validator API - {}", validator_api_url);
 
+        let shutdown = ShutdownNotifier::default();
+
         // spawn concurrent tasks
-        crate::tasks::ExplorerApiTasks::new(self.state.clone()).start();
+        crate::tasks::ExplorerApiTasks::new(self.state.clone(), shutdown.subscribe()).start();
         country_statistics::distribution::CountryStatisticsDistributionTask::new(
             self.state.clone(),
+            shutdown.subscribe(),
         )
         .start();
-        country_statistics::geolocate::GeoLocateTask::new(self.state.clone()).start();
+        country_statistics::geolocate::GeoLocateTask::new(self.state.clone(), shutdown.subscribe())
+            .start();
+
+        // Rocket handles shutdown on it's own, but its shutdown handling should be incorporated
+        // with that of the rest of the tasks.
+        // Currently it's runtime is forcefully terminated once the explorer-api exits.
         http::start(self.state.clone());
 
         // wait for user to press ctrl+C
-        self.wait_for_interrupt().await
+        self.wait_for_interrupt(shutdown).await
     }
 
-    async fn wait_for_interrupt(&self) {
-        if let Err(e) = tokio::signal::ctrl_c().await {
-            error!(
-                "There was an error while capturing SIGINT - {:?}. We will terminate regardless",
-                e
-            );
+    async fn wait_for_interrupt(&self, mut shutdown: ShutdownNotifier) {
+        wait_for_signal().await;
+
+        log::info!("Sending shutdown");
+        shutdown.signal_shutdown().ok();
+        log::info!("Waiting for tasks to finish... (Press ctrl-c to force)");
+        shutdown.wait_for_shutdown().await;
+        log::info!("Stopping explorer API");
+    }
+}
+
+#[cfg(unix)]
+async fn wait_for_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+    let mut sigterm = signal(SignalKind::terminate()).expect("Failed to setup SIGTERM channel");
+    let mut sigquit = signal(SignalKind::quit()).expect("Failed to setup SIGQUIT channel");
+
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            log::info!("Received SIGINT");
+        },
+        _ = sigterm.recv() => {
+            log::info!("Received SIGTERM");
         }
-        info!(
-            "Received SIGINT - the mixnode will terminate now (threads are not yet nicely stopped, if you see stack traces that's alright)."
-        );
+        _ = sigquit.recv() => {
+            log::info!("Received SIGQUIT");
+        }
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_signal() {
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            log::info!("Received SIGINT");
+        },
     }
 }
 


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1453

Let explorer-api also listen for SIGTERM and SIGQUIT, in addition to SIGINT that it already listens too.
Also, introduce graceful termination of the spawned tasks.

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
