### PR TITLE
Fix NC filter for domains suffix-only domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - native & socks5 clients: deduplicate big chunks of init logic
 - validator: fixed local docker-compose setup to work on Apple M1 ([#1329])
 - explorer-api: listen out for SIGTERM and SIGQUIT too, making it play nicely as a system service ([#1482]).
+- network-requester: fix filter for suffix-only domains ([#1487])
 
 ### Changed
 
@@ -75,6 +76,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1463]: https://github.com/nymtech/nym/pull/1463
 [#1478]: https://github.com/nymtech/nym/pull/1478
 [#1482]: https://github.com/nymtech/nym/pull/1482
+[#1487]: https://github.com/nymtech/nym/pull/1487
 
 ## [nym-connect-v1.0.1](https://github.com/nymtech/nym/tree/nym-connect-v1.0.1) (2022-07-22)
 

--- a/service-providers/network-requester/src/allowed_hosts.rs
+++ b/service-providers/network-requester/src/allowed_hosts.rs
@@ -115,7 +115,7 @@ impl OutboundRequestFilter {
             Ok(d) => Some(
                 d.root()
                     .map(|root| root.to_string())
-                    .unwrap_or(d.full().to_string()),
+                    .unwrap_or_else(|| d.full().to_string()),
             ),
             Err(_) => {
                 log::warn!("Error parsing domain: {:?}", host);

--- a/service-providers/network-requester/src/allowed_hosts.rs
+++ b/service-providers/network-requester/src/allowed_hosts.rs
@@ -353,9 +353,12 @@ mod tests {
         }
 
         #[test]
-        fn returns_none_on_nonsense_domains() {
+        fn returns_full_on_suffix_domains() {
             let filter = setup();
-            assert_eq!(None, filter.get_domain_root("flappappa"));
+            assert_eq!(
+                Some("s3.amazonaws.com".to_string()),
+                filter.get_domain_root("s3.amazonaws.com")
+            );
         }
     }
 

--- a/service-providers/network-requester/src/allowed_hosts.rs
+++ b/service-providers/network-requester/src/allowed_hosts.rs
@@ -109,9 +109,14 @@ impl OutboundRequestFilter {
     }
 
     /// Attempts to get the root domain, shorn of subdomains, using publicsuffix.
+    /// If the domain is itself a suffix, then just use the full address as root.
     fn get_domain_root(&self, host: &str) -> Option<String> {
         match self.domain_list.parse_domain(host) {
-            Ok(d) => d.root().map(|root| root.to_string()),
+            Ok(d) => Some(
+                d.root()
+                    .map(|root| root.to_string())
+                    .unwrap_or(d.full().to_string()),
+            ),
             Err(_) => {
                 log::warn!("Error parsing domain: {:?}", host);
                 None // domain couldn't be parsed


### PR DESCRIPTION
# Description

Domains that are themselves a public suffix in the https://publicsuffix.org/list/public_suffix_list.dat list can be reached. For those domains we need to specify the full domain in the `allowed` list

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
