### PR TITLE
Explorer: tweak selection probability categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - multisig-contract: Limit the proposal creating functionality to one address (coconut-bandwidth-contract address) ([#1457])
 - All binaries and cosmwasm blobs are configured at runtime now; binaries are configured using environment variables or .env files and contracts keep the configuration parameters in storage ([#1463])
 - gateway, network-statistics: include gateway id in the sent statistical data ([#1478])
+- network explorer: tweak how active set probability is shown ([#1503])
 
 
 [#1249]: https://github.com/nymtech/nym/pull/1249
@@ -79,6 +80,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1482]: https://github.com/nymtech/nym/pull/1482
 [#1487]: https://github.com/nymtech/nym/pull/1487
 [#1496]: https://github.com/nymtech/nym/pull/1496
+[#1503]: https://github.com/nymtech/nym/pull/1503
 
 ## [nym-connect-v1.0.1](https://github.com/nymtech/nym/tree/nym-connect-v1.0.1) (2022-07-22)
 

--- a/nym-wallet/src/pages/settings/system-variables.tsx
+++ b/nym-wallet/src/pages/settings/system-variables.tsx
@@ -30,18 +30,14 @@ const DataField = ({ title, info, Indicator }: { title: string; info: string; In
 );
 
 const colorMap: { [key in SelectionChance]: string } = {
-  VeryLow: 'error.main',
   Low: 'error.main',
   Moderate: 'warning.main',
-  High: 'success.main',
   VeryHigh: 'success.main',
 };
 
 const textMap: { [key in SelectionChance]: string } = {
-  VeryLow: 'Very low',
   Low: 'Low',
   Moderate: 'Moderate',
-  High: 'High',
   VeryHigh: 'Very high',
 };
 

--- a/ts-packages/types/src/types/rust/SelectionChance.ts
+++ b/ts-packages/types/src/types/rust/SelectionChance.ts
@@ -1,1 +1,1 @@
-export type SelectionChance = 'VeryHigh' | 'High' | 'Moderate' | 'Low' | 'VeryLow';
+export type SelectionChance = 'VeryHigh' | 'Moderate' | 'Low';

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -101,20 +101,16 @@ pub type StakeSaturation = f32;
 )]
 pub enum SelectionChance {
     VeryHigh,
-    High,
     Moderate,
     Low,
-    VeryLow,
 }
 
 impl From<f64> for SelectionChance {
     fn from(p: f64) -> SelectionChance {
         match p {
-            p if p >= 1. => SelectionChance::VeryHigh,
-            p if p > 0.9 => SelectionChance::High,
-            p if p > 0.7 => SelectionChance::Moderate,
-            p if p > 0.5 => SelectionChance::Low,
-            _ => SelectionChance::VeryLow,
+            p if p > 0.15 => SelectionChance::VeryHigh,
+            p if p >= 0.05 => SelectionChance::Moderate,
+            _ => SelectionChance::Low,
         }
     }
 }
@@ -123,10 +119,8 @@ impl fmt::Display for SelectionChance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SelectionChance::VeryHigh => write!(f, "VeryHigh"),
-            SelectionChance::High => write!(f, "High"),
             SelectionChance::Moderate => write!(f, "Moderate"),
             SelectionChance::Low => write!(f, "Low"),
-            SelectionChance::VeryLow => write!(f, "VeryLow"),
         }
     }
 }


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/2336

Tweak how active set probability is shown

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
