### PR TITLE
Fixed mixnode compatibility by changing read node details fields

### DIFF
--- a/common/mixnode-common/src/verloc/mod.rs
+++ b/common/mixnode-common/src/verloc/mod.rs
@@ -321,17 +321,18 @@ impl VerlocMeasurer {
             let tested_nodes = all_mixes
                 .into_iter()
                 .filter_map(|node| {
+                    let mix_node = node.bond_information.mix_node;
                     // check if the node has sufficient version to be able to understand the packets
-                    let node_version = parse_version(&node.mix_node.version).ok()?;
+                    let node_version = parse_version(&mix_node.version).ok()?;
                     if node_version < self.config.minimum_compatible_node_version {
                         return None;
                     }
 
                     // try to parse the identity and host
                     let node_identity =
-                        identity::PublicKey::from_base58_string(node.mix_node.identity_key).ok()?;
+                        identity::PublicKey::from_base58_string(mix_node.identity_key).ok()?;
 
-                    let verloc_host = (&*node.mix_node.host, node.mix_node.verloc_port)
+                    let verloc_host = (&*mix_node.host, mix_node.verloc_port)
                         .to_socket_addrs()
                         .ok()?
                         .next()?;

--- a/mixnode/src/node/mod.rs
+++ b/mixnode/src/node/mod.rs
@@ -265,6 +265,8 @@ impl MixNode {
 
     // TODO: ask DH whether this function still makes sense in ^0.10
     async fn check_if_same_ip_node_exists(&mut self) -> Option<String> {
+        // TODO: if anything, this should be getting data directly from the contract
+        // as opposed to the validator API
         let validator_client = self.random_api_client();
         let existing_nodes = match validator_client.get_cached_mixnodes().await {
             Ok(nodes) => nodes,
@@ -281,8 +283,8 @@ impl MixNode {
 
         existing_nodes
             .iter()
-            .find(|node| node.mix_node.host == our_host)
-            .map(|node| node.mix_node.identity_key.clone())
+            .find(|node| node.bond_information.mix_node.host == our_host)
+            .map(|node| node.bond_information.mix_node.identity_key.clone())
     }
 
     async fn wait_for_interrupt(&self, mut shutdown: ShutdownNotifier) {


### PR DESCRIPTION
# Description

This should make mixnode compatible with the on-going changes to the rewarding contract.