### PR TITLE
socks5: remove pub mod not needed anymore

### DIFF
--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -3,7 +3,6 @@
 
 use crate::client::config::{Config, SocketType};
 use clap::{Parser, Subcommand};
-use url::Url;
 
 #[cfg(not(feature = "coconut"))]
 pub(crate) const DEFAULT_ETH_ENDPOINT: &str =
@@ -97,28 +96,17 @@ pub(crate) async fn execute(args: &Cli) {
     }
 }
 
-fn parse_validators(raw: &str) -> Vec<Url> {
-    raw.split(',')
-        .map(|raw_validator| {
-            raw_validator
-                .trim()
-                .parse()
-                .expect("one of the provided validator api urls is invalid")
-        })
-        .collect()
-}
-
 pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Config {
     if let Some(raw_validators) = args.validators {
         config
             .get_base_mut()
-            .set_custom_validator_apis(parse_validators(&raw_validators));
+            .set_custom_validator_apis(config::parse_validators(&raw_validators));
     } else if std::env::var(network_defaults::var_names::CONFIGURED).is_ok() {
         let raw_validators = std::env::var(network_defaults::var_names::API_VALIDATOR)
             .expect("api validator not set");
         config
             .get_base_mut()
-            .set_custom_validator_apis(parse_validators(&raw_validators));
+            .set_custom_validator_apis(config::parse_validators(&raw_validators));
     }
 
     if args.disable_socket {

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::client::config::Config;
 use clap::{Parser, Subcommand};
-use url::Url;
+use config::parse_validators;
 
 pub mod init;
 pub(crate) mod run;
@@ -94,17 +94,6 @@ pub(crate) async fn execute(args: &Cli) {
         Commands::Run(m) => run::execute(m).await,
         Commands::Upgrade(m) => upgrade::execute(m),
     }
-}
-
-pub fn parse_validators(raw: &str) -> Vec<Url> {
-    raw.split(',')
-        .map(|raw_validator| {
-            raw_validator
-                .trim()
-                .parse()
-                .expect("one of the provided validator api urls is invalid")
-        })
-        .collect()
 }
 
 pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Config {

--- a/clients/socks5/src/lib.rs
+++ b/clients/socks5/src/lib.rs
@@ -2,9 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod client;
-// This is only used as we reach into the init functions in nym-connect. We need to refactor the
-// init functions so that nym-connect can just call the same init function as the regular socks5
-// client.
-#[allow(unused)]
-pub mod commands;
 pub mod socks;

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -99,4 +99,3 @@ pub fn parse_validators(raw: &str) -> Vec<url::Url> {
         })
         .collect()
 }
-

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -88,3 +88,15 @@ pub trait NymConfig: Default + Serialize + DeserializeOwned {
             .map_err(|toml_err| io::Error::new(io::ErrorKind::Other, toml_err))
     }
 }
+
+pub fn parse_validators(raw: &str) -> Vec<url::Url> {
+    raw.split(',')
+        .map(|raw_validator| {
+            raw_validator
+                .trim()
+                .parse()
+                .expect("one of the provided validator api urls is invalid")
+        })
+        .collect()
+}
+

--- a/gateway/src/commands/mod.rs
+++ b/gateway/src/commands/mod.rs
@@ -6,11 +6,11 @@ use std::{process, str::FromStr};
 use crate::{config::Config, Cli};
 use clap::Subcommand;
 use colored::Colorize;
+use config::parse_validators;
 use crypto::bech32_address_validation;
 use network_defaults::var_names::{
     API_VALIDATOR, BECH32_PREFIX, CONFIGURED, NYMD_VALIDATOR, STATISTICS_SERVICE_DOMAIN_ADDRESS,
 };
-use url::Url;
 
 pub(crate) mod init;
 pub(crate) mod node_details;
@@ -67,17 +67,6 @@ pub(crate) async fn execute(args: Cli) {
         Commands::Sign(m) => sign::execute(m),
         Commands::Upgrade(m) => upgrade::execute(m).await,
     }
-}
-
-fn parse_validators(raw: &str) -> Vec<Url> {
-    raw.split(',')
-        .map(|raw_validator| {
-            raw_validator
-                .trim()
-                .parse()
-                .expect("one of the provided validator api urls is invalid")
-        })
-        .collect()
 }
 
 pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Config {

--- a/mixnode/src/commands/mod.rs
+++ b/mixnode/src/commands/mod.rs
@@ -6,9 +6,8 @@ use std::process;
 use crate::{config::Config, Cli};
 use clap::Subcommand;
 use colored::Colorize;
-use config::defaults::var_names::{API_VALIDATOR, BECH32_PREFIX, CONFIGURED};
+use config::{defaults::var_names::{API_VALIDATOR, BECH32_PREFIX, CONFIGURED}, parse_validators};
 use crypto::bech32_address_validation;
-use url::Url;
 
 mod describe;
 mod init;
@@ -59,17 +58,6 @@ pub(crate) async fn execute(args: Cli) {
         Commands::Upgrade(m) => upgrade::execute(m),
         Commands::NodeDetails(m) => node_details::execute(m),
     }
-}
-
-fn parse_validators(raw: &str) -> Vec<Url> {
-    raw.split(',')
-        .map(|raw_validator| {
-            raw_validator
-                .trim()
-                .parse()
-                .expect("one of the provided validator api urls is invalid")
-        })
-        .collect()
 }
 
 fn override_config(mut config: Config, args: OverrideConfig) -> Config {

--- a/mixnode/src/commands/mod.rs
+++ b/mixnode/src/commands/mod.rs
@@ -6,7 +6,10 @@ use std::process;
 use crate::{config::Config, Cli};
 use clap::Subcommand;
 use colored::Colorize;
-use config::{defaults::var_names::{API_VALIDATOR, BECH32_PREFIX, CONFIGURED}, parse_validators};
+use config::{
+    defaults::var_names::{API_VALIDATOR, BECH32_PREFIX, CONFIGURED},
+    parse_validators,
+};
 use crypto::bech32_address_validation;
 
 mod describe;

--- a/nym-connect/src-tauri/src/config/mod.rs
+++ b/nym-connect/src-tauri/src/config/mod.rs
@@ -7,7 +7,7 @@ use tokio::sync::RwLock;
 
 use client_core::config::Config as BaseConfig;
 use config_common::NymConfig;
-use nym_socks5::{client::config::Config as Socks5Config, commands::parse_validators};
+use nym_socks5::client::config::Config as Socks5Config;
 
 use crate::{
     error::{BackendError, Result},
@@ -134,10 +134,11 @@ pub async fn init_socks5_config(provider_address: String, chosen_gateway_id: Str
     config
         .get_base_mut()
         .with_eth_private_key(DEFAULT_ETH_PRIVATE_KEY);
+
     if let Ok(raw_validators) = std::env::var(config_common::defaults::var_names::API_VALIDATOR) {
         config
             .get_base_mut()
-            .set_custom_validator_apis(parse_validators(&raw_validators));
+            .set_custom_validator_apis(config_common::parse_validators(&raw_validators));
     }
 
     let gateway = setup_gateway(

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -82,18 +82,6 @@ const REWARDING_MONITOR_THRESHOLD_ARG: &str = "monitor-threshold";
 const MIN_MIXNODE_RELIABILITY_ARG: &str = "min_mixnode_reliability";
 const MIN_GATEWAY_RELIABILITY_ARG: &str = "min_gateway_reliability";
 
-#[cfg(feature = "coconut")]
-fn parse_validators(raw: &str) -> Vec<url::Url> {
-    raw.split(',')
-        .map(|raw_validator| {
-            raw_validator
-                .trim()
-                .parse()
-                .expect("one of the provided validator api urls is invalid")
-        })
-        .collect()
-}
-
 fn long_version() -> String {
     format!(
         r#"
@@ -312,10 +300,10 @@ fn override_config(mut config: Config, matches: &ArgMatches<'_>) -> Config {
 
     #[cfg(feature = "coconut")]
     if let Some(raw_validators) = matches.value_of(API_VALIDATORS_ARG) {
-        config = config.with_custom_validator_apis(parse_validators(raw_validators));
+        config = config.with_custom_validator_apis(::config::parse_validators(raw_validators));
     } else if std::env::var(CONFIGURED).is_ok() {
         let raw_validators = std::env::var(API_VALIDATOR).expect("api validator not set");
-        config = config.with_custom_validator_apis(parse_validators(&raw_validators))
+        config = config.with_custom_validator_apis(::config::parse_validators(&raw_validators))
     }
 
     if let Some(raw_validator) = matches.value_of(NYMD_VALIDATOR_ARG) {


### PR DESCRIPTION
# Description

- Remove pub mod in socks5 client not needed anymore
- Dedup and move `parse_validators` helper to `common/config`

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
