### PR TITLE
Feature/validator api panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - All binaries and cosmwasm blobs are configured at runtime now; binaries are configured using environment variables or .env files and contracts keep the configuration parameters in storage ([#1463])
 - gateway, network-statistics: include gateway id in the sent statistical data ([#1478])
 - network explorer: tweak how active set probability is shown ([#1503])
+- validator-api: rewarder set update fails without panicking on possible nymd queries ([#1520])
 
 
 [#1249]: https://github.com/nymtech/nym/pull/1249
@@ -81,6 +82,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1487]: https://github.com/nymtech/nym/pull/1487
 [#1496]: https://github.com/nymtech/nym/pull/1496
 [#1503]: https://github.com/nymtech/nym/pull/1503
+[#1520]: https://github.com/nymtech/nym/pull/1520
 
 ## [nym-connect-v1.0.1](https://github.com/nymtech/nym/tree/nym-connect-v1.0.1) (2022-07-22)
 

--- a/validator-api/Cargo.toml
+++ b/validator-api/Cargo.toml
@@ -58,6 +58,7 @@ gateway-client = { path="../common/client-libs/gateway-client" }
 mixnet-contract-common = { path= "../common/cosmwasm-smart-contracts/mixnet-contract" }
 multisig-contract-common = { path = "../common/cosmwasm-smart-contracts/multisig-contract" }
 nymsphinx = { path="../common/nymsphinx" }
+nymcoconut = { path = "../common/nymcoconut", optional = true }
 task = { path = "../common/task" }
 topology = { path="../common/topology" }
 validator-api-requests = { path = "validator-api-requests" }
@@ -71,7 +72,7 @@ console-subscriber = { version = "0.1.1", optional = true}
 cfg-if = "1.0"
 
 [features]
-coconut = ["coconut-interface", "credentials", "gateway-client/coconut", "credentials/coconut", "validator-api-requests/coconut"]
+coconut = ["coconut-interface", "credentials", "gateway-client/coconut", "credentials/coconut", "validator-api-requests/coconut", "nymcoconut"]
 no-reward = []
 generate-ts = []
 
@@ -82,6 +83,5 @@ vergen = { version = "5", default-features = false, features = ["build", "git", 
 
 [dev-dependencies]
 attohttpc = {version = "0.18.0", features = ["json"]}
-nymcoconut = { path = "../common/nymcoconut" }
 cw3 = "0.13.2"
 cw-utils = "0.13.2"

--- a/validator-api/src/coconut/error.rs
+++ b/validator-api/src/coconut/error.rs
@@ -31,6 +31,9 @@ pub enum CoconutError {
     #[error("Nymd error - {0}")]
     NymdError(#[from] NymdError),
 
+    #[error("Coconut internal error - {0}")]
+    CoconutInternalError(#[from] nymcoconut::CoconutError),
+
     #[error("Could not find a deposit event in the transaction provided")]
     DepositEventNotFound,
 

--- a/validator-api/src/coconut/mod.rs
+++ b/validator-api/src/coconut/mod.rs
@@ -192,15 +192,14 @@ impl InternalSignRequest {
     }
 }
 
-fn blind_sign(request: InternalSignRequest, key_pair: &KeyPair) -> BlindedSignature {
-    let params = Parameters::new(request.total_params()).unwrap();
-    coconut_interface::blind_sign(
+fn blind_sign(request: InternalSignRequest, key_pair: &KeyPair) -> Result<BlindedSignature> {
+    let params = Parameters::new(request.total_params())?;
+    Ok(coconut_interface::blind_sign(
         &params,
         &key_pair.secret_key(),
         request.blind_sign_request(),
         request.public_attributes(),
-    )
-    .unwrap()
+    )?)
 }
 
 #[post("/blind-sign", data = "<blind_sign_request_body>")]
@@ -226,7 +225,7 @@ pub async fn post_blind_sign(
         blind_sign_request_body.public_attributes(),
         blind_sign_request_body.blind_sign_request().clone(),
     );
-    let blinded_signature = blind_sign(internal_request, &state.key_pair);
+    let blinded_signature = blind_sign(internal_request, &state.key_pair)?;
 
     let response = state
         .encrypt_and_store(


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/2008

Remove some unnecessary `unwraps` in coconut endpoints.
Make the `rewarded_set_updater` thread not panic unless in an unrecoverable error case (db txs) or after multiple attempts to query `nymd`

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
