### PR TITLE
fix(nym-wallet): make get_operator_rewards request success optional

### DIFF
--- a/nym-wallet/src/components/Bonding/BondedMixnode.tsx
+++ b/nym-wallet/src/components/Bonding/BondedMixnode.tsx
@@ -75,7 +75,7 @@ export const BondedMixnode = ({
       id: 'pm-cell',
     },
     {
-      cell: `${operatorRewards.amount} ${operatorRewards.denom}`,
+      cell: operatorRewards ? `${operatorRewards.amount} ${operatorRewards.denom}` : '-',
       id: 'operator-rewards-cell',
     },
     {
@@ -86,7 +86,7 @@ export const BondedMixnode = ({
       cell: (
         <BondedMixnodeActions
           onActionSelect={onActionSelect}
-          disabledRedeemAndCompound={Number(mixnode.operatorRewards.amount) === 0}
+          disabledRedeemAndCompound={(operatorRewards && Number(operatorRewards.amount) === 0) || false}
         />
       ),
       id: 'actions-cell',

--- a/nym-wallet/src/components/Bonding/modals/CompoundRewardsModal.tsx
+++ b/nym-wallet/src/components/Bonding/modals/CompoundRewardsModal.tsx
@@ -43,7 +43,9 @@ export const CompoundRewardsModal = ({
     >
       <ModalListItem
         label="Rewards to redeem"
-        value={`${node.operatorRewards.amount} ${node.operatorRewards.denom.toUpperCase()}`}
+        value={
+          node.operatorRewards ? `${node.operatorRewards.amount} ${node.operatorRewards.denom.toUpperCase()}` : '-'
+        }
         divider
       />
       <ModalFee fee={fee} isLoading={isFeeLoading} divider />

--- a/nym-wallet/src/components/Bonding/modals/RedeemRewardsModal.tsx
+++ b/nym-wallet/src/components/Bonding/modals/RedeemRewardsModal.tsx
@@ -43,7 +43,9 @@ export const RedeemRewardsModal = ({
     >
       <ModalListItem
         label="Rewards to redeem"
-        value={`${node.operatorRewards.amount} ${node.operatorRewards.denom.toUpperCase()}`}
+        value={
+          node.operatorRewards ? `${node.operatorRewards.amount} ${node.operatorRewards.denom.toUpperCase()}` : '-'
+        }
         divider
       />
       <ModalFee fee={fee} isLoading={isFeeLoading} divider />

--- a/nym-wallet/src/components/Bonding/modals/UnbondModal.tsx
+++ b/nym-wallet/src/components/Bonding/modals/UnbondModal.tsx
@@ -61,7 +61,9 @@ export const UnbondModal = ({ node, onConfirm, onClose, onError }: Props) => {
       {isMixnode(node) && (
         <ModalListItem
           label="Operator rewards"
-          value={`${node.operatorRewards.amount} ${node.operatorRewards.denom.toUpperCase()}`}
+          value={
+            node.operatorRewards ? `${node.operatorRewards.amount} ${node.operatorRewards.denom.toUpperCase()}` : '-'
+          }
           divider
         />
       )}

--- a/nym-wallet/src/components/Modals/ModalListItem.tsx
+++ b/nym-wallet/src/components/Modals/ModalListItem.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { Box, Stack, Typography, TypographyProps } from '@mui/material';
 import { ModalDivider } from './ModalDivider';
-import { fontWeight } from '@mui/system';
-
-type TFontWeight = 'strong' | 'light';
 
 export const ModalListItem: React.FC<{
   label: string;

--- a/nym-wallet/src/context/bonding.tsx
+++ b/nym-wallet/src/context/bonding.tsx
@@ -1,6 +1,6 @@
 import { FeeDetails, DecCoin, MixnodeStatus, TransactionExecuteResult } from '@nymproject/types';
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { isGateway, isMixnode, Network, TBondGatewayArgs, TBondMixNodeArgs } from 'src/types';
+import { isGateway, isMixnode, TBondGatewayArgs, TBondMixNodeArgs } from 'src/types';
 import { Console } from 'src/utils/console';
 import {
   bondGateway as bondGatewayRequest,
@@ -28,19 +28,6 @@ import {
 import { useCheckOwnership } from '../hooks/useCheckOwnership';
 import { AppContext } from './main';
 
-const bonded: TBondedMixnode = {
-  name: 'Monster node',
-  identityKey: 'B2Xx4haarLWMajX8w259oHjtRZsC7nHwagbWrJNiA3QC',
-  bond: { denom: 'nym', amount: '1234' },
-  delegators: 123,
-  operatorRewards: { denom: 'nym', amount: '12' },
-  profitMargin: 10,
-  stake: { denom: 'nym', amount: '99' },
-  stakeSaturation: 99,
-  status: 'active',
-};
-
-// TODO add relevant data
 export type TBondedMixnode = {
   name?: string;
   identityKey: string;
@@ -48,13 +35,12 @@ export type TBondedMixnode = {
   bond: DecCoin;
   stakeSaturation: number;
   profitMargin: number;
-  operatorRewards: DecCoin;
+  operatorRewards?: DecCoin;
   delegators: number;
   status: MixnodeStatus;
   proxy?: string;
 };
 
-// TODO add relevant data
 export interface TBondedGateway {
   name: string;
   identityKey: string;
@@ -173,7 +159,12 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
     if (ownership.hasOwnership && ownership.nodeType === 'mixnode' && clientDetails) {
       try {
         const data = await getMixnodeBondDetails();
-        const operatorRewards = await getOperatorRewards(clientDetails?.client_address);
+        let operatorRewards;
+        try {
+          operatorRewards = await getOperatorRewards(clientDetails?.client_address);
+        } catch (e) {
+          console.warn(`get_operator_rewards request failed: ${e}`);
+        }
         if (data) {
           const { status, stakeSaturation, numberOfDelegators } = await getAdditionalMixnodeDetails(
             data.mix_node.identity_key,
@@ -195,6 +186,7 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
           } as TBondedMixnode);
         }
       } catch (e: any) {
+        console.warn(e);
         setError(`While fetching current bond state, an error occurred: ${e}`);
       }
     }
@@ -211,7 +203,6 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
             ip: data.gateway.host,
             location: data.gateway.location,
             bond: data.pledge_amount,
-            delegators: bonded.delegators,
             proxy: data.proxy,
           } as TBondedGateway);
         }


### PR DESCRIPTION
# Description

`get_operator_rewards` request can fails. Make it optional as well its `operatorRewards` data so that we can render the rest of the UI in case of bonded mixnode.