### PR TITLE
validator-api: create node status cache with selection probabilies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - validator-api: add Swagger to document the REST API ([#1249]).
 - validator-api: Added new endpoints for coconut spending flow and communications with coconut & multisig contracts ([#1261])
 - validator-api: add `uptime`, `estimated_operator_apy`, `estimated_delegators_apy` to `/mixnodes/detailed` endpoint ([#1393])
+- validator-api: add node info cache storing simulated active set inclusion probabilities
 - network-statistics: a new mixnet service that aggregates and exposes anonymized data about mixnet services ([#1328])
 - mixnode: Added basic mixnode hardware reporting to the HTTP API ([#1308]).
 - validator-api: endpoint, in coconut mode, for returning the validator-api cosmos address ([#1404]).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,7 @@ dependencies = [
 name = "inclusion-probability"
 version = "0.1.0"
 dependencies = [
+ "log",
  "rand 0.8.5",
  "thiserror",
 ]
@@ -2751,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -3314,6 +3315,7 @@ dependencies = [
  "gateway-client",
  "getset",
  "humantime-serde",
+ "inclusion-probability",
  "log",
  "mixnet-contract-common",
  "multisig-contract-common",
@@ -3333,6 +3335,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tap",
  "task",
  "thiserror",
  "time 0.3.9",

--- a/common/inclusion-probability/Cargo.toml
+++ b/common/inclusion-probability/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = "0.4.17"
 rand = "0.8.5"
 thiserror = "1.0.32"

--- a/common/inclusion-probability/src/error.rs
+++ b/common/inclusion-probability/src/error.rs
@@ -4,6 +4,8 @@ pub enum Error {
     EmptyListCumulStake,
     #[error("Sample point was unexpectedly out of bounds")]
     SamplePointOutOfBounds,
-    #[error("Norm computation failed on different size arrarys")]
+    #[error("Norm computation failed on different size arrays")]
     NormDifferenceSizeArrays,
+    #[error("Computed probabilities are fewer than input number of nodes")]
+    ResultsShorterThanInput,
 }

--- a/common/inclusion-probability/src/lib.rs
+++ b/common/inclusion-probability/src/lib.rs
@@ -5,22 +5,36 @@ use error::Error;
 mod error;
 
 const TOLERANCE_L2_NORM: f64 = 1e-4;
-const TOLERANCE_MAX_NORM: f64 = 1e-3;
+const TOLERANCE_MAX_NORM: f64 = 1e-4;
 
 pub struct SelectionProbability {
     pub active_set_probability: Vec<f64>,
     pub reserve_set_probability: Vec<f64>,
-    pub samples: u32,
+    pub samples: u64,
     pub delta_l2: f64,
     pub delta_max: f64,
 }
 
 pub fn simulate_selection_probability_mixnodes(
-    list_stake_for_mixnodes: &[u64],
+    list_stake_for_mixnodes: &[u128],
     active_set_size: usize,
     reserve_set_size: usize,
-    max_samples: u32,
+    max_samples: u64,
 ) -> Result<SelectionProbability, Error> {
+    log::trace!("Simulating mixnode active set selection probability");
+
+    // In case the active set size is larger than the number of bonded mixnodes, they all have 100%
+    // chance we don't have to go through with the simulation
+    if list_stake_for_mixnodes.len() <= active_set_size {
+        return Ok(SelectionProbability {
+            active_set_probability: vec![1.0; list_stake_for_mixnodes.len()],
+            reserve_set_probability: vec![0.0; list_stake_for_mixnodes.len()],
+            samples: 0,
+            delta_l2: 0.0,
+            delta_max: 0.0,
+        });
+    }
+
     // Total number of existing (registered) nodes
     let num_mixnodes = list_stake_for_mixnodes.len();
 
@@ -46,7 +60,9 @@ pub fn simulate_selection_probability_mixnodes(
         let active_set_probability_previous = active_set_probability.clone();
 
         // Select the active nodes for the epoch (hour)
-        while sample_active_mixnodes.len() < active_set_size {
+        while sample_active_mixnodes.len() < active_set_size
+            && sample_active_mixnodes.len() < list_cumul_temp.len()
+        {
             let candidate = sample_candidate(&list_cumul_temp, &mut rng)?;
 
             if !sample_active_mixnodes.contains(&candidate) {
@@ -56,7 +72,9 @@ pub fn simulate_selection_probability_mixnodes(
         }
 
         // Select the reserve nodes for the epoch (hour)
-        while sample_reserve_mixnodes.len() < reserve_set_size {
+        while sample_reserve_mixnodes.len() < reserve_set_size
+            && sample_reserve_mixnodes.len() + sample_active_mixnodes.len() < list_cumul_temp.len()
+        {
             let candidate = sample_candidate(&list_cumul_temp, &mut rng)?;
 
             if !sample_reserve_mixnodes.contains(&candidate)
@@ -78,10 +96,10 @@ pub fn simulate_selection_probability_mixnodes(
         // Convergence critera only on active set.
         // We devide by samples to get the average, that is not really part of the delta
         // computation.
-        delta_l2 = l2_diff(&active_set_probability, &active_set_probability_previous)?
-            / f64::from(samples);
-        delta_max = max_diff(&active_set_probability, &active_set_probability_previous)?
-            / f64::from(samples);
+        delta_l2 =
+            l2_diff(&active_set_probability, &active_set_probability_previous)? / (samples as f64);
+        delta_max =
+            max_diff(&active_set_probability, &active_set_probability_previous)? / (samples as f64);
         if samples > 10 && delta_l2 < TOLERANCE_L2_NORM && delta_max < TOLERANCE_MAX_NORM
             || samples >= max_samples
         {
@@ -89,12 +107,19 @@ pub fn simulate_selection_probability_mixnodes(
         }
     }
 
+    // Divide occurrences with the number of samples once we're done to get the probabilities.
     active_set_probability
         .iter_mut()
-        .for_each(|x| *x /= f64::from(samples));
+        .for_each(|x| *x /= samples as f64);
     reserve_set_probability
         .iter_mut()
-        .for_each(|x| *x /= f64::from(samples));
+        .for_each(|x| *x /= samples as f64);
+
+    // Some sanity checks of the output
+    if active_set_probability.len() != num_mixnodes || reserve_set_probability.len() != num_mixnodes
+    {
+        return Err(Error::ResultsShorterThanInput);
+    }
 
     Ok(SelectionProbability {
         active_set_probability,
@@ -106,7 +131,7 @@ pub fn simulate_selection_probability_mixnodes(
 }
 
 // Compute the cumulative sum
-fn cumul_sum<'a>(list: impl IntoIterator<Item = &'a u64>) -> Vec<u64> {
+fn cumul_sum<'a>(list: impl IntoIterator<Item = &'a u128>) -> Vec<u128> {
     let mut list_cumul = Vec::new();
     let mut cumul = 0;
     for entry in list {
@@ -116,7 +141,7 @@ fn cumul_sum<'a>(list: impl IntoIterator<Item = &'a u64>) -> Vec<u64> {
     list_cumul
 }
 
-fn sample_candidate(list_cumul: &[u64], rng: &mut rand::rngs::ThreadRng) -> Result<usize, Error> {
+fn sample_candidate(list_cumul: &[u128], rng: &mut rand::rngs::ThreadRng) -> Result<usize, Error> {
     use rand::distributions::{Distribution, Uniform};
     let uniform = Uniform::from(0..*list_cumul.last().ok_or(Error::EmptyListCumulStake)?);
     let r = uniform.sample(rng);
@@ -132,7 +157,7 @@ fn sample_candidate(list_cumul: &[u64], rng: &mut rand::rngs::ThreadRng) -> Resu
 }
 
 // Update list of cumulative stake to reflect eliminating the picked node
-fn remove_mixnode_from_cumul_stake(candidate: usize, list_cumul_stake: &mut [u64]) {
+fn remove_mixnode_from_cumul_stake(candidate: usize, list_cumul_stake: &mut [u128]) {
     let prob_candidate = if candidate == 0 {
         list_cumul_stake[0]
     } else {
@@ -268,6 +293,82 @@ mod tests {
         ];
         assert!(
             max_diff(&reserve_set_probability, &expected_reserve_set_probability).unwrap() < 1e-2
+        );
+
+        // We converge around 20_000, add another 500 for some slack due to random values
+        assert!(samples < 20_500);
+        assert!(delta_l2 < TOLERANCE_L2_NORM);
+        assert!(delta_max < TOLERANCE_MAX_NORM);
+    }
+
+    #[test]
+    fn fewer_nodes_than_active_set_size() {
+        let active_set_size = 10;
+        let standby_set_size = 3;
+        let list_mix = vec![100, 100, 3000];
+        let max_samples = 100_000;
+
+        let SelectionProbability {
+            active_set_probability,
+            reserve_set_probability,
+            samples,
+            delta_l2,
+            delta_max,
+        } = simulate_selection_probability_mixnodes(
+            &list_mix,
+            active_set_size,
+            standby_set_size,
+            max_samples,
+        )
+        .unwrap();
+
+        // These values comes from running the python simulator for a very long time
+        let expected_active_set_probability = vec![1.0, 1.0, 1.0];
+        let expected_reserve_set_probability = vec![0.0, 0.0, 0.0];
+        assert!(
+            max_diff(&active_set_probability, &expected_active_set_probability).unwrap()
+                < 1e1 * f64::EPSILON
+        );
+        assert!(
+            max_diff(&reserve_set_probability, &expected_reserve_set_probability).unwrap()
+                < 1e1 * f64::EPSILON
+        );
+
+        // We converge around 20_000, add another 500 for some slack due to random values
+        assert_eq!(samples, 0);
+        assert!(delta_l2 < f64::EPSILON);
+        assert!(delta_max < f64::EPSILON);
+    }
+
+    #[test]
+    fn fewer_nodes_than_reward_set_size() {
+        let active_set_size = 4;
+        let standby_set_size = 3;
+        let list_mix = vec![100, 100, 3000, 342, 3_498_234];
+        let max_samples = 100_000_000;
+
+        let SelectionProbability {
+            active_set_probability,
+            reserve_set_probability,
+            samples,
+            delta_l2,
+            delta_max,
+        } = simulate_selection_probability_mixnodes(
+            &list_mix,
+            active_set_size,
+            standby_set_size,
+            max_samples,
+        )
+        .unwrap();
+
+        // These values comes from running the python simulator for a very long time
+        let expected_active_set_probability = vec![0.546, 0.538, 0.999, 0.915, 1.0];
+        let expected_reserve_set_probability = vec![0.453, 0.461, 0.0005, 0.084, 0.0];
+        assert!(
+            max_diff(&active_set_probability, &expected_active_set_probability).unwrap() < 1e-2,
+        );
+        assert!(
+            max_diff(&reserve_set_probability, &expected_reserve_set_probability).unwrap() < 1e-2,
         );
 
         // We converge around 20_000, add another 500 for some slack due to random values

--- a/nym-wallet/src/pages/settings/system-variables.tsx
+++ b/nym-wallet/src/pages/settings/system-variables.tsx
@@ -30,18 +30,14 @@ const DataField = ({ title, info, Indicator }: { title: string; info: string; In
 );
 
 const colorMap: { [key in SelectionChance]: string } = {
-  VeryLow: 'error.main',
   Low: 'error.main',
   Moderate: 'warning.main',
-  High: 'success.main',
   VeryHigh: 'success.main',
 };
 
 const textMap: { [key in SelectionChance]: string } = {
-  VeryLow: 'Very low',
   Low: 'Low',
   Moderate: 'Moderate',
-  High: 'High',
   VeryHigh: 'Very high',
 };
 

--- a/nym-wallet/src/pages/settings/system-variables.tsx
+++ b/nym-wallet/src/pages/settings/system-variables.tsx
@@ -30,14 +30,18 @@ const DataField = ({ title, info, Indicator }: { title: string; info: string; In
 );
 
 const colorMap: { [key in SelectionChance]: string } = {
+  VeryLow: 'error.main',
   Low: 'error.main',
   Moderate: 'warning.main',
+  High: 'success.main',
   VeryHigh: 'success.main',
 };
 
 const textMap: { [key in SelectionChance]: string } = {
+  VeryLow: 'Very low',
   Low: 'Low',
   Moderate: 'Moderate',
+  High: 'High',
   VeryHigh: 'Very high',
 };
 

--- a/nym-wallet/src/pages/settings/system-variables.tsx
+++ b/nym-wallet/src/pages/settings/system-variables.tsx
@@ -30,14 +30,18 @@ const DataField = ({ title, info, Indicator }: { title: string; info: string; In
 );
 
 const colorMap: { [key in SelectionChance]: string } = {
+  VeryLow: 'error.main',
   Low: 'error.main',
   Moderate: 'warning.main',
+  High: 'success.main',
   VeryHigh: 'success.main',
 };
 
 const textMap: { [key in SelectionChance]: string } = {
+  VeryLow: 'VeryLow',
   Low: 'Low',
   Moderate: 'Moderate',
+  High: 'High',
   VeryHigh: 'Very high',
 };
 

--- a/ts-packages/types/src/types/rust/SelectionChance.ts
+++ b/ts-packages/types/src/types/rust/SelectionChance.ts
@@ -1,1 +1,1 @@
-export type SelectionChance = 'VeryHigh' | 'High' | 'Moderate' | 'Low' | 'VeryLow';
+export type SelectionChance = 'VeryHigh' | 'Moderate' | 'Low';

--- a/ts-packages/types/src/types/rust/SelectionChance.ts
+++ b/ts-packages/types/src/types/rust/SelectionChance.ts
@@ -1,1 +1,1 @@
-export type SelectionChance = 'VeryHigh' | 'Moderate' | 'Low';
+export type SelectionChance = 'VeryHigh' | 'High' | 'Moderate' | 'Low' | 'VeryLow';

--- a/validator-api/Cargo.toml
+++ b/validator-api/Cargo.toml
@@ -16,7 +16,9 @@ rust-version = "1.56"
 
 [dependencies]
 async-trait = "0.1.52"
+cfg-if = "1.0"
 clap = "2.33.0"
+console-subscriber = { version = "0.1.1", optional = true} # validator-api needs to be built with RUSTFLAGS="--cfg tokio_unstable"
 dirs = "4.0"
 dotenv = "0.15.0"
 futures = "0.3"
@@ -31,6 +33,7 @@ rocket = { version = "0.5.0-rc.2", features = ["json"] }
 rocket_cors = { git="https://github.com/lawliet89/rocket_cors", rev="dfd3662c49e2f6fc37df35091cb94d82f7fb5915" }
 serde = "1.0"
 serde_json = "1.0"
+tap = "1.0.1"
 thiserror = "1"
 time = { version = "0.3", features = ["serde-human-readable", "parsing"]}
 tokio = { version = "1.19.1", features = ["rt-multi-thread", "macros", "signal", "time"] }
@@ -51,25 +54,23 @@ schemars = { version = "0.8", features = ["preserve_order"] }
 
 ## internal
 coconut-bandwidth-contract-common = { path = "../common/cosmwasm-smart-contracts/coconut-bandwidth-contract" }
+coconut-interface = { path = "../common/coconut-interface", optional = true }
 config = { path = "../common/config" }
 cosmwasm-std = "1.0.0"
+credential-storage = { path = "../common/credential-storage" }
+credentials = { path = "../common/credentials", optional = true }
 crypto = { path="../common/crypto" }
 gateway-client = { path="../common/client-libs/gateway-client" }
+inclusion-probability = { path = "../common/inclusion-probability" }
 mixnet-contract-common = { path= "../common/cosmwasm-smart-contracts/mixnet-contract" }
 multisig-contract-common = { path = "../common/cosmwasm-smart-contracts/multisig-contract" }
-nymsphinx = { path="../common/nymsphinx" }
 nymcoconut = { path = "../common/nymcoconut", optional = true }
+nymsphinx = { path="../common/nymsphinx" }
 task = { path = "../common/task" }
 topology = { path="../common/topology" }
 validator-api-requests = { path = "validator-api-requests" }
 validator-client = { path="../common/client-libs/validator-client", features = ["nymd-client"] }
 version-checker = { path="../common/version-checker" }
-coconut-interface = { path = "../common/coconut-interface", optional = true }
-credentials = { path = "../common/credentials", optional = true }
-credential-storage = { path = "../common/credential-storage" }
-# validator-api needs to be built with RUSTFLAGS="--cfg tokio_unstable"
-console-subscriber = { version = "0.1.1", optional = true}
-cfg-if = "1.0"
 
 [features]
 coconut = ["coconut-interface", "credentials", "gateway-client/coconut", "credentials/coconut", "validator-api-requests/coconut", "nymcoconut"]

--- a/validator-api/src/contract_cache/mod.rs
+++ b/validator-api/src/contract_cache/mod.rs
@@ -73,14 +73,14 @@ pub struct Cache<T> {
 }
 
 impl<T: Clone> Cache<T> {
-    fn new(value: T) -> Self {
+    pub(super) fn new(value: T) -> Self {
         Cache {
             value,
             as_at: current_unix_timestamp(),
         }
     }
 
-    fn update(&mut self, value: T) {
+    pub(super) fn update(&mut self, value: T) {
         self.value = value;
         self.as_at = current_unix_timestamp()
     }
@@ -271,7 +271,7 @@ impl<C> ValidatorCacheRefresher<C> {
                     }
                 }
                 _ = shutdown.recv() => {
-                    trace!("UpdateHandler: Received shutdown");
+                    trace!("ValidatorCacheRefresher: Received shutdown");
                 }
             }
         }

--- a/validator-api/src/contract_cache/mod.rs
+++ b/validator-api/src/contract_cache/mod.rs
@@ -266,7 +266,9 @@ impl<C> ValidatorCacheRefresher<C> {
             )
             .await;
 
-        self.update_notifier.send(CacheNotification::Updated);
+        if let Err(err) = self.update_notifier.send(CacheNotification::Updated) {
+            warn!("Failed to notify validator cache refresh: {}", err);
+        }
 
         Ok(())
     }

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -17,7 +17,7 @@ use ::config::defaults::var_names::{CONFIGURED, MIXNET_CONTRACT_ADDRESS, MIX_DEN
 use ::config::NymConfig;
 use anyhow::Result;
 use clap::{crate_version, App, Arg, ArgMatches};
-use contract_cache::{CacheNotification, ValidatorCache};
+use contract_cache::ValidatorCache;
 use log::{info, warn};
 use node_status_api::NodeStatusCache;
 use okapi::openapi3::OpenApi;
@@ -33,7 +33,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{fs, process};
 use task::ShutdownNotifier;
-use tokio::sync::{watch, Notify};
+use tokio::sync::Notify;
 // use validator_client::nymd::SigningNymdClient;
 // use validator_client::ValidatorClientError;
 

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -19,6 +19,7 @@ use anyhow::Result;
 use clap::{crate_version, App, Arg, ArgMatches};
 use contract_cache::ValidatorCache;
 use log::{info, warn};
+use node_status_api::NodeStatusCache;
 use okapi::openapi3::OpenApi;
 use rocket::fairing::AdHoc;
 use rocket::http::Method;
@@ -470,7 +471,8 @@ async fn setup_rocket(
         .mount("/swagger", make_swagger_ui(&swagger::get_docs()))
         .attach(setup_cors()?)
         .attach(setup_liftoff_notify(liftoff_notify))
-        .attach(ValidatorCache::stage());
+        .attach(ValidatorCache::stage())
+        .attach(NodeStatusCache::stage());
 
     // This is not a very nice approach. A lazy value would be more suitable, but that's still
     // a nightly feature: https://github.com/rust-lang/rust/issues/74465
@@ -579,6 +581,7 @@ async fn run_validator_api(matches: ArgMatches<'static>) -> Result<()> {
     let monitor_builder = setup_network_monitor(&config, system_version, &rocket);
 
     let validator_cache = rocket.state::<ValidatorCache>().unwrap().clone();
+    let node_status_cache = rocket.state::<NodeStatusCache>().unwrap().clone();
 
     // if network monitor is disabled, we're not going to be sending any rewarding hence
     // we're not starting signing client
@@ -592,7 +595,7 @@ async fn run_validator_api(matches: ArgMatches<'static>) -> Result<()> {
         let shutdown_listener = shutdown.subscribe();
         tokio::spawn(async move { uptime_updater.run(shutdown_listener).await });
 
-        // spawn the cache refresher
+        // spawn the validator cache refresher
         let validator_cache_refresher = ValidatorCacheRefresher::new(
             signing_nymd_client.clone(),
             config.get_caching_interval(),
@@ -607,18 +610,28 @@ async fn run_validator_api(matches: ArgMatches<'static>) -> Result<()> {
             RewardedSetUpdater::new(signing_nymd_client, validator_cache.clone(), storage).await?;
         tokio::spawn(async move { rewarded_set_updater.run().await.unwrap() });
     } else {
+        // Spawn the validator cache refresher.
+        // When the network monitor is not enabled, we spawn the validator cache refresher task
+        // with just a nymd client, in contrast to a signing client.
         let nymd_client = Client::new_query(&config);
         let validator_cache_refresher = ValidatorCacheRefresher::new(
             nymd_client,
             config.get_caching_interval(),
-            validator_cache,
+            validator_cache.clone(),
             None,
         );
-
         let shutdown_listener = shutdown.subscribe();
-        // spawn our cacher
         tokio::spawn(async move { validator_cache_refresher.run(shutdown_listener).await });
     }
+
+    // Spawn the node status cache refresher
+    let validator_api_cache_refresher = node_status_api::NodeStatusCacheRefresher::new(
+        node_status_cache.clone(),
+        config.get_caching_interval(),
+        validator_cache,
+    );
+    let shutdown_listener = shutdown.subscribe();
+    tokio::spawn(async move { validator_api_cache_refresher.run(shutdown_listener).await });
 
     // launch the rocket!
     // Rocket handles shutdown on it's own, but its shutdown handling should be incorporated

--- a/validator-api/src/node_status_api/cache.rs
+++ b/validator-api/src/node_status_api/cache.rs
@@ -206,7 +206,7 @@ fn compute_inclusion_probabilities(
 
     Some(InclusionProbabilities {
         inclusion_probabilities: zip_ids_together_with_results(&ids, &results),
-        samples: results.samples.into(),
+        samples: results.samples,
         elapsed,
     })
 }

--- a/validator-api/src/node_status_api/mod.rs
+++ b/validator-api/src/node_status_api/mod.rs
@@ -1,11 +1,14 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) use cache::{InclusionProbabilities, NodeStatusCache, NodeStatusCacheRefresher};
+
 use okapi::openapi3::OpenApi;
 use rocket::Route;
 use rocket_okapi::{openapi_get_routes_spec, settings::OpenApiSettings};
 use std::time::Duration;
 
+pub(crate) mod cache;
 pub(crate) mod local_guard;
 pub(crate) mod models;
 pub(crate) mod routes;
@@ -33,8 +36,10 @@ pub(crate) fn node_status_routes(
             routes::compute_mixnode_reward_estimation,
             routes::get_mixnode_stake_saturation,
             routes::get_mixnode_inclusion_probability,
+            routes::get_mixnode_inclusion_probability2,
             routes::get_mixnode_avg_uptime,
             routes::get_mixnode_avg_uptimes,
+            routes::get_mixnode_inclusion_probabilities,
         ]
     } else {
         // in the minimal variant we would not have access to endpoints relying on existence
@@ -43,6 +48,8 @@ pub(crate) fn node_status_routes(
             routes::get_mixnode_status,
             routes::get_mixnode_stake_saturation,
             routes::get_mixnode_inclusion_probability,
+            routes::get_mixnode_inclusion_probability2,
+            routes::get_mixnode_inclusion_probabilities,
         ]
     }
 }

--- a/validator-api/src/node_status_api/mod.rs
+++ b/validator-api/src/node_status_api/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-pub(crate) use cache::{InclusionProbabilities, NodeStatusCache, NodeStatusCacheRefresher};
+pub(crate) use cache::{NodeStatusCache, NodeStatusCacheRefresher};
 
 use okapi::openapi3::OpenApi;
 use rocket::Route;

--- a/validator-api/src/node_status_api/mod.rs
+++ b/validator-api/src/node_status_api/mod.rs
@@ -36,7 +36,6 @@ pub(crate) fn node_status_routes(
             routes::compute_mixnode_reward_estimation,
             routes::get_mixnode_stake_saturation,
             routes::get_mixnode_inclusion_probability,
-            routes::get_mixnode_inclusion_probability2,
             routes::get_mixnode_avg_uptime,
             routes::get_mixnode_avg_uptimes,
             routes::get_mixnode_inclusion_probabilities,
@@ -48,7 +47,6 @@ pub(crate) fn node_status_routes(
             routes::get_mixnode_status,
             routes::get_mixnode_stake_saturation,
             routes::get_mixnode_inclusion_probability,
-            routes::get_mixnode_inclusion_probability2,
             routes::get_mixnode_inclusion_probabilities,
         ]
     }

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -4,7 +4,7 @@
 use mixnet_contract_common::{reward_params::RewardParams, MixNode, MixNodeBond};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{fmt, time::Duration};
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[cfg_attr(feature = "generate-ts", derive(ts_rs::TS))]
@@ -151,3 +151,21 @@ impl fmt::Display for InclusionProbabilityResponse {
         )
     }
 }
+
+#[derive(Clone, Serialize, schemars::JsonSchema)]
+pub struct AllInclusionProbabilitiesResponse {
+    pub inclusion_probabilities: Vec<InclusionProbability>,
+    pub samples: u64,
+    pub elapsed: Duration,
+    pub delta_max: f64,
+    pub delta_l2: f64,
+    pub as_at: i64,
+}
+
+#[derive(Clone, Serialize, schemars::JsonSchema)]
+pub struct InclusionProbability {
+    pub id: String,
+    pub in_active: f64,
+    pub in_reserve: f64,
+}
+

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -168,4 +168,3 @@ pub struct InclusionProbability {
     pub in_active: f64,
     pub in_reserve: f64,
 }
-

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -101,16 +101,20 @@ pub type StakeSaturation = f32;
 )]
 pub enum SelectionChance {
     VeryHigh,
+    High,
     Moderate,
     Low,
+    VeryLow,
 }
 
 impl From<f64> for SelectionChance {
     fn from(p: f64) -> SelectionChance {
         match p {
-            p if p > 0.15 => SelectionChance::VeryHigh,
-            p if p >= 0.05 => SelectionChance::Moderate,
-            _ => SelectionChance::Low,
+            p if p >= 1. => SelectionChance::VeryHigh,
+            p if p > 0.9 => SelectionChance::High,
+            p if p > 0.7 => SelectionChance::Moderate,
+            p if p > 0.5 => SelectionChance::Low,
+            _ => SelectionChance::VeryLow,
         }
     }
 }
@@ -119,8 +123,10 @@ impl fmt::Display for SelectionChance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SelectionChance::VeryHigh => write!(f, "VeryHigh"),
+            SelectionChance::High => write!(f, "High"),
             SelectionChance::Moderate => write!(f, "Moderate"),
             SelectionChance::Low => write!(f, "Low"),
+            SelectionChance::VeryLow => write!(f, "VeryLow"),
         }
     }
 }

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -101,20 +101,16 @@ pub type StakeSaturation = f32;
 )]
 pub enum SelectionChance {
     VeryHigh,
-    High,
     Moderate,
     Low,
-    VeryLow,
 }
 
 impl From<f64> for SelectionChance {
     fn from(p: f64) -> SelectionChance {
         match p {
-            p if p >= 1. => SelectionChance::VeryHigh,
-            p if p > 0.9 => SelectionChance::High,
-            p if p > 0.7 => SelectionChance::Moderate,
-            p if p > 0.5 => SelectionChance::Low,
-            _ => SelectionChance::VeryLow,
+            p if p > 0.95 => SelectionChance::VeryHigh,
+            p if p > 0.4 => SelectionChance::Moderate,
+            _ => SelectionChance::Low,
         }
     }
 }
@@ -123,10 +119,8 @@ impl fmt::Display for SelectionChance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SelectionChance::VeryHigh => write!(f, "VeryHigh"),
-            SelectionChance::High => write!(f, "High"),
             SelectionChance::Moderate => write!(f, "Moderate"),
             SelectionChance::Low => write!(f, "Low"),
-            SelectionChance::VeryLow => write!(f, "VeryLow"),
         }
     }
 }

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -101,16 +101,20 @@ pub type StakeSaturation = f32;
 )]
 pub enum SelectionChance {
     VeryHigh,
+    High,
     Moderate,
     Low,
+    VeryLow,
 }
 
 impl From<f64> for SelectionChance {
     fn from(p: f64) -> SelectionChance {
         match p {
-            p if p > 0.95 => SelectionChance::VeryHigh,
-            p if p > 0.4 => SelectionChance::Moderate,
-            _ => SelectionChance::Low,
+            p if p > 0.98 => SelectionChance::VeryHigh,
+            p if p > 0.9 => SelectionChance::High,
+            p if p > 0.7 => SelectionChance::Moderate,
+            p if p > 0.5 => SelectionChance::Low,
+            _ => SelectionChance::VeryLow,
         }
     }
 }
@@ -119,8 +123,10 @@ impl fmt::Display for SelectionChance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SelectionChance::VeryHigh => write!(f, "VeryHigh"),
+            SelectionChance::High => write!(f, "High"),
             SelectionChance::Moderate => write!(f, "Moderate"),
             SelectionChance::Low => write!(f, "Low"),
+            SelectionChance::VeryLow => write!(f, "VeryLow"),
         }
     }
 }


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/2088
Closes: https://github.com/nymtech/nym/issues/2336
Closes: https://github.com/nymtech/nym/issues/1996

- Create a node status cache to complement the contract cache. 
- Store the simulated active set selection probabilities
- Replace selection probabilities in REST endpoint with the new ones

## For the future

Move non-contract values from the contract cache to the new node info cache. Probably just want to move the whole `mixnodes/detailed` endpoint. This should remove the dependency that the contract cache / validator cache has on the validator storage.

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
