### PR TITLE
Exposed direct queries to smart contract on NymdClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 ## Unreleased
 
+### Added
+
+- validator-client: added `query_contract_smart` and `query_contract_raw` on `NymdClient` ([#1558])
+
+
 ### Changed
 
 - validator-client: made `fee` argument optional for `execute` and `execute_multiple` ([#1541])
 
 [#1541]: https://github.com/nymtech/nym/pull/1541
+[#1558]: https://github.com/nymtech/nym/pull/1558
 
 
 ## [nym-binaries-1.0.2](https://github.com/nymtech/nym/tree/nym-binaries-1.0.2)

--- a/common/client-libs/validator-client/src/nymd/mod.rs
+++ b/common/client-libs/validator-client/src/nymd/mod.rs
@@ -24,7 +24,7 @@ use mixnet_contract_common::{
     PagedMixDelegationsResponse, PagedMixnodeResponse, PagedRewardedSetResponse, QueryMsg,
     RewardedSetUpdateDetails,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::time::SystemTime;
 use vesting_contract_common::ExecuteMsg as VestingExecuteMsg;
@@ -280,6 +280,30 @@ impl<C> NymdClient<C> {
 
     pub fn set_simulated_gas_multiplier(&mut self, multiplier: f32) {
         self.simulated_gas_multiplier = multiplier;
+    }
+
+    pub async fn query_contract_smart<M, T>(
+        &self,
+        contract: &AccountId,
+        query_msg: &M,
+    ) -> Result<T, NymdError>
+    where
+        C: CosmWasmClient + Sync,
+        M: ?Sized + Serialize + Sync,
+        for<'a> T: Deserialize<'a>,
+    {
+        self.client.query_contract_smart(contract, query_msg).await
+    }
+
+    pub async fn query_contract_raw(
+        &self,
+        contract: &AccountId,
+        query_data: Vec<u8>,
+    ) -> Result<Vec<u8>, NymdError>
+    where
+        C: CosmWasmClient + Sync,
+    {
+        self.client.query_contract_raw(contract, query_data).await
     }
 
     pub fn wrap_contract_execute_message<M>(


### PR DESCRIPTION
# Description

Makes it possible to query smart contract directly with an arbitrary message (or key) using a `NymdClient`

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
