### PR TITLE
inclusion-prob: make rng generic and predictable in tests

### DIFF
--- a/validator-api/src/node_status_api/cache.rs
+++ b/validator-api/src/node_status_api/cache.rs
@@ -200,12 +200,14 @@ fn compute_inclusion_probabilities(
     let (ids, mixnode_total_bonds) = unzip_into_mixnode_ids_and_total_bonds(mixnode_bonds);
 
     // Compute inclusion probabilitites and keep track of how long time it took.
+    let mut rng = rand::thread_rng();
     let results = inclusion_probability::simulate_selection_probability_mixnodes(
         &mixnode_total_bonds,
         active_set_size,
         standby_set_size,
         MAX_SIMULATION_SAMPLES,
         Duration::from_secs(MAX_SIMULATION_TIME_SEC),
+        &mut rng,
     )
     .tap_err(|err| error!("{err}"))
     .ok()?;


### PR DESCRIPTION
# Description

- Make the random number generator generic in the Monte Carlo simulation for the active set inclusion probabilities. 
- Seed rng in unit tests to make them predictable and repeatable

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
