### PR TITLE
Connect: remove some sources of panics when initializing socks5-client

### DIFF
--- a/clients/native/src/client/config/mod.rs
+++ b/clients/native/src/client/config/mod.rs
@@ -50,6 +50,10 @@ impl NymConfig for Config {
             .join("clients")
     }
 
+    fn try_default_root_directory() -> Option<PathBuf> {
+        dirs::home_dir().map(|path| path.join(".nym").join("clients"))
+    }
+
     fn root_directory(&self) -> PathBuf {
         self.base.get_nym_root_directory()
     }

--- a/clients/socks5/src/client/config/mod.rs
+++ b/clients/socks5/src/client/config/mod.rs
@@ -27,6 +27,7 @@ impl NymConfig for Config {
     }
 
     fn default_root_directory() -> PathBuf {
+        // WIP(JON): consider removing this expect? At least try triggering it
         dirs::home_dir()
             .expect("Failed to evaluate $HOME value")
             .join(".nym")

--- a/clients/socks5/src/client/config/mod.rs
+++ b/clients/socks5/src/client/config/mod.rs
@@ -27,11 +27,14 @@ impl NymConfig for Config {
     }
 
     fn default_root_directory() -> PathBuf {
-        // WIP(JON): consider removing this expect? At least try triggering it
         dirs::home_dir()
             .expect("Failed to evaluate $HOME value")
             .join(".nym")
             .join("socks5-clients")
+    }
+
+    fn try_default_root_directory() -> Option<PathBuf> {
+        dirs::home_dir().map(|path| path.join(".nym").join("socks5-clients"))
     }
 
     fn root_directory(&self) -> PathBuf {

--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -41,6 +41,30 @@ pub trait NymConfig: Default + Serialize + DeserializeOwned {
         Self::default_config_directory(id).join(Self::config_file_name())
     }
 
+    // We provide a second set of functions that tries to not panic.
+
+    fn try_default_root_directory() -> Option<PathBuf>;
+
+    fn try_default_config_directory(id: Option<&str>) -> Option<PathBuf> {
+        if let Some(id) = id {
+            Self::try_default_root_directory().map(|d| d.join(id).join("config"))
+        } else {
+            Self::try_default_root_directory().map(|d| d.join("config"))
+        }
+    }
+
+    fn try_default_data_directory(id: Option<&str>) -> Option<PathBuf> {
+        if let Some(id) = id {
+            Self::try_default_root_directory().map(|d| d.join(id).join("data"))
+        } else {
+            Self::try_default_root_directory().map(|d| d.join("data"))
+        }
+    }
+
+    fn try_default_config_file_path(id: Option<&str>) -> Option<PathBuf> {
+        Self::try_default_config_directory(id).map(|d| d.join(Self::config_file_name()))
+    }
+
     fn root_directory(&self) -> PathBuf;
     fn config_directory(&self) -> PathBuf;
     fn data_directory(&self) -> PathBuf;

--- a/gateway/src/config/mod.rs
+++ b/gateway/src/config/mod.rs
@@ -66,6 +66,10 @@ impl NymConfig for Config {
             .join("gateways")
     }
 
+    fn try_default_root_directory() -> Option<PathBuf> {
+        dirs::home_dir().map(|path| path.join(".nym").join("gateways"))
+    }
+
     fn root_directory(&self) -> PathBuf {
         self.gateway.nym_root_directory.clone()
     }

--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -96,6 +96,10 @@ impl NymConfig for Config {
             .join("mixnodes")
     }
 
+    fn try_default_root_directory() -> Option<PathBuf> {
+        dirs::home_dir().map(|path| path.join(".nym").join("mixnodes"))
+    }
+
     fn root_directory(&self) -> PathBuf {
         self.mixnode.nym_root_directory.clone()
     }

--- a/nym-connect/src-tauri/src/error.rs
+++ b/nym-connect/src-tauri/src/error.rs
@@ -52,6 +52,8 @@ pub enum BackendError {
     CouldNotInitWithoutServiceProvider,
     #[error("Could not get file name")]
     CouldNotGetFilename,
+    #[error("Could not get config file location")]
+    CouldNotGetConfigFilename,
     #[error("Could not load existing gateway configuration")]
     CouldNotLoadExistingGatewayConfiguration(std::io::Error),
 }

--- a/nym-connect/src-tauri/src/error.rs
+++ b/nym-connect/src-tauri/src/error.rs
@@ -52,6 +52,8 @@ pub enum BackendError {
     CouldNotInitWithoutServiceProvider,
     #[error("Could not get file name")]
     CouldNotGetFilename,
+    #[error("Could not load existing gateway configuration")]
+    CouldNotLoadExistingGatewayConfiguration(std::io::Error),
 }
 
 impl Serialize for BackendError {

--- a/nym-connect/src-tauri/src/state.rs
+++ b/nym-connect/src-tauri/src/state.rs
@@ -101,7 +101,7 @@ impl State {
 
         // Setup configuration by writing to file
         if let Err(err) = self.init_config().await {
-            log::warn!("Failed to initialize: {}", err);
+            log::error!("Failed to initialize: {}", err);
 
             // Wait a little to give the user some rudimentary feedback that the click actually
             // registered.

--- a/nym-wallet/src-tauri/src/platform_constants.rs
+++ b/nym-wallet/src-tauri/src/platform_constants.rs
@@ -1,9 +1,6 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-// Specify filenames and other platform specific constants to respect platform conventions, or at
-// least, something popular on each respective platform.
-
 pub const CONFIG_DIR_NAME: &str = "nym-wallet";
 pub const CONFIG_FILENAME: &str = "config.toml";
 pub const STORAGE_DIR_NAME: &str = "nym-wallet";

--- a/validator-api/src/config/mod.rs
+++ b/validator-api/src/config/mod.rs
@@ -72,6 +72,10 @@ impl NymConfig for Config {
             .join("validator-api")
     }
 
+    fn try_default_root_directory() -> Option<PathBuf> {
+        dirs::home_dir().map(|path| path.join(".nym").join("validator-api"))
+    }
+
     fn root_directory(&self) -> PathBuf {
         Self::default_root_directory()
     }


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/2011

Remove a few sources of panics when initializing the socks5-client in nym-connect

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
