### PR TITLE
fix(wallet): error UI feedback

### DIFF
--- a/nym-wallet/src/components/Delegation/DelegateModal.tsx
+++ b/nym-wallet/src/components/Delegation/DelegateModal.tsx
@@ -193,7 +193,7 @@ export const DelegateModal: React.FC<{
         setMixId(res);
         setMixIdError(undefined);
       } else {
-        setMixIdError('No matching mix_id for that address');
+        setMixIdError('Mixnode with this identity does not seem to be currently bonded');
       }
     }, 500),
     [],

--- a/nym-wallet/src/components/Delegation/DelegateModal.tsx
+++ b/nym-wallet/src/components/Delegation/DelegateModal.tsx
@@ -70,6 +70,7 @@ export const DelegateModal: React.FC<{
   const [errorAmount, setErrorAmount] = useState<string | undefined>();
   const [tokenPool, setTokenPool] = useState<TPoolOption>('balance');
   const [errorIdentityKey, setErrorIdentityKey] = useState<string>();
+  const [mixIdError, setMixIdError] = useState<string>();
 
   const { fee, getFee, resetFeeState, feeError } = useGetFee();
 
@@ -121,7 +122,14 @@ export const DelegateModal: React.FC<{
       newValidatedValue = false;
     }
 
+    if (!mixId) {
+      newValidatedValue = false;
+    }
+
     setErrorIdentityKey(errorIdentityKeyMessage);
+    if (mixIdError && !errorIdentityKeyMessage) {
+      setErrorIdentityKey(mixIdError);
+    }
     setErrorAmount(errorAmountMessage);
     setValidated(newValidatedValue);
   };
@@ -167,7 +175,7 @@ export const DelegateModal: React.FC<{
 
   React.useEffect(() => {
     validate();
-  }, [amount, identityKey]);
+  }, [amount, identityKey, mixIdError]);
 
   const resolveMixId = useCallback(
     debounce(async (idKey) => {
@@ -183,6 +191,9 @@ export const DelegateModal: React.FC<{
       }
       if (res) {
         setMixId(res);
+        setMixIdError(undefined);
+      } else {
+        setMixIdError('No matching mix_id for that address');
       }
     }, 500),
     [],

--- a/nym-wallet/src/pages/settings/system-variables.tsx
+++ b/nym-wallet/src/pages/settings/system-variables.tsx
@@ -31,18 +31,14 @@ const DataField = ({ title, info, Indicator }: { title: string; info: string; In
 );
 
 const colorMap: { [key in SelectionChance]: string } = {
-  VeryLow: 'error.main',
   Low: 'error.main',
   Moderate: 'warning.main',
-  High: 'success.main',
   VeryHigh: 'success.main',
 };
 
 const textMap: { [key in SelectionChance]: string } = {
-  VeryLow: 'VeryLow',
   Low: 'Low',
   Moderate: 'Moderate',
-  High: 'High',
   VeryHigh: 'Very high',
 };
 


### PR DESCRIPTION
Enhance the error UI when there is no matching mix_id for a given mixnode address, but that address has a valid format.

![image](https://user-images.githubusercontent.com/6359431/186657969-39e3c36c-0b1d-4723-9cfd-e9289a7be794.png)
