### PR TITLE
Delegator compoudning to bypass pending events

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,12 +4,18 @@
 
 - vesting-contract: added queries for delegation timestamps and paged query for all vesting delegations in the contract ([#1569])
 
+### Changed
+
+- mixnet-contract: compounding delegator rewards now happens instantaneously as opposed to having to wait for the current epoch to finish ([#1571])
+
 ### Fixed
 
 - vesting-contract: the contract now correctly stores delegations with their timestamp as opposed to using block height ([#1544])
+- mixnet-contract: compounding delegator rewards is now possible even if the associated mixnode had already unbonded ([#1571])
 
 [#1544]: https://github.com/nymtech/nym/pull/1544
 [#1569]: https://github.com/nymtech/nym/pull/1569
+[#1569]: https://github.com/nymtech/nym/pull/1571
 
 ## [nym-contracts-v1.0.1](https://github.com/nymtech/nym/tree/nym-contracts-v1.0.1) (2022-06-22)
 


### PR DESCRIPTION
# Description

Makes delegator reward compounding instant and bypasses  the `_try_delegate_to_mixnode` path. Without it, universal compound was failing for delegators that delegated to nodes that have already unbonded.

Closes https://github.com/nymtech/nym/issues/1990

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
