### PR TITLE
NE: Display raw bond instead of self %

### DIFF
--- a/explorer/src/api/constants.ts
+++ b/explorer/src/api/constants.ts
@@ -1,7 +1,7 @@
 // master APIs
 export const API_BASE_URL = process.env.EXPLORER_API_URL;
 export const VALIDATOR_API_BASE_URL = process.env.VALIDATOR_API_URL;
-export const VALIDATOR_URL = process.env.VALIDATOR_URL;
+export const { VALIDATOR_URL } = process.env;
 export const BIG_DIPPER = process.env.BIG_DIPPER_URL;
 
 // specific API routes

--- a/explorer/src/components/DetailTable.tsx
+++ b/explorer/src/components/DetailTable.tsx
@@ -35,10 +35,7 @@ function formatCellValues(val: string | number, field: string) {
     );
   }
   if (field === 'bond') {
-    if (typeof val === 'string') {
-      return currencyToString(val);
-    }
-    return currencyToString(val?.toString());
+    return currencyToString(val.toString());
   }
   return val;
 }

--- a/explorer/src/components/DetailTable.tsx
+++ b/explorer/src/components/DetailTable.tsx
@@ -35,7 +35,10 @@ function formatCellValues(val: string | number, field: string) {
     );
   }
   if (field === 'bond') {
-    return currencyToString(val.toString());
+    if (typeof val === 'string') {
+      return currencyToString(val);
+    }
+    return currencyToString(val?.toString());
   }
   return val;
 }

--- a/explorer/src/components/MixNodes/index.ts
+++ b/explorer/src/components/MixNodes/index.ts
@@ -9,10 +9,7 @@ export type MixnodeRowType = {
   identity_key: string;
   bond: number;
   self_percentage: string;
-  pledge_amount: {
-    amount: string;
-    denom: string;
-  };
+  pledge_amount: number;
   host: string;
   layer: string;
   profit_percentage: string;
@@ -26,7 +23,6 @@ export function mixnodeToGridRow(arrayOfMixnodes?: MixNodeResponse): MixnodeRowT
 
 export function mixNodeResponseItemToMixnodeRowType(item: MixNodeResponseItem): MixnodeRowType {
   const pledge = Number(item.pledge_amount.amount) || 0;
-  const { denom } = item.pledge_amount;
   const delegations = Number(item.total_delegation.amount) || 0;
   const totalBond = pledge + delegations;
   const selfPercentage = ((pledge * 100) / totalBond).toFixed(2);
@@ -40,7 +36,7 @@ export function mixNodeResponseItemToMixnodeRowType(item: MixNodeResponseItem): 
     bond: totalBond || 0,
     location: item?.location?.country_name || '',
     self_percentage: selfPercentage,
-    pledge_amount: { amount: pledge.toString(), denom },
+    pledge_amount: pledge,
     host: item?.mix_node?.host || '',
     layer: item?.layer || '',
     profit_percentage: `${profitPercentage}%`,

--- a/explorer/src/components/MixNodes/index.ts
+++ b/explorer/src/components/MixNodes/index.ts
@@ -9,6 +9,10 @@ export type MixnodeRowType = {
   identity_key: string;
   bond: number;
   self_percentage: string;
+  pledge_amount: {
+    amount: string;
+    denom: string;
+  };
   host: string;
   layer: string;
   profit_percentage: string;
@@ -22,6 +26,7 @@ export function mixnodeToGridRow(arrayOfMixnodes?: MixNodeResponse): MixnodeRowT
 
 export function mixNodeResponseItemToMixnodeRowType(item: MixNodeResponseItem): MixnodeRowType {
   const pledge = Number(item.pledge_amount.amount) || 0;
+  const { denom } = item.pledge_amount;
   const delegations = Number(item.total_delegation.amount) || 0;
   const totalBond = pledge + delegations;
   const selfPercentage = ((pledge * 100) / totalBond).toFixed(2);
@@ -35,6 +40,7 @@ export function mixNodeResponseItemToMixnodeRowType(item: MixNodeResponseItem): 
     bond: totalBond || 0,
     location: item?.location?.country_name || '',
     self_percentage: selfPercentage,
+    pledge_amount: { amount: pledge.toString(), denom },
     host: item?.mix_node?.host || '',
     layer: item?.layer || '',
     profit_percentage: `${profitPercentage}%`,

--- a/explorer/src/pages/Mixnodes/index.tsx
+++ b/explorer/src/pages/Mixnodes/index.tsx
@@ -188,7 +188,7 @@ export const PageMixnodes: React.FC = () => {
         />
       ),
       headerClassName: 'MuiDataGrid-header-override',
-      width: 190,
+      width: 185,
       headerAlign: 'left',
       renderCell: (params: GridRenderCellParams) => (
         <MuiLink
@@ -205,10 +205,10 @@ export const PageMixnodes: React.FC = () => {
     },
     {
       field: 'self_percentage',
-      headerName: 'Self %',
-      width: 110,
+      headerName: 'Raw Bond',
+      width: 140,
       headerClassName: 'MuiDataGrid-header-override',
-      renderHeader: () => <CustomColumnHeading headingTitle="Self %" />,
+      renderHeader: () => <CustomColumnHeading headingTitle="Raw Bond" tooltipInfo="Node operator's share of stake." />,
       type: 'number',
       headerAlign: 'left',
       renderCell: (params: GridRenderCellParams) => (
@@ -231,7 +231,7 @@ export const PageMixnodes: React.FC = () => {
         />
       ),
       headerClassName: 'MuiDataGrid-header-override',
-      width: 165,
+      width: 160,
       headerAlign: 'left',
       renderCell: (params: GridRenderCellParams) => (
         <MuiLink
@@ -253,7 +253,7 @@ export const PageMixnodes: React.FC = () => {
         />
       ),
       headerClassName: 'MuiDataGrid-header-override',
-      width: 160,
+      width: 165,
       headerAlign: 'left',
       renderCell: (params: GridRenderCellParams) => (
         <MuiLink

--- a/explorer/src/pages/Mixnodes/index.tsx
+++ b/explorer/src/pages/Mixnodes/index.tsx
@@ -204,11 +204,11 @@ export const PageMixnodes: React.FC = () => {
       ),
     },
     {
-      field: 'self_percentage',
-      headerName: 'Raw Bond',
-      width: 140,
+      field: 'pledge_amount',
+      headerName: 'Bond',
+      width: 200,
       headerClassName: 'MuiDataGrid-header-override',
-      renderHeader: () => <CustomColumnHeading headingTitle="Raw Bond" tooltipInfo="Node operator's share of stake." />,
+      renderHeader: () => <CustomColumnHeading headingTitle="Bond" tooltipInfo="Node operator's share of stake." />,
       type: 'number',
       headerAlign: 'left',
       renderCell: (params: GridRenderCellParams) => (
@@ -217,7 +217,7 @@ export const PageMixnodes: React.FC = () => {
           component={RRDLink}
           to={`/network-components/mixnode/${params.row.identity_key}`}
         >
-          {params.value}%
+          {currencyToString(params.value.amount, params.value.denom)}
         </MuiLink>
       ),
     },

--- a/explorer/src/pages/Mixnodes/index.tsx
+++ b/explorer/src/pages/Mixnodes/index.tsx
@@ -217,7 +217,7 @@ export const PageMixnodes: React.FC = () => {
           component={RRDLink}
           to={`/network-components/mixnode/${params.row.identity_key}`}
         >
-          {currencyToString(params.value.amount, params.value.denom)}
+          {currencyToString(params.value)}
         </MuiLink>
       ),
     },

--- a/explorer/src/styles.css
+++ b/explorer/src/styles.css
@@ -4,7 +4,7 @@
 the theme declaration in index.tsx or the style prop
 in <DataGrid /> */
 
-.MuiDataGrid-sortIcon, .MuiDataGrid-menuIcon {
+.MuiDataGrid-sortIcon, .MuiDataGrid-menuIcon, .MuiDataGrid-iconButtonContainer{
     display: none !important;
 }
 


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/2260

I added also `display none`  to the class `.MuiDataGrid-iconButtonContainer`, to avoid this grey circle we have hovering the right side of each column header: 

![image](https://user-images.githubusercontent.com/33252067/189937564-ad62f90a-ee78-4088-97d6-75ab066ceb69.png)



It's allows me to fit a bit better some columns width.
