### PR TITLE
NE: 407 filters granularity

### DIFF
--- a/explorer/src/api/constants.ts
+++ b/explorer/src/api/constants.ts
@@ -1,7 +1,7 @@
 // master APIs
 export const API_BASE_URL = process.env.EXPLORER_API_URL;
 export const VALIDATOR_API_BASE_URL = process.env.VALIDATOR_API_URL;
-export const VALIDATOR_URL = process.env.VALIDATOR_URL;
+export const { VALIDATOR_URL } = process.env;
 export const BIG_DIPPER = process.env.BIG_DIPPER_URL;
 
 // specific API routes

--- a/explorer/src/components/Filters/Filters.tsx
+++ b/explorer/src/components/Filters/Filters.tsx
@@ -47,6 +47,7 @@ const FilterItem = ({
       scale={scale}
       min={min}
       max={max}
+      valueLabelFormat={(val: number) => (val === 100 && id === 'stakeSaturation' ? '>100' : val)}
     />
   </Box>
 );

--- a/explorer/src/components/Filters/filterSchema.ts
+++ b/explorer/src/components/Filters/filterSchema.ts
@@ -26,32 +26,19 @@ export const generateFilterSchema = (upperSaturationValue?: number) => ({
     label: 'Stake saturation (%)',
     id: EnumFilterKey.stakeSaturation,
     value: [0, upperSaturationValue || 100],
-    marks: [
-      { label: '0', value: 0 },
-
-      {
-        label: '10',
-        value: 10,
-      },
-
-      {
-        label: '50',
-        value: 50,
-      },
-      { label: '90', value: 90 },
-
-      {
-        label: upperSaturationValue ? `${upperSaturationValue}` : '100',
-        value: upperSaturationValue || 100,
-      },
-    ],
-    max: upperSaturationValue,
+    isSmooth: true,
+    marks: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, upperSaturationValue || 100].map((value) => ({
+      value: value < 100 ? value : 100,
+      label: value < 100 ? value : '>100',
+    })),
+    max: 100,
     tooltipInfo: "Select nodes with <100% saturation. Any additional stake above 100% saturation won't get rewards",
   },
   routingScore: {
     label: 'Routing score (%)',
     id: EnumFilterKey.routingScore,
     value: [0, 100],
+    isSmooth: true,
     marks: [
       { label: '0', value: 0 },
       { label: '10', value: 10 },


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/2266

More granularity on Stake Saturation filter and now nodes with over-saturation above to 100& are on the same bucket:
<img width="988" alt="image" src="https://user-images.githubusercontent.com/33252067/190403752-d1b6bfef-23cb-4040-b505-da9297bd6f03.png">

More granularity on Profit Margin filter:
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/33252067/190403789-740b7736-586f-44db-b575-a5c223d1b1f3.png">
