### PR TITLE
validator-api: guard against funny numbers in apy calc

### DIFF
--- a/common/client-libs/validator-client/src/validator_api/mod.rs
+++ b/common/client-libs/validator-client/src/validator_api/mod.rs
@@ -57,6 +57,7 @@ impl Client {
         V: AsRef<str>,
     {
         let url = create_api_url(&self.url, path, params);
+        log::trace!("url: {:?}", url.as_str());
         Ok(self.reqwest_client.get(url).send().await?.json().await?)
     }
 

--- a/validator-api/src/contract_cache/reward_estimate.rs
+++ b/validator-api/src/contract_cache/reward_estimate.rs
@@ -7,7 +7,28 @@ use mixnet_contract_common::reward_params::{EpochRewardParams, NodeRewardParams,
 use mixnet_contract_common::MixNodeBond;
 
 pub fn compute_apy(epochs_per_hour: f64, reward: f64, pledge_amount: f64) -> f64 {
-    epochs_per_hour * 24.0 * 365.0 * 100.0 * reward / pledge_amount
+    if epochs_per_hour < 0.0 {
+        log::warn!("epochs_per_hour is negative");
+    }
+    if reward < 0.0 {
+        log::warn!("reward is negative");
+    }
+    if pledge_amount < 0.0 {
+        log::warn!("pledge_amount is negative");
+    }
+    if pledge_amount == 0.0 {
+        return 0.0;
+    }
+
+    let apy = epochs_per_hour * 24.0 * 365.0 * 100.0 * reward / pledge_amount;
+
+    // Guard against unexpected results
+    if apy.is_finite() {
+        apy
+    } else {
+        log::warn!("computed apy is not finite!");
+        0.0
+    }
 }
 
 pub fn compute_reward_estimate(


### PR DESCRIPTION
# Description

Fix bug where estimated APY could be NaN, causing deserialization errors in the `explorer-api`

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
