### PR TITLE
Made config.toml values in validator-api take precedence over mainnet defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - network-requester: added additional Blockstream Green wallet endpoint to `example.allowed.list` ([#1611](https://github.com/nymtech/nym/pull/1611))
 - common/ledger: new library for communicating with a Ledger device ([#1640])
 
+### Fixed
+
+- validator-api, mixnode, gateway should now prefer values in config.toml over mainnet defaults ([#1645])
+
 ### Changed
 
 - validator-client: made `fee` argument optional for `execute` and `execute_multiple` ([#1541])
@@ -23,6 +27,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1585]: https://github.com/nymtech/nym/pull/1585
 [#1591]: https://github.com/nymtech/nym/pull/1591
 [#1640]: https://github.com/nymtech/nym/pull/1640
+[#1645]: https://github.com/nymtech/nym/pull/1645
 
 
 ## [nym-binaries-1.0.2](https://github.com/nymtech/nym/tree/nym-binaries-1.0.2)

--- a/common/network-defaults/src/lib.rs
+++ b/common/network-defaults/src/lib.rs
@@ -285,12 +285,17 @@ pub fn setup_env(config_env_file: Option<PathBuf>) {
                     .expect("Invalid path to environment configuration file");
             } else {
                 // if nothing is set, the use mainnet defaults
+                // if the user has not set `CONFIGURED`, then even if they set any of the env variables,
+                // overwrite them
                 crate::mainnet::export_to_env();
             }
         }
         Err(_) => crate::mainnet::export_to_env(),
         _ => {}
     }
+
+    // if we haven't explicitly defined any of the constants, fallback to defaults
+    crate::mainnet::export_to_env_if_not_set()
 }
 
 // Name of the event triggered by the eth contract. If the event name is changed,

--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -31,42 +31,107 @@ pub(crate) fn validators() -> Vec<ValidatorDetails> {
     vec![ValidatorDetails::new(NYMD_VALIDATOR, Some(API_VALIDATOR))]
 }
 
+const DEFAULT_SUFFIX: &str = "_MAINNET_DEFAULT";
+
+fn set_var_to_default(var: &str, value: &str) {
+    std::env::set_var(var, value);
+    std::env::set_var(format!("{}{}", var, DEFAULT_SUFFIX), "1")
+}
+
+fn set_var_conditionally_to_default(var: &str, value: &str) {
+    if std::env::var(var).is_err() {
+        set_var_to_default(var, value)
+    }
+}
+
+pub fn uses_default(var: &str) -> bool {
+    std::env::var(format!("{}{}", var, DEFAULT_SUFFIX)).is_ok()
+}
+
+pub fn read_var_if_not_default(var: &str) -> Option<String> {
+    if uses_default(var) {
+        None
+    } else {
+        std::env::var(var).ok()
+    }
+}
+
 pub fn export_to_env() {
-    std::env::set_var(var_names::CONFIGURED, "true");
-    std::env::set_var(var_names::BECH32_PREFIX, BECH32_PREFIX);
-    std::env::set_var(var_names::MIX_DENOM, MIX_DENOM.base);
-    std::env::set_var(var_names::MIX_DENOM_DISPLAY, MIX_DENOM.display);
-    std::env::set_var(var_names::STAKE_DENOM, STAKE_DENOM.base);
-    std::env::set_var(var_names::STAKE_DENOM_DISPLAY, STAKE_DENOM.display);
-    std::env::set_var(
+    set_var_to_default(var_names::CONFIGURED, "true");
+    set_var_to_default(var_names::BECH32_PREFIX, BECH32_PREFIX);
+    set_var_to_default(var_names::MIX_DENOM, MIX_DENOM.base);
+    set_var_to_default(var_names::MIX_DENOM_DISPLAY, MIX_DENOM.display);
+    set_var_to_default(var_names::STAKE_DENOM, STAKE_DENOM.base);
+    set_var_to_default(var_names::STAKE_DENOM_DISPLAY, STAKE_DENOM.display);
+    set_var_to_default(
         var_names::DENOMS_EXPONENT,
-        STAKE_DENOM.display_exponent.to_string(),
+        &STAKE_DENOM.display_exponent.to_string(),
     );
-    std::env::set_var(var_names::MIXNET_CONTRACT_ADDRESS, MIXNET_CONTRACT_ADDRESS);
-    std::env::set_var(
+    set_var_to_default(var_names::MIXNET_CONTRACT_ADDRESS, MIXNET_CONTRACT_ADDRESS);
+    set_var_to_default(
         var_names::VESTING_CONTRACT_ADDRESS,
         VESTING_CONTRACT_ADDRESS,
     );
-    std::env::set_var(
+    set_var_to_default(
         var_names::BANDWIDTH_CLAIM_CONTRACT_ADDRESS,
         BANDWIDTH_CLAIM_CONTRACT_ADDRESS,
     );
-    std::env::set_var(
+    set_var_to_default(
         var_names::COCONUT_BANDWIDTH_CONTRACT_ADDRESS,
         COCONUT_BANDWIDTH_CONTRACT_ADDRESS,
     );
-    std::env::set_var(
+    set_var_to_default(
         var_names::MULTISIG_CONTRACT_ADDRESS,
         MULTISIG_CONTRACT_ADDRESS,
     );
-    std::env::set_var(
+    set_var_to_default(
         var_names::REWARDING_VALIDATOR_ADDRESS,
         REWARDING_VALIDATOR_ADDRESS,
     );
-    std::env::set_var(
+    set_var_to_default(
         var_names::STATISTICS_SERVICE_DOMAIN_ADDRESS,
         STATISTICS_SERVICE_DOMAIN_ADDRESS,
     );
-    std::env::set_var(var_names::NYMD_VALIDATOR, NYMD_VALIDATOR);
-    std::env::set_var(var_names::API_VALIDATOR, API_VALIDATOR);
+    set_var_to_default(var_names::NYMD_VALIDATOR, NYMD_VALIDATOR);
+    set_var_to_default(var_names::API_VALIDATOR, API_VALIDATOR);
+}
+
+pub fn export_to_env_if_not_set() {
+    set_var_conditionally_to_default(var_names::CONFIGURED, "true");
+    set_var_conditionally_to_default(var_names::BECH32_PREFIX, BECH32_PREFIX);
+    set_var_conditionally_to_default(var_names::MIX_DENOM, MIX_DENOM.base);
+    set_var_conditionally_to_default(var_names::MIX_DENOM_DISPLAY, MIX_DENOM.display);
+    set_var_conditionally_to_default(var_names::STAKE_DENOM, STAKE_DENOM.base);
+    set_var_conditionally_to_default(var_names::STAKE_DENOM_DISPLAY, STAKE_DENOM.display);
+    set_var_conditionally_to_default(
+        var_names::DENOMS_EXPONENT,
+        &STAKE_DENOM.display_exponent.to_string(),
+    );
+    set_var_conditionally_to_default(var_names::MIXNET_CONTRACT_ADDRESS, MIXNET_CONTRACT_ADDRESS);
+    set_var_conditionally_to_default(
+        var_names::VESTING_CONTRACT_ADDRESS,
+        VESTING_CONTRACT_ADDRESS,
+    );
+    set_var_conditionally_to_default(
+        var_names::BANDWIDTH_CLAIM_CONTRACT_ADDRESS,
+        BANDWIDTH_CLAIM_CONTRACT_ADDRESS,
+    );
+    set_var_conditionally_to_default(
+        var_names::COCONUT_BANDWIDTH_CONTRACT_ADDRESS,
+        COCONUT_BANDWIDTH_CONTRACT_ADDRESS,
+    );
+    set_var_conditionally_to_default(
+        var_names::MULTISIG_CONTRACT_ADDRESS,
+        MULTISIG_CONTRACT_ADDRESS,
+    );
+    set_var_conditionally_to_default(
+        var_names::REWARDING_VALIDATOR_ADDRESS,
+        REWARDING_VALIDATOR_ADDRESS,
+    );
+    set_var_conditionally_to_default(
+        var_names::STATISTICS_SERVICE_DOMAIN_ADDRESS,
+        STATISTICS_SERVICE_DOMAIN_ADDRESS,
+    );
+    set_var_conditionally_to_default(var_names::NYMD_VALIDATOR, NYMD_VALIDATOR);
+    set_var_conditionally_to_default(var_names::API_VALIDATOR, API_VALIDATOR);
 }

--- a/mixnode/src/commands/mod.rs
+++ b/mixnode/src/commands/mod.rs
@@ -8,6 +8,7 @@ use clap::CommandFactory;
 use clap::Subcommand;
 use colored::Colorize;
 use completions::{fig_generate, ArgShell};
+use config::defaults::mainnet::read_var_if_not_default;
 use config::{
     defaults::var_names::{API_VALIDATOR, BECH32_PREFIX, CONFIGURED},
     parse_validators,
@@ -97,8 +98,9 @@ fn override_config(mut config: Config, args: OverrideConfig) -> Config {
     if let Some(ref raw_validators) = args.validators {
         config = config.with_custom_validator_apis(parse_validators(raw_validators));
     } else if std::env::var(CONFIGURED).is_ok() {
-        let raw_validators = std::env::var(API_VALIDATOR).expect("api validator not set");
-        config = config.with_custom_validator_apis(parse_validators(&raw_validators))
+        if let Some(raw_validators) = read_var_if_not_default(API_VALIDATOR) {
+            config = config.with_custom_validator_apis(::config::parse_validators(&raw_validators))
+        }
     }
 
     if let Some(ref announce_host) = args.announce_host {

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -10,6 +10,7 @@ use crate::network_monitor::NetworkMonitorBuilder;
 use crate::node_status_api::uptime_updater::HistoricalUptimeUpdater;
 use crate::nymd_client::Client;
 use crate::storage::ValidatorApiStorage;
+use ::config::defaults::mainnet::read_var_if_not_default;
 use ::config::defaults::setup_env;
 #[cfg(feature = "coconut")]
 use ::config::defaults::var_names::API_VALIDATOR;
@@ -294,8 +295,9 @@ fn override_config(mut config: Config, matches: &ArgMatches) -> Config {
     if let Some(raw_validators) = matches.value_of(API_VALIDATORS_ARG) {
         config = config.with_custom_validator_apis(::config::parse_validators(raw_validators));
     } else if std::env::var(CONFIGURED).is_ok() {
-        let raw_validators = std::env::var(API_VALIDATOR).expect("api validator not set");
-        config = config.with_custom_validator_apis(::config::parse_validators(&raw_validators))
+        if let Some(raw_validators) = read_var_if_not_default(API_VALIDATOR) {
+            config = config.with_custom_validator_apis(::config::parse_validators(&raw_validators))
+        }
     }
 
     if let Some(raw_validator) = matches.value_of(NYMD_VALIDATOR_ARG) {
@@ -312,9 +314,9 @@ fn override_config(mut config: Config, matches: &ArgMatches) -> Config {
     if let Some(mixnet_contract) = matches.value_of(MIXNET_CONTRACT_ARG) {
         config = config.with_custom_mixnet_contract(mixnet_contract)
     } else if std::env::var(CONFIGURED).is_ok() {
-        let mixnet_contract =
-            std::env::var(MIXNET_CONTRACT_ADDRESS).expect("mixnet contract not set");
-        config = config.with_custom_mixnet_contract(mixnet_contract)
+        if let Some(mixnet_contract) = read_var_if_not_default(MIXNET_CONTRACT_ADDRESS) {
+            config = config.with_custom_mixnet_contract(mixnet_contract)
+        }
     }
 
     if let Some(mnemonic) = matches.value_of(MNEMONIC_ARG) {


### PR DESCRIPTION
# Description

Deals with https://github.com/nymtech/nym/issues/1972

As pointed out by @neacsu, I should also update other binaries (apart from the validator-api) to make the same checks for the env values.

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
