### PR TITLE
NE: Fix validators url

### DIFF
--- a/explorer/src/api/constants.ts
+++ b/explorer/src/api/constants.ts
@@ -1,7 +1,7 @@
 // master APIs
 export const API_BASE_URL = process.env.EXPLORER_API_URL;
 export const VALIDATOR_API_BASE_URL = process.env.VALIDATOR_API_URL;
-export const { VALIDATOR_URL } = process.env;
+export const VALIDATOR_BASE_URL = process.env.VALIDATOR_URL;
 export const BIG_DIPPER = process.env.BIG_DIPPER_URL;
 
 // specific API routes
@@ -10,7 +10,7 @@ export const MIXNODE_PING = `${API_BASE_URL}/ping`;
 export const MIXNODES_API = `${API_BASE_URL}/mix-nodes`;
 export const MIXNODE_API = `${API_BASE_URL}/mix-node`;
 export const GATEWAYS_API = `${VALIDATOR_API_BASE_URL}/api/v1/gateways`;
-export const VALIDATORS_API = `${VALIDATOR_URL}/validators`;
+export const VALIDATORS_API = `${VALIDATOR_BASE_URL}/validators`;
 export const BLOCK_API = `${VALIDATOR_API_BASE_URL}/block`;
 export const COUNTRY_DATA_API = `${API_BASE_URL}/countries`;
 export const UPTIME_STORY_API = `${VALIDATOR_API_BASE_URL}/api/v1/status/mixnode`; // add ID then '/history' to this.


### PR DESCRIPTION
# Description

<!-- If appropriate, insert relevant description here -->

We started having a typescript error telling that we should use destructuring for the const `VALIDATOR_URL `. Using destructuring, we are not accessing to the .env file, and the `VALIDATOR_URL ` comes as undefined. I changed this constant name, to avoid the TS error.


The endpoint is not correct using `destructuring`:
<img width="767" alt="image" src="https://user-images.githubusercontent.com/33252067/191757060-5e3447dd-ac40-42e3-ab27-1bd7164f0115.png">
