### PR TITLE
Removes humantime_serde serialization of epoch_length

### DIFF
--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
@@ -75,8 +75,7 @@ pub struct Interval {
     #[serde(with = "string_rfc3339_offset_date_time")]
     current_epoch_start: OffsetDateTime,
     current_epoch_id: EpochId,
-    #[cfg_attr(feature = "generate-ts", ts(type = "string"))]
-    #[serde(with = "humantime_serde")]
+    #[cfg_attr(feature = "generate-ts", ts(type = "{ secs: number; nanos: number; }"))]
     epoch_length: Duration,
     total_elapsed_epochs: EpochId,
 }


### PR DESCRIPTION
# Description

Removes `#[serde(with = "humantime_serde")]` tag on `epoch_length` in `Interval` struct introduced in https://github.com/nymtech/nym/pull/1660. 

When `humantime_serde` is imported into smart contract context, it introduces, among other things, an `F64Load` instruction which is not supported by our validators and thus contract upload fails. (it also gets us above 800kb which is another issue).

For completion sake, the full failure message when attempting to upload the contract (with `humantime_serde`):
```
'failed to execute message; message index: 0: Error calling the VM: Error
  compiling Wasm: Could not compile: WebAssembly translation error: Error in middleware
  Gatekeeper: Float operator detected: F64Load { memarg: MemoryImmediate { align:
  3, offset: 0, memory: 0 } }. The use of floats is not supported.: create wasm contract
  failed'
```
