### PR TITLE
Introduced disable_main_poisson_packet_distribution to force real_traffic_stream to disable poisson sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - network-requester: added additional Blockstream Green wallet endpoint to `example.allowed.list` ([#1611](https://github.com/nymtech/nym/pull/1611))
 - common/ledger: new library for communicating with a Ledger device ([#1640])
 - native-client/socks5-client: `disable_loop_cover_traffic_stream` Debug config option to disable the separate loop cover traffic stream ([#1666])
+- native-client/socks5-client: `disable_main_poisson_packet_distribution` Debug config option to make the client ignore poisson distribution in the main packet stream and ONLY send real message (and as fast as they come) ([#1664])
 
 ### Fixed
 
@@ -30,6 +31,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1591]: https://github.com/nymtech/nym/pull/1591
 [#1640]: https://github.com/nymtech/nym/pull/1640
 [#1645]: https://github.com/nymtech/nym/pull/1645
+[#1664]: https://github.com/nymtech/nym/pull/1664
 [#1666]: https://github.com/nymtech/nym/pull/1645
 [#1669]: https://github.com/nymtech/nym/pull/1669
 

--- a/clients/client-core/src/client/real_messages_control/mod.rs
+++ b/clients/client-core/src/client/real_messages_control/mod.rs
@@ -50,9 +50,15 @@ pub struct Config {
 
     /// Average delay an acknowledgement packet is going to get delayed at a single mixnode.
     average_ack_delay_duration: Duration,
+
+    /// Controls whether the main packet stream constantly produces packets according to the predefined
+    /// poisson distribution.
+    disable_main_poisson_packet_distribution: bool,
 }
 
 impl Config {
+    // TODO: change the config into a builder
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ack_key: Arc<AckKey>,
         ack_wait_multiplier: f64,
@@ -60,6 +66,7 @@ impl Config {
         average_ack_delay_duration: Duration,
         average_message_sending_delay: Duration,
         average_packet_delay_duration: Duration,
+        disable_main_poisson_packet_distribution: bool,
         self_recipient: Recipient,
     ) -> Self {
         Config {
@@ -70,6 +77,7 @@ impl Config {
             average_message_sending_delay,
             average_packet_delay_duration,
             average_ack_delay_duration,
+            disable_main_poisson_packet_distribution,
         }
     }
 }
@@ -128,6 +136,7 @@ impl RealMessagesController<OsRng> {
             config.average_ack_delay_duration,
             config.average_packet_delay_duration,
             config.average_message_sending_delay,
+            config.disable_main_poisson_packet_distribution,
         );
 
         let out_queue_control = OutQueueControl::new(

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -32,6 +32,10 @@ pub(crate) struct Config {
 
     /// Average delay between sending subsequent packets.
     average_message_sending_delay: Duration,
+
+    /// Controls whether the stream constantly produces packets according to the predefined
+    /// poisson distribution.
+    disable_poisson_packet_distribution: bool,
 }
 
 impl Config {
@@ -39,11 +43,13 @@ impl Config {
         average_ack_delay: Duration,
         average_packet_delay: Duration,
         average_message_sending_delay: Duration,
+        disable_poisson_packet_distribution: bool,
     ) -> Self {
         Config {
             average_ack_delay,
             average_packet_delay,
             average_message_sending_delay,
+            disable_poisson_packet_distribution,
         }
     }
 }
@@ -63,7 +69,7 @@ where
 
     /// Internal state, determined by `average_message_sending_delay`,
     /// used to keep track of when a next packet should be sent out.
-    next_delay: Pin<Box<time::Sleep>>,
+    next_delay: Option<Pin<Box<time::Sleep>>>,
 
     /// Channel used for sending prepared sphinx packets to `MixTrafficController` that sends them
     /// out to the network without any further delays.
@@ -113,55 +119,6 @@ pub(crate) enum StreamMessage {
     Real(Box<RealMessage>),
 }
 
-impl<R> Stream for OutQueueControl<R>
-where
-    R: CryptoRng + Rng + Unpin,
-{
-    type Item = StreamMessage;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // it is not yet time to return a message
-        if self.next_delay.as_mut().poll(cx).is_pending() {
-            return Poll::Pending;
-        };
-
-        // we know it's time to send a message, so let's prepare delay for the next one
-        // Get the `now` by looking at the current `delay` deadline
-        let avg_delay = self.config.average_message_sending_delay;
-        let now = self.next_delay.deadline();
-        let next_poisson_delay = sample_poisson_duration(&mut self.rng, avg_delay);
-
-        // The next interval value is `next_poisson_delay` after the one that just
-        // yielded.
-        let next = now + next_poisson_delay;
-        self.next_delay.as_mut().reset(next);
-
-        // check if we have anything immediately available
-        if let Some(real_available) = self.received_buffer.pop_front() {
-            return Poll::Ready(Some(StreamMessage::Real(Box::new(real_available))));
-        }
-
-        // decide what kind of message to send
-        match Pin::new(&mut self.real_receiver).poll_next(cx) {
-            // in the case our real message channel stream was closed, we should also indicate we are closed
-            // (and whoever is using the stream should panic)
-            Poll::Ready(None) => Poll::Ready(None),
-
-            // if there are more messages available, return first one and store the rest
-            Poll::Ready(Some(real_messages)) => {
-                self.received_buffer = real_messages.into();
-                // we MUST HAVE received at least ONE message
-                Poll::Ready(Some(StreamMessage::Real(Box::new(
-                    self.received_buffer.pop_front().unwrap(),
-                ))))
-            }
-
-            // otherwise construct a dummy one
-            Poll::Pending => Poll::Ready(Some(StreamMessage::Cover)),
-        }
-    }
-}
-
 impl<R> OutQueueControl<R>
 where
     R: CryptoRng + Rng + Unpin,
@@ -184,7 +141,7 @@ where
             config,
             ack_key,
             sent_notifier,
-            next_delay: Box::pin(time::sleep(Default::default())),
+            next_delay: None,
             mix_tx,
             real_receiver,
             our_full_destination,
@@ -265,12 +222,6 @@ where
 
     // Send messages at certain rate and if no real traffic is available, send cover message.
     async fn run_normal_out_queue(&mut self) {
-        // we should set initial delay only when we actually start the stream
-        self.next_delay = Box::pin(time::sleep(sample_poisson_duration(
-            &mut self.rng,
-            self.config.average_message_sending_delay,
-        )));
-
         let mut shutdown = self.shutdown.clone();
         while !shutdown.is_shutdown() {
             tokio::select! {
@@ -296,5 +247,111 @@ where
     pub(crate) async fn run_out_queue_control(&mut self) {
         debug!("Starting out queue controller...");
         self.run_normal_out_queue().await
+    }
+
+    fn poll_poisson(&mut self, cx: &mut Context<'_>) -> Poll<Option<StreamMessage>> {
+        if let Some(ref mut next_delay) = &mut self.next_delay {
+            // it is not yet time to return a message
+            if next_delay.as_mut().poll(cx).is_pending() {
+                return Poll::Pending;
+            };
+
+            // we know it's time to send a message, so let's prepare delay for the next one
+            // Get the `now` by looking at the current `delay` deadline
+            let avg_delay = self.config.average_message_sending_delay;
+            let now = next_delay.deadline();
+            let next_poisson_delay = sample_poisson_duration(&mut self.rng, avg_delay);
+
+            // The next interval value is `next_poisson_delay` after the one that just
+            // yielded.
+            let next = now + next_poisson_delay;
+            next_delay.as_mut().reset(next);
+
+            // check if we have anything immediately available
+            if let Some(real_available) = self.received_buffer.pop_front() {
+                return Poll::Ready(Some(StreamMessage::Real(Box::new(real_available))));
+            }
+
+            // decide what kind of message to send
+            match Pin::new(&mut self.real_receiver).poll_next(cx) {
+                // in the case our real message channel stream was closed, we should also indicate we are closed
+                // (and whoever is using the stream should panic)
+                Poll::Ready(None) => Poll::Ready(None),
+
+                // if there are more messages available, return first one and store the rest
+                Poll::Ready(Some(real_messages)) => {
+                    self.received_buffer = real_messages.into();
+                    // we MUST HAVE received at least ONE message
+                    Poll::Ready(Some(StreamMessage::Real(Box::new(
+                        self.received_buffer.pop_front().unwrap(),
+                    ))))
+                }
+
+                // otherwise construct a dummy one
+                Poll::Pending => Poll::Ready(Some(StreamMessage::Cover)),
+            }
+        } else {
+            // we never set an initial delay - let's do it now
+            cx.waker().wake_by_ref();
+
+            self.next_delay = Some(Box::pin(time::sleep(sample_poisson_duration(
+                &mut self.rng,
+                self.config.average_message_sending_delay,
+            ))));
+
+            Poll::Pending
+        }
+    }
+
+    fn poll_immediate(&mut self, cx: &mut Context<'_>) -> Poll<Option<StreamMessage>> {
+        // check if we have anything immediately available
+        if let Some(real_available) = self.received_buffer.pop_front() {
+            // if there are more messages immediately available, notify the runtime
+            // because we should be polled again
+            if !self.received_buffer.is_empty() {
+                cx.waker().wake_by_ref()
+            }
+            return Poll::Ready(Some(StreamMessage::Real(Box::new(real_available))));
+        }
+
+        match Pin::new(&mut self.real_receiver).poll_next(cx) {
+            // in the case our real message channel stream was closed, we should also indicate we are closed
+            // (and whoever is using the stream should panic)
+            Poll::Ready(None) => Poll::Ready(None),
+
+            // if there are more messages available, return first one and store the rest
+            Poll::Ready(Some(real_messages)) => {
+                self.received_buffer = real_messages.into();
+                // we MUST HAVE received at least ONE message
+                Poll::Ready(Some(StreamMessage::Real(Box::new(
+                    self.received_buffer.pop_front().unwrap(),
+                ))))
+            }
+
+            // if there's nothing, then there's nothing
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_next_message(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<StreamMessage>> {
+        if self.config.disable_poisson_packet_distribution {
+            self.poll_immediate(cx)
+        } else {
+            self.poll_poisson(cx)
+        }
+    }
+}
+
+impl<R> Stream for OutQueueControl<R>
+where
+    R: CryptoRng + Rng + Unpin,
+{
+    type Item = StreamMessage;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.poll_next_message(cx)
     }
 }

--- a/clients/client-core/src/config/mod.rs
+++ b/clients/client-core/src/config/mod.rs
@@ -240,6 +240,10 @@ impl<T: NymConfig> Config<T> {
         self.debug.disable_loop_cover_traffic_stream
     }
 
+    pub fn get_disabled_main_poisson_packet_distribution(&self) -> bool {
+        self.debug.disable_main_poisson_packet_distribution
+    }
+
     pub fn get_version(&self) -> &str {
         &self.client.version
     }
@@ -453,6 +457,10 @@ pub struct Debug {
     /// Controls whether the dedicated loop cover traffic stream should be enabled.
     /// (and sending packets, on average, every [Self::loop_cover_traffic_average_delay])
     pub disable_loop_cover_traffic_stream: bool,
+
+    /// Controls whether the main packet stream constantly produces packets according to the predefined
+    /// poisson distribution.
+    pub disable_main_poisson_packet_distribution: bool,
 }
 
 impl Default for Debug {
@@ -468,6 +476,7 @@ impl Default for Debug {
             topology_refresh_rate: DEFAULT_TOPOLOGY_REFRESH_RATE,
             topology_resolution_timeout: DEFAULT_TOPOLOGY_RESOLUTION_TIMEOUT,
             disable_loop_cover_traffic_stream: false,
+            disable_main_poisson_packet_distribution: false,
         }
     }
 }

--- a/clients/native/src/client/mod.rs
+++ b/clients/native/src/client/mod.rs
@@ -121,6 +121,9 @@ impl NymClient {
             self.config.get_base().get_average_ack_delay(),
             self.config.get_base().get_message_sending_average_delay(),
             self.config.get_base().get_average_packet_delay(),
+            self.config
+                .get_base()
+                .get_disabled_main_poisson_packet_distribution(),
             self.as_mix_recipient(),
         );
 

--- a/clients/socks5/src/client/mod.rs
+++ b/clients/socks5/src/client/mod.rs
@@ -122,6 +122,9 @@ impl NymClient {
             self.config.get_base().get_average_ack_delay(),
             self.config.get_base().get_message_sending_average_delay(),
             self.config.get_base().get_average_packet_delay(),
+            self.config
+                .get_base()
+                .get_disabled_main_poisson_packet_distribution(),
             self.as_mix_recipient(),
         );
 


### PR DESCRIPTION
# Description

https://github.com/nymtech/nym/issues/1963

Due to changes in `Stream` implementation, could I have some extra eyes on it? @octol @neacsu @durch

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
