### PR TITLE
Introduced a client-configurable option to force it to use extended packet size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - common/ledger: new library for communicating with a Ledger device ([#1640])
 - native-client/socks5-client: `disable_loop_cover_traffic_stream` Debug config option to disable the separate loop cover traffic stream ([#1666])
 - native-client/socks5-client: `disable_main_poisson_packet_distribution` Debug config option to make the client ignore poisson distribution in the main packet stream and ONLY send real message (and as fast as they come) ([#1664])
+- native-client/socks5-client: `use_extended_packet_size` Debug config option to make the client use 'ExtendedPacketSize' for its traffic (32kB as opposed to 2kB in 1.0.2) ([#1671])
 
 ### Fixed
 
@@ -34,6 +35,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1664]: https://github.com/nymtech/nym/pull/1664
 [#1666]: https://github.com/nymtech/nym/pull/1645
 [#1669]: https://github.com/nymtech/nym/pull/1669
+[#1671]: https://github.com/nymtech/nym/pull/1671
 
 
 ## [nym-binaries-1.0.2](https://github.com/nymtech/nym/tree/nym-binaries-1.0.2)

--- a/clients/client-core/src/client/cover_traffic_stream.rs
+++ b/clients/client-core/src/client/cover_traffic_stream.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use task::ShutdownListener;
 use tokio::task::JoinHandle;
 use tokio::time;
+use nymsphinx::params::PacketSize;
 
 pub struct LoopCoverTrafficStream<R>
 where
@@ -49,6 +50,9 @@ where
 
     /// Accessor to the common instance of network topology.
     topology_access: TopologyAccessor,
+
+    /// Predefined packet size used for the loop cover messages.
+    packet_size: PacketSize,
 
     /// Listen to shutdown signals.
     shutdown: ShutdownListener,
@@ -111,8 +115,13 @@ impl LoopCoverTrafficStream<OsRng> {
             our_full_destination,
             rng,
             topology_access,
+            packet_size: Default::default(),
             shutdown,
         }
+    }
+
+    pub fn set_custom_packet_size(&mut self, packet_size: PacketSize) {
+        self.packet_size = packet_size;
     }
 
     async fn on_new_message(&mut self) {
@@ -140,6 +149,7 @@ impl LoopCoverTrafficStream<OsRng> {
             &self.our_full_destination,
             self.average_ack_delay,
             self.average_packet_delay,
+            self.packet_size,
         )
         .expect("Somehow failed to generate a loop cover message with a valid topology");
 

--- a/clients/client-core/src/client/cover_traffic_stream.rs
+++ b/clients/client-core/src/client/cover_traffic_stream.rs
@@ -9,6 +9,7 @@ use log::*;
 use nymsphinx::acknowledgements::AckKey;
 use nymsphinx::addressing::clients::Recipient;
 use nymsphinx::cover::generate_loop_cover_packet;
+use nymsphinx::params::PacketSize;
 use nymsphinx::utils::sample_poisson_duration;
 use rand::{rngs::OsRng, CryptoRng, Rng};
 use std::pin::Pin;
@@ -16,7 +17,6 @@ use std::sync::Arc;
 use task::ShutdownListener;
 use tokio::task::JoinHandle;
 use tokio::time;
-use nymsphinx::params::PacketSize;
 
 pub struct LoopCoverTrafficStream<R>
 where

--- a/clients/client-core/src/client/real_messages_control/acknowledgement_control/mod.rs
+++ b/clients/client-core/src/client/real_messages_control/acknowledgement_control/mod.rs
@@ -13,6 +13,7 @@ use crate::client::{inbound_messages::InputMessageReceiver, topology_control::To
 use futures::channel::mpsc;
 use gateway_client::AcknowledgementReceiver;
 use log::*;
+use nymsphinx::params::PacketSize;
 use nymsphinx::{
     acknowledgements::AckKey,
     addressing::clients::Recipient,
@@ -27,7 +28,6 @@ use std::{
 };
 use task::ShutdownListener;
 use tokio::task::JoinHandle;
-use nymsphinx::params::PacketSize;
 
 mod acknowledgement_listener;
 mod action_controller;
@@ -138,7 +138,7 @@ impl Config {
             ack_wait_multiplier,
             average_ack_delay,
             average_packet_delay,
-            packet_size: Default::default()
+            packet_size: Default::default(),
         }
     }
 
@@ -186,7 +186,8 @@ where
             ack_recipient,
             config.average_packet_delay,
             config.average_ack_delay,
-        ).with_custom_real_message_packet_size(config.packet_size);
+        )
+        .with_custom_real_message_packet_size(config.packet_size);
 
         // will listen for any acks coming from the network
         let acknowledgement_listener = AcknowledgementListener::new(

--- a/clients/client-core/src/client/real_messages_control/acknowledgement_control/mod.rs
+++ b/clients/client-core/src/client/real_messages_control/acknowledgement_control/mod.rs
@@ -27,6 +27,7 @@ use std::{
 };
 use task::ShutdownListener;
 use tokio::task::JoinHandle;
+use nymsphinx::params::PacketSize;
 
 mod acknowledgement_listener;
 mod action_controller;
@@ -120,6 +121,9 @@ pub(super) struct Config {
 
     /// Average delay a data packet is going to get delayed at a single mixnode.
     average_packet_delay: Duration,
+
+    /// Predefined packet size used for the encapsulated messages.
+    packet_size: PacketSize,
 }
 
 impl Config {
@@ -134,7 +138,13 @@ impl Config {
             ack_wait_multiplier,
             average_ack_delay,
             average_packet_delay,
+            packet_size: Default::default()
         }
+    }
+
+    pub fn with_custom_packet_size(mut self, packet_size: PacketSize) -> Self {
+        self.packet_size = packet_size;
+        self
     }
 }
 
@@ -176,7 +186,7 @@ where
             ack_recipient,
             config.average_packet_delay,
             config.average_ack_delay,
-        );
+        ).with_custom_real_message_packet_size(config.packet_size);
 
         // will listen for any acks coming from the network
         let acknowledgement_listener = AcknowledgementListener::new(

--- a/clients/client-core/src/client/real_messages_control/mod.rs
+++ b/clients/client-core/src/client/real_messages_control/mod.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use task::ShutdownListener;
 use tokio::task::JoinHandle;
+use nymsphinx::params::PacketSize;
 
 mod acknowledgement_control;
 mod real_traffic_stream;
@@ -54,6 +55,9 @@ pub struct Config {
     /// Controls whether the main packet stream constantly produces packets according to the predefined
     /// poisson distribution.
     disable_main_poisson_packet_distribution: bool,
+
+    /// Predefined packet size used for the encapsulated messages.
+    packet_size: PacketSize,
 }
 
 impl Config {
@@ -78,7 +82,12 @@ impl Config {
             average_packet_delay_duration,
             average_ack_delay_duration,
             disable_main_poisson_packet_distribution,
+            packet_size: Default::default()
         }
+    }
+
+    pub fn set_custom_packet_size(&mut self, packet_size: PacketSize) {
+        self.packet_size = packet_size;
     }
 }
 
@@ -119,7 +128,7 @@ impl RealMessagesController<OsRng> {
             config.ack_wait_multiplier,
             config.average_ack_delay_duration,
             config.average_packet_delay_duration,
-        );
+        ).with_custom_packet_size(config.packet_size);
 
         let ack_control = AcknowledgementController::new(
             ack_control_config,
@@ -137,7 +146,7 @@ impl RealMessagesController<OsRng> {
             config.average_packet_delay_duration,
             config.average_message_sending_delay,
             config.disable_main_poisson_packet_distribution,
-        );
+        ).with_custom_cover_packet_size(config.packet_size);
 
         let out_queue_control = OutQueueControl::new(
             out_queue_config,

--- a/clients/client-core/src/client/real_messages_control/mod.rs
+++ b/clients/client-core/src/client/real_messages_control/mod.rs
@@ -19,12 +19,12 @@ use gateway_client::AcknowledgementReceiver;
 use log::*;
 use nymsphinx::acknowledgements::AckKey;
 use nymsphinx::addressing::clients::Recipient;
+use nymsphinx::params::PacketSize;
 use rand::{rngs::OsRng, CryptoRng, Rng};
 use std::sync::Arc;
 use std::time::Duration;
 use task::ShutdownListener;
 use tokio::task::JoinHandle;
-use nymsphinx::params::PacketSize;
 
 mod acknowledgement_control;
 mod real_traffic_stream;
@@ -82,7 +82,7 @@ impl Config {
             average_packet_delay_duration,
             average_ack_delay_duration,
             disable_main_poisson_packet_distribution,
-            packet_size: Default::default()
+            packet_size: Default::default(),
         }
     }
 
@@ -128,7 +128,8 @@ impl RealMessagesController<OsRng> {
             config.ack_wait_multiplier,
             config.average_ack_delay_duration,
             config.average_packet_delay_duration,
-        ).with_custom_packet_size(config.packet_size);
+        )
+        .with_custom_packet_size(config.packet_size);
 
         let ack_control = AcknowledgementController::new(
             ack_control_config,
@@ -146,7 +147,8 @@ impl RealMessagesController<OsRng> {
             config.average_packet_delay_duration,
             config.average_message_sending_delay,
             config.disable_main_poisson_packet_distribution,
-        ).with_custom_cover_packet_size(config.packet_size);
+        )
+        .with_custom_cover_packet_size(config.packet_size);
 
         let out_queue_control = OutQueueControl::new(
             out_queue_config,

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -13,6 +13,7 @@ use nymsphinx::addressing::clients::Recipient;
 use nymsphinx::chunking::fragment::FragmentIdentifier;
 use nymsphinx::cover::generate_loop_cover_packet;
 use nymsphinx::forwarding::packet::MixPacket;
+use nymsphinx::params::PacketSize;
 use nymsphinx::utils::sample_poisson_duration;
 use rand::{CryptoRng, Rng};
 use std::collections::VecDeque;
@@ -21,7 +22,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use task::ShutdownListener;
 use tokio::time;
-use nymsphinx::params::PacketSize;
 
 /// Configurable parameters of the `OutQueueControl`
 pub(crate) struct Config {
@@ -54,7 +54,7 @@ impl Config {
             average_packet_delay,
             average_message_sending_delay,
             disable_poisson_packet_distribution,
-            cover_packet_size: Default::default()
+            cover_packet_size: Default::default(),
         }
     }
 

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use task::ShutdownListener;
 use tokio::time;
+use nymsphinx::params::PacketSize;
 
 /// Configurable parameters of the `OutQueueControl`
 pub(crate) struct Config {
@@ -36,6 +37,9 @@ pub(crate) struct Config {
     /// Controls whether the stream constantly produces packets according to the predefined
     /// poisson distribution.
     disable_poisson_packet_distribution: bool,
+
+    /// Predefined packet size used for the loop cover messages.
+    cover_packet_size: PacketSize,
 }
 
 impl Config {
@@ -50,7 +54,13 @@ impl Config {
             average_packet_delay,
             average_message_sending_delay,
             disable_poisson_packet_distribution,
+            cover_packet_size: Default::default()
         }
+    }
+
+    pub fn with_custom_cover_packet_size(mut self, packet_size: PacketSize) -> Self {
+        self.cover_packet_size = packet_size;
+        self
     }
 }
 
@@ -189,6 +199,7 @@ where
                     &self.our_full_destination,
                     self.config.average_ack_delay,
                     self.config.average_packet_delay,
+                    self.config.cover_packet_size,
                 )
                 .expect("Somehow failed to generate a loop cover message with a valid topology")
             }

--- a/clients/client-core/src/config/mod.rs
+++ b/clients/client-core/src/config/mod.rs
@@ -484,7 +484,7 @@ impl Default for Debug {
             topology_resolution_timeout: DEFAULT_TOPOLOGY_RESOLUTION_TIMEOUT,
             disable_loop_cover_traffic_stream: false,
             disable_main_poisson_packet_distribution: false,
-            use_extended_packet_size: false
+            use_extended_packet_size: false,
         }
     }
 }

--- a/clients/client-core/src/config/mod.rs
+++ b/clients/client-core/src/config/mod.rs
@@ -244,6 +244,10 @@ impl<T: NymConfig> Config<T> {
         self.debug.disable_main_poisson_packet_distribution
     }
 
+    pub fn get_use_extended_packet_size(&self) -> bool {
+        self.debug.use_extended_packet_size
+    }
+
     pub fn get_version(&self) -> &str {
         &self.client.version
     }
@@ -461,6 +465,9 @@ pub struct Debug {
     /// Controls whether the main packet stream constantly produces packets according to the predefined
     /// poisson distribution.
     pub disable_main_poisson_packet_distribution: bool,
+
+    /// Controls whether the sent sphinx packet use the NON-DEFAULT bigger size.
+    pub use_extended_packet_size: bool,
 }
 
 impl Default for Debug {
@@ -477,6 +484,7 @@ impl Default for Debug {
             topology_resolution_timeout: DEFAULT_TOPOLOGY_RESOLUTION_TIMEOUT,
             disable_loop_cover_traffic_stream: false,
             disable_main_poisson_packet_distribution: false,
+            use_extended_packet_size: false
         }
     }
 }

--- a/clients/native/src/client/mod.rs
+++ b/clients/native/src/client/mod.rs
@@ -31,6 +31,7 @@ use log::*;
 use nymsphinx::addressing::clients::Recipient;
 use nymsphinx::addressing::nodes::NodeIdentity;
 use nymsphinx::anonymous_replies::ReplySurb;
+use nymsphinx::params::PacketSize;
 use nymsphinx::receiver::ReconstructedMessage;
 use task::{wait_for_signal, ShutdownListener, ShutdownNotifier};
 
@@ -90,7 +91,7 @@ impl NymClient {
     ) {
         info!("Starting loop cover traffic stream...");
 
-        LoopCoverTrafficStream::new(
+        let mut stream = LoopCoverTrafficStream::new(
             self.key_manager.ack_key(),
             self.config.get_base().get_average_ack_delay(),
             self.config.get_base().get_average_packet_delay(),
@@ -101,8 +102,13 @@ impl NymClient {
             self.as_mix_recipient(),
             topology_accessor,
             shutdown,
-        )
-        .start();
+        );
+
+        if self.config.get_base().get_use_extended_packet_size() {
+            stream.set_custom_packet_size(PacketSize::ExtendedPacket)
+        }
+
+        stream.start();
     }
 
     fn start_real_traffic_controller(
@@ -114,7 +120,7 @@ impl NymClient {
         mix_sender: BatchMixMessageSender,
         shutdown: ShutdownListener,
     ) {
-        let controller_config = real_messages_control::Config::new(
+        let mut controller_config = real_messages_control::Config::new(
             self.key_manager.ack_key(),
             self.config.get_base().get_ack_wait_multiplier(),
             self.config.get_base().get_ack_wait_addition(),
@@ -126,6 +132,10 @@ impl NymClient {
                 .get_disabled_main_poisson_packet_distribution(),
             self.as_mix_recipient(),
         );
+
+        if self.config.get_base().get_use_extended_packet_size() {
+            controller_config.set_custom_packet_size(PacketSize::ExtendedPacket)
+        }
 
         info!("Starting real traffic stream...");
 

--- a/clients/socks5/src/client/mod.rs
+++ b/clients/socks5/src/client/mod.rs
@@ -3,6 +3,11 @@
 
 use std::sync::atomic::Ordering;
 
+use crate::client::config::Config;
+use crate::socks::{
+    authentication::{AuthenticationMethods, Authenticator, User},
+    server::SphinxSocksServer,
+};
 use client_core::client::cover_traffic_stream::LoopCoverTrafficStream;
 use client_core::client::inbound_messages::{
     InputMessage, InputMessageReceiver, InputMessageSender,
@@ -33,12 +38,6 @@ use nymsphinx::addressing::clients::Recipient;
 use nymsphinx::addressing::nodes::NodeIdentity;
 use nymsphinx::params::PacketSize;
 use task::{wait_for_signal, ShutdownListener, ShutdownNotifier};
-
-use crate::client::config::Config;
-use crate::socks::{
-    authentication::{AuthenticationMethods, Authenticator, User},
-    server::SphinxSocksServer,
-};
 
 pub mod config;
 

--- a/common/client-libs/gateway-client/src/packet_router.rs
+++ b/common/client-libs/gateway-client/src/packet_router.rs
@@ -59,11 +59,12 @@ impl PacketRouter {
             } else if received_packet.len()
                 == PacketSize::RegularPacket.plaintext_size() - ack_overhead
             {
+                trace!("routing regular packet");
                 received_messages.push(received_packet);
             } else if received_packet.len()
                 == PacketSize::ExtendedPacket.plaintext_size() - ack_overhead
             {
-                warn!("received extended packet? Did not expect this...");
+                trace!("routing extended packet");
                 received_messages.push(received_packet);
             } else {
                 // this can happen if other clients are not padding their messages

--- a/common/nymsphinx/cover/src/lib.rs
+++ b/common/nymsphinx/cover/src/lib.rs
@@ -76,6 +76,7 @@ pub fn generate_loop_cover_packet<R>(
     full_address: &Recipient,
     average_ack_delay: time::Duration,
     average_packet_delay: time::Duration,
+    packet_size: PacketSize,
 ) -> Result<MixPacket, CoverMessageError>
 where
     R: RngCore + CryptoRng,
@@ -96,7 +97,7 @@ where
 
     let public_key_bytes = ephemeral_keypair.public_key().to_bytes();
     let cover_size =
-        PacketSize::default().plaintext_size() - public_key_bytes.len() - ack_bytes.len();
+        packet_size.plaintext_size() - public_key_bytes.len() - ack_bytes.len();
 
     let mut cover_content: Vec<_> = LOOP_COVER_MESSAGE_PAYLOAD
         .iter()
@@ -129,7 +130,7 @@ where
 
     // once merged, that's an easy rng injection point for sphinx packets : )
     let packet = SphinxPacketBuilder::new()
-        .with_payload_size(PacketSize::default().payload_size())
+        .with_payload_size(packet_size.payload_size())
         .build_packet(packet_payload, &route, &destination, &delays)
         .unwrap();
 

--- a/common/nymsphinx/cover/src/lib.rs
+++ b/common/nymsphinx/cover/src/lib.rs
@@ -96,8 +96,7 @@ where
     >(rng, full_address.encryption_key());
 
     let public_key_bytes = ephemeral_keypair.public_key().to_bytes();
-    let cover_size =
-        packet_size.plaintext_size() - public_key_bytes.len() - ack_bytes.len();
+    let cover_size = packet_size.plaintext_size() - public_key_bytes.len() - ack_bytes.len();
 
     let mut cover_content: Vec<_> = LOOP_COVER_MESSAGE_PAYLOAD
         .iter()

--- a/common/nymsphinx/src/preparer/mod.rs
+++ b/common/nymsphinx/src/preparer/mod.rs
@@ -104,7 +104,7 @@ where
     }
 
     /// Allows setting non-default size of the sphinx packets sent out.
-    pub fn with_packet_size(mut self, packet_size: PacketSize) -> Self {
+    pub fn with_custom_real_message_packet_size(mut self, packet_size: PacketSize) -> Self {
         self.packet_size = packet_size;
         self
     }


### PR DESCRIPTION

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
