### PR TITLE
validator-api: add operating cost and profit margin to compute reward est

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - native-client/socks5-client: `disable_main_poisson_packet_distribution` Debug config option to make the client ignore poisson distribution in the main packet stream and ONLY send real message (and as fast as they come) ([#1664])
 - native-client/socks5-client: `use_extended_packet_size` Debug config option to make the client use 'ExtendedPacketSize' for its traffic (32kB as opposed to 2kB in 1.0.2) ([#1671])
 - wasm-client: uses updated wasm-compatible `client-core` so that it's now capable of packet retransmission, cover traffic and poisson delay (among other things!) ([#1673])
+- validator-api: add `interval_operating_cost` and `profit_margin_percent` to cmpute reward estimation endpoint
 
 ### Fixed
 

--- a/validator-api/src/node_status_api/helpers.rs
+++ b/validator-api/src/node_status_api/helpers.rs
@@ -148,6 +148,14 @@ pub(crate) async fn _compute_mixnode_reward_estimation(
                 Decimal::from_ratio(total_delegation, 1u64);
         }
 
+        if let Some(profit_margin_percent) = user_reward_param.profit_margin_percent {
+            mixnode.mixnode_details.rewarding_details.cost_params.profit_margin_percent = profit_margin_percent;
+        }
+
+        if let Some(interval_operating_cost) = user_reward_param.interval_operating_cost {
+            mixnode.mixnode_details.rewarding_details.cost_params.interval_operating_cost = interval_operating_cost;
+        }
+
         if mixnode.mixnode_details.rewarding_details.operator
             + mixnode.mixnode_details.rewarding_details.delegates
             > reward_params.interval.staking_supply

--- a/validator-api/src/node_status_api/helpers.rs
+++ b/validator-api/src/node_status_api/helpers.rs
@@ -149,11 +149,19 @@ pub(crate) async fn _compute_mixnode_reward_estimation(
         }
 
         if let Some(profit_margin_percent) = user_reward_param.profit_margin_percent {
-            mixnode.mixnode_details.rewarding_details.cost_params.profit_margin_percent = profit_margin_percent;
+            mixnode
+                .mixnode_details
+                .rewarding_details
+                .cost_params
+                .profit_margin_percent = profit_margin_percent;
         }
 
         if let Some(interval_operating_cost) = user_reward_param.interval_operating_cost {
-            mixnode.mixnode_details.rewarding_details.cost_params.interval_operating_cost = interval_operating_cost;
+            mixnode
+                .mixnode_details
+                .rewarding_details
+                .cost_params
+                .interval_operating_cost = interval_operating_cost;
         }
 
         if mixnode.mixnode_details.rewarding_details.operator

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -1,11 +1,11 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use cosmwasm_std::Decimal;
+use cosmwasm_std::{Decimal, Coin};
 use mixnet_contract_common::mixnode::MixNodeDetails;
 use mixnet_contract_common::reward_params::{Performance, RewardingParams};
 use mixnet_contract_common::rewarding::RewardEstimate;
-use mixnet_contract_common::{Interval, MixNode, NodeId, RewardedSetNodeStatus};
+use mixnet_contract_common::{Interval, MixNode, NodeId, RewardedSetNodeStatus, Percent};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{fmt, time::Duration};
@@ -99,6 +99,8 @@ pub struct ComputeRewardEstParam {
     pub active_in_rewarded_set: Option<bool>,
     pub pledge_amount: Option<u64>,
     pub total_delegation: Option<u64>,
+    pub interval_operating_cost: Option<Coin>,
+    pub profit_margin_percent: Option<Percent>,
 }
 
 #[cfg_attr(feature = "generate-ts", derive(ts_rs::TS))]

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -1,11 +1,11 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use cosmwasm_std::{Decimal, Coin};
+use cosmwasm_std::{Coin, Decimal};
 use mixnet_contract_common::mixnode::MixNodeDetails;
 use mixnet_contract_common::reward_params::{Performance, RewardingParams};
 use mixnet_contract_common::rewarding::RewardEstimate;
-use mixnet_contract_common::{Interval, MixNode, NodeId, RewardedSetNodeStatus, Percent};
+use mixnet_contract_common::{Interval, MixNode, NodeId, Percent, RewardedSetNodeStatus};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{fmt, time::Duration};


### PR DESCRIPTION
# Description

Add two more fields to compute reward estimation

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
