### PR TITLE
Improved error propagation for fallible validator api queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - socks5 client: graceful shutdown should fix error on disconnect in nym-connect ([#1591])
 - wasm-client: fixed build errors on MacOS and changed example JS code to use mainnet ([#1585])
 - gateway-client: will attempt to read now as many as 8 websocket messages at once, assuming they're already available on the socket ([#1669])
+- validator-api: changed error serialization on `inclusion_probability`, `stake-saturation` and `reward-estimation` endpoints to provide more accurate information ([#1681]) 
 - moved `Percent` struct to to `contracts-common`, change affects explorer-api
 - clients: bound the sphinx packet channel and reduce sending rate if gateway can't keep up ([#1703],[#1725])
 
@@ -45,6 +46,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1669]: https://github.com/nymtech/nym/pull/1669
 [#1671]: https://github.com/nymtech/nym/pull/1671
 [#1673]: https://github.com/nymtech/nym/pull/1673
+[#1681]: https://github.com/nymtech/nym/pull/1681
 [#1687]: https://github.com/nymtech/nym/pull/1687
 [#1702]: https://github.com/nymtech/nym/pull/1702
 [#1703]: https://github.com/nymtech/nym/pull/1703

--- a/common/client-libs/validator-client/src/validator_api/error.rs
+++ b/common/client-libs/validator-client/src/validator_api/error.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use validator_api_requests::models::RequestError;
 
 #[derive(Error, Debug)]
 pub enum ValidatorAPIError {
@@ -10,4 +11,7 @@ pub enum ValidatorAPIError {
 
     #[error("Request failed with error message - {0}")]
     GenericRequestFailure(String),
+
+    #[error("The validator API has failed to resolve our request. It returned status code {status} and additional error message: {}", error.message())]
+    ApiRequestFailure { status: u16, error: RequestError },
 }

--- a/validator-api/src/node_status_api/models.rs
+++ b/validator-api/src/node_status_api/models.rs
@@ -6,8 +6,9 @@ use crate::storage::models::NodeStatus;
 use mixnet_contract_common::reward_params::Performance;
 use mixnet_contract_common::{IdentityKey, MixId};
 use okapi::openapi3::{Responses, SchemaObject};
-use rocket::http::{ContentType, Status};
+use rocket::http::Status;
 use rocket::response::{self, Responder, Response};
+use rocket::serde::json::Json;
 use rocket::Request;
 use rocket_okapi::gen::OpenApiGenerator;
 use rocket_okapi::response::OpenApiResponderInner;
@@ -19,11 +20,10 @@ use serde::{Deserialize, Serialize};
 use sqlx::Error;
 use std::convert::TryFrom;
 use std::fmt::{self, Display, Formatter};
-use std::io::Cursor;
 use time::OffsetDateTime;
 use validator_api_requests::models::{
     GatewayStatusReportResponse, GatewayUptimeHistoryResponse, HistoricalUptimeResponse,
-    MixnodeStatusReportResponse, MixnodeUptimeHistoryResponse,
+    MixnodeStatusReportResponse, MixnodeUptimeHistoryResponse, RequestError,
 };
 
 // todo: put into some error enum
@@ -302,24 +302,25 @@ impl From<HistoricalUptime> for HistoricalUptimeResponse {
 }
 
 pub(crate) struct ErrorResponse {
-    error_message: String,
+    error_message: RequestError,
     status: Status,
 }
 
 impl ErrorResponse {
     pub(crate) fn new(error_message: impl Into<String>, status: Status) -> Self {
         ErrorResponse {
-            error_message: error_message.into(),
+            error_message: RequestError::new(error_message),
             status,
         }
     }
 }
 
 impl<'r, 'o: 'r> Responder<'r, 'o> for ErrorResponse {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'o> {
+        // piggyback on the existing implementation
+        // also prefer json over plain for ease of use in frontend
         Response::build()
-            .header(ContentType::Plain)
-            .sized_body(self.error_message.len(), Cursor::new(self.error_message))
+            .merge(Json(self.error_message).respond_to(req)?)
             .status(self.status)
             .ok()
     }

--- a/validator-api/validator-api-requests/src/models.rs
+++ b/validator-api/validator-api-requests/src/models.rs
@@ -12,6 +12,23 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{fmt, time::Duration};
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+pub struct RequestError {
+    message: String,
+}
+
+impl RequestError {
+    pub fn new<S: Into<String>>(msg: S) -> Self {
+        RequestError {
+            message: msg.into(),
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[cfg_attr(feature = "generate-ts", derive(ts_rs::TS))]
 #[cfg_attr(


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1957

The change is best represented with the following code snippet:
```rust
let client = ApiClient::new("https://qa-validator-api.nymtech.net/api/".parse().unwrap());
let mix_id_that_doesnt_exist = 123456;
let res = client
    .get_mixnode_stake_saturation(mix_id_that_doesnt_exist)
    .await;
println!("{:?}", res)

// old: Err(ValidatorAPIError { source: ReqwestClientError { source: reqwest::Error { kind: Decode, source: Error("expected value", line: 1, column: 1) } } })
// new: Err(ValidatorAPIError { source: ApiRequestFailure { status: 404, error: RequestError { message: "mixnode bond not found" } } })
```

Note: it requires both, validator-api redeployment and local client updates

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
