### PR TITLE
validator-api: remove storage dependency in contract cache

### DIFF
--- a/common/client-libs/validator-client/src/validator_api/mod.rs
+++ b/common/client-libs/validator-client/src/validator_api/mod.rs
@@ -136,7 +136,12 @@ impl Client {
         &self,
     ) -> Result<Vec<MixNodeBondAnnotated>, ValidatorAPIError> {
         self.query_validator_api(
-            &[routes::API_VERSION, routes::MIXNODES, routes::DETAILED],
+            &[
+                routes::API_VERSION,
+                routes::STATUS,
+                routes::MIXNODES,
+                routes::DETAILED,
+            ],
             NO_PARAMS,
         )
         .await
@@ -161,6 +166,7 @@ impl Client {
         self.query_validator_api(
             &[
                 routes::API_VERSION,
+                routes::STATUS,
                 routes::MIXNODES,
                 routes::ACTIVE,
                 routes::DETAILED,
@@ -252,6 +258,7 @@ impl Client {
         self.query_validator_api(
             &[
                 routes::API_VERSION,
+                routes::STATUS,
                 routes::MIXNODES,
                 routes::REWARDED,
                 routes::DETAILED,

--- a/validator-api/src/contract_cache/mod.rs
+++ b/validator-api/src/contract_cache/mod.rs
@@ -25,7 +25,6 @@ use tokio::time;
 use validator_api_requests::models::MixnodeStatus;
 use validator_client::nymd::CosmWasmClient;
 
-pub(crate) mod reward_estimate;
 pub(crate) mod routes;
 
 // The cache can emit notifications to listeners about the current state

--- a/validator-api/src/contract_cache/mod.rs
+++ b/validator-api/src/contract_cache/mod.rs
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::nymd_client::Client;
-use crate::storage::ValidatorApiStorage;
 use ::time::OffsetDateTime;
 use anyhow::Result;
-use mixnet_contract_common::mixnode::MixNodeDetails;
-use mixnet_contract_common::reward_params::{Performance, RewardingParams};
 use mixnet_contract_common::{
-    GatewayBond, IdentityKey, Interval, MixId, MixNodeBond, RewardedSetNodeStatus,
+    mixnode::MixNodeDetails, reward_params::RewardingParams, GatewayBond, IdentityKey, Interval,
+    MixId, MixNodeBond, RewardedSetNodeStatus,
 };
 use okapi::openapi3::OpenApi;
 use rocket::fairing::AdHoc;
@@ -16,15 +14,15 @@ use rocket::Route;
 use rocket_okapi::openapi_get_routes_spec;
 use rocket_okapi::settings::OpenApiSettings;
 use serde::Serialize;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use task::ShutdownListener;
 use tokio::sync::{watch, RwLock};
 use tokio::time;
-use validator_api_requests::models::{MixNodeBondAnnotated, MixnodeStatus};
+use validator_api_requests::models::MixnodeStatus;
 use validator_client::nymd::CosmWasmClient;
 
 pub(crate) mod reward_estimate;
@@ -42,9 +40,6 @@ pub struct ValidatorCacheRefresher<C> {
     cache: ValidatorCache,
     caching_interval: Duration,
 
-    // Readonly: some of the quantities cached depends on values from the storage.
-    storage: Option<ValidatorApiStorage>,
-
     // Notify listeners that the cache has been updated
     update_notifier: watch::Sender<CacheNotification>,
 }
@@ -56,14 +51,14 @@ pub struct ValidatorCache {
 }
 
 struct ValidatorCacheInner {
-    mixnodes: Cache<Vec<MixNodeBondAnnotated>>,
+    mixnodes: Cache<Vec<MixNodeDetails>>,
     gateways: Cache<Vec<GatewayBond>>,
 
     mixnodes_blacklist: Cache<HashSet<MixId>>,
     gateways_blacklist: Cache<HashSet<IdentityKey>>,
 
-    rewarded_set: Cache<Vec<MixNodeBondAnnotated>>,
-    active_set: Cache<Vec<MixNodeBondAnnotated>>,
+    rewarded_set: Cache<Vec<MixNodeDetails>>,
+    active_set: Cache<Vec<MixNodeDetails>>,
 
     current_reward_params: Cache<Option<RewardingParams>>,
     current_interval: Cache<Option<Interval>>,
@@ -102,88 +97,31 @@ impl<T: Clone> Cache<T> {
     }
 }
 
+impl<T> Deref for Cache<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
 impl<C> ValidatorCacheRefresher<C> {
     pub(crate) fn new(
         nymd_client: Client<C>,
         caching_interval: Duration,
         cache: ValidatorCache,
-        storage: Option<ValidatorApiStorage>,
     ) -> Self {
         let (tx, _) = watch::channel(CacheNotification::Start);
         ValidatorCacheRefresher {
             nymd_client,
             cache,
             caching_interval,
-            storage,
             update_notifier: tx,
         }
     }
 
-    async fn get_performance(&self, mix_id: MixId, epoch: Interval) -> Option<Performance> {
-        self.storage
-            .as_ref()?
-            .get_average_mixnode_uptime_in_the_last_24hrs(
-                mix_id,
-                epoch.current_epoch_end_unix_timestamp(),
-            )
-            .await
-            .ok()
-            .map(Into::into)
-    }
-
     pub fn subscribe(&self) -> watch::Receiver<CacheNotification> {
         self.update_notifier.subscribe()
-    }
-
-    async fn annotate_node_with_details(
-        &self,
-        mixnodes: Vec<MixNodeDetails>,
-        interval_reward_params: RewardingParams,
-        current_interval: Interval,
-        rewarded_set: &HashMap<MixId, RewardedSetNodeStatus>,
-    ) -> Vec<MixNodeBondAnnotated> {
-        let mut annotated = Vec::new();
-        for mixnode in mixnodes {
-            let stake_saturation = mixnode
-                .rewarding_details
-                .bond_saturation(&interval_reward_params);
-
-            let uncapped_stake_saturation = mixnode
-                .rewarding_details
-                .uncapped_bond_saturation(&interval_reward_params);
-
-            let performance = self
-                .get_performance(mixnode.mix_id(), current_interval)
-                .await
-                .unwrap_or_default();
-
-            let rewarded_set_status = rewarded_set.get(&mixnode.mix_id()).cloned();
-
-            let reward_estimate = reward_estimate::compute_reward_estimate(
-                &mixnode,
-                performance,
-                rewarded_set_status,
-                interval_reward_params,
-                current_interval,
-            );
-
-            let (estimated_operator_apy, estimated_delegators_apy) =
-                reward_estimate::compute_apy_from_reward(
-                    &mixnode,
-                    reward_estimate,
-                    current_interval,
-                );
-
-            annotated.push(MixNodeBondAnnotated {
-                mixnode_details: mixnode,
-                stake_saturation,
-                uncapped_stake_saturation,
-                performance,
-                estimated_operator_apy,
-                estimated_delegators_apy,
-            });
-        }
-        annotated
     }
 
     async fn get_rewarded_set_map(&self) -> HashMap<MixId, RewardedSetNodeStatus>
@@ -198,9 +136,9 @@ impl<C> ValidatorCacheRefresher<C> {
     }
 
     fn collect_rewarded_and_active_set_details(
-        all_mixnodes: &[MixNodeBondAnnotated],
+        all_mixnodes: &[MixNodeDetails],
         rewarded_set_nodes: &HashMap<MixId, RewardedSetNodeStatus>,
-    ) -> (Vec<MixNodeBondAnnotated>, Vec<MixNodeBondAnnotated>) {
+    ) -> (Vec<MixNodeDetails>, Vec<MixNodeDetails>) {
         let mut active_set = Vec::new();
         let mut rewarded_set = Vec::new();
 
@@ -226,14 +164,10 @@ impl<C> ValidatorCacheRefresher<C> {
         let mixnodes = self.nymd_client.get_mixnodes().await?;
         let gateways = self.nymd_client.get_gateways().await?;
 
-        let rewarded_set = self.get_rewarded_set_map().await;
-
-        let mixnodes = self
-            .annotate_node_with_details(mixnodes, rewarding_params, current_interval, &rewarded_set)
-            .await;
+        let rewarded_set_map = self.get_rewarded_set_map().await;
 
         let (rewarded_set, active_set) =
-            Self::collect_rewarded_and_active_set_details(&mixnodes, &rewarded_set);
+            Self::collect_rewarded_and_active_set_details(&mixnodes, &rewarded_set_map);
 
         info!(
             "Updating validator cache. There are {} mixnodes and {} gateways",
@@ -324,10 +258,10 @@ impl ValidatorCache {
 
     async fn update_cache(
         &self,
-        mixnodes: Vec<MixNodeBondAnnotated>,
+        mixnodes: Vec<MixNodeDetails>,
         gateways: Vec<GatewayBond>,
-        rewarded_set: Vec<MixNodeBondAnnotated>,
-        active_set: Vec<MixNodeBondAnnotated>,
+        rewarded_set: Vec<MixNodeDetails>,
+        active_set: Vec<MixNodeDetails>,
         rewarding_params: RewardingParams,
         current_interval: Interval,
     ) {
@@ -422,7 +356,7 @@ impl ValidatorCache {
         error!("Failed to update gateways blacklist");
     }
 
-    pub async fn mixnodes_detailed(&self) -> Vec<MixNodeBondAnnotated> {
+    pub async fn mixnodes(&self) -> Vec<MixNodeDetails> {
         let blacklist = self.mixnodes_blacklist().await;
         let mixnodes = match time::timeout(Duration::from_millis(100), self.inner.read()).await {
             Ok(cache) => cache.mixnodes.clone(),
@@ -444,14 +378,6 @@ impl ValidatorCache {
         }
     }
 
-    pub async fn mixnodes(&self) -> Vec<MixNodeDetails> {
-        self.mixnodes_detailed()
-            .await
-            .into_iter()
-            .map(|bond| bond.mixnode_details)
-            .collect()
-    }
-
     pub async fn mixnodes_basic(&self) -> Vec<MixNodeBond> {
         match time::timeout(Duration::from_millis(100), self.inner.read()).await {
             Ok(cache) => cache
@@ -459,7 +385,7 @@ impl ValidatorCache {
                 .clone()
                 .into_inner()
                 .into_iter()
-                .map(|bond| bond.mixnode_details.bond_information)
+                .map(|bond| bond.bond_information)
                 .collect(),
             Err(e) => {
                 error!("{}", e);
@@ -500,7 +426,7 @@ impl ValidatorCache {
         }
     }
 
-    pub async fn rewarded_set_detailed(&self) -> Cache<Vec<MixNodeBondAnnotated>> {
+    pub async fn rewarded_set(&self) -> Cache<Vec<MixNodeDetails>> {
         match time::timeout(Duration::from_millis(100), self.inner.read()).await {
             Ok(cache) => cache.rewarded_set.clone(),
             Err(e) => {
@@ -510,16 +436,7 @@ impl ValidatorCache {
         }
     }
 
-    pub async fn rewarded_set(&self) -> Vec<MixNodeDetails> {
-        self.rewarded_set_detailed()
-            .await
-            .value
-            .into_iter()
-            .map(|bond| bond.mixnode_details)
-            .collect()
-    }
-
-    pub async fn active_set_detailed(&self) -> Cache<Vec<MixNodeBondAnnotated>> {
+    pub async fn active_set(&self) -> Cache<Vec<MixNodeDetails>> {
         match time::timeout(Duration::from_millis(100), self.inner.read()).await {
             Ok(cache) => cache.active_set.clone(),
             Err(e) => {
@@ -527,15 +444,6 @@ impl ValidatorCache {
                 Cache::new(Vec::new())
             }
         }
-    }
-
-    pub async fn active_set(&self) -> Vec<MixNodeDetails> {
-        self.active_set_detailed()
-            .await
-            .value
-            .into_iter()
-            .map(|bond| bond.mixnode_details)
-            .collect()
     }
 
     pub(crate) async fn interval_reward_params(&self) -> Cache<Option<RewardingParams>> {
@@ -558,24 +466,21 @@ impl ValidatorCache {
         }
     }
 
-    pub async fn mixnode_details(
-        &self,
-        mix_id: MixId,
-    ) -> (Option<MixNodeBondAnnotated>, MixnodeStatus) {
+    pub async fn mixnode_details(&self, mix_id: MixId) -> (Option<MixNodeDetails>, MixnodeStatus) {
         // it might not be the most optimal to possibly iterate the entire vector to find (or not)
         // the relevant value. However, the vectors are relatively small (< 10_000 elements, < 1000 for active set)
 
-        let active_set = &self.active_set_detailed().await.value;
+        let active_set = &self.active_set().await.value;
         if let Some(bond) = active_set.iter().find(|mix| mix.mix_id() == mix_id) {
             return (Some(bond.clone()), MixnodeStatus::Active);
         }
 
-        let rewarded_set = &self.rewarded_set_detailed().await.value;
+        let rewarded_set = &self.rewarded_set().await.value;
         if let Some(bond) = rewarded_set.iter().find(|mix| mix.mix_id() == mix_id) {
             return (Some(bond.clone()), MixnodeStatus::Standby);
         }
 
-        let all_bonded = &self.mixnodes_detailed().await;
+        let all_bonded = &self.mixnodes().await;
         if let Some(bond) = all_bonded.iter().find(|mix| mix.mix_id() == mix_id) {
             (Some(bond.clone()), MixnodeStatus::Inactive)
         } else {

--- a/validator-api/src/contract_cache/routes.rs
+++ b/validator-api/src/contract_cache/routes.rs
@@ -1,13 +1,19 @@
 // Copyright 2021-2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::contract_cache::ValidatorCache;
-use mixnet_contract_common::mixnode::MixNodeDetails;
-use mixnet_contract_common::reward_params::RewardingParams;
-use mixnet_contract_common::{GatewayBond, Interval, MixId};
-use rocket::response::Redirect;
-use rocket::serde::json::Json;
-use rocket::State;
+use crate::{
+    contract_cache::ValidatorCache,
+    node_status_api::{
+        helpers::{_get_active_set_detailed, _get_mixnodes_detailed, _get_rewarded_set_detailed},
+        NodeStatusCache,
+    },
+};
+use mixnet_contract_common::{
+    mixnode::MixNodeDetails, reward_params::RewardingParams, GatewayBond, Interval, MixId,
+};
+use validator_api_requests::models::MixNodeBondAnnotated;
+
+use rocket::{serde::json::Json, State};
 use rocket_okapi::openapi;
 use std::collections::HashSet;
 
@@ -17,10 +23,19 @@ pub async fn get_mixnodes(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeDeta
     Json(cache.mixnodes().await)
 }
 
+// DEPRECATED: this endpoint now lives in `node_status_api`. Once all consumers are updated,
+// replace this with
+// ```
+//  pub fn get_mixnodes_detailed() -> Redirect {
+//      Redirect::to(uri!("/v1/status/mixnodes/detailed"))
+//  }
+// ```
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/detailed")]
-pub fn get_mixnodes_detailed() -> Redirect {
-    Redirect::to(uri!("/v1/status/mixnodes/detailed"))
+pub async fn get_mixnodes_detailed(
+    cache: &State<NodeStatusCache>,
+) -> Json<Vec<MixNodeBondAnnotated>> {
+    Json(_get_mixnodes_detailed(cache).await)
 }
 
 #[openapi(tag = "contract-cache")]
@@ -35,10 +50,19 @@ pub async fn get_rewarded_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNode
     Json(cache.rewarded_set().await.value)
 }
 
+// DEPRECATED: this endpoint now lives in `node_status_api`. Once all consumers are updated,
+// replace this with
+// ```
+//  pub fn get_mixnodes_set_detailed() -> Redirect {
+//      Redirect::to(uri!("/v1/status/mixnodes/rewarded/detailed"))
+//  }
+// ```
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/rewarded/detailed")]
-pub fn get_rewarded_set_detailed() -> Redirect {
-    Redirect::to(uri!("/status/mixnodes/rewarded/detailed"))
+pub async fn get_rewarded_set_detailed(
+    cache: &State<NodeStatusCache>,
+) -> Json<Vec<MixNodeBondAnnotated>> {
+    Json(_get_rewarded_set_detailed(cache).await)
 }
 
 #[openapi(tag = "contract-cache")]
@@ -47,10 +71,19 @@ pub async fn get_active_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeDe
     Json(cache.active_set().await.value)
 }
 
+// DEPRECATED: this endpoint now lives in `node_status_api`. Once all consumers are updated,
+// replace this with
+// ```
+//  pub fn get_active_set_detailed() -> Redirect {
+//      Redirect::to(uri!("/status/mixnodes/active/detailed"))
+//  }
+// ```
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/active/detailed")]
-pub fn get_active_set_detailed() -> Redirect {
-    Redirect::to(uri!("/status/mixnodes/active/detailed"))
+pub async fn get_active_set_detailed(
+    cache: &State<NodeStatusCache>,
+) -> Json<Vec<MixNodeBondAnnotated>> {
+    Json(_get_active_set_detailed(cache).await)
 }
 
 #[openapi(tag = "contract-cache")]

--- a/validator-api/src/contract_cache/routes.rs
+++ b/validator-api/src/contract_cache/routes.rs
@@ -5,11 +5,11 @@ use crate::contract_cache::ValidatorCache;
 use mixnet_contract_common::mixnode::MixNodeDetails;
 use mixnet_contract_common::reward_params::RewardingParams;
 use mixnet_contract_common::{GatewayBond, Interval, MixId};
+use rocket::response::Redirect;
 use rocket::serde::json::Json;
 use rocket::State;
 use rocket_okapi::openapi;
 use std::collections::HashSet;
-use validator_api_requests::models::MixNodeBondAnnotated;
 
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes")]
@@ -19,10 +19,8 @@ pub async fn get_mixnodes(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeDeta
 
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/detailed")]
-pub async fn get_mixnodes_detailed(
-    cache: &State<ValidatorCache>,
-) -> Json<Vec<MixNodeBondAnnotated>> {
-    Json(cache.mixnodes_detailed().await)
+pub fn get_mixnodes_detailed() -> Redirect {
+    Redirect::to(uri!("/v1/status/mixnodes/detailed"))
 }
 
 #[openapi(tag = "contract-cache")]
@@ -34,29 +32,25 @@ pub async fn get_gateways(cache: &State<ValidatorCache>) -> Json<Vec<GatewayBond
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/rewarded")]
 pub async fn get_rewarded_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeDetails>> {
-    Json(cache.rewarded_set().await)
+    Json(cache.rewarded_set().await.value)
 }
 
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/rewarded/detailed")]
-pub async fn get_rewarded_set_detailed(
-    cache: &State<ValidatorCache>,
-) -> Json<Vec<MixNodeBondAnnotated>> {
-    Json(cache.rewarded_set_detailed().await.value)
+pub fn get_rewarded_set_detailed() -> Redirect {
+    Redirect::to(uri!("/status/mixnodes/rewarded/detailed"))
 }
 
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/active")]
 pub async fn get_active_set(cache: &State<ValidatorCache>) -> Json<Vec<MixNodeDetails>> {
-    Json(cache.active_set().await)
+    Json(cache.active_set().await.value)
 }
 
 #[openapi(tag = "contract-cache")]
 #[get("/mixnodes/active/detailed")]
-pub async fn get_active_set_detailed(
-    cache: &State<ValidatorCache>,
-) -> Json<Vec<MixNodeBondAnnotated>> {
-    Json(cache.active_set_detailed().await.value)
+pub fn get_active_set_detailed() -> Redirect {
+    Redirect::to(uri!("/status/mixnodes/active/detailed"))
 }
 
 #[openapi(tag = "contract-cache")]

--- a/validator-api/src/epoch_operations/mod.rs
+++ b/validator-api/src/epoch_operations/mod.rs
@@ -156,7 +156,7 @@ impl RewardedSetUpdater {
             Err(err) => {
                 warn!("failed to obtain the current rewarded set - {}. falling back to the cached version", err);
                 self.validator_cache
-                    .rewarded_set_detailed()
+                    .rewarded_set()
                     .await
                     .into_inner()
                     .into_iter()

--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -578,7 +578,6 @@ async fn run_validator_api(matches: ArgMatches) -> Result<()> {
             signing_nymd_client.clone(),
             config.get_caching_interval(),
             validator_cache.clone(),
-            Some(storage.clone()),
         );
         let validator_cache_listener = validator_cache_refresher.subscribe();
         let shutdown_listener = shutdown.subscribe();
@@ -600,7 +599,6 @@ async fn run_validator_api(matches: ArgMatches) -> Result<()> {
             nymd_client,
             config.get_caching_interval(),
             validator_cache.clone(),
-            None,
         );
         let validator_cache_listener = validator_cache_refresher.subscribe();
         let shutdown_listener = shutdown.subscribe();
@@ -612,11 +610,13 @@ async fn run_validator_api(matches: ArgMatches) -> Result<()> {
     // Spawn the node status cache refresher.
     // It is primarily refreshed in-sync with the validator cache, however provide a fallback
     // caching interval that is twice the validator cache
+    let storage = rocket.state::<ValidatorApiStorage>().cloned();
     let mut validator_api_cache_refresher = node_status_api::NodeStatusCacheRefresher::new(
         node_status_cache,
+        config.get_caching_interval().saturating_mul(2),
         validator_cache,
         validator_cache_listener,
-        config.get_caching_interval().saturating_mul(2),
+        storage,
     );
     let shutdown_listener = shutdown.subscribe();
     tokio::spawn(async move { validator_api_cache_refresher.run(shutdown_listener).await });

--- a/validator-api/src/node_status_api/cache.rs
+++ b/validator-api/src/node_status_api/cache.rs
@@ -20,6 +20,8 @@ use validator_api_requests::models::{MixNodeBondAnnotated, MixnodeStatus};
 
 use self::inclusion_probabilities::InclusionProbabilities;
 
+use super::reward_estimate::{compute_apy_from_reward, compute_reward_estimate};
+
 mod inclusion_probabilities;
 
 const CACHE_TIMOUT_MS: u64 = 100;
@@ -319,8 +321,7 @@ impl NodeStatusCacheRefresher {
 
             let rewarded_set_status = rewarded_set.get(&mixnode.mix_id()).copied();
 
-            // WIP(JON): these functions (and module) probably needs to be moved
-            let reward_estimate = crate::contract_cache::reward_estimate::compute_reward_estimate(
+            let reward_estimate = compute_reward_estimate(
                 &mixnode,
                 performance,
                 rewarded_set_status,
@@ -329,11 +330,7 @@ impl NodeStatusCacheRefresher {
             );
 
             let (estimated_operator_apy, estimated_delegators_apy) =
-                crate::contract_cache::reward_estimate::compute_apy_from_reward(
-                    &mixnode,
-                    reward_estimate,
-                    current_interval,
-                );
+                compute_apy_from_reward(&mixnode, reward_estimate, current_interval);
 
             annotated.push(MixNodeBondAnnotated {
                 mixnode_details: mixnode,

--- a/validator-api/src/node_status_api/cache/inclusion_probabilities.rs
+++ b/validator-api/src/node_status_api/cache/inclusion_probabilities.rs
@@ -1,0 +1,89 @@
+use contracts_common::truncate_decimal;
+use mixnet_contract_common::{MixId, MixNodeDetails, RewardingParams};
+use serde::Serialize;
+use std::time::Duration;
+use tap::TapFallible;
+use validator_api_requests::models::InclusionProbability;
+
+const MAX_SIMULATION_SAMPLES: u64 = 5000;
+const MAX_SIMULATION_TIME_SEC: u64 = 15;
+
+#[derive(Clone, Default, Serialize, schemars::JsonSchema)]
+pub(crate) struct InclusionProbabilities {
+    pub inclusion_probabilities: Vec<InclusionProbability>,
+    pub samples: u64,
+    pub elapsed: Duration,
+    pub delta_max: f64,
+    pub delta_l2: f64,
+}
+
+impl InclusionProbabilities {
+    pub(crate) fn compute(
+        mixnodes: &[MixNodeDetails],
+        params: RewardingParams,
+    ) -> Option<InclusionProbabilities> {
+        compute_inclusion_probabilities(mixnodes, params)
+    }
+
+    pub(crate) fn node(&self, mix_id: MixId) -> Option<&InclusionProbability> {
+        self.inclusion_probabilities
+            .iter()
+            .find(|x| x.mix_id == mix_id)
+    }
+}
+
+fn compute_inclusion_probabilities(
+    mixnodes: &[MixNodeDetails],
+    params: RewardingParams,
+) -> Option<InclusionProbabilities> {
+    let active_set_size = params.active_set_size;
+    let standby_set_size = params.rewarded_set_size - active_set_size;
+
+    // Unzip list of total bonds into ids and bonds.
+    // We need to go through this zip/unzip procedure to make sure we have matching identities
+    // for the input to the simulator, which assumes the identity is the position in the vec
+    let (ids, mixnode_total_bonds) = unzip_into_mixnode_ids_and_total_bonds(mixnodes);
+
+    // Compute inclusion probabilitites and keep track of how long time it took.
+    let mut rng = rand::thread_rng();
+    let results = inclusion_probability::simulate_selection_probability_mixnodes(
+        &mixnode_total_bonds,
+        active_set_size as usize,
+        standby_set_size as usize,
+        MAX_SIMULATION_SAMPLES,
+        Duration::from_secs(MAX_SIMULATION_TIME_SEC),
+        &mut rng,
+    )
+    .tap_err(|err| error!("{err}"))
+    .ok()?;
+
+    Some(InclusionProbabilities {
+        inclusion_probabilities: zip_ids_together_with_results(&ids, &results),
+        samples: results.samples,
+        elapsed: results.time,
+        delta_max: results.delta_max,
+        delta_l2: results.delta_l2,
+    })
+}
+
+fn unzip_into_mixnode_ids_and_total_bonds(mixnodes: &[MixNodeDetails]) -> (Vec<MixId>, Vec<u128>) {
+    mixnodes
+        .iter()
+        .map(|m| (m.mix_id(), truncate_decimal(m.total_stake()).u128()))
+        .unzip()
+}
+
+fn zip_ids_together_with_results(
+    ids: &[MixId],
+    results: &inclusion_probability::SelectionProbability,
+) -> Vec<InclusionProbability> {
+    ids.iter()
+        .zip(results.active_set_probability.iter())
+        .zip(results.reserve_set_probability.iter())
+        .map(|((&mix_id, a), r)| InclusionProbability {
+            mix_id,
+            in_active: *a,
+            in_reserve: *r,
+        })
+        .collect()
+}

--- a/validator-api/src/node_status_api/helpers.rs
+++ b/validator-api/src/node_status_api/helpers.rs
@@ -1,7 +1,6 @@
 // Copyright 2021-2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::contract_cache::reward_estimate::compute_reward_estimate;
 use crate::contract_cache::Cache;
 use crate::node_status_api::models::ErrorResponse;
 use crate::storage::ValidatorApiStorage;
@@ -17,6 +16,8 @@ use validator_api_requests::models::{
     MixnodeStatusResponse, MixnodeUptimeHistoryResponse, RewardEstimationResponse,
     StakeSaturationResponse, UptimeResponse,
 };
+
+use super::reward_estimate::compute_reward_estimate;
 
 pub(crate) async fn _mixnode_report(
     storage: &ValidatorApiStorage,

--- a/validator-api/src/node_status_api/mod.rs
+++ b/validator-api/src/node_status_api/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod cache;
 pub(crate) mod helpers;
 pub(crate) mod local_guard;
 pub(crate) mod models;
+pub(crate) mod reward_estimate;
 pub(crate) mod routes;
 pub(crate) mod uptime_updater;
 pub(crate) mod utils;

--- a/validator-api/src/node_status_api/mod.rs
+++ b/validator-api/src/node_status_api/mod.rs
@@ -37,6 +37,9 @@ pub(crate) fn node_status_routes(
             routes::get_mixnode_inclusion_probability,
             routes::get_mixnode_avg_uptime,
             routes::get_mixnode_inclusion_probabilities,
+            routes::get_mixnodes_detailed,
+            routes::get_rewarded_set_detailed,
+            routes::get_active_set_detailed,
         ]
     } else {
         // in the minimal variant we would not have access to endpoints relying on existence
@@ -46,6 +49,9 @@ pub(crate) fn node_status_routes(
             routes::get_mixnode_stake_saturation,
             routes::get_mixnode_inclusion_probability,
             routes::get_mixnode_inclusion_probabilities,
+            routes::get_mixnodes_detailed,
+            routes::get_rewarded_set_detailed,
+            routes::get_active_set_detailed,
         ]
     }
 }

--- a/validator-api/src/node_status_api/reward_estimate.rs
+++ b/validator-api/src/node_status_api/reward_estimate.rs
@@ -7,7 +7,7 @@ use mixnet_contract_common::reward_params::{NodeRewardParams, Performance, Rewar
 use mixnet_contract_common::rewarding::RewardEstimate;
 use mixnet_contract_common::{Interval, RewardedSetNodeStatus};
 
-pub fn compute_apy(epochs_in_year: Decimal, reward: Decimal, pledge_amount: Decimal) -> Decimal {
+fn compute_apy(epochs_in_year: Decimal, reward: Decimal, pledge_amount: Decimal) -> Decimal {
     if pledge_amount.is_zero() {
         return Decimal::zero();
     }


### PR DESCRIPTION
# Description

Remove validator storage dependency in the contract cache

# Checklist:

- [x] some way to still support the old endpoints for a while longer
- [ ] added a changelog entry to `CHANGELOG.md`
