### PR TITLE
fix up  operating cost

### DIFF
--- a/nym-wallet/src/components/Bonding/BondedMixnode.tsx
+++ b/nym-wallet/src/components/Bonding/BondedMixnode.tsx
@@ -33,7 +33,7 @@ const headers: Header[] = [
       'The percentage of the node rewards that you as the node operator will take before the rest of the reward is shared between you and the delegators.',
   },
   {
-    header: 'Operator cost',
+    header: 'Operating cost',
     id: 'operator-cost',
     // tooltipText: 'TODO', // TODO
   },
@@ -94,7 +94,7 @@ export const BondedMixnode = ({
       id: 'pm-cell',
     },
     {
-      cell: operatorCost ? `${operatorCost} NYM` : '-',
+      cell: operatorCost ? `${operatorCost.amount} ${operatorCost.denom}` : '-',
       id: 'operator-cost-cell',
     },
     {

--- a/nym-wallet/src/components/Bonding/forms/mixnodeValidationSchema.ts
+++ b/nym-wallet/src/components/Bonding/forms/mixnodeValidationSchema.ts
@@ -37,15 +37,17 @@ export const mixnodeValidationSchema = Yup.object().shape({
 
 const operatingCostAndPmValidation = {
   profitMargin: Yup.number().required('Profit Percentage is required').min(0).max(100),
-  operatorCost: Yup.string()
-    .required('An operating cost is required')
-    .test('valid-operating-cost', 'A valid amount is required (min 40)', async function isValidAmount(this, value) {
-      if (value && (!Number(value) || isLessThan(+value, 40))) {
-        return false;
-      }
+  operatorCost: Yup.object().shape({
+    amount: Yup.string()
+      .required('An operating cost is required')
+      .test('valid-operating-cost', 'A valid amount is required (min 40)', async function isValidAmount(this, value) {
+        if (value && (!Number(value) || isLessThan(+value, 40))) {
+          return false;
+        }
 
-      return true;
-    }),
+        return true;
+      }),
+  }),
 };
 
 export const amountSchema = Yup.object().shape({

--- a/nym-wallet/src/context/bonding.tsx
+++ b/nym-wallet/src/context/bonding.tsx
@@ -54,7 +54,7 @@ export type TBondedMixnode = {
   delegators: number;
   status: MixnodeStatus;
   proxy?: string;
-  operatorCost?: string;
+  operatorCost: DecCoin;
   host: string;
   estimatedRewards?: DecCoin;
   activeSetProbability?: SelectionChance;
@@ -141,7 +141,6 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
     const additionalDetails: {
       status: MixnodeStatus;
       stakeSaturation: string;
-      operatorCost?: string;
       estimatedRewards?: DecCoin;
     } = {
       status: 'not_found',
@@ -163,7 +162,6 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
     }
     try {
       const rewardEstimation = await getMixnodeRewardEstimation(mixId);
-      additionalDetails.operatorCost = unymToNym(rewardEstimation.estimation.operating_cost);
       const estimatedRewards = unymToNym(rewardEstimation.estimation.total_node_reward);
       if (estimatedRewards) {
         additionalDetails.estimatedRewards = {
@@ -240,7 +238,7 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
             bond_information: { mix_id },
           } = data;
 
-          const { status, stakeSaturation, operatorCost, estimatedRewards } = await getAdditionalMixnodeDetails(mix_id);
+          const { status, stakeSaturation, estimatedRewards } = await getAdditionalMixnodeDetails(mix_id);
           const setProbabilities = await getSetProbabilities(mix_id);
           const nodeDescription = await getNodeDescription(
             bond_information.mix_node.host,
@@ -261,7 +259,7 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
             operatorRewards,
             status,
             stakeSaturation,
-            operatorCost,
+            operatorCost: rewarding_details.cost_params.interval_operating_cost,
             host: bond_information.mix_node.host.replace(/\s/g, ''),
             routingScore,
             activeSetProbability: setProbabilities?.in_active,

--- a/nym-wallet/src/context/mocks/bonding.tsx
+++ b/nym-wallet/src/context/mocks/bonding.tsx
@@ -16,7 +16,7 @@ const bondedMixnodeMock: TBondedMixnode = {
   operatorRewards: { denom: 'nym', amount: '1234' },
   delegators: 5423,
   status: 'active',
-  operatorCost: '0.22',
+  operatorCost: { denom: 'nym', amount: '1234' },
   host: '1.2.3.4',
   routingScore: 75,
   activeSetProbability: 'High',

--- a/nym-wallet/src/pages/bonding/node-settings/settings-pages/general-settings/index.tsx
+++ b/nym-wallet/src/pages/bonding/node-settings/settings-pages/general-settings/index.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Divider, Grid } from '@mui/material';
 import { TBondedMixnode, TBondedGateway } from '../../../../../context/bonding';
 import { InfoSettings } from './InfoSettings';
 import { ParametersSettings } from './ParametersSettings';
+import { isMixnode } from 'src/types';
 
 const nodeGeneralNav = ['Info', 'Parameters'];
 
@@ -34,7 +35,7 @@ export const NodeGeneralSettings = ({ bondedNode }: { bondedNode: TBondedMixnode
         </Grid>
         <Divider orientation="vertical" flexItem />
         {settingsCard === nodeGeneralNav[0] && <InfoSettings bondedNode={bondedNode} />}
-        {settingsCard === nodeGeneralNav[1] && <ParametersSettings bondedNode={bondedNode} />}
+        {settingsCard === nodeGeneralNav[1] && isMixnode(bondedNode) && <ParametersSettings bondedNode={bondedNode} />}
       </Grid>
     </Box>
   );


### PR DESCRIPTION
# Description

Operating cost is now available directly through the the "getMixnodeDetails" response. I've updated the type on the frontend and removed a unnecessary extra request. I've also harmonized the operating cost fields and field validations between bonding a new node and updating an existing node.
