### PR TITLE
only display general settings for mixnodes

### DIFF
--- a/nym-wallet/src/components/Bonding/forms/gatewayValidationSchema.ts
+++ b/nym-wallet/src/components/Bonding/forms/gatewayValidationSchema.ts
@@ -1,5 +1,6 @@
 import * as Yup from 'yup';
 import {
+  isLessThan,
   isValidHostname,
   validateAmount,
   validateKey,
@@ -53,6 +54,17 @@ export const amountSchema = Yup.object().shape({
         if (!isValid) {
           return this.createError({ message: 'A valid amount is required (min 100)' });
         }
+        return true;
+      }),
+  }),
+  operatorCost: Yup.object().shape({
+    amount: Yup.string()
+      .required('An operating cost is required')
+      .test('valid-operating-cost', 'A valid amount is required (min 40)', async function isValidAmount(this, value) {
+        if (value && (!Number(value) || isLessThan(+value, 40))) {
+          return false;
+        }
+
         return true;
       }),
   }),

--- a/nym-wallet/src/components/Bonding/modals/BondGatewayModal.tsx
+++ b/nym-wallet/src/components/Bonding/modals/BondGatewayModal.tsx
@@ -24,7 +24,7 @@ const defaultGatewayValues: GatewayData = {
 
 const defaultAmountValues = (denom: CurrencyDenom) => ({
   amount: { amount: '100', denom },
-  operatorCost: { amount: '0', denom },
+  operatorCost: { amount: '40', denom },
   tokenPool: 'balance',
 });
 

--- a/nym-wallet/src/pages/bonding/node-settings/NodeSettings.tsx
+++ b/nym-wallet/src/pages/bonding/node-settings/NodeSettings.tsx
@@ -15,7 +15,8 @@ import { AppContext, urls } from 'src/context/main';
 
 import { NodeGeneralSettings } from './settings-pages/general-settings';
 import { NodeUnbondPage } from './settings-pages/NodeUnbondPage';
-import { navItems, NodeSettingsNav } from './node-settings.constant';
+import { createNavItems } from './node-settings.constant';
+import { isMixnode } from 'src/types';
 
 export const NodeSettings = () => {
   const theme = useTheme();
@@ -25,9 +26,9 @@ export const NodeSettings = () => {
   const location = useLocation();
 
   const [confirmationDetails, setConfirmationDetails] = useState<ConfirmationDetailProps>();
-  const [value, setValue] = React.useState<NodeSettingsNav>('General');
+  const [value, setValue] = React.useState('General');
   const handleChange = (event: React.SyntheticEvent, tab: string) => {
-    setValue(tab as NodeSettingsNav);
+    setValue(tab);
   };
 
   useEffect(() => {
@@ -53,6 +54,11 @@ export const NodeSettings = () => {
     });
   };
 
+  if (!bondedNode) {
+    navigate('/bond');
+    return <></>;
+  }
+
   return (
     <PageLayout>
       <NymCard
@@ -76,7 +82,7 @@ export const NodeSettings = () => {
             </Box>
             <Box sx={{ width: '100%' }}>
               <Tabs
-                tabs={navItems}
+                tabs={createNavItems(isMixnode(bondedNode))}
                 selectedTab={value}
                 onChange={handleChange}
                 tabSx={{

--- a/nym-wallet/src/pages/bonding/node-settings/NodeSettings.tsx
+++ b/nym-wallet/src/pages/bonding/node-settings/NodeSettings.tsx
@@ -55,8 +55,7 @@ export const NodeSettings = () => {
   };
 
   if (!bondedNode) {
-    navigate('/bond');
-    return <></>;
+    return null;
   }
 
   return (

--- a/nym-wallet/src/pages/bonding/node-settings/node-settings.constant.tsx
+++ b/nym-wallet/src/pages/bonding/node-settings/node-settings.constant.tsx
@@ -1,3 +1,5 @@
-export const navItems = ['General', 'Unbond'] as const;
-
-export type NodeSettingsNav = typeof navItems[number]; // type NodeSettingsNav = 'General' | 'Unbond';
+export const createNavItems = (isMixnode: boolean) => {
+  const navItems = ['Unbond'];
+  if (isMixnode) return ['General', ...navItems];
+  return navItems;
+};


### PR DESCRIPTION
# Description

Prevent mixnode general settings being accessed when a gateway is bonded

Closes: https://github.com/nymtech/nym/issues/2224
