### PR TITLE
fix(explorer): mixnode location overflow

### DIFF
--- a/explorer/src/pages/Mixnodes/index.tsx
+++ b/explorer/src/pages/Mixnodes/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
-import { Button, Card, Grid, Link as MuiLink } from '@mui/material';
+import { Button, Card, Grid, Link as MuiLink, Tooltip, Box } from '@mui/material';
 import { Link as RRDLink, useParams, useNavigate } from 'react-router-dom';
 import { SelectChangeEvent } from '@mui/material/Select';
 import { SxProps } from '@mui/system';
@@ -244,7 +244,34 @@ export const PageMixnodes: React.FC = () => {
             justifyContent: 'flex-start',
           }}
         >
-          {params.value}
+          <Tooltip
+            title={params.value}
+            id="location-long-text"
+            placement="top-start"
+            componentsProps={{
+              tooltip: {
+                sx: {
+                  maxWidth: 200,
+                  background: theme.palette.nym.networkExplorer.tooltip.background,
+                  color: theme.palette.nym.networkExplorer.tooltip.color,
+                  '& .MuiTooltip-arrow': {
+                    color: theme.palette.nym.networkExplorer.tooltip.background,
+                  },
+                },
+              },
+            }}
+            arrow
+          >
+            <Box
+              sx={{
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {params.value}
+            </Box>
+          </Tooltip>
         </Button>
       ),
     },


### PR DESCRIPTION
# Description

Closes: NE mixnodes list, location overflow
![image](https://user-images.githubusercontent.com/6359431/198059986-2a858561-63fc-4893-a357-03b4a00cda27.png)
![image](https://user-images.githubusercontent.com/6359431/198060330-072cf477-1652-401c-a858-8ddf7bb88d92.png)

nymtech/nym#2219
