### PR TITLE
client: additional error handling in client + socks5-client + network-requester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - native-client/socks5-client: `use_extended_packet_size` Debug config option to make the client use 'ExtendedPacketSize' for its traffic (32kB as opposed to 2kB in 1.0.2) ([#1671])
 - wasm-client: uses updated wasm-compatible `client-core` so that it's now capable of packet retransmission, cover traffic and poisson delay (among other things!) ([#1673])
 - validator-api: add `interval_operating_cost` and `profit_margin_percent` to cmpute reward estimation endpoint
-- native-client: improve handling error cases ([#1713])
+- native-client/socks5-client/network-requester: improve handling error cases ([#1713])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - native-client/socks5-client: `use_extended_packet_size` Debug config option to make the client use 'ExtendedPacketSize' for its traffic (32kB as opposed to 2kB in 1.0.2) ([#1671])
 - wasm-client: uses updated wasm-compatible `client-core` so that it's now capable of packet retransmission, cover traffic and poisson delay (among other things!) ([#1673])
 - validator-api: add `interval_operating_cost` and `profit_margin_percent` to cmpute reward estimation endpoint
+- native-client: improve handling error cases ([#1713])
 
 ### Fixed
 
@@ -43,6 +44,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1673]: https://github.com/nymtech/nym/pull/1673
 [#1702]: https://github.com/nymtech/nym/pull/1702
 [#1703]: https://github.com/nymtech/nym/pull/1703
+[#1713]: https://github.com/nymtech/nym/pull/1713
 
 
 ## [nym-binaries-1.0.2](https://github.com/nymtech/nym/tree/nym-binaries-1.0.2)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3304,6 +3304,7 @@ dependencies = [
  "snafu 0.6.10",
  "socks5-requests",
  "task",
+ "thiserror",
  "tokio",
  "topology",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,6 +3132,7 @@ dependencies = [
  "serde_json",
  "sled",
  "task",
+ "thiserror",
  "tokio",
  "tokio-tungstenite 0.14.0",
  "topology",

--- a/clients/client-core/src/error.rs
+++ b/clients/client-core/src/error.rs
@@ -24,4 +24,6 @@ pub enum ClientCoreError {
     ListOfValidatorApisIsEmpty,
     #[error("Could not load existing gateway configuration: {0}")]
     CouldNotLoadExistingGatewayConfiguration(std::io::Error),
+    #[error("The current network topology seem to be insufficient to route any packets through")]
+    InsufficientNetworkTopology,
 }

--- a/clients/native/Cargo.toml
+++ b/clients/native/Cargo.toml
@@ -27,6 +27,7 @@ pretty_env_logger = "0.4" # for formatting log messages
 rand = { version = "0.7.3", features = ["wasm-bindgen"] } # rng-related traits + some rng implementation to use
 serde = { version = "1.0.104", features = ["derive"] } # for config serialization/deserialization
 sled = "0.34" # for storage of replySURB decryption keys
+thiserror = "1.0.34"
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "net", "signal"] } # async runtime
 tokio-tungstenite = "0.14" # websocket
 

--- a/clients/native/src/client/mod.rs
+++ b/clients/native/src/client/mod.rs
@@ -18,6 +18,7 @@ use client_core::client::topology_control::{
     TopologyAccessor, TopologyRefresher, TopologyRefresherConfig,
 };
 use client_core::config::persistence::key_pathfinder::ClientKeyPathfinder;
+use client_core::error::ClientCoreError;
 use crypto::asymmetric::identity;
 use futures::channel::mpsc;
 use gateway_client::bandwidth::BandwidthController;
@@ -34,6 +35,7 @@ use nymsphinx::receiver::ReconstructedMessage;
 use task::{wait_for_signal, ShutdownListener, ShutdownNotifier};
 
 use crate::client::config::{Config, SocketType};
+use crate::error::ClientError;
 use crate::websocket;
 
 pub(crate) mod config;
@@ -231,7 +233,7 @@ impl NymClient {
         &mut self,
         topology_accessor: TopologyAccessor,
         shutdown: ShutdownListener,
-    ) {
+    ) -> Result<(), ClientError> {
         let topology_refresher_config = TopologyRefresherConfig::new(
             self.config.get_base().get_validator_api_endpoints(),
             self.config.get_base().get_topology_refresh_rate(),
@@ -246,14 +248,16 @@ impl NymClient {
 
         // TODO: a slightly more graceful termination here
         if !topology_refresher.is_topology_routable().await {
-            panic!(
-                "The current network topology seem to be insufficient to route any packets through\
+            log::error!(
+                "The current network topology seem to be insufficient to route any packets through \
                 - check if enough nodes and a gateway are online"
             );
+            return Err(ClientCoreError::InsufficientNetworkTopology.into());
         }
 
         info!("Starting topology refresher...");
         topology_refresher.start_with_shutdown(shutdown);
+        Ok(())
     }
 
     // controller for sending sphinx packets to mixnet (either real traffic or cover traffic)
@@ -327,8 +331,8 @@ impl NymClient {
     }
 
     /// blocking version of `start` method. Will run forever (or until SIGINT is sent)
-    pub async fn run_forever(&mut self) {
-        let shutdown = self.start().await;
+    pub async fn run_forever(&mut self) -> Result<(), ClientError> {
+        let shutdown = self.start().await?;
         wait_for_signal().await;
 
         println!(
@@ -345,9 +349,10 @@ impl NymClient {
         //shutdown.wait_for_shutdown().await;
 
         log::info!("Stopping nym-client");
+        Ok(())
     }
 
-    pub async fn start(&mut self) -> ShutdownNotifier {
+    pub async fn start(&mut self) -> Result<ShutdownNotifier, ClientError> {
         info!("Starting nym client");
         // channels for inter-component communication
         // TODO: make the channels be internally created by the relevant components
@@ -378,7 +383,7 @@ impl NymClient {
         // the components are started in very specific order. Unless you know what you are doing,
         // do not change that.
         self.start_topology_refresher(shared_topology_accessor.clone(), shutdown.subscribe())
-            .await;
+            .await?;
         self.start_received_messages_buffer_controller(
             received_buffer_request_receiver,
             mixnet_messages_receiver,
@@ -442,6 +447,6 @@ impl NymClient {
         info!("Client startup finished!");
         info!("The address of this client is: {}", self.as_mix_recipient());
 
-        shutdown
+        Ok(shutdown)
     }
 }

--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::client::config::{Config, SocketType};
+use crate::error::ClientError;
 use clap::CommandFactory;
 use clap::{Parser, Subcommand};
 use completions::{fig_generate, ArgShell};
@@ -83,16 +84,17 @@ pub(crate) struct OverrideConfig {
     enabled_credentials_mode: bool,
 }
 
-pub(crate) async fn execute(args: &Cli) {
+pub(crate) async fn execute(args: &Cli) -> Result<(), ClientError> {
     let bin_name = "nym-native-client";
 
     match &args.command {
         Commands::Init(m) => init::execute(m).await,
-        Commands::Run(m) => run::execute(m).await,
+        Commands::Run(m) => run::execute(m).await?,
         Commands::Upgrade(m) => upgrade::execute(m),
         Commands::Completions(s) => s.generate(&mut Cli::into_app(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut Cli::into_app(), bin_name),
     }
+    Ok(())
 }
 
 pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Config {

--- a/clients/native/src/commands/run.rs
+++ b/clients/native/src/commands/run.rs
@@ -3,7 +3,8 @@
 
 use crate::{
     client::{config::Config, NymClient},
-    commands::{override_config, OverrideConfig}, error::ClientError,
+    commands::{override_config, OverrideConfig},
+    error::ClientError,
 };
 
 use clap::Args;
@@ -80,8 +81,7 @@ pub(crate) async fn execute(args: &Run) -> Result<(), ClientError> {
         Ok(cfg) => cfg,
         Err(err) => {
             error!("Failed to load config for {}. Are you sure you have run `init` before? (Error was: {})", id, err);
-            // WIP(JON)
-            return Ok(());
+            return Err(ClientError::FailedToLoadConfig(id.to_string()));
         }
     };
 
@@ -90,8 +90,7 @@ pub(crate) async fn execute(args: &Run) -> Result<(), ClientError> {
 
     if !version_check(&config) {
         error!("failed the local version check");
-        // WIP(JON)
-        return Ok(());
+        return Err(ClientError::FailedLocalVersionCheck);
     }
 
     NymClient::new(config).run_forever().await

--- a/clients/native/src/commands/run.rs
+++ b/clients/native/src/commands/run.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     client::{config::Config, NymClient},
-    commands::{override_config, OverrideConfig},
+    commands::{override_config, OverrideConfig}, error::ClientError,
 };
 
 use clap::Args;
@@ -73,14 +73,15 @@ fn version_check(cfg: &Config) -> bool {
     }
 }
 
-pub(crate) async fn execute(args: &Run) {
+pub(crate) async fn execute(args: &Run) -> Result<(), ClientError> {
     let id = &args.id;
 
     let mut config = match Config::load_from_file(Some(id)) {
         Ok(cfg) => cfg,
         Err(err) => {
             error!("Failed to load config for {}. Are you sure you have run `init` before? (Error was: {})", id, err);
-            return;
+            // WIP(JON)
+            return Ok(());
         }
     };
 
@@ -89,8 +90,9 @@ pub(crate) async fn execute(args: &Run) {
 
     if !version_check(&config) {
         error!("failed the local version check");
-        return;
+        // WIP(JON)
+        return Ok(());
     }
 
-    NymClient::new(config).run_forever().await;
+    NymClient::new(config).run_forever().await
 }

--- a/clients/native/src/error.rs
+++ b/clients/native/src/error.rs
@@ -1,0 +1,21 @@
+use client_core::error::ClientCoreError;
+use crypto::asymmetric::identity::Ed25519RecoveryError;
+use gateway_client::error::GatewayClientError;
+use validator_client::ValidatorClientError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ClientError {
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("Gateway client error: {0}")]
+    GatewayClientError(#[from] GatewayClientError),
+    #[error("Ed25519 error: {0}")]
+    Ed25519RecoveryError(#[from] Ed25519RecoveryError),
+    #[error("Validator client error: {0}")]
+    ValidatorClientError(#[from] ValidatorClientError),
+    #[error("client-core error: {0}")]
+    ClientCoreError(#[from] ClientCoreError),
+
+    #[error("test")]
+    Test,
+}

--- a/clients/native/src/error.rs
+++ b/clients/native/src/error.rs
@@ -16,6 +16,8 @@ pub enum ClientError {
     #[error("client-core error: {0}")]
     ClientCoreError(#[from] ClientCoreError),
 
-    #[error("test")]
-    Test,
+    #[error("Failed to load config for: {0}")]
+    FailedToLoadConfig(String),
+    #[error("Failed local version check, client and config mismatch")]
+    FailedLocalVersionCheck,
 }

--- a/clients/native/src/lib.rs
+++ b/clients/native/src/lib.rs
@@ -3,3 +3,4 @@
 
 pub mod client;
 pub mod websocket;
+pub mod error;

--- a/clients/native/src/lib.rs
+++ b/clients/native/src/lib.rs
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod client;
-pub mod websocket;
 pub mod error;
+pub mod websocket;

--- a/clients/native/src/main.rs
+++ b/clients/native/src/main.rs
@@ -2,20 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{crate_version, Parser};
+use error::ClientError;
 use network_defaults::setup_env;
 
 pub mod client;
 pub mod commands;
+pub mod error;
 pub mod websocket;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), ClientError> {
     setup_logging();
     println!("{}", banner());
 
     let args = commands::Cli::parse();
     setup_env(args.config_env_file.clone());
-    commands::execute(&args).await;
+    commands::execute(&args).await
 }
 
 fn banner() -> String {

--- a/clients/native/src/main.rs
+++ b/clients/native/src/main.rs
@@ -47,14 +47,14 @@ fn setup_logging() {
     }
 
     log_builder
-        .filter_module("hyper", log::LevelFilter::Warn)
-        .filter_module("tokio_reactor", log::LevelFilter::Warn)
-        .filter_module("reqwest", log::LevelFilter::Warn)
-        .filter_module("mio", log::LevelFilter::Warn)
-        .filter_module("want", log::LevelFilter::Warn)
-        .filter_module("tungstenite", log::LevelFilter::Warn)
-        .filter_module("tokio_tungstenite", log::LevelFilter::Warn)
         .filter_module("handlebars", log::LevelFilter::Warn)
+        .filter_module("hyper", log::LevelFilter::Warn)
+        .filter_module("mio", log::LevelFilter::Warn)
+        .filter_module("reqwest", log::LevelFilter::Warn)
         .filter_module("sled", log::LevelFilter::Warn)
+        .filter_module("tokio_reactor", log::LevelFilter::Warn)
+        .filter_module("tokio_tungstenite", log::LevelFilter::Warn)
+        .filter_module("tungstenite", log::LevelFilter::Warn)
+        .filter_module("want", log::LevelFilter::Warn)
         .init();
 }

--- a/clients/socks5/Cargo.toml
+++ b/clients/socks5/Cargo.toml
@@ -20,6 +20,7 @@ pretty_env_logger = "0.4"
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }
 serde = { version = "1.0", features = ["derive"] } # for config serialization/deserialization
 snafu = "0.6"
+thiserror = "1.0.34"
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "net", "signal"] }
 url = "2.2"
 

--- a/clients/socks5/src/client/mod.rs
+++ b/clients/socks5/src/client/mod.rs
@@ -4,6 +4,7 @@
 use std::sync::atomic::Ordering;
 
 use crate::client::config::Config;
+use crate::error::Socks5ClientError;
 use crate::socks::{
     authentication::{AuthenticationMethods, Authenticator, User},
     server::SphinxSocksServer,
@@ -23,6 +24,7 @@ use client_core::client::topology_control::{
     TopologyAccessor, TopologyRefresher, TopologyRefresherConfig,
 };
 use client_core::config::persistence::key_pathfinder::ClientKeyPathfinder;
+use client_core::error::ClientCoreError;
 use crypto::asymmetric::identity;
 use futures::channel::mpsc;
 use futures::StreamExt;
@@ -231,7 +233,7 @@ impl NymClient {
         &mut self,
         topology_accessor: TopologyAccessor,
         shutdown: ShutdownListener,
-    ) {
+    ) -> Result<(), Socks5ClientError> {
         let topology_refresher_config = TopologyRefresherConfig::new(
             self.config.get_base().get_validator_api_endpoints(),
             self.config.get_base().get_topology_refresh_rate(),
@@ -246,14 +248,16 @@ impl NymClient {
 
         // TODO: a slightly more graceful termination here
         if !topology_refresher.is_topology_routable().await {
-            panic!(
-                "The current network topology seem to be insufficient to route any packets through\
+            log::error!(
+                "The current network topology seem to be insufficient to route any packets through \
                 - check if enough nodes and a gateway are online"
             );
+            return Err(ClientCoreError::InsufficientNetworkTopology.into());
         }
 
         info!("Starting topology refresher...");
         topology_refresher.start_with_shutdown(shutdown);
+        Ok(())
     }
 
     // controller for sending sphinx packets to mixnet (either real traffic or cover traffic)
@@ -292,8 +296,8 @@ impl NymClient {
     }
 
     /// blocking version of `start` method. Will run forever (or until SIGINT is sent)
-    pub async fn run_forever(&mut self) {
-        let mut shutdown = self.start().await;
+    pub async fn run_forever(&mut self) -> Result<(), Socks5ClientError> {
+        let mut shutdown = self.start().await?;
         wait_for_signal().await;
 
         log::info!("Sending shutdown");
@@ -304,11 +308,15 @@ impl NymClient {
         shutdown.wait_for_shutdown().await;
 
         log::info!("Stopping nym-socks5-client");
+        Ok(())
     }
 
     // Variant of `run_forever` that listends for remote control messages
-    pub async fn run_and_listen(&mut self, mut receiver: Socks5ControlMessageReceiver) {
-        let mut shutdown = self.start().await;
+    pub async fn run_and_listen(
+        &mut self,
+        mut receiver: Socks5ControlMessageReceiver,
+    ) -> Result<(), Socks5ClientError> {
+        let mut shutdown = self.start().await?;
         tokio::select! {
             message = receiver.next() => {
                 log::debug!("Received message: {:?}", message);
@@ -334,9 +342,10 @@ impl NymClient {
         shutdown.wait_for_shutdown().await;
 
         log::info!("Stopping nym-socks5-client");
+        Ok(())
     }
 
-    pub async fn start(&mut self) -> ShutdownNotifier {
+    pub async fn start(&mut self) -> Result<ShutdownNotifier, Socks5ClientError> {
         info!("Starting nym client");
         // channels for inter-component communication
         // TODO: make the channels be internally created by the relevant components
@@ -367,7 +376,7 @@ impl NymClient {
         // the components are started in very specific order. Unless you know what you are doing,
         // do not change that.
         self.start_topology_refresher(shared_topology_accessor.clone(), shutdown.subscribe())
-            .await;
+            .await?;
         self.start_received_messages_buffer_controller(
             received_buffer_request_receiver,
             mixnet_messages_receiver,
@@ -416,6 +425,6 @@ impl NymClient {
         info!("Client startup finished!");
         info!("The address of this client is: {}", self.as_mix_recipient());
 
-        shutdown
+        Ok(shutdown)
     }
 }

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::client::config::Config;
+use crate::error::Socks5ClientError;
 use clap::CommandFactory;
 use clap::{Parser, Subcommand};
 use completions::{fig_generate, ArgShell};
@@ -83,16 +84,17 @@ pub(crate) struct OverrideConfig {
     enabled_credentials_mode: bool,
 }
 
-pub(crate) async fn execute(args: &Cli) {
+pub(crate) async fn execute(args: &Cli) -> Result<(), Socks5ClientError> {
     let bin_name = "nym-socks5-client";
 
     match &args.command {
         Commands::Init(m) => init::execute(m).await,
-        Commands::Run(m) => run::execute(m).await,
+        Commands::Run(m) => run::execute(m).await?,
         Commands::Upgrade(m) => upgrade::execute(m),
         Commands::Completions(s) => s.generate(&mut Cli::into_app(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut Cli::into_app(), bin_name),
     }
+    Ok(())
 }
 
 pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Config {

--- a/clients/socks5/src/error.rs
+++ b/clients/socks5/src/error.rs
@@ -1,0 +1,23 @@
+use client_core::error::ClientCoreError;
+use crypto::asymmetric::identity::Ed25519RecoveryError;
+use gateway_client::error::GatewayClientError;
+use validator_client::ValidatorClientError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Socks5ClientError {
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("Gateway client error: {0}")]
+    GatewayClientError(#[from] GatewayClientError),
+    #[error("Ed25519 error: {0}")]
+    Ed25519RecoveryError(#[from] Ed25519RecoveryError),
+    #[error("Validator client error: {0}")]
+    ValidatorClientError(#[from] ValidatorClientError),
+    #[error("client-core error: {0}")]
+    ClientCoreError(#[from] ClientCoreError),
+
+    #[error("Failed to load config for: {0}")]
+    FailedToLoadConfig(String),
+    #[error("Failed local version check, client and config mismatch")]
+    FailedLocalVersionCheck,
+}

--- a/clients/socks5/src/lib.rs
+++ b/clients/socks5/src/lib.rs
@@ -3,3 +3,4 @@
 
 pub mod client;
 pub mod socks;
+pub mod error;

--- a/clients/socks5/src/lib.rs
+++ b/clients/socks5/src/lib.rs
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod client;
-pub mod socks;
 pub mod error;
+pub mod socks;

--- a/clients/socks5/src/main.rs
+++ b/clients/socks5/src/main.rs
@@ -2,20 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{crate_version, Parser};
+use error::Socks5ClientError;
 use network_defaults::setup_env;
 
 pub mod client;
 mod commands;
+pub mod error;
 pub mod socks;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Socks5ClientError> {
     setup_logging();
     println!("{}", banner());
 
     let args = commands::Cli::parse();
     setup_env(args.config_env_file.clone());
-    commands::execute(&args).await;
+    commands::execute(&args).await
 }
 
 fn banner() -> String {
@@ -45,12 +47,14 @@ fn setup_logging() {
     }
 
     log_builder
+        .filter_module("handlebars", log::LevelFilter::Warn)
         .filter_module("hyper", log::LevelFilter::Warn)
-        .filter_module("tokio_reactor", log::LevelFilter::Warn)
-        .filter_module("reqwest", log::LevelFilter::Warn)
         .filter_module("mio", log::LevelFilter::Warn)
-        .filter_module("want", log::LevelFilter::Warn)
-        .filter_module("tungstenite", log::LevelFilter::Warn)
+        .filter_module("reqwest", log::LevelFilter::Warn)
+        .filter_module("sled", log::LevelFilter::Warn)
+        .filter_module("tokio_reactor", log::LevelFilter::Warn)
         .filter_module("tokio_tungstenite", log::LevelFilter::Warn)
+        .filter_module("tungstenite", log::LevelFilter::Warn)
+        .filter_module("want", log::LevelFilter::Warn)
         .init();
 }

--- a/nym-connect/Cargo.lock
+++ b/nym-connect/Cargo.lock
@@ -3261,6 +3261,7 @@ dependencies = [
  "snafu",
  "socks5-requests",
  "task",
+ "thiserror",
  "tokio",
  "topology",
  "url",

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -22,7 +22,6 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use task::ShutdownListener;
 use tokio_tungstenite::tungstenite::protocol::Message;
-use websocket::WebsocketConnectionError;
 use websocket_requests::{requests::ClientRequest, responses::ServerResponse};
 
 // Since it's an atomic, it's safe to be kept static and shared across threads

--- a/service-providers/network-requester/src/error.rs
+++ b/service-providers/network-requester/src/error.rs
@@ -1,0 +1,10 @@
+use crate::websocket::WebsocketConnectionError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum NetworkRequesterError {
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Websocket error")]
+    WebsocketConnectionError(#[from] WebsocketConnectionError),
+}

--- a/service-providers/network-requester/src/statistics/error.rs
+++ b/service-providers/network-requester/src/statistics/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum StatsError {
-    #[error("Reqwuest error {0}")]
+    #[error("Reqwest error {0}")]
     ReqwestError(#[from] reqwest::Error),
 
     #[error("Invalid stats provider client address")]

--- a/service-providers/network-requester/src/websocket.rs
+++ b/service-providers/network-requester/src/websocket.rs
@@ -22,12 +22,13 @@ impl Connection {
     pub async fn connect(&self) -> Result<TSWebsocketStream, WebsocketConnectionError> {
         match connect_async(&self.uri).await {
             Ok((ws_stream, _)) => Ok(ws_stream),
-            Err(_e) => Err(WebsocketConnectionError::ConnectionNotEstablished),
+            Err(e) => Err(WebsocketConnectionError::ConnectionNotEstablished(e)),
         }
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum WebsocketConnectionError {
-    ConnectionNotEstablished,
+    #[error("Connection not established")]
+    ConnectionNotEstablished(tokio_tungstenite::tungstenite::Error),
 }


### PR DESCRIPTION
# Description

Add error type to `nym-client`, `nym-socks5-client`, `nym-network-requester`, and handle a few errors.
This fixes some local panics I encountered from local usage.

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
