### PR TITLE
Jedrzej/bugfix/historical uptimes recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 ### Fixed
 
 - validator-api, mixnode, gateway should now prefer values in config.toml over mainnet defaults ([#1645])
+- validator-api should now correctly update historical uptimes for all mixnodes and gateways every 24h ([#1721])
 - socks5-client: fix bug where in some cases packet reordering could trigger a connection being closed too early ([#1702],[#1724])
 
 ### Changed
@@ -47,6 +48,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1687]: https://github.com/nymtech/nym/pull/1687
 [#1702]: https://github.com/nymtech/nym/pull/1702
 [#1703]: https://github.com/nymtech/nym/pull/1703
+[#1721]: https://github.com/nymtech/nym/pull/1721
 [#1724]: https://github.com/nymtech/nym/pull/1724
 [#1725]: https://github.com/nymtech/nym/pull/1725
 

--- a/validator-api/src/epoch_operations/mod.rs
+++ b/validator-api/src/epoch_operations/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod error;
 mod helpers;
 
 use crate::epoch_operations::helpers::stake_to_f64;
+use crate::node_status_api::ONE_DAY;
 use error::RewardingError;
 use mixnet_contract_common::mixnode::MixNodeDetails;
 use task::ShutdownListener;
@@ -266,7 +267,7 @@ impl RewardedSetUpdater {
         }
 
         log::info!("Purging old node statuses from the storage...");
-        let cutoff = (epoch_end - Duration::from_secs(86400)).unix_timestamp();
+        let cutoff = (epoch_end - 2 * ONE_DAY).unix_timestamp();
         self.storage.purge_old_statuses(cutoff).await?;
 
         Ok(())

--- a/validator-api/src/epoch_operations/mod.rs
+++ b/validator-api/src/epoch_operations/mod.rs
@@ -50,9 +50,6 @@ impl From<MixnodeToReward> for ExecuteMsg {
     }
 }
 
-// // Epoch has all the same semantics as interval, but has a lower set duration
-// type Epoch = Interval;
-
 pub struct RewardedSetUpdater {
     nymd_client: Client<SigningNymdClient>,
     validator_cache: ValidatorCache,

--- a/validator-api/src/epoch_operations/mod.rs
+++ b/validator-api/src/epoch_operations/mod.rs
@@ -265,7 +265,7 @@ impl RewardedSetUpdater {
             log::info!("Advanced the epoch and updated the rewarded set... SUCCESS");
         }
 
-        log::info!("Puring all node statuses from the storage...");
+        log::info!("Purging old node statuses from the storage...");
         let cutoff = (epoch_end - Duration::from_secs(86400)).unix_timestamp();
         self.storage.purge_old_statuses(cutoff).await?;
 


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1942

Due to incorrectly used futures when shutdown was introduced, validator-api would fail to trigger any subsequent runs of the historical uptime updates; this PR fixes it + makes uptime happen at constant, predictable time as opposed to being based on when the binary was started

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
