### PR TITLE
Jedrzej/feature/version field in framed sphinx packets

### DIFF
--- a/common/client-libs/mixnet-client/src/client.rs
+++ b/common/client-libs/mixnet-client/src/client.rs
@@ -23,6 +23,7 @@ pub struct Config {
     maximum_reconnection_backoff: Duration,
     initial_connection_timeout: Duration,
     maximum_connection_buffer_size: usize,
+    use_legacy_version: bool,
 }
 
 impl Config {
@@ -31,12 +32,14 @@ impl Config {
         maximum_reconnection_backoff: Duration,
         initial_connection_timeout: Duration,
         maximum_connection_buffer_size: usize,
+        use_legacy_version: bool,
     ) -> Self {
         Config {
             initial_reconnection_backoff,
             maximum_reconnection_backoff,
             initial_connection_timeout,
             maximum_connection_buffer_size,
+            use_legacy_version,
         }
     }
 }
@@ -201,7 +204,8 @@ impl SendWithoutResponse for Client {
         packet_mode: PacketMode,
     ) -> io::Result<()> {
         trace!("Sending packet to {:?}", address);
-        let framed_packet = FramedSphinxPacket::new(packet, packet_mode);
+        let framed_packet =
+            FramedSphinxPacket::new(packet, packet_mode, self.config.use_legacy_version);
 
         if let Some(sender) = self.conn_new.get_mut(&address) {
             if let Err(err) = sender.channel.try_send(framed_packet) {
@@ -259,6 +263,7 @@ mod tests {
             maximum_reconnection_backoff: Duration::from_millis(300_000),
             initial_connection_timeout: Duration::from_millis(1_500),
             maximum_connection_buffer_size: 128,
+            use_legacy_version: false,
         })
     }
 

--- a/common/client-libs/mixnet-client/src/forwarder.rs
+++ b/common/client-libs/mixnet-client/src/forwarder.rs
@@ -24,12 +24,14 @@ impl PacketForwarder {
         maximum_reconnection_backoff: Duration,
         initial_connection_timeout: Duration,
         maximum_connection_buffer_size: usize,
+        use_legacy_version: bool,
     ) -> (PacketForwarder, MixForwardingSender) {
         let client_config = Config::new(
             initial_reconnection_backoff,
             maximum_reconnection_backoff,
             initial_connection_timeout,
             maximum_connection_buffer_size,
+            use_legacy_version,
         );
 
         let (packet_sender, packet_receiver) = mpsc::unbounded();

--- a/common/nymsphinx/framing/src/codec.rs
+++ b/common/nymsphinx/framing/src/codec.rs
@@ -6,7 +6,6 @@ use bytes::{Buf, BufMut, BytesMut};
 use nymsphinx_params::packet_modes::InvalidPacketMode;
 use nymsphinx_params::packet_sizes::{InvalidPacketSize, PacketSize};
 use nymsphinx_types::SphinxPacket;
-use std::convert::TryFrom;
 use std::io;
 use tokio_util::codec::{Decoder, Encoder};
 
@@ -75,7 +74,7 @@ impl Decoder for SphinxCodec {
         if src.is_empty() {
             // can't do anything if we have no bytes, but let's reserve enough for the most
             // conservative case, i.e. receiving an ack packet
-            src.reserve(Header::SIZE + PacketSize::AckPacket.size());
+            src.reserve(Header::LEGACY_SIZE + PacketSize::AckPacket.size());
             return Ok(None);
         }
 
@@ -87,7 +86,7 @@ impl Decoder for SphinxCodec {
         };
 
         let sphinx_packet_size = header.packet_size.size();
-        let frame_len = Header::SIZE + sphinx_packet_size;
+        let frame_len = header.size() + sphinx_packet_size;
 
         if src.len() < frame_len {
             // we don't have enough bytes to read the rest of frame
@@ -96,7 +95,7 @@ impl Decoder for SphinxCodec {
         }
 
         // advance buffer past the header - at this point we have enough bytes
-        src.advance(Header::SIZE);
+        src.advance(header.size());
         let sphinx_packet_bytes = src.split_to(sphinx_packet_size);
         let sphinx_packet = match SphinxPacket::from_bytes(&sphinx_packet_bytes) {
             Ok(sphinx_packet) => sphinx_packet,
@@ -115,21 +114,27 @@ impl Decoder for SphinxCodec {
         // has appropriate capacity in anticipation of future calls to decode.
         // Failing to do so leads to inefficiency.
 
-        // if we have at least one more byte available, we can reserve enough bytes for
+        // if we have enough bytes to decode the header of the next packet, we can reserve enough bytes for
         // the entire next frame, if not, we assume the next frame is an ack packet and
         // reserve for that.
+        // we also assume the next packet coming from the same client will use exactly the same versioning
+        // as the current packet
+        let mut allocate_for_next_packet = header.size() + PacketSize::AckPacket.size();
         if !src.is_empty() {
-            let next_packet_len = match PacketSize::try_from(src[0]) {
-                Ok(next_packet_len) => next_packet_len,
+            match Header::decode(src) {
+                Ok(Some(next_header)) => {
+                    allocate_for_next_packet = next_header.size() + next_header.packet_size.size();
+                }
+                Ok(None) => {
+                    // we don't have enough information to know how much to reserve, fallback to the ack case
+                }
+
                 // the next frame will be malformed but let's leave handling the error to the next
                 // call to 'decode', as presumably, the current sphinx packet is still valid
                 Err(_) => return Ok(Some(nymsphinx_packet)),
             };
-            let next_frame_len = next_packet_len.size() + Header::SIZE;
-            src.reserve(next_frame_len - 1);
-        } else {
-            src.reserve(Header::SIZE + PacketSize::AckPacket.size());
         }
+        src.reserve(allocate_for_next_packet);
 
         Ok(Some(nymsphinx_packet))
     }
@@ -199,6 +204,8 @@ mod packet_encoding {
     #[cfg(test)]
     mod decode_will_allocate_enough_bytes_for_next_call {
         use super::*;
+        use nymsphinx_params::packet_version::PacketVersion;
+        use nymsphinx_params::PacketMode;
 
         #[test]
         fn for_empty_bytes() {
@@ -207,12 +214,12 @@ mod packet_encoding {
             assert!(SphinxCodec.decode(&mut empty_bytes).unwrap().is_none());
             assert_eq!(
                 empty_bytes.capacity(),
-                Header::SIZE + PacketSize::AckPacket.size()
+                Header::LEGACY_SIZE + PacketSize::AckPacket.size()
             );
         }
 
         #[test]
-        fn for_bytes_with_header() {
+        fn for_bytes_with_legacy_header() {
             // if header gets decoded there should be enough bytes for the entire frame
             let packet_sizes = vec![
                 PacketSize::AckPacket,
@@ -223,6 +230,7 @@ mod packet_encoding {
             ];
             for packet_size in packet_sizes {
                 let header = Header {
+                    packet_version: PacketVersion::Legacy,
                     packet_size,
                     packet_mode: Default::default(),
                 };
@@ -230,12 +238,60 @@ mod packet_encoding {
                 header.encode(&mut bytes);
                 assert!(SphinxCodec.decode(&mut bytes).unwrap().is_none());
 
-                assert_eq!(bytes.capacity(), Header::SIZE + packet_size.size())
+                assert_eq!(bytes.capacity(), Header::LEGACY_SIZE + packet_size.size())
             }
         }
 
         #[test]
-        fn for_full_frame() {
+        fn for_bytes_with_versioned_header() {
+            // if header gets decoded there should be enough bytes for the entire frame
+            let packet_sizes = vec![
+                PacketSize::AckPacket,
+                PacketSize::RegularPacket,
+                PacketSize::ExtendedPacket8,
+                PacketSize::ExtendedPacket16,
+                PacketSize::ExtendedPacket32,
+            ];
+            for packet_size in packet_sizes {
+                let header = Header {
+                    packet_version: PacketVersion::Versioned(123),
+                    packet_size,
+                    packet_mode: Default::default(),
+                };
+                let mut bytes = BytesMut::new();
+                header.encode(&mut bytes);
+                assert!(SphinxCodec.decode(&mut bytes).unwrap().is_none());
+
+                assert_eq!(
+                    bytes.capacity(),
+                    Header::VERSIONED_SIZE + packet_size.size()
+                )
+            }
+        }
+
+        #[test]
+        fn for_full_frame_with_legacy_header() {
+            // if full frame is used exactly, there should be enough space for header + ack packet
+            let packet = FramedSphinxPacket {
+                header: Header {
+                    packet_version: PacketVersion::Legacy,
+                    packet_size: Default::default(),
+                    packet_mode: Default::default(),
+                },
+                packet: make_valid_sphinx_packet(Default::default()),
+            };
+
+            let mut bytes = BytesMut::new();
+            SphinxCodec.encode(packet, &mut bytes).unwrap();
+            assert!(SphinxCodec.decode(&mut bytes).unwrap().is_some());
+            assert_eq!(
+                bytes.capacity(),
+                Header::LEGACY_SIZE + PacketSize::AckPacket.size()
+            );
+        }
+
+        #[test]
+        fn for_full_frame_with_versioned_header() {
             // if full frame is used exactly, there should be enough space for header + ack packet
             let packet = FramedSphinxPacket {
                 header: Header::default(),
@@ -247,13 +303,44 @@ mod packet_encoding {
             assert!(SphinxCodec.decode(&mut bytes).unwrap().is_some());
             assert_eq!(
                 bytes.capacity(),
-                Header::SIZE + PacketSize::AckPacket.size()
+                Header::VERSIONED_SIZE + PacketSize::AckPacket.size()
             );
         }
 
         #[test]
-        fn for_full_frame_with_extra_byte() {
-            // if there was at least 1 byte left, there should be enough space for entire next frame
+        fn for_full_frame_with_extra_bytes_with_legacy_header() {
+            // if there was at least 2 byte left, there should be enough space for entire next frame
+            let packet_sizes = vec![
+                PacketSize::AckPacket,
+                PacketSize::RegularPacket,
+                PacketSize::ExtendedPacket8,
+                PacketSize::ExtendedPacket16,
+                PacketSize::ExtendedPacket32,
+            ];
+
+            for packet_size in packet_sizes {
+                let first_packet = FramedSphinxPacket {
+                    header: Header {
+                        packet_version: PacketVersion::Legacy,
+                        packet_size: Default::default(),
+                        packet_mode: Default::default(),
+                    },
+                    packet: make_valid_sphinx_packet(Default::default()),
+                };
+
+                let mut bytes = BytesMut::new();
+                SphinxCodec.encode(first_packet, &mut bytes).unwrap();
+                bytes.put_u8(packet_size as u8);
+                bytes.put_u8(PacketMode::default() as u8);
+                assert!(SphinxCodec.decode(&mut bytes).unwrap().is_some());
+
+                assert!(bytes.capacity() >= Header::LEGACY_SIZE + packet_size.size())
+            }
+        }
+
+        #[test]
+        fn for_full_frame_with_extra_bytes_with_versioned_header() {
+            // if there was at least 3 byte left, there should be enough space for entire next frame
             let packet_sizes = vec![
                 PacketSize::AckPacket,
                 PacketSize::RegularPacket,
@@ -270,10 +357,12 @@ mod packet_encoding {
 
                 let mut bytes = BytesMut::new();
                 SphinxCodec.encode(first_packet, &mut bytes).unwrap();
+                bytes.put_u8(PacketVersion::new_versioned(123).as_u8().unwrap());
                 bytes.put_u8(packet_size as u8);
+                bytes.put_u8(PacketMode::default() as u8);
                 assert!(SphinxCodec.decode(&mut bytes).unwrap().is_some());
 
-                assert!(bytes.capacity() >= Header::SIZE + packet_size.size())
+                assert!(bytes.capacity() >= Header::VERSIONED_SIZE + packet_size.size())
             }
         }
     }

--- a/common/nymsphinx/framing/src/packet.rs
+++ b/common/nymsphinx/framing/src/packet.rs
@@ -4,6 +4,7 @@
 use crate::codec::SphinxCodecError;
 use bytes::{BufMut, BytesMut};
 use nymsphinx_params::packet_sizes::PacketSize;
+use nymsphinx_params::packet_version::PacketVersion;
 use nymsphinx_params::PacketMode;
 use nymsphinx_types::SphinxPacket;
 use std::convert::TryFrom;
@@ -17,12 +18,14 @@ pub struct FramedSphinxPacket {
 }
 
 impl FramedSphinxPacket {
-    pub fn new(packet: SphinxPacket, packet_mode: PacketMode) -> Self {
+    pub fn new(packet: SphinxPacket, packet_mode: PacketMode, use_legacy_version: bool) -> Self {
         // If this fails somebody is using the library in a super incorrect way, because they
         // already managed to somehow create a sphinx packet
         let packet_size = PacketSize::get_type(packet.len()).unwrap();
+
         FramedSphinxPacket {
             header: Header {
+                packet_version: PacketVersion::new(use_legacy_version),
                 packet_size,
                 packet_mode,
             },
@@ -48,6 +51,9 @@ impl FramedSphinxPacket {
 // but would that really be worth it?
 #[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
 pub struct Header {
+    /// Represents the wire format version used to construct this packet.
+    pub(crate) packet_version: PacketVersion,
+
     /// Represents type and consequently size of the included SphinxPacket.
     pub(crate) packet_size: PacketSize,
 
@@ -64,11 +70,25 @@ pub struct Header {
 }
 
 impl Header {
-    pub(crate) const SIZE: usize = 2;
+    pub(crate) const LEGACY_SIZE: usize = 2;
+    pub(crate) const VERSIONED_SIZE: usize = 3;
+
+    pub(crate) fn size(&self) -> usize {
+        if self.packet_version.is_legacy() {
+            Self::LEGACY_SIZE
+        } else {
+            Self::VERSIONED_SIZE
+        }
+    }
 
     pub(crate) fn encode(&self, dst: &mut BytesMut) {
         // we reserve one byte for `packet_size` and the other for `mode`
-        dst.reserve(Self::SIZE);
+        dst.reserve(Self::LEGACY_SIZE);
+        if let Some(version) = self.packet_version.as_u8() {
+            dst.reserve(Self::VERSIONED_SIZE);
+            dst.put_u8(version)
+        }
+
         dst.put_u8(self.packet_size as u8);
         dst.put_u8(self.packet_mode as u8);
         // reserve bytes for the actual packet
@@ -76,16 +96,30 @@ impl Header {
     }
 
     pub(crate) fn decode(src: &mut BytesMut) -> Result<Option<Self>, SphinxCodecError> {
-        if src.len() < Self::SIZE {
+        if src.len() < Self::LEGACY_SIZE {
             // can't do anything if we don't have enough bytes - but reserve enough for the next call
-            src.reserve(Self::SIZE);
+            src.reserve(Self::LEGACY_SIZE);
             return Ok(None);
         }
 
-        Ok(Some(Header {
-            packet_size: PacketSize::try_from(src[0])?,
-            packet_mode: PacketMode::try_from(src[1])?,
-        }))
+        let packet_version = PacketVersion::from(src[0]);
+        if packet_version.is_legacy() {
+            Ok(Some(Header {
+                packet_version,
+                packet_size: PacketSize::try_from(src[0])?,
+                packet_mode: PacketMode::try_from(src[1])?,
+            }))
+        } else if src.len() < Self::VERSIONED_SIZE {
+            // we're missing that 1 byte to read the full header...
+            src.reserve(Self::VERSIONED_SIZE);
+            Ok(None)
+        } else {
+            Ok(Some(Header {
+                packet_version,
+                packet_size: PacketSize::try_from(src[1])?,
+                packet_mode: PacketMode::try_from(src[2])?,
+            }))
+        }
     }
 }
 
@@ -127,31 +161,32 @@ mod header_encoding {
         let mut empty_bytes = BytesMut::new();
         let decode_attempt_1 = Header::decode(&mut empty_bytes).unwrap();
         assert!(decode_attempt_1.is_none());
-        assert!(empty_bytes.capacity() > Header::SIZE);
+        assert!(empty_bytes.capacity() > Header::LEGACY_SIZE);
 
         let mut empty_bytes = BytesMut::with_capacity(1);
         let decode_attempt_2 = Header::decode(&mut empty_bytes).unwrap();
         assert!(decode_attempt_2.is_none());
-        assert!(empty_bytes.capacity() > Header::SIZE);
+        assert!(empty_bytes.capacity() > Header::LEGACY_SIZE);
     }
 
     #[test]
     fn header_encoding_reserves_enough_bytes_for_full_sphinx_packet() {
-        let packet_sizes = vec![
-            PacketSize::AckPacket,
-            PacketSize::RegularPacket,
-            PacketSize::ExtendedPacket8,
-            PacketSize::ExtendedPacket16,
-            PacketSize::ExtendedPacket32,
-        ];
-        for packet_size in packet_sizes {
-            let header = Header {
-                packet_size,
-                packet_mode: Default::default(),
-            };
-            let mut bytes = BytesMut::new();
-            header.encode(&mut bytes);
-            assert_eq!(bytes.capacity(), bytes.len() + packet_size.size())
-        }
+        todo!()
+        // let packet_sizes = vec![
+        //     PacketSize::AckPacket,
+        //     PacketSize::RegularPacket,
+        //     PacketSize::ExtendedPacket8,
+        //     PacketSize::ExtendedPacket16,
+        //     PacketSize::ExtendedPacket32,
+        // ];
+        // for packet_size in packet_sizes {
+        //     let header = Header {
+        //         packet_size,
+        //         packet_mode: Default::default(),
+        //     };
+        //     let mut bytes = BytesMut::new();
+        //     header.encode(&mut bytes);
+        //     assert_eq!(bytes.capacity(), bytes.len() + packet_size.size())
+        // }
     }
 }

--- a/common/nymsphinx/params/src/lib.rs
+++ b/common/nymsphinx/params/src/lib.rs
@@ -13,6 +13,7 @@ pub use packet_sizes::PacketSize;
 
 pub mod packet_modes;
 pub mod packet_sizes;
+pub mod packet_version;
 
 // If somebody can provide an argument why it might be reasonable to have more than 255 mix hops,
 // I will change this to [`usize`]
@@ -23,6 +24,17 @@ pub const DEFAULT_NUM_MIX_HOPS: u8 = 3;
 // access to that
 pub const FRAG_ID_LEN: usize = 5;
 pub type SerializedFragmentIdentifier = [u8; FRAG_ID_LEN];
+
+// wait, wait, but why are we starting with version 7?
+// when packet header gets serialized, the following bytes (in that order) are put onto the wire:
+// - packet_version (starting with v1.1.0)
+// - packet_size indicator
+// - packet_mode
+// it also just so happens that the only valid values for packet_size indicator include values 1-6
+// therefore if we receive byte `7` (or larger than that) we'll know we received a versioned packet,
+// otherwise we should treat it as legacy
+/// Increment it whenever we perform any breaking change in the wire format!
+const CURRENT_PACKET_VERSION_NUMBER: u8 = 7;
 
 // TODO: ask @AP about the choice of below algorithms
 

--- a/common/nymsphinx/params/src/packet_version.rs
+++ b/common/nymsphinx/params/src/packet_version.rs
@@ -1,0 +1,59 @@
+// Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{PacketSize, CURRENT_PACKET_VERSION_NUMBER};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PacketVersion {
+    // this will allow updated mixnodes to still understand packets from before the update
+    Legacy,
+    Versioned(u8),
+}
+
+impl PacketVersion {
+    pub fn new(use_legacy: bool) -> Self {
+        if use_legacy {
+            Self::new_legacy()
+        } else {
+            Self::new_versioned(CURRENT_PACKET_VERSION_NUMBER)
+        }
+    }
+
+    pub fn new_legacy() -> Self {
+        PacketVersion::Legacy
+    }
+
+    pub fn new_versioned(version: u8) -> Self {
+        PacketVersion::Versioned(version)
+    }
+
+    pub fn is_legacy(&self) -> bool {
+        matches!(self, PacketVersion::Legacy)
+    }
+
+    pub fn as_u8(&self) -> Option<u8> {
+        match self {
+            PacketVersion::Legacy => None,
+            PacketVersion::Versioned(version) => Some(*version),
+        }
+    }
+}
+
+impl From<u8> for PacketVersion {
+    fn from(v: u8) -> Self {
+        match v {
+            n if n == PacketSize::RegularPacket as u8 => PacketVersion::Legacy,
+            n if n == PacketSize::AckPacket as u8 => PacketVersion::Legacy,
+            n if n == PacketSize::ExtendedPacket8 as u8 => PacketVersion::Legacy,
+            n if n == PacketSize::ExtendedPacket16 as u8 => PacketVersion::Legacy,
+            n if n == PacketSize::ExtendedPacket32 as u8 => PacketVersion::Legacy,
+            n => PacketVersion::Versioned(n),
+        }
+    }
+}
+
+impl Default for PacketVersion {
+    fn default() -> Self {
+        PacketVersion::Versioned(CURRENT_PACKET_VERSION_NUMBER)
+    }
+}

--- a/gateway/src/config/mod.rs
+++ b/gateway/src/config/mod.rs
@@ -289,6 +289,10 @@ impl Config {
         self.debug.maximum_connection_buffer_size
     }
 
+    pub fn get_use_legacy_sphinx_framing(&self) -> bool {
+        self.debug.use_legacy_framed_packet_version
+    }
+
     pub fn get_message_retrieval_limit(&self) -> i64 {
         self.debug.message_retrieval_limit
     }
@@ -456,6 +460,12 @@ struct Debug {
 
     /// Number of messages from offline client that can be pulled at once from the storage.
     message_retrieval_limit: i64,
+
+    /// Specifies whether the mixnode should be using the legacy framing for the sphinx packets.
+    // it's set to true by default. The reason for that decision is to preserve compatibility with the
+    // existing nodes whilst everyone else is upgrading and getting the code for handling the new field.
+    // It shall be disabled in the subsequent releases.
+    use_legacy_framed_packet_version: bool,
 }
 
 impl Default for Debug {
@@ -468,6 +478,8 @@ impl Default for Debug {
             maximum_connection_buffer_size: DEFAULT_MAXIMUM_CONNECTION_BUFFER_SIZE,
             stored_messages_filename_length: DEFAULT_STORED_MESSAGE_FILENAME_LENGTH,
             message_retrieval_limit: DEFAULT_MESSAGE_RETRIEVAL_LIMIT,
+            // TODO: remember to change it in one of future releases!!
+            use_legacy_framed_packet_version: true,
         }
     }
 }

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -211,6 +211,7 @@ where
             self.config.get_packet_forwarding_maximum_backoff(),
             self.config.get_initial_connection_timeout(),
             self.config.get_maximum_connection_buffer_size(),
+            self.config.get_use_legacy_sphinx_framing(),
         );
 
         tokio::spawn(async move { packet_forwarder.run().await });

--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -485,6 +485,12 @@ struct Debug {
 
     /// Maximum number of packets that can be stored waiting to get sent to a particular connection.
     maximum_connection_buffer_size: usize,
+
+    /// Specifies whether the mixnode should be using the legacy framing for the sphinx packets.
+    // it's set to true by default. The reason for that decision is to preserve compatibility with the
+    // existing nodes whilst everyone else is upgrading and getting the code for handling the new field.
+    // It shall be disabled in the subsequent releases.
+    use_legacy_framed_packet_version: bool,
 }
 
 impl Default for Debug {
@@ -496,6 +502,7 @@ impl Default for Debug {
             packet_forwarding_maximum_backoff: DEFAULT_PACKET_FORWARDING_MAXIMUM_BACKOFF,
             initial_connection_timeout: DEFAULT_INITIAL_CONNECTION_TIMEOUT,
             maximum_connection_buffer_size: DEFAULT_MAXIMUM_CONNECTION_BUFFER_SIZE,
+            // use_legacy_framed_packet_version: true,
         }
     }
 }

--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -280,6 +280,10 @@ impl Config {
         self.debug.maximum_connection_buffer_size
     }
 
+    pub fn get_use_legacy_sphinx_framing(&self) -> bool {
+        self.debug.use_legacy_framed_packet_version
+    }
+
     pub fn get_version(&self) -> &str {
         &self.mixnode.version
     }
@@ -502,7 +506,8 @@ impl Default for Debug {
             packet_forwarding_maximum_backoff: DEFAULT_PACKET_FORWARDING_MAXIMUM_BACKOFF,
             initial_connection_timeout: DEFAULT_INITIAL_CONNECTION_TIMEOUT,
             maximum_connection_buffer_size: DEFAULT_MAXIMUM_CONNECTION_BUFFER_SIZE,
-            // use_legacy_framed_packet_version: true,
+            // TODO: remember to change it in one of future releases!!
+            use_legacy_framed_packet_version: true,
         }
     }
 }

--- a/mixnode/src/node/mod.rs
+++ b/mixnode/src/node/mod.rs
@@ -200,6 +200,7 @@ impl MixNode {
             self.config.get_packet_forwarding_maximum_backoff(),
             self.config.get_initial_connection_timeout(),
             self.config.get_maximum_connection_buffer_size(),
+            self.config.get_use_legacy_sphinx_framing(),
         );
 
         let mut packet_forwarder = DelayForwarder::new(


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1937

This PR introduces `PacketVersion` into our `FramedSphinxPacket` (i.e. the data blob that's being sent between mixnodes). However, it's coded in such a way that by default everything uses `Legacy` mode, meaning they send packets as if the `PacketVersion` didn't exist. But, the second we decide to turn it on (say in hypothetical v1.1.1 release), all existing v1.1.0 binaries will already know how to handle it and therefore (in theory) the existing networks could be preserved whilst this incompatible change is getting introduced.

To fully test it you will need to do the following:
### test1
- set a minimal network (i.e. 3x mixnode + 1 gateway) running binaries **WITHOUT** the code from this PR
- swap one of the mixnodes to run **updated ** code (i.e. from this PR) - the network should still work (i.e. clients should be able to send packets just fine)
- then do the same with gateway (i.e. swap the old one with the new one)
### test2
- set another minimal network, but this time running binaries **WITH** the code from this PR
- then in one of the mixnodes set the following in the config:
```toml
[debug]
use_legacy_framed_packet_version = false
```
- everything should still work just fine
- then set the same config option on the gateway
- again, everything should still continue working


# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
