### PR TITLE
socks5: wait to close buffer (v1.1 branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 ### Fixed
 
 - validator-api, mixnode, gateway should now prefer values in config.toml over mainnet defaults ([#1645])
+- socks5-client: fix bug where in some cases packet reordering could trigger a connection being closed too early ([#1702])
 
 ### Changed
 
@@ -43,6 +44,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1671]: https://github.com/nymtech/nym/pull/1671
 [#1673]: https://github.com/nymtech/nym/pull/1673
 [#1687]: https://github.com/nymtech/nym/pull/1687
+[#1702]: https://github.com/nymtech/nym/pull/1702
 
 
 ## [nym-binaries-1.0.2](https://github.com/nymtech/nym/tree/nym-binaries-1.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 ### Fixed
 
 - validator-api, mixnode, gateway should now prefer values in config.toml over mainnet defaults ([#1645])
-- socks5-client: fix bug where in some cases packet reordering could trigger a connection being closed too early ([#1702])
+- socks5-client: fix bug where in some cases packet reordering could trigger a connection being closed too early ([#1702],[#1724])
 
 ### Changed
 
@@ -45,6 +45,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 [#1673]: https://github.com/nymtech/nym/pull/1673
 [#1687]: https://github.com/nymtech/nym/pull/1687
 [#1702]: https://github.com/nymtech/nym/pull/1702
+[#1724]: https://github.com/nymtech/nym/pull/1724
 
 
 ## [nym-binaries-1.0.2](https://github.com/nymtech/nym/tree/nym-binaries-1.0.2)

--- a/common/socks5/ordered-buffer/src/buffer.rs
+++ b/common/socks5/ordered-buffer/src/buffer.rs
@@ -102,14 +102,14 @@ mod test_chunking_and_reassembling {
                 };
 
                 buffer.write(first_message);
-                let first_read = buffer.read().unwrap();
+                let first_read = buffer.read().0.unwrap();
                 assert_eq!(vec![1, 2, 3, 4], first_read);
 
                 buffer.write(second_message);
-                let second_read = buffer.read().unwrap();
+                let second_read = buffer.read().0.unwrap();
                 assert_eq!(vec![5, 6, 7, 8], second_read);
 
-                assert_eq!(None, buffer.read()); // second read on fully ordered result set is empty
+                assert_eq!(None, buffer.read().0); // second read on fully ordered result set is empty
             }
 
             #[test]
@@ -128,8 +128,8 @@ mod test_chunking_and_reassembling {
                 buffer.write(first_message);
                 buffer.write(second_message);
                 let second_read = buffer.read();
-                assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8], second_read.unwrap());
-                assert_eq!(None, buffer.read()); // second read on fully ordered result set is empty
+                assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8], second_read.0.unwrap());
+                assert_eq!(None, buffer.read().0); // second read on fully ordered result set is empty
             }
 
             #[test]
@@ -147,9 +147,9 @@ mod test_chunking_and_reassembling {
 
                 buffer.write(second_message);
                 buffer.write(first_message);
-                let read = buffer.read();
+                let read = buffer.read().0;
                 assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8], read.unwrap());
-                assert_eq!(None, buffer.read()); // second read on fully ordered result set is empty
+                assert_eq!(None, buffer.read().0); // second read on fully ordered result set is empty
             }
         }
 
@@ -182,11 +182,11 @@ mod test_chunking_and_reassembling {
             #[test]
             fn everything_up_to_the_indexing_gap_is_returned() {
                 let mut buffer = setup();
-                let ordered_bytes = buffer.read().unwrap();
+                let ordered_bytes = buffer.read().0.unwrap();
                 assert_eq!([0, 0, 0, 0, 1, 1, 1, 1].to_vec(), ordered_bytes);
 
                 // we shouldn't get any more from a second attempt if nothing is added
-                assert_eq!(None, buffer.read());
+                assert_eq!(None, buffer.read().0);
 
                 // let's add another message, leaving a gap in place at index 2
                 let five_message = OrderedMessage {
@@ -194,7 +194,7 @@ mod test_chunking_and_reassembling {
                     index: 5,
                 };
                 buffer.write(five_message);
-                assert_eq!(None, buffer.read());
+                assert_eq!(None, buffer.read().0);
             }
 
             #[test]
@@ -208,7 +208,7 @@ mod test_chunking_and_reassembling {
                 };
                 buffer.write(two_message);
 
-                let more_ordered_bytes = buffer.read().unwrap();
+                let more_ordered_bytes = buffer.read().0.unwrap();
                 assert_eq!([2, 2, 2, 2, 3, 3, 3, 3].to_vec(), more_ordered_bytes);
 
                 // let's add another message
@@ -218,7 +218,7 @@ mod test_chunking_and_reassembling {
                 };
                 buffer.write(five_message);
 
-                assert_eq!(None, buffer.read());
+                assert_eq!(None, buffer.read().0);
 
                 // let's fill in the gap of 4s now and read again
                 let four_message = OrderedMessage {
@@ -227,10 +227,10 @@ mod test_chunking_and_reassembling {
                 };
                 buffer.write(four_message);
 
-                assert_eq!([4, 4, 4, 4, 5, 5, 5, 5].to_vec(), buffer.read().unwrap());
+                assert_eq!([4, 4, 4, 4, 5, 5, 5, 5].to_vec(), buffer.read().0.unwrap());
 
                 // at this point we should again get back nothing if we try a read
-                assert_eq!(None, buffer.read());
+                assert_eq!(None, buffer.read().0);
             }
 
             #[test]
@@ -250,11 +250,11 @@ mod test_chunking_and_reassembling {
                 };
 
                 buffer.write(zero_message);
-                assert!(buffer.read().is_some()); // burn the buffer
+                assert!(buffer.read().0.is_some()); // burn the buffer
 
                 buffer.write(two_message);
                 buffer.write(one_message);
-                assert!(buffer.read().is_some());
+                assert!(buffer.read().0.is_some());
                 assert_eq!(buffer.next_index, 3);
             }
 
@@ -282,23 +282,23 @@ mod test_chunking_and_reassembling {
                     index: 4,
                 };
                 buffer.write(zero_message);
-                assert!(buffer.read().is_some());
+                assert!(buffer.read().0.is_some());
                 assert_eq!(buffer.next_index, 1);
 
                 buffer.write(four_message);
-                assert!(buffer.read().is_none());
+                assert!(buffer.read().0.is_none());
                 assert_eq!(buffer.next_index, 1);
 
                 buffer.write(three_message);
-                assert!(buffer.read().is_none());
+                assert!(buffer.read().0.is_none());
                 assert_eq!(buffer.next_index, 1);
 
                 buffer.write(two_message);
-                assert!(buffer.read().is_none());
+                assert!(buffer.read().0.is_none());
                 assert_eq!(buffer.next_index, 1);
 
                 buffer.write(one_message);
-                assert!(buffer.read().is_some());
+                assert!(buffer.read().0.is_some());
                 assert_eq!(buffer.next_index, 5)
             }
         }

--- a/common/socks5/ordered-buffer/src/buffer.rs
+++ b/common/socks5/ordered-buffer/src/buffer.rs
@@ -13,6 +13,13 @@ pub struct OrderedMessageBuffer {
     messages: HashMap<u64, OrderedMessage>,
 }
 
+/// Data returned from `OrderedMessageBuffer` on a successful read of gapless ordered data.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReadContiguousData {
+    pub data: Vec<u8>,
+    pub last_index: u64,
+}
+
 impl OrderedMessageBuffer {
     pub fn new() -> OrderedMessageBuffer {
         OrderedMessageBuffer {
@@ -42,9 +49,9 @@ impl OrderedMessageBuffer {
     /// a read will return the bytes of messages 0, 1, 2. Subsequent reads will
     /// return `None` until message 3 comes in, at which point 3, 4, and any
     /// further contiguous messages which have arrived will be returned.
-    pub fn read(&mut self) -> (Option<Vec<u8>>, u64) {
+    pub fn read(&mut self) -> Option<ReadContiguousData> {
         if !self.messages.contains_key(&self.next_index) {
-            return (None, self.next_index);
+            return None;
         }
 
         let mut contiguous_messages = Vec::new();
@@ -66,7 +73,10 @@ impl OrderedMessageBuffer {
             .collect();
 
         trace!("Returning {} bytes from ordered message buffer", data.len());
-        (Some(data), index)
+        Some(ReadContiguousData {
+            data,
+            last_index: index,
+        })
     }
 }
 
@@ -102,14 +112,14 @@ mod test_chunking_and_reassembling {
                 };
 
                 buffer.write(first_message);
-                let first_read = buffer.read().0.unwrap();
+                let first_read = buffer.read().unwrap().data;
                 assert_eq!(vec![1, 2, 3, 4], first_read);
 
                 buffer.write(second_message);
-                let second_read = buffer.read().0.unwrap();
+                let second_read = buffer.read().unwrap().data;
                 assert_eq!(vec![5, 6, 7, 8], second_read);
 
-                assert_eq!(None, buffer.read().0); // second read on fully ordered result set is empty
+                assert_eq!(None, buffer.read()); // second read on fully ordered result set is empty
             }
 
             #[test]
@@ -128,8 +138,8 @@ mod test_chunking_and_reassembling {
                 buffer.write(first_message);
                 buffer.write(second_message);
                 let second_read = buffer.read();
-                assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8], second_read.0.unwrap());
-                assert_eq!(None, buffer.read().0); // second read on fully ordered result set is empty
+                assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8], second_read.unwrap().data);
+                assert_eq!(None, buffer.read()); // second read on fully ordered result set is empty
             }
 
             #[test]
@@ -147,9 +157,9 @@ mod test_chunking_and_reassembling {
 
                 buffer.write(second_message);
                 buffer.write(first_message);
-                let read = buffer.read().0;
-                assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8], read.unwrap());
-                assert_eq!(None, buffer.read().0); // second read on fully ordered result set is empty
+                let read = buffer.read().unwrap().data;
+                assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8], read);
+                assert_eq!(None, buffer.read()); // second read on fully ordered result set is empty
             }
         }
 
@@ -182,11 +192,11 @@ mod test_chunking_and_reassembling {
             #[test]
             fn everything_up_to_the_indexing_gap_is_returned() {
                 let mut buffer = setup();
-                let ordered_bytes = buffer.read().0.unwrap();
+                let ordered_bytes = buffer.read().unwrap().data;
                 assert_eq!([0, 0, 0, 0, 1, 1, 1, 1].to_vec(), ordered_bytes);
 
                 // we shouldn't get any more from a second attempt if nothing is added
-                assert_eq!(None, buffer.read().0);
+                assert_eq!(None, buffer.read());
 
                 // let's add another message, leaving a gap in place at index 2
                 let five_message = OrderedMessage {
@@ -194,7 +204,7 @@ mod test_chunking_and_reassembling {
                     index: 5,
                 };
                 buffer.write(five_message);
-                assert_eq!(None, buffer.read().0);
+                assert_eq!(None, buffer.read());
             }
 
             #[test]
@@ -208,7 +218,7 @@ mod test_chunking_and_reassembling {
                 };
                 buffer.write(two_message);
 
-                let more_ordered_bytes = buffer.read().0.unwrap();
+                let more_ordered_bytes = buffer.read().unwrap().data;
                 assert_eq!([2, 2, 2, 2, 3, 3, 3, 3].to_vec(), more_ordered_bytes);
 
                 // let's add another message
@@ -218,7 +228,7 @@ mod test_chunking_and_reassembling {
                 };
                 buffer.write(five_message);
 
-                assert_eq!(None, buffer.read().0);
+                assert_eq!(None, buffer.read());
 
                 // let's fill in the gap of 4s now and read again
                 let four_message = OrderedMessage {
@@ -227,10 +237,13 @@ mod test_chunking_and_reassembling {
                 };
                 buffer.write(four_message);
 
-                assert_eq!([4, 4, 4, 4, 5, 5, 5, 5].to_vec(), buffer.read().0.unwrap());
+                assert_eq!(
+                    [4, 4, 4, 4, 5, 5, 5, 5].to_vec(),
+                    buffer.read().unwrap().data
+                );
 
                 // at this point we should again get back nothing if we try a read
-                assert_eq!(None, buffer.read().0);
+                assert_eq!(None, buffer.read());
             }
 
             #[test]
@@ -250,11 +263,11 @@ mod test_chunking_and_reassembling {
                 };
 
                 buffer.write(zero_message);
-                assert!(buffer.read().0.is_some()); // burn the buffer
+                assert!(buffer.read().is_some()); // burn the buffer
 
                 buffer.write(two_message);
                 buffer.write(one_message);
-                assert!(buffer.read().0.is_some());
+                assert!(buffer.read().is_some());
                 assert_eq!(buffer.next_index, 3);
             }
 
@@ -282,23 +295,23 @@ mod test_chunking_and_reassembling {
                     index: 4,
                 };
                 buffer.write(zero_message);
-                assert!(buffer.read().0.is_some());
+                assert!(buffer.read().is_some());
                 assert_eq!(buffer.next_index, 1);
 
                 buffer.write(four_message);
-                assert!(buffer.read().0.is_none());
+                assert!(buffer.read().is_none());
                 assert_eq!(buffer.next_index, 1);
 
                 buffer.write(three_message);
-                assert!(buffer.read().0.is_none());
+                assert!(buffer.read().is_none());
                 assert_eq!(buffer.next_index, 1);
 
                 buffer.write(two_message);
-                assert!(buffer.read().0.is_none());
+                assert!(buffer.read().is_none());
                 assert_eq!(buffer.next_index, 1);
 
                 buffer.write(one_message);
-                assert!(buffer.read().0.is_some());
+                assert!(buffer.read().is_some());
                 assert_eq!(buffer.next_index, 5)
             }
         }

--- a/common/socks5/ordered-buffer/src/buffer.rs
+++ b/common/socks5/ordered-buffer/src/buffer.rs
@@ -42,9 +42,9 @@ impl OrderedMessageBuffer {
     /// a read will return the bytes of messages 0, 1, 2. Subsequent reads will
     /// return `None` until message 3 comes in, at which point 3, 4, and any
     /// further contiguous messages which have arrived will be returned.
-    pub fn read(&mut self) -> Option<Vec<u8>> {
+    pub fn read(&mut self) -> (Option<Vec<u8>>, u64) {
         if !self.messages.contains_key(&self.next_index) {
-            return None;
+            return (None, self.next_index);
         }
 
         let mut contiguous_messages = Vec::new();
@@ -66,7 +66,7 @@ impl OrderedMessageBuffer {
             .collect();
 
         trace!("Returning {} bytes from ordered message buffer", data.len());
-        Some(data)
+        (Some(data), index)
     }
 }
 

--- a/common/socks5/ordered-buffer/src/lib.rs
+++ b/common/socks5/ordered-buffer/src/lib.rs
@@ -2,7 +2,7 @@ mod buffer;
 mod message;
 mod sender;
 
-pub use buffer::OrderedMessageBuffer;
+pub use buffer::{OrderedMessageBuffer, ReadContiguousData};
 pub use message::MessageError;
 pub use message::OrderedMessage;
 pub use sender::OrderedMessageSender;

--- a/common/socks5/proxy-helpers/src/connection_controller.rs
+++ b/common/socks5/proxy-helpers/src/connection_controller.rs
@@ -58,7 +58,7 @@ impl ActiveConnection {
         self.ordered_buffer.write(ordered_message);
     }
 
-    fn fn read_from_buf(&mut self) -> (Option<Vec<u8>>, u64) {
+    fn read_from_buf(&mut self) -> (Option<Vec<u8>>, u64) {
         self.ordered_buffer.read()
     }
 }

--- a/common/socks5/proxy-helpers/src/connection_controller.rs
+++ b/common/socks5/proxy-helpers/src/connection_controller.rs
@@ -38,12 +38,13 @@ pub enum ControllerCommand {
 
 struct ActiveConnection {
     is_closed: bool,
+    closed_at: u64,
     connection_sender: Option<ConnectionSender>,
     ordered_buffer: OrderedMessageBuffer,
 }
 
 impl ActiveConnection {
-    fn write_to_buf(&mut self, payload: Vec<u8>) {
+    fn write_to_buf(&mut self, payload: Vec<u8>, is_closed: bool) {
         let ordered_message = match OrderedMessage::try_from_bytes(payload) {
             Ok(msg) => msg,
             Err(err) => {
@@ -51,10 +52,13 @@ impl ActiveConnection {
                 return;
             }
         };
+        if is_closed{
+            self.closed_at = ordered_message.index;
+        }
         self.ordered_buffer.write(ordered_message);
     }
 
-    fn read_from_buf(&mut self) -> Option<Vec<u8>> {
+    fn fn read_from_buf(&mut self) -> (Option<Vec<u8>>, u64) {
         self.ordered_buffer.read()
     }
 }
@@ -99,6 +103,7 @@ impl Controller {
             is_closed: false,
             connection_sender: Some(connection_sender),
             ordered_buffer: OrderedMessageBuffer::new(),
+            closed_at: u64::MAX,
         };
         if let Some(_active_conn) = self.active_connections.insert(conn_id, active_connection) {
             error!("Received a duplicate 'Connect'!")
@@ -127,15 +132,17 @@ impl Controller {
     fn send_to_connection(&mut self, conn_id: ConnectionId, payload: Vec<u8>, is_closed: bool) {
         if let Some(active_connection) = self.active_connections.get_mut(&conn_id) {
             if !payload.is_empty() {
-                active_connection.write_to_buf(payload);
+                active_connection.write_to_buf(payload, is_closed);
             } else if !is_closed {
                 error!("Tried to write an empty message to a not-closing connection. Please let us know if you see this message");
             }
             // if messages get unordered, make sure we don't lose information about
             // remote socket getting closed!
-            active_connection.is_closed |= is_closed;
 
-            if let Some(payload) = active_connection.read_from_buf() {
+            if let (Some(payload), last_index) = active_connection.read_from_buf() {
+                if last_index > active_connection.closed_at {
+                    active_connection.is_closed = true;
+                }
                 if let Err(err) = active_connection
                     .connection_sender
                     .as_mut()

--- a/common/socks5/proxy-helpers/src/connection_controller.rs
+++ b/common/socks5/proxy-helpers/src/connection_controller.rs
@@ -52,7 +52,7 @@ impl ActiveConnection {
                 return;
             }
         };
-        if is_closed{
+        if is_closed {
             self.closed_at = ordered_message.index;
         }
         self.ordered_buffer.write(ordered_message);


### PR DESCRIPTION
# Description

Part of: https://github.com/nymtech/nym/issues/1960
Closes: https://github.com/nymtech/nym/issues/1701

This is the same fix as #1702 , but applied to release/v1.1.0 branch.

This is the fix proposed by @simonwicky in https://github.com/nymtech/nym/issues/1701

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
