### PR TITLE
Feature/delegations without bonded node

### DIFF
--- a/common/types/src/delegation.rs
+++ b/common/types/src/delegation.rs
@@ -62,6 +62,7 @@ pub struct DelegationWithEverything {
 
     // DEPRECATED, IF POSSIBLE TRY TO DISCONTINUE USE OF IT!
     pub pending_events: Vec<DelegationEvent>,
+    pub mixnode_is_unbonding: Option<bool>,
 }
 
 #[cfg_attr(feature = "generate-ts", derive(ts_rs::TS))]

--- a/nym-wallet/src-tauri/src/operations/mixnet/delegate.rs
+++ b/nym-wallet/src-tauri/src/operations/mixnet/delegate.rs
@@ -266,6 +266,13 @@ pub async fn get_all_mix_delegations(
             pending_events.len()
         );
 
+        let mixnode_is_unbonding = mixnode.as_ref().map(|m| m.is_unbonding());
+        log::trace!(
+            "  >>> mixnode with mix_id: {} is unbonding: {:?}",
+            d.mix_id,
+            mixnode_is_unbonding
+        );
+
         with_everything.push(DelegationWithEverything {
             owner: d.owner,
             mix_id: d.mix_id,
@@ -283,6 +290,7 @@ pub async fn get_all_mix_delegations(
             cost_params,
             unclaimed_rewards: accumulated_rewards,
             pending_events,
+            mixnode_is_unbonding,
         })
     }
     log::trace!("<<< {:?}", with_everything);

--- a/nym-wallet/src/components/Bonding/BondedGateway.tsx
+++ b/nym-wallet/src/components/Bonding/BondedGateway.tsx
@@ -1,14 +1,12 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Stack, Typography } from '@mui/material';
 import { Link } from '@nymproject/react/link/Link';
 import { TBondedGateway, urls } from 'src/context';
 import { NymCard } from 'src/components';
 import { Network } from 'src/types';
 import { IdentityKey } from 'src/components/IdentityKey';
-import { getGatewayReport } from 'src/requests';
 import { Cell, Header, NodeTable } from './NodeTable';
 import { BondedGatewayActions, TBondedGatwayActions } from './BondedGatewayAction';
-import { Console } from 'src/utils/console';
 
 const headers: Header[] = [
   {

--- a/nym-wallet/src/components/Bonding/BondedMixnode.tsx
+++ b/nym-wallet/src/components/Bonding/BondedMixnode.tsx
@@ -35,7 +35,8 @@ const headers: Header[] = [
   {
     header: 'Operating cost',
     id: 'operator-cost',
-    // tooltipText: 'TODO', // TODO
+    tooltipText:
+      'Monthly operational costs of running your node. The cost also influences how the rewards are split between you and your delegators. ',
   },
   {
     header: 'Operator rewards',

--- a/nym-wallet/src/components/Bonding/BondedMixnode.tsx
+++ b/nym-wallet/src/components/Bonding/BondedMixnode.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Box, Button, Stack, Tooltip, Typography } from '@mui/material';
+import { Box, Button, Chip, Stack, Tooltip, Typography } from '@mui/material';
 import { Link } from '@nymproject/react/link/Link';
 import { isMixnode, Network } from 'src/types';
 import { TBondedMixnode, urls } from 'src/context';
@@ -107,12 +107,13 @@ export const BondedMixnode = ({
       id: 'delegators-cell',
     },
     {
-      cell: (
+      cell: mixnode.isUnbonding ? (
+        <Chip label="Pending unbond" sx={{ textTransform: 'initial' }} />
+      ) : (
         <BondedMixnodeActions
           onActionSelect={onActionSelect}
           disabledRedeemAndCompound={(operatorRewards && Number(operatorRewards.amount) === 0) || false}
           disabledBondMore // TODO for now disable bond more feature until backend is ready
-          disableUnbond={mixnode.isUnbonding}
         />
       ),
       id: 'actions-cell',

--- a/nym-wallet/src/components/Bonding/BondedMixnode.tsx
+++ b/nym-wallet/src/components/Bonding/BondedMixnode.tsx
@@ -144,7 +144,7 @@ export const BondedMixnode = ({
         }
         Action={
           isMixnode(mixnode) && (
-            <Tooltip title="You have a pending unbond event. Node settings are disabled.">
+            <Tooltip title={mixnode.isUnbonding ? 'You have a pending unbond event. Node settings are disabled.' : ''}>
               <Box>
                 <Button
                   variant="text"

--- a/nym-wallet/src/components/Bonding/BondedMixnode.tsx
+++ b/nym-wallet/src/components/Bonding/BondedMixnode.tsx
@@ -112,6 +112,7 @@ export const BondedMixnode = ({
           onActionSelect={onActionSelect}
           disabledRedeemAndCompound={(operatorRewards && Number(operatorRewards.amount) === 0) || false}
           disabledBondMore // TODO for now disable bond more feature until backend is ready
+          disableUnbond={mixnode.isUnbonding}
         />
       ),
       id: 'actions-cell',
@@ -143,14 +144,19 @@ export const BondedMixnode = ({
         }
         Action={
           isMixnode(mixnode) && (
-            <Button
-              variant="text"
-              color="secondary"
-              onClick={() => navigate('/bonding/node-settings')}
-              startIcon={<NodeIcon />}
-            >
-              Node Settings
-            </Button>
+            <Tooltip title="You have a pending unbond event. Node settings are disabled.">
+              <Box>
+                <Button
+                  variant="text"
+                  color="secondary"
+                  onClick={() => navigate('/bonding/node-settings')}
+                  startIcon={<NodeIcon />}
+                  disabled={mixnode.isUnbonding}
+                >
+                  Node Settings
+                </Button>
+              </Box>
+            </Tooltip>
           )
         }
       >

--- a/nym-wallet/src/components/Bonding/BondedMixnodeActions.tsx
+++ b/nym-wallet/src/components/Bonding/BondedMixnodeActions.tsx
@@ -9,10 +9,12 @@ export const BondedMixnodeActions = ({
   onActionSelect,
   disabledRedeemAndCompound,
   disabledBondMore,
+  disableUnbond,
 }: {
   onActionSelect: (action: TBondedMixnodeActions) => void;
   disabledRedeemAndCompound: boolean;
   disabledBondMore?: boolean;
+  disableUnbond: boolean;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -43,6 +45,7 @@ export const BondedMixnodeActions = ({
         title="Unbond"
         Icon={<UnbondIcon fontSize="inherit" />}
         onClick={() => handleActionClick('unbond')}
+        disabled={disableUnbond}
       />
     </ActionsMenu>
   );

--- a/nym-wallet/src/components/Bonding/BondedMixnodeActions.tsx
+++ b/nym-wallet/src/components/Bonding/BondedMixnodeActions.tsx
@@ -9,12 +9,10 @@ export const BondedMixnodeActions = ({
   onActionSelect,
   disabledRedeemAndCompound,
   disabledBondMore,
-  disableUnbond,
 }: {
   onActionSelect: (action: TBondedMixnodeActions) => void;
   disabledRedeemAndCompound: boolean;
   disabledBondMore?: boolean;
-  disableUnbond: boolean;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -45,7 +43,6 @@ export const BondedMixnodeActions = ({
         title="Unbond"
         Icon={<UnbondIcon fontSize="inherit" />}
         onClick={() => handleActionClick('unbond')}
-        disabled={disableUnbond}
       />
     </ActionsMenu>
   );

--- a/nym-wallet/src/components/Delegation/DelegationActions.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationActions.tsx
@@ -68,7 +68,8 @@ export const DelegationsActionsMenu: React.FC<{
   onActionClick?: (action: DelegationListItemActions) => void;
   isPending?: DelegationEventKind;
   disableRedeemingRewards?: boolean;
-}> = ({ disableRedeemingRewards, onActionClick, isPending }) => {
+  disableDelegateMore?: boolean | null;
+}> = ({ disableRedeemingRewards, disableDelegateMore, onActionClick, isPending }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleOpenMenu = () => setIsOpen(true);
@@ -93,7 +94,12 @@ export const DelegationsActionsMenu: React.FC<{
 
   return (
     <ActionsMenu open={isOpen} onOpen={handleOpenMenu} onClose={handleOnClose}>
-      <ActionsMenuItem title="Delegate more" Icon={<Delegate />} onClick={() => handleActionSelect('delegate')} />
+      <ActionsMenuItem
+        title="Delegate more"
+        Icon={<Delegate />}
+        onClick={() => handleActionSelect('delegate')}
+        disabled={Boolean(disableDelegateMore)}
+      />
       <ActionsMenuItem title="Undelegate" Icon={<Undelegate />} onClick={() => handleActionSelect('undelegate')} />
       <ActionsMenuItem
         title="Redeem"

--- a/nym-wallet/src/components/Delegation/DelegationActions.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationActions.tsx
@@ -66,10 +66,9 @@ export const DelegationActions: React.FC<{
 
 export const DelegationsActionsMenu: React.FC<{
   onActionClick?: (action: DelegationListItemActions) => void;
-  isPending?: DelegationEventKind;
   disableRedeemingRewards?: boolean;
   disableDelegateMore?: boolean | null;
-}> = ({ disableRedeemingRewards, disableDelegateMore, onActionClick, isPending }) => {
+}> = ({ disableRedeemingRewards, disableDelegateMore, onActionClick }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleOpenMenu = () => setIsOpen(true);
@@ -80,22 +79,11 @@ export const DelegationsActionsMenu: React.FC<{
     handleOnClose();
   };
 
-  if (isPending) {
-    return (
-      <Box py={0.5} fontSize="inherit" minWidth={MIN_WIDTH} minHeight={BUTTON_SIZE}>
-        <Tooltip title="There will be a new epoch roughly every hour when your changes will take effect" arrow>
-          <Typography fontSize="inherit" color="text.disabled">
-            Pending {isPending === 'Delegate' ? 'delegation' : 'undelegation'}...
-          </Typography>
-        </Tooltip>
-      </Box>
-    );
-  }
-
   return (
     <ActionsMenu open={isOpen} onOpen={handleOpenMenu} onClose={handleOnClose}>
       <ActionsMenuItem
         title="Delegate more"
+        description={disableDelegateMore ? 'This node is unbonding, action disabled.' : undefined}
         Icon={<Delegate />}
         onClick={() => handleActionSelect('delegate')}
         disabled={Boolean(disableDelegateMore)}

--- a/nym-wallet/src/components/Delegation/DelegationItem.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationItem.tsx
@@ -79,7 +79,6 @@ export const DelegationItem = ({
         <TableCell align="right" sx={{ color: 'inherit' }}>
           {!item.pending_events.length && !nodeIsUnbonded && (
             <DelegationsActionsMenu
-              isPending={undefined}
               onActionClick={(action) => (onItemActionClick ? onItemActionClick(item, action) : undefined)}
               disableRedeemingRewards={!item.unclaimed_rewards || item.unclaimed_rewards.amount === '0'}
               disableDelegateMore={item.mixnode_is_unbonding}

--- a/nym-wallet/src/components/Delegation/DelegationItem.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationItem.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { Chip, IconButton, TableCell, TableCellProps, TableRow, Tooltip, Typography } from '@mui/material';
+import { Link } from '@nymproject/react/link/Link';
+import { decimalToPercentage, DelegationWithEverything } from '@nymproject/types';
+import { DelegationListItemActions, DelegationsActionsMenu } from './DelegationActions';
+import { isDelegation } from 'src/context/delegations';
+import { toPercentIntegerString } from 'src/utils';
+import { format } from 'date-fns';
+import { Undelegate } from 'src/svg-icons';
+
+const getStakeSaturation = (item: DelegationWithEverything) =>
+  !item.stake_saturation ? '-' : `${decimalToPercentage(item.stake_saturation)}%`;
+
+const getRewardValue = (item: DelegationWithEverything) => {
+  const { unclaimed_rewards } = item;
+  return !unclaimed_rewards ? '-' : `${unclaimed_rewards.amount} ${unclaimed_rewards.denom}`;
+};
+
+const WrappedTableCell = (props: TableCellProps & { withWarning?: boolean }) => (
+  <TableCell {...props}>
+    <Typography color={props.withWarning ? 'error.main' : 'inherit'}>{props.children}</Typography>
+  </TableCell>
+);
+
+export const DelegationItem = ({
+  item,
+  explorerUrl,
+  nodeIsUnbonded,
+  onItemActionClick,
+}: {
+  item: DelegationWithEverything;
+  explorerUrl: string;
+  nodeIsUnbonded: boolean;
+  onItemActionClick?: (item: DelegationWithEverything, action: DelegationListItemActions) => void;
+}) => {
+  return (
+    <TableRow key={item.node_identity}>
+      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>
+        {nodeIsUnbonded ? (
+          '-'
+        ) : (
+          <Link
+            target="_blank"
+            href={`${explorerUrl}/network-components/mixnode/${item.node_identity}`}
+            text={`${item.node_identity.slice(0, 6)}...${item.node_identity.slice(-6)}`}
+            color="text.primary"
+            noIcon
+          />
+        )}
+      </WrappedTableCell>
+      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>
+        {isDelegation(item) && (!item.avg_uptime_percent ? '-' : `${item.avg_uptime_percent}%`)}
+      </WrappedTableCell>
+      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>
+        {isDelegation(item) &&
+          (!item.cost_params?.profit_margin_percent
+            ? '-'
+            : `${toPercentIntegerString(item.cost_params.profit_margin_percent)}%`)}
+      </WrappedTableCell>
+      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>{getStakeSaturation(item)}</WrappedTableCell>
+      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>
+        {format(new Date(item.delegated_on_iso_datetime), 'dd/MM/yyyy')}
+      </WrappedTableCell>
+      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>
+        <Typography style={{ textTransform: 'uppercase' }}>
+          {isDelegation(item) && `${item.amount.amount} ${item.amount.denom}`}
+        </Typography>
+      </WrappedTableCell>
+      <WrappedTableCell withWarning={!Boolean(item.node_identity)} sx={{ textTransform: 'uppercase' }}>
+        {getRewardValue(item)}
+      </WrappedTableCell>
+      <WrappedTableCell align="right">
+        {!item.pending_events.length && !nodeIsUnbonded && (
+          <DelegationsActionsMenu
+            isPending={undefined}
+            onActionClick={(action) => (onItemActionClick ? onItemActionClick(item, action) : undefined)}
+            disableRedeemingRewards={!item.unclaimed_rewards || item.unclaimed_rewards.amount === '0'}
+          />
+        )}
+        {!item.pending_events.length && nodeIsUnbonded && (
+          <IconButton>
+            <Undelegate onClick={() => (onItemActionClick ? onItemActionClick(item, 'undelegate') : undefined)} />
+          </IconButton>
+        )}
+        {item.pending_events.length > 0 && (
+          <Tooltip
+            title="Your changes will take effect when the new epoch starts. There is a new epoch every hour."
+            arrow
+          >
+            <Chip label="Pending Events" />
+          </Tooltip>
+        )}
+      </WrappedTableCell>
+    </TableRow>
+  );
+};

--- a/nym-wallet/src/components/Delegation/DelegationItem.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationItem.tsx
@@ -72,7 +72,7 @@ export const DelegationItem = ({
         </TableCell>
         <TableCell sx={{ color: 'inherit' }}>
           <Typography style={{ textTransform: 'uppercase' }}>
-            {isDelegation(item) && `${item.amount.amount} ${item.amount.denom}`}
+            {isDelegation(item) ? `${item.amount.amount} ${item.amount.denom}` : '-'}
           </Typography>
         </TableCell>
         <TableCell sx={{ textTransform: 'uppercase', color: 'inherit' }}>{getRewardValue(item)}</TableCell>

--- a/nym-wallet/src/components/Delegation/DelegationItem.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationItem.tsx
@@ -7,6 +7,8 @@ import { isDelegation } from 'src/context/delegations';
 import { toPercentIntegerString } from 'src/utils';
 import { format } from 'date-fns';
 import { Undelegate } from 'src/svg-icons';
+import { Box } from '@mui/system';
+import { identity } from 'lodash';
 
 const getStakeSaturation = (item: DelegationWithEverything) =>
   !item.stake_saturation ? '-' : `${decimalToPercentage(item.stake_saturation)}%`;
@@ -15,12 +17,6 @@ const getRewardValue = (item: DelegationWithEverything) => {
   const { unclaimed_rewards } = item;
   return !unclaimed_rewards ? '-' : `${unclaimed_rewards.amount} ${unclaimed_rewards.denom}`;
 };
-
-const WrappedTableCell = (props: TableCellProps & { withWarning?: boolean }) => (
-  <TableCell {...props}>
-    <Typography color={props.withWarning ? 'error.main' : 'inherit'}>{props.children}</Typography>
-  </TableCell>
-);
 
 export const DelegationItem = ({
   item,
@@ -34,63 +30,70 @@ export const DelegationItem = ({
   onItemActionClick?: (item: DelegationWithEverything, action: DelegationListItemActions) => void;
 }) => {
   return (
-    <TableRow key={item.node_identity}>
-      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>
-        {nodeIsUnbonded ? (
-          '-'
-        ) : (
-          <Link
-            target="_blank"
-            href={`${explorerUrl}/network-components/mixnode/${item.node_identity}`}
-            text={`${item.node_identity.slice(0, 6)}...${item.node_identity.slice(-6)}`}
-            color="text.primary"
-            noIcon
-          />
-        )}
-      </WrappedTableCell>
-      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>
-        {isDelegation(item) && (!item.avg_uptime_percent ? '-' : `${item.avg_uptime_percent}%`)}
-      </WrappedTableCell>
-      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>
-        {isDelegation(item) &&
-          (!item.cost_params?.profit_margin_percent
-            ? '-'
-            : `${toPercentIntegerString(item.cost_params.profit_margin_percent)}%`)}
-      </WrappedTableCell>
-      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>{getStakeSaturation(item)}</WrappedTableCell>
-      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>
-        {format(new Date(item.delegated_on_iso_datetime), 'dd/MM/yyyy')}
-      </WrappedTableCell>
-      <WrappedTableCell withWarning={!Boolean(item.node_identity)}>
-        <Typography style={{ textTransform: 'uppercase' }}>
-          {isDelegation(item) && `${item.amount.amount} ${item.amount.denom}`}
-        </Typography>
-      </WrappedTableCell>
-      <WrappedTableCell withWarning={!Boolean(item.node_identity)} sx={{ textTransform: 'uppercase' }}>
-        {getRewardValue(item)}
-      </WrappedTableCell>
-      <WrappedTableCell align="right">
-        {!item.pending_events.length && !nodeIsUnbonded && (
-          <DelegationsActionsMenu
-            isPending={undefined}
-            onActionClick={(action) => (onItemActionClick ? onItemActionClick(item, action) : undefined)}
-            disableRedeemingRewards={!item.unclaimed_rewards || item.unclaimed_rewards.amount === '0'}
-          />
-        )}
-        {!item.pending_events.length && nodeIsUnbonded && (
-          <IconButton>
-            <Undelegate onClick={() => (onItemActionClick ? onItemActionClick(item, 'undelegate') : undefined)} />
-          </IconButton>
-        )}
-        {item.pending_events.length > 0 && (
-          <Tooltip
-            title="Your changes will take effect when the new epoch starts. There is a new epoch every hour."
-            arrow
-          >
-            <Chip label="Pending Events" />
-          </Tooltip>
-        )}
-      </WrappedTableCell>
-    </TableRow>
+    <Tooltip
+      arrow
+      title={
+        nodeIsUnbonded
+          ? 'This node has unbonded and it does not exist anymore. You need to undelegate from it to get your stake and outstanding rewards (if any) back.'
+          : ''
+      }
+    >
+      <TableRow key={item.node_identity} sx={{ color: !Boolean(item.node_identity) ? 'error.main' : 'inherit' }}>
+        <TableCell sx={{ color: 'inherit' }}>
+          {nodeIsUnbonded ? (
+            '-'
+          ) : (
+            <Link
+              target="_blank"
+              href={`${explorerUrl}/network-components/mixnode/${item.node_identity}`}
+              text={`${item.node_identity.slice(0, 6)}...${item.node_identity.slice(-6)}`}
+              color="text.primary"
+              noIcon
+            />
+          )}
+        </TableCell>
+        <TableCell sx={{ color: 'inherit' }}>
+          {isDelegation(item) && (!item.avg_uptime_percent ? '-' : `${item.avg_uptime_percent}%`)}
+        </TableCell>
+        <TableCell sx={{ color: 'inherit' }}>
+          {isDelegation(item) &&
+            (!item.cost_params?.profit_margin_percent
+              ? '-'
+              : `${toPercentIntegerString(item.cost_params.profit_margin_percent)}%`)}
+        </TableCell>
+        <TableCell sx={{ color: 'inherit' }}>{getStakeSaturation(item)}</TableCell>
+        <TableCell sx={{ color: 'inherit' }}>
+          {format(new Date(item.delegated_on_iso_datetime), 'dd/MM/yyyy')}
+        </TableCell>
+        <TableCell sx={{ color: 'inherit' }}>
+          <Typography style={{ textTransform: 'uppercase' }}>
+            {isDelegation(item) && `${item.amount.amount} ${item.amount.denom}`}
+          </Typography>
+        </TableCell>
+        <TableCell sx={{ textTransform: 'uppercase', color: 'inherit' }}>{getRewardValue(item)}</TableCell>
+        <TableCell align="right" sx={{ color: 'inherit' }}>
+          {!item.pending_events.length && !nodeIsUnbonded && (
+            <DelegationsActionsMenu
+              isPending={undefined}
+              onActionClick={(action) => (onItemActionClick ? onItemActionClick(item, action) : undefined)}
+              disableRedeemingRewards={!item.unclaimed_rewards || item.unclaimed_rewards.amount === '0'}
+            />
+          )}
+          {!item.pending_events.length && nodeIsUnbonded && (
+            <IconButton sx={{ color: (t) => t.palette.nym.nymWallet.text.main }}>
+              <Undelegate onClick={() => (onItemActionClick ? onItemActionClick(item, 'undelegate') : undefined)} />
+            </IconButton>
+          )}
+          {item.pending_events.length > 0 && (
+            <Tooltip
+              title="Your changes will take effect when the new epoch starts. There is a new epoch every hour."
+              arrow
+            >
+              <Chip label="Pending Events" />
+            </Tooltip>
+          )}
+        </TableCell>
+      </TableRow>
+    </Tooltip>
   );
 };

--- a/nym-wallet/src/components/Delegation/DelegationItem.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationItem.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import { Chip, IconButton, TableCell, TableCellProps, TableRow, Tooltip, Typography } from '@mui/material';
+import { Chip, IconButton, TableCell, TableRow, Tooltip, Typography } from '@mui/material';
 import { Link } from '@nymproject/react/link/Link';
 import { decimalToPercentage, DelegationWithEverything } from '@nymproject/types';
-import { DelegationListItemActions, DelegationsActionsMenu } from './DelegationActions';
 import { isDelegation } from 'src/context/delegations';
 import { toPercentIntegerString } from 'src/utils';
 import { format } from 'date-fns';
 import { Undelegate } from 'src/svg-icons';
-import { Box } from '@mui/system';
-import { identity } from 'lodash';
+import { DelegationListItemActions, DelegationsActionsMenu } from './DelegationActions';
 
 const getStakeSaturation = (item: DelegationWithEverything) =>
   !item.stake_saturation ? '-' : `${decimalToPercentage(item.stake_saturation)}%`;
@@ -29,6 +27,8 @@ export const DelegationItem = ({
   nodeIsUnbonded: boolean;
   onItemActionClick?: (item: DelegationWithEverything, action: DelegationListItemActions) => void;
 }) => {
+  const operatingCost = isDelegation(item) && item.cost_params?.interval_operating_cost;
+
   return (
     <Tooltip
       arrow
@@ -38,8 +38,8 @@ export const DelegationItem = ({
           : ''
       }
     >
-      <TableRow key={item.node_identity} sx={{ color: !Boolean(item.node_identity) ? 'error.main' : 'inherit' }}>
-        <TableCell sx={{ color: 'inherit' }}>
+      <TableRow key={item.node_identity} sx={{ color: !item.node_identity ? 'error.main' : 'inherit' }}>
+        <TableCell sx={{ color: 'inherit', pr: 1 }} padding="normal">
           {nodeIsUnbonded ? (
             '-'
           ) : (
@@ -60,6 +60,11 @@ export const DelegationItem = ({
             (!item.cost_params?.profit_margin_percent
               ? '-'
               : `${toPercentIntegerString(item.cost_params.profit_margin_percent)}%`)}
+        </TableCell>
+        <TableCell sx={{ color: 'inherit' }}>
+          <Typography style={{ textTransform: 'uppercase' }}>
+            {operatingCost ? `${operatingCost.amount} ${operatingCost.denom}` : '-'}
+          </Typography>
         </TableCell>
         <TableCell sx={{ color: 'inherit' }}>{getStakeSaturation(item)}</TableCell>
         <TableCell sx={{ color: 'inherit' }}>

--- a/nym-wallet/src/components/Delegation/DelegationItem.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationItem.tsx
@@ -82,6 +82,7 @@ export const DelegationItem = ({
               isPending={undefined}
               onActionClick={(action) => (onItemActionClick ? onItemActionClick(item, action) : undefined)}
               disableRedeemingRewards={!item.unclaimed_rewards || item.unclaimed_rewards.amount === '0'}
+              disableDelegateMore={item.mixnode_is_unbonding}
             />
           )}
           {!item.pending_events.length && nodeIsUnbonded && (

--- a/nym-wallet/src/components/Delegation/DelegationList.stories.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationList.stories.tsx
@@ -64,4 +64,4 @@ export const Empty = () => <DelegationList items={[]} explorerUrl={explorerUrl} 
 
 export const OneItem = () => <DelegationList items={[items[0]]} explorerUrl={explorerUrl} />;
 
-export const Loading = () => <DelegationList isLoading explorerUrl={explorerUrl} />;
+export const Loading = () => <DelegationList items={[]} isLoading explorerUrl={explorerUrl} />;

--- a/nym-wallet/src/components/Delegation/DelegationList.stories.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationList.stories.tsx
@@ -33,6 +33,7 @@ export const items: DelegationWithEverything[] = [
     avg_uptime_percent: 0.5,
     uses_vesting_contract_tokens: false,
     pending_events: [],
+    mixnode_is_unbonding: true,
   },
   {
     mix_id: 5678,
@@ -55,6 +56,7 @@ export const items: DelegationWithEverything[] = [
     avg_uptime_percent: 0.1,
     uses_vesting_contract_tokens: true,
     pending_events: [],
+    mixnode_is_unbonding: true,
   },
 ];
 

--- a/nym-wallet/src/components/Delegation/DelegationList.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationList.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Box,
-  Chip,
   CircularProgress,
   Table,
   TableBody,
@@ -39,43 +38,12 @@ const headCells: HeadCell[] = [
   { id: 'node_identity', label: 'Node ID', sortable: true, align: 'left' },
   { id: 'avg_uptime_percent', label: 'Routing score', sortable: true, align: 'left' },
   { id: 'profit_margin_percent', label: 'Profit margin', sortable: true, align: 'left' },
+  { id: 'operating_cost', label: 'Operating Cost', sortable: true, align: 'left' },
   { id: 'stake_saturation', label: 'Stake saturation', sortable: true, align: 'left' },
   { id: 'delegated_on_iso_datetime', label: 'Delegated on', sortable: true, align: 'left' },
   { id: 'amount', label: 'Delegation', sortable: true, align: 'left' },
   { id: 'unclaimed_rewards', label: 'Reward', sortable: true, align: 'left' },
 ];
-
-function descendingComparator(a: any, b: any, orderBy: string) {
-  if (b[orderBy] < a[orderBy]) {
-    return -1;
-  }
-  if (b[orderBy] > a[orderBy]) {
-    return 1;
-  }
-  return 0;
-}
-// Sorting function needs fixing
-
-function sortPendingDelegation(a: DelegationWithEvent, b: DelegationWithEvent) {
-  if (isPendingDelegation(a) && isPendingDelegation(b)) return 0;
-  if (isPendingDelegation(b)) return -1;
-  if (isPendingDelegation(a)) return 1;
-  return 2;
-}
-
-function getComparator(order: Order, orderBy: string): (a: DelegationWithEvent, b: DelegationWithEvent) => number {
-  return order === 'desc'
-    ? (a, b) => {
-        const pendingSort = sortPendingDelegation(a, b);
-        if (pendingSort === 2) return descendingComparator(a, b, orderBy);
-        return pendingSort;
-      }
-    : (a, b) => {
-        const pendingSort = -sortPendingDelegation(a, b);
-        if (pendingSort === 2) return -descendingComparator(a, b, orderBy);
-        return pendingSort;
-      };
-}
 
 const EnhancedTableHead: React.FC<EnhancedTableProps> = ({ order, orderBy, onRequestSort }) => {
   const createSortHandler = (property: string) => (event: React.MouseEvent<unknown>) => {
@@ -112,6 +80,11 @@ const EnhancedTableHead: React.FC<EnhancedTableProps> = ({ order, orderBy, onReq
       </TableRow>
     </TableHead>
   );
+};
+
+const sortByUnbondedMixnodeFirst = (a: DelegationWithEvent) => {
+  if (!a.node_identity) return -1;
+  return 1;
 };
 
 export const DelegationList: React.FC<{

--- a/nym-wallet/src/components/Delegation/DelegationList.tsx
+++ b/nym-wallet/src/components/Delegation/DelegationList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   Chip,
@@ -10,17 +10,14 @@ import {
   TableHead,
   TableRow,
   TableSortLabel,
-  Tooltip,
-  Typography,
 } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
-import { decimalToPercentage, DelegationWithEverything } from '@nymproject/types';
-import { Link } from '@nymproject/react/link/Link';
-import { format } from 'date-fns';
-import { DelegationListItemActions, DelegationsActionsMenu } from './DelegationActions';
+import { DelegationWithEverything } from '@nymproject/types';
+import { DelegationListItemActions } from './DelegationActions';
 import { DelegationWithEvent, isDelegation, isPendingDelegation, TDelegations } from '../../context/delegations';
-import { toPercentIntegerString } from '../../utils';
+import { DelegationItem } from './DelegationItem';
+import { PendingDelegationItem } from './PendingDelegationItem';
 
 type Order = 'asc' | 'desc';
 
@@ -119,7 +116,7 @@ const EnhancedTableHead: React.FC<EnhancedTableProps> = ({ order, orderBy, onReq
 
 export const DelegationList: React.FC<{
   isLoading?: boolean;
-  items?: TDelegations;
+  items: TDelegations;
   onItemActionClick?: (item: DelegationWithEverything, action: DelegationListItemActions) => void;
   explorerUrl: string;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -133,89 +130,25 @@ export const DelegationList: React.FC<{
     setOrderBy(property);
   };
 
-  const getStakeSaturation = (item: DelegationWithEvent) => {
-    if (isDelegation(item)) {
-      return !item.stake_saturation ? '-' : `${decimalToPercentage(item.stake_saturation)}%`;
-    }
-    return '';
-  };
-
-  const getRewardValue = (item: DelegationWithEvent) => {
-    if (isPendingDelegation(item)) {
-      return '';
-    }
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { unclaimed_rewards } = item;
-    return !unclaimed_rewards ? '-' : `${unclaimed_rewards.amount} ${unclaimed_rewards.denom}`;
-  };
-
   return (
     <TableContainer>
       <Table sx={{ width: '100%' }}>
         <EnhancedTableHead order={order} orderBy={orderBy} onRequestSort={handleRequestSort} />
         <TableBody>
-          {items?.length ? (
-            items.map((item) => (
-              <TableRow key={item.node_identity}>
-                <TableCell>
-                  <Link
-                    target="_blank"
-                    href={`${explorerUrl}/network-components/mixnode/${item.node_identity}`}
-                    text={`${item.node_identity.slice(0, 6)}...${item.node_identity.slice(-6)}`}
-                    color="text.primary"
-                    noIcon
+          {items.length ? (
+            items.map((item) => {
+              if (isPendingDelegation(item)) return <PendingDelegationItem item={item} explorerUrl={explorerUrl} />;
+              if (isDelegation(item))
+                return (
+                  <DelegationItem
+                    item={item}
+                    explorerUrl={explorerUrl}
+                    nodeIsUnbonded={Boolean(!item.node_identity)}
+                    onItemActionClick={onItemActionClick}
                   />
-                </TableCell>
-                <TableCell>
-                  {isDelegation(item) && (!item.avg_uptime_percent ? '-' : `${item.avg_uptime_percent}%`)}
-                </TableCell>
-                <TableCell>
-                  {isDelegation(item) &&
-                    (!item.cost_params?.profit_margin_percent
-                      ? '-'
-                      : `${toPercentIntegerString(item.cost_params.profit_margin_percent)}%`)}
-                </TableCell>
-                <TableCell>{getStakeSaturation(item)}</TableCell>
-                <TableCell>
-                  {isDelegation(item) && format(new Date(item.delegated_on_iso_datetime), 'dd/MM/yyyy')}
-                </TableCell>
-                <TableCell>
-                  <Typography style={{ textTransform: 'uppercase' }}>
-                    {isDelegation(item) && `${item.amount.amount} ${item.amount.denom}`}
-                  </Typography>
-                </TableCell>
-                <TableCell sx={{ textTransform: 'uppercase' }}>{getRewardValue(item)}</TableCell>
-                <TableCell align="right">
-                  {isDelegation(item) && !item.pending_events.length && (
-                    <DelegationsActionsMenu
-                      isPending={undefined}
-                      onActionClick={(action) => (onItemActionClick ? onItemActionClick(item, action) : undefined)}
-                      disableRedeemingRewards={!item.unclaimed_rewards || item.unclaimed_rewards.amount === '0'}
-                    />
-                  )}
-                  {isDelegation(item) && item.pending_events.length > 0 && (
-                    <Tooltip
-                      title="Your changes will take effect when
-the new epoch starts. There is a new
-epoch every hour."
-                      arrow
-                    >
-                      <Chip label="Pending Events" />
-                    </Tooltip>
-                  )}
-                  {isPendingDelegation(item) && (
-                    <Tooltip
-                      title={`Your delegation of ${item.event.amount?.amount} ${item.event.amount?.denom} will take effect 
-                        when the new epoch starts. There is a new
-                        epoch every hour.`}
-                      arrow
-                    >
-                      <Chip label="Pending Events" />
-                    </Tooltip>
-                  )}
-                </TableCell>
-              </TableRow>
-            ))
+                );
+              return null;
+            })
           ) : (
             <TableRow>
               <TableCell colSpan={7}>

--- a/nym-wallet/src/components/Delegation/Delegations.tsx
+++ b/nym-wallet/src/components/Delegation/Delegations.tsx
@@ -7,7 +7,7 @@ import { DelegationListItemActions } from './DelegationActions';
 
 export const Delegations: React.FC<{
   isLoading?: boolean;
-  items?: DelegationWithEverything[];
+  items: DelegationWithEverything[];
   explorerUrl: string;
   onDelegationItemActionClick?: (item: DelegationWithEverything, action: DelegationListItemActions) => void;
 }> = ({ isLoading, items, explorerUrl, onDelegationItemActionClick }) => (

--- a/nym-wallet/src/components/Delegation/PendingDelegationItem.tsx
+++ b/nym-wallet/src/components/Delegation/PendingDelegationItem.tsx
@@ -21,6 +21,7 @@ export const PendingDelegationItem = ({ item, explorerUrl }: { item: WrappedDele
       <TableCell>-</TableCell>
       <TableCell>-</TableCell>
       <TableCell>-</TableCell>
+      <TableCell>-</TableCell>
       <TableCell align="right">
         <Tooltip
           title={`Your delegation of ${item.event.amount?.amount} ${item.event.amount?.denom} will take effect 

--- a/nym-wallet/src/components/Delegation/PendingDelegationItem.tsx
+++ b/nym-wallet/src/components/Delegation/PendingDelegationItem.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Chip, TableCell, TableRow, Tooltip } from '@mui/material';
+import { WrappedDelegationEvent } from '@nymproject/types';
+import { Link } from '@nymproject/react/link/Link';
+
+export const PendingDelegationItem = ({ item, explorerUrl }: { item: WrappedDelegationEvent; explorerUrl: string }) => {
+  return (
+    <TableRow key={item.node_identity}>
+      <TableCell>
+        <Link
+          target="_blank"
+          href={`${explorerUrl}/network-components/mixnode/${item.node_identity}`}
+          text={`${item.node_identity.slice(0, 6)}...${item.node_identity.slice(-6)}`}
+          color="text.primary"
+          noIcon
+        />
+      </TableCell>
+      <TableCell>-</TableCell>
+      <TableCell>-</TableCell>
+      <TableCell>-</TableCell>
+      <TableCell>-</TableCell>
+      <TableCell>-</TableCell>
+      <TableCell>-</TableCell>
+      <TableCell align="right">
+        <Tooltip
+          title={`Your delegation of ${item.event.amount?.amount} ${item.event.amount?.denom} will take effect 
+            when the new epoch starts. There is a new
+            epoch every hour.`}
+          arrow
+        >
+          <Chip label="Pending Events" />
+        </Tooltip>
+      </TableCell>
+    </TableRow>
+  );
+};

--- a/nym-wallet/src/components/Delegation/UndelegateModal.tsx
+++ b/nym-wallet/src/components/Delegation/UndelegateModal.tsx
@@ -46,15 +46,8 @@ export const UndelegateModal: React.FC<{
       sx={sx}
       backdropProps={backdropProps}
     >
-      <IdentityKeyFormField
-        readOnly
-        fullWidth
-        placeholder="Node identity key"
-        initialValue={identityKey}
-        showTickOnValid={false}
-      />
-
       <Box sx={{ mt: 3 }}>
+        <ModalListItem label="Node identity" value={identityKey || '-'} divider />
         <ModalListItem label="Delegation amount" value={`${amount} ${currency.toUpperCase()}`} divider />
         <ModalFee fee={fee} isLoading={isFeeLoading} error={feeError} divider />
         <ModalListItem label=" Tokens will be transferred to account you are logged in with now" value="" divider />

--- a/nym-wallet/src/context/bonding.tsx
+++ b/nym-wallet/src/context/bonding.tsx
@@ -8,7 +8,7 @@ import {
 } from '@nymproject/types';
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import Big from 'big.js';
-import { isGateway, isMixnode, isUnbondEvent, TBondGatewayArgs, TBondMixNodeArgs } from 'src/types';
+import { isGateway, isMixnode, TBondGatewayArgs, TBondMixNodeArgs } from 'src/types';
 import { Console } from 'src/utils/console';
 import {
   bondGateway as bondGatewayRequest,
@@ -233,17 +233,6 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
     }
   };
 
-  const checkPendingUnbond = async () => {
-    try {
-      const res = await getPendingEpochEvents();
-      const match = res.find((item) => isUnbondEvent(item.event));
-      return Boolean(match);
-    } catch (e) {
-      Console.error(e);
-      return false;
-    }
-  };
-
   const refresh = useCallback(async () => {
     setIsLoading(true);
 
@@ -274,7 +263,6 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
             bond_information.mix_node.http_api_port,
           );
           const routingScore = await getAvgUptime();
-          const isUnbonding = await checkPendingUnbond();
           setBondedNode({
             name: nodeDescription?.name,
             identityKey: bond_information.mix_node.identity_key,
@@ -299,7 +287,7 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
             mixPort: bond_information.mix_node.mix_port,
             verlocPort: bond_information.mix_node.verloc_port,
             version: bond_information.mix_node.version,
-            isUnbonding,
+            isUnbonding: bond_information.is_unbonding,
           } as TBondedMixnode);
         }
       } catch (e: any) {
@@ -314,7 +302,6 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
         if (data) {
           const nodeDescription = await getNodeDescription(data.gateway.host, data.gateway.clients_port);
           const routingScore = await getGatewayReportDetails(data.gateway.identity_key);
-          const isUnbonding = await checkPendingUnbond();
           setBondedNode({
             name: nodeDescription?.name,
             identityKey: data.gateway.identity_key,
@@ -323,7 +310,7 @@ export const BondingContextProvider = ({ children }: { children?: React.ReactNod
             bond: data.pledge_amount,
             proxy: data.proxy,
             routingScore,
-            isUnbonding,
+            isUnbonding: false,
           } as TBondedGateway);
         }
       } catch (e: any) {

--- a/nym-wallet/src/context/delegations.tsx
+++ b/nym-wallet/src/context/delegations.tsx
@@ -36,7 +36,8 @@ export type TDelegationTransaction = {
 };
 
 export type DelegationWithEvent = DelegationWithEverything | WrappedDelegationEvent;
-export type TDelegations = DelegationWithEvent[];
+export type TDelegation = DelegationWithEvent;
+export type TDelegations = TDelegation[];
 
 export const isPendingDelegation = (delegation: DelegationWithEvent): delegation is WrappedDelegationEvent =>
   'event' in delegation;

--- a/nym-wallet/src/context/mocks/bonding.tsx
+++ b/nym-wallet/src/context/mocks/bonding.tsx
@@ -26,6 +26,7 @@ const bondedMixnodeMock: TBondedMixnode = {
   mixPort: 1789,
   verlocPort: 1790,
   version: '1.0.2',
+  isUnbonding: false,
 };
 
 const bondedGatewayMock: TBondedGateway = {
@@ -42,6 +43,7 @@ const bondedGatewayMock: TBondedGateway = {
     average: 100,
     current: 100,
   },
+  isUnbonding: false,
 };
 
 const TxResultMock: TransactionExecuteResult = {

--- a/nym-wallet/src/context/mocks/delegations.tsx
+++ b/nym-wallet/src/context/mocks/delegations.tsx
@@ -29,6 +29,7 @@ let mockDelegations: DelegationWithEverything[] = [
     accumulated_by_operator: { amount: '0', denom: 'nym' },
     uses_vesting_contract_tokens: false,
     pending_events: [],
+    mixnode_is_unbonding: false,
   },
   {
     mix_id: 5678,
@@ -51,6 +52,7 @@ let mockDelegations: DelegationWithEverything[] = [
     accumulated_by_operator: { amount: '0', denom: 'nym' },
     uses_vesting_contract_tokens: true,
     pending_events: [],
+    mixnode_is_unbonding: false,
   },
 ];
 

--- a/nym-wallet/src/pages/bonding/node-settings/NodeSettings.tsx
+++ b/nym-wallet/src/pages/bonding/node-settings/NodeSettings.tsx
@@ -54,6 +54,8 @@ export const NodeSettings = () => {
     });
   };
 
+  if (isLoading) return <LoadingModal />;
+
   if (!bondedNode) {
     return null;
   }
@@ -133,7 +135,6 @@ export const NodeSettings = () => {
             }}
           />
         )}
-        {isLoading && <LoadingModal />}
       </NymCard>
     </PageLayout>
   );

--- a/nym-wallet/src/pages/delegation/index.tsx
+++ b/nym-wallet/src/pages/delegation/index.tsx
@@ -111,7 +111,7 @@ export const Delegation: FC<{ isStorybook?: boolean }> = ({ isStorybook }) => {
 
   const handleNewDelegation = async (
     mix_id: number,
-    identityKey: string,
+    _: string,
     amount: DecCoin,
     tokenPool: TPoolOption,
     fee?: FeeDetails,
@@ -275,7 +275,8 @@ export const Delegation: FC<{ isStorybook?: boolean }> = ({ isStorybook }) => {
           <CircularProgress />
         </Box>
       );
-    } else if (Boolean(delegations?.length)) {
+    }
+    if (delegations && Boolean(delegations?.length)) {
       return (
         <DelegationList
           explorerUrl={urls(network).networkExplorer}

--- a/nym-wallet/src/requests/index.ts
+++ b/nym-wallet/src/requests/index.ts
@@ -10,3 +10,4 @@ export * from './signature';
 export * from './simulate';
 export * from './utils';
 export * from './vesting';
+export * from './pendingEvents';

--- a/nym-wallet/src/requests/pendingEvents.ts
+++ b/nym-wallet/src/requests/pendingEvents.ts
@@ -1,0 +1,4 @@
+import { PendingEpochEvent } from '@nymproject/types';
+import { invokeWrapper } from './wrapper';
+
+export const getPendingEpochEvents = async () => invokeWrapper<PendingEpochEvent[]>('get_pending_epoch_events');

--- a/nym-wallet/src/types/global.ts
+++ b/nym-wallet/src/types/global.ts
@@ -1,4 +1,12 @@
-import { Gateway, DecCoin, MixNode, PledgeData, MixNodeCostParams } from '@nymproject/types';
+import {
+  Gateway,
+  DecCoin,
+  MixNode,
+  PledgeData,
+  MixNodeCostParams,
+  PendingIntervalEventData,
+  PendingEpochEventData,
+} from '@nymproject/types';
 import { Fee } from '@nymproject/types/dist/types/rust/Fee';
 import { TBondedGateway, TBondedMixnode } from 'src/context';
 
@@ -73,3 +81,6 @@ export const isMixnode = (node: TBondedMixnode | TBondedGateway): node is TBonde
   (node as TBondedMixnode).profitMargin !== undefined;
 
 export const isGateway = (node: TBondedMixnode | TBondedGateway): node is TBondedGateway => !isMixnode(node);
+
+export const isUnbondEvent = (event: PendingEpochEventData): event is { UnbondMixnode: { mix_id: number } } =>
+  'UnbondMixnode' in event;

--- a/nym-wallet/src/types/global.ts
+++ b/nym-wallet/src/types/global.ts
@@ -81,6 +81,3 @@ export const isMixnode = (node: TBondedMixnode | TBondedGateway): node is TBonde
   (node as TBondedMixnode).profitMargin !== undefined;
 
 export const isGateway = (node: TBondedMixnode | TBondedGateway): node is TBondedGateway => !isMixnode(node);
-
-export const isUnbondEvent = (event: PendingEpochEventData): event is { UnbondMixnode: { mix_id: number } } =>
-  'UnbondMixnode' in event;

--- a/ts-packages/types/src/types/global.ts
+++ b/ts-packages/types/src/types/global.ts
@@ -1,4 +1,4 @@
-import { MixNode, DecCoin, CurrencyDenom } from './rust';
+import { MixNode, DecCoin } from './rust';
 
 export type TNodeType = 'mixnode' | 'gateway';
 

--- a/ts-packages/types/src/types/rust/DelegationWithEverything.ts
+++ b/ts-packages/types/src/types/rust/DelegationWithEverything.ts
@@ -17,4 +17,5 @@ export interface DelegationWithEverything {
   uses_vesting_contract_tokens: boolean;
   unclaimed_rewards: DecCoin | null;
   pending_events: Array<DelegationEvent>;
+  mixnode_is_unbonding: boolean | null;
 }


### PR DESCRIPTION
# Description

- Highlight delegations on unbonded mixnodes in red
- Only allow undelgate action on delegations on unbonded mixnode
- Sort delegations on unbonded mixnodes to top of list
- Add Operating Cost to delegation table (on delegations, not event)

Closes: 
https://github.com/nymtech/nym/issues/2233 
https://github.com/nymtech/nym/issues/2240
https://github.com/nymtech/nym/issues/2220

