### PR TITLE
refactor(explorer-api): route ping use mix_id as param

### DIFF
--- a/explorer-api/src/mix_nodes/models.rs
+++ b/explorer-api/src/mix_nodes/models.rs
@@ -126,19 +126,6 @@ impl ThreadsafeMixNodesCache {
         self.mixnodes.read().await.get_mixnode(mix_id)
     }
 
-    pub(crate) async fn get_mixnode_by_identity(
-        &self,
-        pubkey: &str,
-    ) -> Option<MixNodeBondAnnotated> {
-        let all_nodes = self.get_mixnodes().await?;
-        for (_, node) in all_nodes {
-            if node.mix_node().identity_key == pubkey {
-                return Some(node);
-            }
-        }
-        None
-    }
-
     pub(crate) async fn get_mixnodes(&self) -> Option<HashMap<MixId, MixNodeBondAnnotated>> {
         self.mixnodes.read().await.get_mixnodes()
     }

--- a/explorer-api/src/ping/http.rs
+++ b/explorer-api/src/ping/http.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use mixnet_contract_common::MixNode;
+use mixnet_contract_common::{MixNode, MixId};
 use rocket::serde::json::Json;
 use rocket::{Route, State};
 use rocket_okapi::okapi::openapi3::OpenApi;
@@ -23,38 +23,38 @@ pub fn ping_make_default_routes(settings: &OpenApiSettings) -> (Vec<Route>, Open
 // TODO: I'm not deprecating this one explicitly since we don't have
 // a decision on whether nodes should be accessed (as in using URL) by id or identity key
 #[openapi(tag = "ping")]
-#[get("/<pubkey>")]
+#[get("/<mix_id>")]
 pub(crate) async fn index(
-    pubkey: &str,
+    mix_id: MixId,
     state: &State<ExplorerApiStateContext>,
 ) -> Option<Json<PingResponse>> {
-    match state.inner.ping.clone().get(pubkey).await {
+    match state.inner.ping.clone().get(mix_id).await {
         Some(cache_value) => {
-            trace!("Returning cached value for {}", pubkey);
+            trace!("Returning cached value for {}", mix_id);
             Some(Json(PingResponse {
                 pending: cache_value.pending,
                 ports: cache_value.ports,
             }))
         }
         None => {
-            trace!("No cache value for {}", pubkey);
+            trace!("No cache value for {}", mix_id);
 
-            match state.inner.get_mix_node_by_pubkey(pubkey).await {
+            match state.inner.get_mix_node(mix_id).await {
                 Some(node) => {
                     // set status to pending, so that any HTTP requests are pending
-                    state.inner.ping.set_pending(pubkey).await;
+                    state.inner.ping.set_pending(mix_id).await;
 
                     // do the check
                     let ports = Some(port_check(node.mix_node()).await);
-                    trace!("Tested mix node {}: {:?}", pubkey, ports);
+                    trace!("Tested mix node {}: {:?}", mix_id, ports);
                     let response = PingResponse {
                         ports,
                         pending: false,
                     };
 
                     // cache for 1 min
-                    trace!("Caching value for {}", pubkey);
-                    state.inner.ping.set(pubkey, response.clone()).await;
+                    trace!("Caching value for {}", mix_id);
+                    state.inner.ping.set(mix_id, response.clone()).await;
 
                     // return response
                     Some(Json(response))

--- a/explorer-api/src/ping/http.rs
+++ b/explorer-api/src/ping/http.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use mixnet_contract_common::{MixNode, MixId};
+use mixnet_contract_common::{MixId, MixNode};
 use rocket::serde::json::Json;
 use rocket::{Route, State};
 use rocket_okapi::okapi::openapi3::OpenApi;

--- a/explorer-api/src/ping/http.rs
+++ b/explorer-api/src/ping/http.rs
@@ -20,8 +20,6 @@ pub fn ping_make_default_routes(settings: &OpenApiSettings) -> (Vec<Route>, Open
     openapi_get_routes_spec![settings: index]
 }
 
-// TODO: I'm not deprecating this one explicitly since we don't have
-// a decision on whether nodes should be accessed (as in using URL) by id or identity key
 #[openapi(tag = "ping")]
 #[get("/<mix_id>")]
 pub(crate) async fn index(

--- a/explorer-api/src/state.rs
+++ b/explorer-api/src/state.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use chrono::{DateTime, Utc};
 use log::info;
-use mixnet_contract_common::{IdentityKeyRef, MixId};
+use mixnet_contract_common::MixId;
 use serde::{Deserialize, Serialize};
 
 use crate::client::ThreadsafeValidatorClient;
@@ -40,13 +40,6 @@ pub struct ExplorerApiState {
 impl ExplorerApiState {
     pub(crate) async fn get_mix_node(&self, mix_id: MixId) -> Option<MixNodeBondAnnotated> {
         self.mixnodes.get_mixnode(mix_id).await
-    }
-
-    pub(crate) async fn get_mix_node_by_pubkey(
-        &self,
-        pubkey: IdentityKeyRef<'_>,
-    ) -> Option<MixNodeBondAnnotated> {
-        self.mixnodes.get_mixnode_by_identity(pubkey).await
     }
 }
 


### PR DESCRIPTION
# Description

fix on explorer API `/ping` route answering 404, refactor it to use `mix_id` as request parameter

Closes: nymtech/nym#2219