### PR TITLE
add profit margin percent to response

### DIFF
--- a/explorer-api/.gitignore
+++ b/explorer-api/.gitignore
@@ -1,3 +1,3 @@
 target
 explorer-api-state.json
-/geo_ip
+geo_ip

--- a/explorer-api/.gitignore
+++ b/explorer-api/.gitignore
@@ -1,3 +1,3 @@
 target
 explorer-api-state.json
-geo_ip
+/geo_ip

--- a/explorer-api/src/mix_node/models.rs
+++ b/explorer-api/src/mix_node/models.rs
@@ -3,6 +3,7 @@
 
 use crate::cache::Cache;
 use crate::mix_nodes::location::Location;
+use contracts_common::Percent;
 use mixnet_contract_common::Delegation;
 use mixnet_contract_common::{Addr, Coin, Layer, MixId, MixNode};
 use serde::Deserialize;
@@ -37,7 +38,7 @@ pub(crate) struct PrettyDetailedMixNodeBond {
     pub estimated_operator_apy: f64,
     pub estimated_delegators_apy: f64,
     pub operating_cost: Coin,
-    pub profit_margin_percent: f64,
+    pub profit_margin_percent: Percent,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]

--- a/explorer-api/src/mix_node/models.rs
+++ b/explorer-api/src/mix_node/models.rs
@@ -37,6 +37,7 @@ pub(crate) struct PrettyDetailedMixNodeBond {
     pub estimated_operator_apy: f64,
     pub estimated_delegators_apy: f64,
     pub operating_cost: Coin,
+    pub profit_margin_percent: f64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]

--- a/explorer-api/src/mix_nodes/models.rs
+++ b/explorer-api/src/mix_nodes/models.rs
@@ -167,8 +167,7 @@ impl ThreadsafeMixNodesCache {
             estimated_operator_apy: best_effort_small_dec_to_f64(node.estimated_operator_apy),
             estimated_delegators_apy: best_effort_small_dec_to_f64(node.estimated_delegators_apy),
             operating_cost: rewarding_info.cost_params.interval_operating_cost.clone(),
-            profit_margin_percent: rewarding_info
-                .best_effort_small_dec_to_f64(cost_params.profit_margin_percent),
+            profit_margin_percent: rewarding_info.cost_params.profit_margin_percent,
         }
     }
 

--- a/explorer-api/src/mix_nodes/models.rs
+++ b/explorer-api/src/mix_nodes/models.rs
@@ -167,6 +167,8 @@ impl ThreadsafeMixNodesCache {
             estimated_operator_apy: best_effort_small_dec_to_f64(node.estimated_operator_apy),
             estimated_delegators_apy: best_effort_small_dec_to_f64(node.estimated_delegators_apy),
             operating_cost: rewarding_info.cost_params.interval_operating_cost.clone(),
+            profit_margin_percent: rewarding_info
+                .best_effort_small_dec_to_f64(cost_params.profit_margin_percent),
         }
     }
 

--- a/explorer/src/components/MixNodes/Economics/Rows.ts
+++ b/explorer/src/components/MixNodes/Economics/Rows.ts
@@ -2,6 +2,7 @@ import { currencyToString, unymToNym } from '../../../utils/currency';
 import { useMixnodeContext } from '../../../context/mixnode';
 import { ApiState, MixNodeEconomicDynamicsStatsResponse } from '../../../typeDefs/explorer-api';
 import { EconomicsInfoRowWithIndex } from './types';
+import { toPercentIntegerString } from '../../../utils';
 
 const selectionChance = (economicDynamicsStats: ApiState<MixNodeEconomicDynamicsStatsResponse> | undefined) => {
   const inclusionProbability = economicDynamicsStats?.data?.active_set_inclusion_probability;
@@ -29,7 +30,9 @@ export const EconomicsInfoRows = (): EconomicsInfoRowWithIndex => {
   const estimatedOperatorRewards =
     currencyToString((economicDynamicsStats?.data?.estimated_operator_reward || '').toString()) || '-';
   const stakeSaturation = economicDynamicsStats?.data?.stake_saturation || '-';
-  const profitMargin = mixNode?.data?.mix_node.profit_margin_percent || '-';
+  const profitMargin = mixNode?.data?.profit_margin_percent
+    ? toPercentIntegerString(mixNode?.data?.profit_margin_percent)
+    : '-';
   const avgUptime = economicDynamicsStats?.data?.current_interval_uptime;
 
   const opCost = mixNode?.data?.operating_cost;

--- a/explorer/src/components/MixNodes/index.ts
+++ b/explorer/src/components/MixNodes/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import { MixNodeResponse, MixNodeResponseItem, MixnodeStatus } from '../../typeDefs/explorer-api';
+import { toPercentIntegerString } from '../../utils';
 import { unymToNym } from '../../utils/currency';
 
 export type MixnodeRowType = {
@@ -29,7 +30,7 @@ export function mixNodeResponseItemToMixnodeRowType(item: MixNodeResponseItem): 
   const delegations = Number(item.total_delegation.amount) || 0;
   const totalBond = pledge + delegations;
   const selfPercentage = ((pledge * 100) / totalBond).toFixed(2);
-  const profitPercentage = item.mix_node.profit_margin_percent || 0;
+  const profitPercentage = toPercentIntegerString(item.profit_margin_percent) || 0;
   const stakeSaturation = typeof item.stake_saturation === 'number' ? item.stake_saturation * 100 : 0;
 
   return {

--- a/explorer/src/context/main.tsx
+++ b/explorer/src/context/main.tsx
@@ -99,8 +99,8 @@ export const MainContextProvider: React.FC = ({ children }) => {
 
     const filtered = mxns?.filter(
       (m) =>
-        m.mix_node.profit_margin_percent >= filters.profitMargin[0] &&
-        m.mix_node.profit_margin_percent <= filters.profitMargin[1] &&
+        +m.profit_margin_percent >= filters.profitMargin[0] / 100 &&
+        +m.profit_margin_percent <= filters.profitMargin[1] / 100 &&
         m.stake_saturation >= filters.stakeSaturation[0] &&
         m.stake_saturation <= filters.stakeSaturation[1] &&
         m.avg_uptime >= filters.routingScore[0] &&

--- a/explorer/src/context/main.tsx
+++ b/explorer/src/context/main.tsx
@@ -96,6 +96,7 @@ export const MainContextProvider: React.FC = ({ children }) => {
   const filterMixnodes = async (filters: { [key in EnumFilterKey]: number[] }, status?: MixnodeStatus) => {
     setMixnodes((d) => ({ ...d, isLoading: true }));
     const mxns = status ? await Api.fetchMixnodesActiveSetByStatus(status) : await Api.fetchMixnodes();
+
     const filtered = mxns?.filter(
       (m) =>
         m.mix_node.profit_margin_percent >= filters.profitMargin[0] &&
@@ -105,6 +106,7 @@ export const MainContextProvider: React.FC = ({ children }) => {
         m.avg_uptime >= filters.routingScore[0] &&
         m.avg_uptime <= filters.routingScore[1],
     );
+
     setMixnodes({ data: filtered, isLoading: false });
   };
 

--- a/explorer/src/typeDefs/explorer-api.ts
+++ b/explorer/src/typeDefs/explorer-api.ts
@@ -30,7 +30,6 @@ export interface MixNode {
   sphinx_key: string;
   identity_key: string;
   version: string;
-  profit_margin_percent: number;
   location: string;
 }
 
@@ -87,6 +86,7 @@ export interface MixNodeResponseItem {
   avg_uptime: number;
   stake_saturation: number;
   operating_cost: Amount;
+  profit_margin_percent: string;
 }
 
 export type MixNodeResponse = MixNodeResponseItem[];

--- a/explorer/src/utils/index.ts
+++ b/explorer/src/utils/index.ts
@@ -45,3 +45,11 @@ export const splice = (start: number, deleteCount: number, address?: string): st
   }
   return '';
 };
+
+/**
+ * Converts a stringified percentage float (0.0-1.0) to a stringified integer (0-100).
+ *
+ * @param value - the percentage to convert
+ * @returns A stringified integer
+ */
+export const toPercentIntegerString = (value: string) => Math.round(Number(value) * 100).toString();


### PR DESCRIPTION
# Description

Profit margin percent missing from the `MixNodeResponseItem` type

This PR 

- adds `profit_margin_percent` to `MixNodeResponseItem` 
- updates `profit_margin_percent` to be string type from number
- uses `toPercentIntegerString` to convert `profit_margin_percent` to a display percentage

Closes: https://github.com/nymtech/nym/issues/2214