### PR TITLE
Added migration code for updating vesting contract address

### DIFF
--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
@@ -413,4 +413,6 @@ pub enum QueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {}
+pub struct MigrateMsg {
+    pub vesting_contract_address: String,
+}

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+## Added
+
+- Added migration code to the mixnet contract to allow updating stored vesting contract address to make it easier to deploy any future environments ([#1759])
+
+[#1759]: https://github.com/nymtech/nym/pull/1759
+
 ## [nym-contracts-v1.1.0](https://github.com/nymtech/nym/tree/nym-contracts-v1.1.0) (2022-11-09)
 
 ### Changed

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -467,10 +467,20 @@ pub fn query(
 
 #[entry_point]
 pub fn migrate(
-    _deps: DepsMut<'_>,
+    deps: DepsMut<'_>,
     _env: Env,
-    _msg: MigrateMsg,
+    msg: MigrateMsg,
 ) -> Result<Response, MixnetContractError> {
+    // due to circular dependency on contract addresses (i.e. mixnet contract requiring vesting contract address
+    // and vesting contract requiring the mixnet contract address), if we ever want to deploy any new fresh
+    // environment, one of the contracts will HAVE TO go through a migration
+    if !msg.vesting_contract_address.is_empty() {
+        let mut current_state = mixnet_params_storage::CONTRACT_STATE.load(deps.storage)?;
+        current_state.vesting_contract_address =
+            deps.api.addr_validate(&msg.vesting_contract_address)?;
+        mixnet_params_storage::CONTRACT_STATE.save(deps.storage, &current_state)?;
+    }
+
     Ok(Default::default())
 }
 


### PR DESCRIPTION
# Description

This PR introduces default migration to the mixnet contract so that it would be possible to update the stored vesting contract address. This is required if we ever wanted to deploy any new environment since there exists a circular dependency on contract addresses between vesting and mixnet contracts during instantiation and you can't know both of them ahead of time (well, not without changes from wasmd 0.29 that we are NOT on)

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
