### PR TITLE
Fixed layer distribution skewness check (now we shouldn't need at least 36 nodes per layer after minor version upgrades)

### DIFF
--- a/clients/client-core/src/client/topology_control.rs
+++ b/clients/client-core/src/client/topology_control.rs
@@ -184,13 +184,10 @@ impl TopologyRefresher {
     /// # Arguments
     ///
     /// * `topology`: active topology constructed from validator api data
-    /// * `mixnodes_count`: total number of active mixnodes
-    fn check_layer_distribution(
-        &self,
-        active_topology: &NymTopology,
-        mixnodes_count: usize,
-    ) -> bool {
+    fn check_layer_distribution(&self, active_topology: &NymTopology) -> bool {
         let mixes = active_topology.mixes();
+        let mixnodes_count = active_topology.num_mixnodes();
+
         if active_topology.gateways().is_empty() {
             return false;
         }
@@ -255,11 +252,10 @@ impl TopologyRefresher {
             Ok(gateways) => gateways,
         };
 
-        let mixnodes_count = mixnodes.len();
         let topology = nym_topology_from_detailed(mixnodes, gateways)
             .filter_system_version(&self.client_version);
 
-        if !self.check_layer_distribution(&topology, mixnodes_count) {
+        if !self.check_layer_distribution(&topology) {
             warn!("The current filtered active topology has extremely skewed layer distribution. It cannot be used.");
             None
         } else {

--- a/common/topology/src/lib.rs
+++ b/common/topology/src/lib.rs
@@ -84,6 +84,10 @@ impl NymTopology {
         &self.mixes
     }
 
+    pub fn num_mixnodes(&self) -> usize {
+        self.mixes.values().flat_map(|m| m.iter()).count()
+    }
+
     pub fn mixes_as_vec(&self) -> Vec<mix::Node> {
         let mut mixes: Vec<mix::Node> = vec![];
 


### PR DESCRIPTION
# Description

Closes https://github.com/nymtech/nym/issues/1910

Rather than taking the number of active nodes, take the number of nodes in the provided (filtered) topology instead in order to determine skewness

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
