### PR TITLE
Made vesting_contract_address argument peroperly optional

### DIFF
--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
@@ -414,5 +414,5 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MigrateMsg {
-    pub vesting_contract_address: String,
+    pub vesting_contract_address: Option<String>,
 }

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Added
 
-- Added migration code to the mixnet contract to allow updating stored vesting contract address to make it easier to deploy any future environments ([#1759])
+- Added migration code to the mixnet contract to allow updating stored vesting contract address to make it easier to deploy any future environments ([#1759],[#1769])
 
 [#1759]: https://github.com/nymtech/nym/pull/1759
+[#1769]: https://github.com/nymtech/nym/pull/1769
 
 ## [nym-contracts-v1.1.0](https://github.com/nymtech/nym/tree/nym-contracts-v1.1.0) (2022-11-09)
 

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -474,10 +474,10 @@ pub fn migrate(
     // due to circular dependency on contract addresses (i.e. mixnet contract requiring vesting contract address
     // and vesting contract requiring the mixnet contract address), if we ever want to deploy any new fresh
     // environment, one of the contracts will HAVE TO go through a migration
-    if !msg.vesting_contract_address.is_empty() {
+    if let Some(vesting_contract_address) = msg.vesting_contract_address {
         let mut current_state = mixnet_params_storage::CONTRACT_STATE.load(deps.storage)?;
         current_state.vesting_contract_address =
-            deps.api.addr_validate(&msg.vesting_contract_address)?;
+            deps.api.addr_validate(&vesting_contract_address)?;
         mixnet_params_storage::CONTRACT_STATE.save(deps.storage, &current_state)?;
     }
 


### PR DESCRIPTION
# Description

This lets you pass an empty message, i.e. `{}` when migrating the contract when you don't care about changing the vesting contract address

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
