### PR TITLE
client-core: expose lane queue length state to other components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ name = "client-connections"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "log",
 ]
 
 [[package]]

--- a/clients/client-core/src/client/real_messages_control/mod.rs
+++ b/clients/client-core/src/client/real_messages_control/mod.rs
@@ -106,6 +106,7 @@ where
 // obviously when we finally make shared rng that is on 'higher' level, this should become
 // generic `R`
 impl RealMessagesController<OsRng> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Config,
         ack_receiver: AcknowledgementReceiver,

--- a/clients/client-core/src/client/real_messages_control/mod.rs
+++ b/clients/client-core/src/client/real_messages_control/mod.rs
@@ -14,7 +14,7 @@ use crate::client::{
     topology_control::TopologyAccessor,
 };
 use crate::spawn_future;
-use client_connections::ClosedConnectionReceiver;
+use client_connections::{ClosedConnectionReceiver, LaneQueueLength};
 use futures::channel::mpsc;
 use gateway_client::AcknowledgementReceiver;
 use log::*;
@@ -111,6 +111,7 @@ impl RealMessagesController<OsRng> {
         mix_sender: BatchMixMessageSender,
         topology_access: TopologyAccessor,
         #[cfg(feature = "reply-surb")] reply_key_storage: ReplyKeyStorage,
+        lane_queue_length: LaneQueueLength,
         closed_connection_rx: ClosedConnectionReceiver,
     ) -> Self {
         let rng = OsRng;
@@ -161,6 +162,7 @@ impl RealMessagesController<OsRng> {
             rng,
             config.self_recipient,
             topology_access,
+            lane_queue_length,
             closed_connection_rx,
         );
 

--- a/clients/client-core/src/client/real_messages_control/mod.rs
+++ b/clients/client-core/src/client/real_messages_control/mod.rs
@@ -8,13 +8,15 @@
 use self::{
     acknowledgement_control::AcknowledgementController, real_traffic_stream::OutQueueControl,
 };
-use crate::client::real_messages_control::acknowledgement_control::AcknowledgementControllerConnectors;
-use crate::client::{
-    inbound_messages::InputMessageReceiver, mix_traffic::BatchMixMessageSender,
-    topology_control::TopologyAccessor,
+use crate::{
+    client::{
+        inbound_messages::InputMessageReceiver, mix_traffic::BatchMixMessageSender,
+        real_messages_control::acknowledgement_control::AcknowledgementControllerConnectors,
+        topology_control::TopologyAccessor,
+    },
+    spawn_future,
 };
-use crate::spawn_future;
-use client_connections::{ClosedConnectionReceiver, LaneQueueLength};
+use client_connections::{ClosedConnectionReceiver, LaneQueueLengths};
 use futures::channel::mpsc;
 use gateway_client::AcknowledgementReceiver;
 use log::*;
@@ -111,7 +113,7 @@ impl RealMessagesController<OsRng> {
         mix_sender: BatchMixMessageSender,
         topology_access: TopologyAccessor,
         #[cfg(feature = "reply-surb")] reply_key_storage: ReplyKeyStorage,
-        lane_queue_length: LaneQueueLength,
+        lane_queue_lengths: LaneQueueLengths,
         closed_connection_rx: ClosedConnectionReceiver,
     ) -> Self {
         let rng = OsRng;
@@ -162,7 +164,7 @@ impl RealMessagesController<OsRng> {
             rng,
             config.self_recipient,
             topology_access,
-            lane_queue_length,
+            lane_queue_lengths,
             closed_connection_rx,
         );
 

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -5,7 +5,7 @@ use crate::client::mix_traffic::BatchMixMessageSender;
 use crate::client::real_messages_control::acknowledgement_control::SentPacketNotificationSender;
 use crate::client::topology_control::TopologyAccessor;
 use client_connections::{
-    ClosedConnectionReceiver, ConnectionId, LaneQueueLength, TransmissionLane,
+    ClosedConnectionReceiver, ConnectionId, LaneQueueLengths, TransmissionLane,
 };
 use futures::channel::mpsc;
 use futures::task::{Context, Poll};
@@ -138,7 +138,7 @@ where
     closed_connection_rx: ClosedConnectionReceiver,
 
     /// Report queue lengths so that upstream can backoff sending data, and keep connections open.
-    lane_queue_length: LaneQueueLength,
+    lane_queue_lengths: LaneQueueLengths,
 }
 
 pub(crate) struct RealMessage {
@@ -182,7 +182,7 @@ where
         rng: R,
         our_full_destination: Recipient,
         topology_access: TopologyAccessor,
-        lane_queue_length: LaneQueueLength,
+        lane_queue_lengths: LaneQueueLengths,
         closed_connection_rx: ClosedConnectionReceiver,
     ) -> Self {
         OutQueueControl {
@@ -198,7 +198,7 @@ where
             topology_access,
             transmission_buffer: Default::default(),
             closed_connection_rx,
-            lane_queue_length,
+            lane_queue_lengths,
         }
     }
 
@@ -322,7 +322,7 @@ where
 
         // Update the published queue length
         let lane_length = self.transmission_buffer.lane_length(&lane);
-        self.lane_queue_length.set(&lane, lane_length);
+        self.lane_queue_lengths.set(&lane, lane_length);
 
         Some(real_next)
     }

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream/transmission_buffer.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream/transmission_buffer.rs
@@ -41,6 +41,10 @@ impl TransmissionBuffer {
         self.buffer.keys().count()
     }
 
+    pub(crate) fn lane_length(&self, lane: &TransmissionLane) -> Option<usize> {
+        self.buffer.get(lane).map(LaneBufferEntry::len)
+    }
+
     #[allow(unused)]
     pub(crate) fn connections(&self) -> HashSet<u64> {
         self.buffer
@@ -127,7 +131,7 @@ impl TransmissionBuffer {
         Some(real_next)
     }
 
-    pub(crate) fn pop_next_message_at_random(&mut self) -> Option<RealMessage> {
+    pub(crate) fn pop_next_message_at_random(&mut self) -> Option<(TransmissionLane, RealMessage)> {
         if self.buffer.is_empty() {
             return None;
         }
@@ -142,8 +146,9 @@ impl TransmissionBuffer {
             *self.pick_random_lane()?
         };
 
+        let msg = self.pop_front_from_lane(&lane)?;
         log::trace!("picking to send from lane: {:?}", lane);
-        self.pop_front_from_lane(&lane)
+        Some((lane, msg))
     }
 
     pub(crate) fn prune_stale_connections(&mut self) {

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream/transmission_buffer.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream/transmission_buffer.rs
@@ -201,7 +201,6 @@ impl LaneBufferEntry {
             > Duration::from_secs(MSG_CONSIDERED_STALE_AFTER_SECS)
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     fn len(&self) -> usize {
         self.real_messages.len()
     }

--- a/clients/native/src/client/mod.rs
+++ b/clients/native/src/client/mod.rs
@@ -431,7 +431,7 @@ impl NymClient {
             ack_receiver,
             input_receiver,
             sphinx_message_sender.clone(),
-            shared_lane_queue_length.clone(),
+            shared_lane_queue_length,
             closed_connection_rx,
             shutdown.subscribe(),
         );

--- a/clients/native/src/client/mod.rs
+++ b/clients/native/src/client/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use client_connections::{
-    ClosedConnectionReceiver, ClosedConnectionSender, LaneQueueLength, TransmissionLane,
+    ClosedConnectionReceiver, ClosedConnectionSender, LaneQueueLengths, TransmissionLane,
 };
 use client_core::client::cover_traffic_stream::LoopCoverTrafficStream;
 use client_core::client::inbound_messages::{
@@ -121,7 +121,7 @@ impl NymClient {
         ack_receiver: AcknowledgementReceiver,
         input_receiver: InputMessageReceiver,
         mix_sender: BatchMixMessageSender,
-        lane_queue_length: LaneQueueLength,
+        lane_queue_lengths: LaneQueueLengths,
         closed_connection_rx: ClosedConnectionReceiver,
         shutdown: ShutdownListener,
     ) {
@@ -152,7 +152,7 @@ impl NymClient {
             mix_sender,
             topology_accessor,
             reply_key_storage,
-            lane_queue_length,
+            lane_queue_lengths,
             closed_connection_rx,
         )
         .start_with_shutdown(shutdown);
@@ -423,7 +423,7 @@ impl NymClient {
 
         // Shared queue length data. Published by the `OutQueueController` in the client, and used
         // primarily to throttle incoming connections (e.g socks5 for attached network-requesters)
-        let shared_lane_queue_length = LaneQueueLength::new();
+        let shared_lane_queue_length = LaneQueueLengths::new();
 
         self.start_real_traffic_controller(
             shared_topology_accessor.clone(),

--- a/clients/native/src/client/mod.rs
+++ b/clients/native/src/client/mod.rs
@@ -1,7 +1,9 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use client_connections::{ClosedConnectionReceiver, ClosedConnectionSender, TransmissionLane};
+use client_connections::{
+    ClosedConnectionReceiver, ClosedConnectionSender, LaneQueueLength, TransmissionLane,
+};
 use client_core::client::cover_traffic_stream::LoopCoverTrafficStream;
 use client_core::client::inbound_messages::{
     InputMessage, InputMessageReceiver, InputMessageSender,
@@ -119,6 +121,7 @@ impl NymClient {
         ack_receiver: AcknowledgementReceiver,
         input_receiver: InputMessageReceiver,
         mix_sender: BatchMixMessageSender,
+        lane_queue_length: LaneQueueLength,
         closed_connection_rx: ClosedConnectionReceiver,
         shutdown: ShutdownListener,
     ) {
@@ -149,6 +152,7 @@ impl NymClient {
             mix_sender,
             topology_accessor,
             reply_key_storage,
+            lane_queue_length,
             closed_connection_rx,
         )
         .start_with_shutdown(shutdown);
@@ -417,12 +421,17 @@ impl NymClient {
         // controller that connections are closed.
         let (closed_connection_tx, closed_connection_rx) = mpsc::unbounded();
 
+        // Shared queue length data. Published by the `OutQueueController` in the client, and used
+        // primarily to throttle incoming connections (e.g socks5 for attached network-requesters)
+        let shared_lane_queue_length = LaneQueueLength::new();
+
         self.start_real_traffic_controller(
             shared_topology_accessor.clone(),
             reply_key_storage,
             ack_receiver,
             input_receiver,
             sphinx_message_sender.clone(),
+            shared_lane_queue_length.clone(),
             closed_connection_rx,
             shutdown.subscribe(),
         );

--- a/clients/socks5/src/client/mod.rs
+++ b/clients/socks5/src/client/mod.rs
@@ -413,7 +413,7 @@ impl NymClient {
 
         // Shared queue length data. Published by the `OutQueueController` in the client, and used
         // primarily to throttle incoming connections
-        let shared_lane_queue_length = LaneQueueLengths::new();
+        let shared_lane_queue_lengths = LaneQueueLengths::new();
 
         self.start_real_traffic_controller(
             shared_topology_accessor.clone(),
@@ -422,7 +422,7 @@ impl NymClient {
             input_receiver,
             sphinx_message_sender.clone(),
             closed_connection_rx,
-            shared_lane_queue_length.clone(),
+            shared_lane_queue_lengths,
             shutdown.subscribe(),
         );
 

--- a/clients/socks5/src/client/mod.rs
+++ b/clients/socks5/src/client/mod.rs
@@ -9,7 +9,7 @@ use crate::socks::{
     authentication::{AuthenticationMethods, Authenticator, User},
     server::SphinxSocksServer,
 };
-use client_connections::{ClosedConnectionReceiver, ClosedConnectionSender, LaneQueueLength};
+use client_connections::{ClosedConnectionReceiver, ClosedConnectionSender, LaneQueueLengths};
 use client_core::client::cover_traffic_stream::LoopCoverTrafficStream;
 use client_core::client::inbound_messages::{
     InputMessage, InputMessageReceiver, InputMessageSender,
@@ -120,7 +120,7 @@ impl NymClient {
         input_receiver: InputMessageReceiver,
         mix_sender: BatchMixMessageSender,
         closed_connection_rx: ClosedConnectionReceiver,
-        lane_queue_length: LaneQueueLength,
+        lane_queue_lengths: LaneQueueLengths,
         shutdown: ShutdownListener,
     ) {
         let mut controller_config = client_core::client::real_messages_control::Config::new(
@@ -150,7 +150,7 @@ impl NymClient {
             mix_sender,
             topology_accessor,
             reply_key_storage,
-            lane_queue_length,
+            lane_queue_lengths,
             closed_connection_rx,
         )
         .start_with_shutdown(shutdown);
@@ -413,7 +413,7 @@ impl NymClient {
 
         // Shared queue length data. Published by the `OutQueueController` in the client, and used
         // primarily to throttle incoming connections
-        let shared_lane_queue_length = LaneQueueLength::new();
+        let shared_lane_queue_length = LaneQueueLengths::new();
 
         self.start_real_traffic_controller(
             shared_topology_accessor.clone(),

--- a/clients/webassembly/src/client/mod.rs
+++ b/clients/webassembly/src/client/mod.rs
@@ -365,7 +365,7 @@ impl NymClient {
             input_receiver,
             sphinx_message_sender.clone(),
             closed_connection_rx,
-            shared_lane_queue_lengths.clone(),
+            shared_lane_queue_lengths,
         );
 
         if !self.config.debug.disable_loop_cover_traffic_stream {

--- a/clients/webassembly/src/client/mod.rs
+++ b/clients/webassembly/src/client/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use self::config::Config;
-use client_connections::{ClosedConnectionReceiver, TransmissionLane, LaneQueueLengths};
+use client_connections::{ClosedConnectionReceiver, LaneQueueLengths, TransmissionLane};
 use client_core::client::{
     cover_traffic_stream::LoopCoverTrafficStream,
     inbound_messages::{InputMessage, InputMessageReceiver, InputMessageSender},

--- a/common/client-connections/Cargo.toml
+++ b/common/client-connections/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3"
+log = "0.4.17"

--- a/common/client-connections/src/lib.rs
+++ b/common/client-connections/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use futures::channel::mpsc;
 
 pub type ConnectionId = u64;
@@ -19,3 +21,53 @@ pub enum TransmissionLane {
 /// they can forward this to the `OutQueueControl` (via `ClientRequest` for the network-requester)
 pub type ClosedConnectionSender = mpsc::UnboundedSender<ConnectionId>;
 pub type ClosedConnectionReceiver = mpsc::UnboundedReceiver<ConnectionId>;
+
+// The `OutQueueControl` publishes the backlog per lane, primarily so that upstream can slow down
+// if needed.
+#[derive(Clone)]
+pub struct LaneQueueLength(std::sync::Arc<std::sync::Mutex<LaneQueueLengthInner>>);
+
+impl LaneQueueLength {
+    pub fn new() -> Self {
+        LaneQueueLength(std::sync::Arc::new(std::sync::Mutex::new(
+            LaneQueueLengthInner {
+                map: HashMap::new(),
+            },
+        )))
+    }
+
+    pub fn set(&mut self, lane: &TransmissionLane, lane_length: Option<usize>) {
+        match self.0.lock() {
+            Ok(mut inner) => {
+                if let Some(length) = lane_length {
+                    inner
+                        .map
+                        .entry(*lane)
+                        .and_modify(|e| *e = length)
+                        .or_insert(length);
+                } else {
+                    inner.map.remove(lane);
+                }
+            }
+            Err(err) => log::warn!("Failed to set lane queue length: {err}"),
+        }
+    }
+}
+
+impl Default for LaneQueueLength {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::ops::Deref for LaneQueueLength {
+    type Target = std::sync::Arc<std::sync::Mutex<LaneQueueLengthInner>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct LaneQueueLengthInner {
+    map: HashMap<TransmissionLane, usize>,
+}

--- a/common/client-connections/src/lib.rs
+++ b/common/client-connections/src/lib.rs
@@ -25,12 +25,12 @@ pub type ClosedConnectionReceiver = mpsc::UnboundedReceiver<ConnectionId>;
 // The `OutQueueControl` publishes the backlog per lane, primarily so that upstream can slow down
 // if needed.
 #[derive(Clone)]
-pub struct LaneQueueLength(std::sync::Arc<std::sync::Mutex<LaneQueueLengthInner>>);
+pub struct LaneQueueLengths(std::sync::Arc<std::sync::Mutex<LaneQueueLengthsInner>>);
 
-impl LaneQueueLength {
+impl LaneQueueLengths {
     pub fn new() -> Self {
-        LaneQueueLength(std::sync::Arc::new(std::sync::Mutex::new(
-            LaneQueueLengthInner {
+        LaneQueueLengths(std::sync::Arc::new(std::sync::Mutex::new(
+            LaneQueueLengthsInner {
                 map: HashMap::new(),
             },
         )))
@@ -54,20 +54,20 @@ impl LaneQueueLength {
     }
 }
 
-impl Default for LaneQueueLength {
+impl Default for LaneQueueLengths {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::ops::Deref for LaneQueueLength {
-    type Target = std::sync::Arc<std::sync::Mutex<LaneQueueLengthInner>>;
+impl std::ops::Deref for LaneQueueLengths {
+    type Target = std::sync::Arc<std::sync::Mutex<LaneQueueLengthsInner>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-pub struct LaneQueueLengthInner {
+pub struct LaneQueueLengthsInner {
     map: HashMap<TransmissionLane, usize>,
 }


### PR DESCRIPTION
# Description

Part of: https://github.com/nymtech/nym/issues/1960
Part of: https://github.com/nymtech/nym/issues/1934

Setup shared lane queue state that the out queue controller updates. The idea is that connection handlers can use this to throttle incoming data and connections.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
