### PR TITLE
Possibilty to change gateway ws listener

### DIFF
--- a/sdk/typescript/packages/sdk/src/mixnet/wasm/types.ts
+++ b/sdk/typescript/packages/sdk/src/mixnet/wasm/types.ts
@@ -27,6 +27,11 @@ export interface NymClientConfig {
    * Optional. The identity key of the preferred gateway to connect to.
    */
   preferredGatewayIdentityKey?: string;
+  
+  /**
+   * Optional. The listener websocket of the preferred gateway to connect to.
+   */
+  gatewayListener?: string;
 
   /**
    * Optional. Settings for the WASM client.

--- a/sdk/typescript/packages/sdk/src/mixnet/wasm/worker.ts
+++ b/sdk/typescript/packages/sdk/src/mixnet/wasm/worker.ts
@@ -133,7 +133,11 @@ wasm_bindgen(wasmUrl)
         config.validatorApiUrl,
         config.preferredGatewayIdentityKey,
       );
-
+      
+      // set a different gatewayListener in order to avoid workaround ws over https error
+      if (!config.gatewayListener)
+            gatewayEndpoint.gateway_listener  = config.gatewayListener;
+      
       // create the client, passing handlers for events
       wrapper.init(
         new wasm_bindgen.Config(

--- a/sdk/typescript/packages/sdk/src/mixnet/wasm/worker.ts
+++ b/sdk/typescript/packages/sdk/src/mixnet/wasm/worker.ts
@@ -135,7 +135,7 @@ wasm_bindgen(wasmUrl)
       );
       
       // set a different gatewayListener in order to avoid workaround ws over https error
-      if (!config.gatewayListener)
+      if (config.gatewayListener)
             gatewayEndpoint.gateway_listener  = config.gatewayListener;
       
       // create the client, passing handlers for events


### PR DESCRIPTION
# Description
Give the possibility to set a different gatewayListener endpoint that support `wss://` in order to use application hosted on https


Closes: #1778

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
