### PR TITLE
Fix decrypting stored received msg

### DIFF
--- a/common/client-libs/gateway-client/src/client.rs
+++ b/common/client-libs/gateway-client/src/client.rs
@@ -335,8 +335,9 @@ impl GatewayClient {
                         Ok(msg) => msg
                     };
                     match ws_msg {
-                        Message::Binary(bin_msg) => {
-                            if let Err(err) = self.packet_router.route_received(vec![bin_msg]) {
+                        Message::Binary(ref _bin_msg) => {
+                            let plaintexts = PartiallyDelegated::recover_received_plaintexts(vec![ws_msg],self.shared_key.as_ref().unwrap());
+                            if let Err(err) = self.packet_router.route_received(plaintexts) {
                                 log::warn!("Route received failed: {:?}", err);
                             }
                         }

--- a/common/client-libs/gateway-client/src/client.rs
+++ b/common/client-libs/gateway-client/src/client.rs
@@ -2,19 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::bandwidth::BandwidthController;
-use crate::cleanup_socket_message;
 use crate::error::GatewayClientError;
 use crate::packet_router::PacketRouter;
 pub use crate::packet_router::{
     AcknowledgementReceiver, AcknowledgementSender, MixnetMessageReceiver, MixnetMessageSender,
 };
 use crate::socket_state::{PartiallyDelegated, SocketState};
-#[cfg(target_arch = "wasm32")]
-use crate::wasm_storage::PersistentStorage;
-#[cfg(feature = "coconut")]
-use coconut_interface::Credential;
-#[cfg(not(target_arch = "wasm32"))]
-use credential_storage::PersistentStorage;
+use crate::{cleanup_socket_message, try_decrypt_binary_message};
 use crypto::asymmetric::identity;
 use futures::{FutureExt, SinkExt, StreamExt};
 use gateway_requests::authentication::encrypted_address::EncryptedAddressBytes;
@@ -28,13 +22,20 @@ use rand::rngs::OsRng;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use std::time::Duration;
-#[cfg(not(target_arch = "wasm32"))]
-use task::ShutdownListener;
 use tungstenite::protocol::Message;
 
+#[cfg(feature = "coconut")]
+use coconut_interface::Credential;
+
+#[cfg(not(target_arch = "wasm32"))]
+use credential_storage::PersistentStorage;
+#[cfg(not(target_arch = "wasm32"))]
+use task::ShutdownListener;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio_tungstenite::connect_async;
 
+#[cfg(target_arch = "wasm32")]
+use crate::wasm_storage::PersistentStorage;
 #[cfg(target_arch = "wasm32")]
 use wasm_timer;
 #[cfg(target_arch = "wasm32")]
@@ -335,9 +336,16 @@ impl GatewayClient {
                         Ok(msg) => msg
                     };
                     match ws_msg {
-                        Message::Binary(ref _bin_msg) => {
-                            let plaintexts = PartiallyDelegated::recover_received_plaintexts(vec![ws_msg],self.shared_key.as_ref().unwrap());
-                            if let Err(err) = self.packet_router.route_received(plaintexts) {
+                        Message::Binary(bin_msg) => {
+                            // if we have established the shared key already, attempt to use it for decryption
+                            // otherwise there's not much we can do apart from just routing what we have on hand
+                            if let Some(shared_keys) = &self.shared_key {
+                                if let Some(plaintext) = try_decrypt_binary_message(bin_msg, shared_keys) {
+                                    if let Err(err) = self.packet_router.route_received(vec![plaintext]) {
+                                        log::warn!("Route received failed: {:?}", err);
+                                    }
+                                }
+                            } else if let Err(err) = self.packet_router.route_received(vec![bin_msg]) {
                                 log::warn!("Route received failed: {:?}", err);
                             }
                         }

--- a/common/client-libs/gateway-client/src/socket_state.rs
+++ b/common/client-libs/gateway-client/src/socket_state.rs
@@ -44,7 +44,7 @@ pub(crate) struct PartiallyDelegated {
 }
 
 impl PartiallyDelegated {
-    fn recover_received_plaintexts(ws_msgs: Vec<Message>, shared_key: &SharedKeys) -> Vec<Vec<u8>> {
+    pub(crate) fn recover_received_plaintexts(ws_msgs: Vec<Message>, shared_key: &SharedKeys) -> Vec<Vec<u8>> {
         let mut plaintexts = Vec::with_capacity(ws_msgs.len());
         for ws_msg in ws_msgs {
             match ws_msg {

--- a/common/client-libs/gateway-client/src/socket_state.rs
+++ b/common/client-libs/gateway-client/src/socket_state.rs
@@ -44,7 +44,10 @@ pub(crate) struct PartiallyDelegated {
 }
 
 impl PartiallyDelegated {
-    pub(crate) fn recover_received_plaintexts(ws_msgs: Vec<Message>, shared_key: &SharedKeys) -> Vec<Vec<u8>> {
+    pub(crate) fn recover_received_plaintexts(
+        ws_msgs: Vec<Message>,
+        shared_key: &SharedKeys,
+    ) -> Vec<Vec<u8>> {
         let mut plaintexts = Vec::with_capacity(ws_msgs.len());
         for ws_msg in ws_msgs {
             match ws_msg {


### PR DESCRIPTION
Closes: https://github.com/nymtech/nym/issues/1915

# Description

Identified by @simonwicky.

When the client goes offline and the gateway stores messages, then when the client goes online again these messages are not correctly decrypted.

This PR should fix all those error messages you get when restarting a client.

```
 2022-11-21T23:38:33.037Z WARN  client_core::client::received_buffer  > failed to recover fragment from raw data: MalformedFragmentError. The whole underlying message might be corrupted and unrecoverable!                                   
 2022-11-21T23:38:33.037Z WARN  gateway_client::packet_router         > Received message of unexpected size. Probably from an outdated client... len: 1675                                                                                     
 2022-11-21T23:38:33.037Z WARN  gateway_client::packet_router         > Received message of unexpected size. Probably from an outdated client... len: 1675                                                                                     
 2022-11-21T23:38:33.037Z WARN  client_core::client::received_buffer  > failed to recover fragment from raw data: MalformedFragmentError. The whole underlying message might be corrupted and unrecoverable!                                
```

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
