### PR TITLE
Network-requester: throttle inbound connections

### DIFF
--- a/clients/client-core/src/client/real_messages_control/mod.rs
+++ b/clients/client-core/src/client/real_messages_control/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     spawn_future,
 };
-use client_connections::{ClosedConnectionReceiver, LaneQueueLengths};
+use client_connections::{ConnectionCommandReceiver, LaneQueueLengths};
 use futures::channel::mpsc;
 use gateway_client::AcknowledgementReceiver;
 use log::*;
@@ -115,7 +115,7 @@ impl RealMessagesController<OsRng> {
         topology_access: TopologyAccessor,
         #[cfg(feature = "reply-surb")] reply_key_storage: ReplyKeyStorage,
         lane_queue_lengths: LaneQueueLengths,
-        closed_connection_rx: ClosedConnectionReceiver,
+        closed_connection_rx: ConnectionCommandReceiver,
     ) -> Self {
         let rng = OsRng;
 

--- a/clients/client-core/src/client/real_messages_control/mod.rs
+++ b/clients/client-core/src/client/real_messages_control/mod.rs
@@ -115,7 +115,7 @@ impl RealMessagesController<OsRng> {
         topology_access: TopologyAccessor,
         #[cfg(feature = "reply-surb")] reply_key_storage: ReplyKeyStorage,
         lane_queue_lengths: LaneQueueLengths,
-        closed_connection_rx: ConnectionCommandReceiver,
+        client_connection_rx: ConnectionCommandReceiver,
     ) -> Self {
         let rng = OsRng;
 
@@ -166,7 +166,7 @@ impl RealMessagesController<OsRng> {
             config.self_recipient,
             topology_access,
             lane_queue_lengths,
-            closed_connection_rx,
+            client_connection_rx,
         );
 
         RealMessagesController {

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -5,7 +5,7 @@ use crate::client::mix_traffic::BatchMixMessageSender;
 use crate::client::real_messages_control::acknowledgement_control::SentPacketNotificationSender;
 use crate::client::topology_control::TopologyAccessor;
 use client_connections::{
-    ConnectionCommandReceiver, ConnectionCommand, ConnectionId, LaneQueueLengths, TransmissionLane,
+    ConnectionCommand, ConnectionCommandReceiver, ConnectionId, LaneQueueLengths, TransmissionLane,
 };
 use futures::task::{Context, Poll};
 use futures::{Future, Stream, StreamExt};
@@ -134,7 +134,7 @@ where
 
     /// Incoming channel for being notified of closed connections, so that we can close lanes
     /// corresponding to connections. To avoid sending traffic unnecessary
-    closed_connection_rx: ConnectionCommandReceiver,
+    client_connection_rx: ConnectionCommandReceiver,
 
     /// Report queue lengths so that upstream can backoff sending data, and keep connections open.
     lane_queue_lengths: LaneQueueLengths,
@@ -182,7 +182,7 @@ where
         our_full_destination: Recipient,
         topology_access: TopologyAccessor,
         lane_queue_lengths: LaneQueueLengths,
-        closed_connection_rx: ConnectionCommandReceiver,
+        client_connection_rx: ConnectionCommandReceiver,
     ) -> Self {
         OutQueueControl {
             config,
@@ -196,7 +196,7 @@ where
             rng,
             topology_access,
             transmission_buffer: Default::default(),
-            closed_connection_rx,
+            client_connection_rx,
             lane_queue_lengths,
         }
     }
@@ -262,7 +262,7 @@ where
             self.sent_notify(fragment_id);
         }
 
-        // In addition to closing connections on receiving messages throught closed_connection_rx,
+        // In addition to closing connections on receiving messages throught client_connection_rx,
         // also close connections when sufficiently stale.
         self.transmission_buffer.prune_stale_connections();
 
@@ -335,7 +335,7 @@ where
         // Start by checking if we have any incoming messages about closed connections
         // NOTE: this feels a bit iffy, the `OutQueueControl` is getting ripe for a rewrite to
         // something simpler.
-        if let Poll::Ready(Some(id)) = Pin::new(&mut self.closed_connection_rx).poll_next(cx) {
+        if let Poll::Ready(Some(id)) = Pin::new(&mut self.client_connection_rx).poll_next(cx) {
             match id {
                 ConnectionCommand::Close(id) => self.on_close_connection(id),
                 ConnectionCommand::ActiveConnections(_) => panic!(),
@@ -414,7 +414,7 @@ where
 
     fn poll_immediate(&mut self, cx: &mut Context<'_>) -> Poll<Option<StreamMessage>> {
         // Start by checking if we have any incoming messages about closed connections
-        if let Poll::Ready(Some(id)) = Pin::new(&mut self.closed_connection_rx).poll_next(cx) {
+        if let Poll::Ready(Some(id)) = Pin::new(&mut self.client_connection_rx).poll_next(cx) {
             match id {
                 ConnectionCommand::Close(id) => self.on_close_connection(id),
                 ConnectionCommand::ActiveConnections(_) => panic!(),

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -5,7 +5,7 @@ use crate::client::mix_traffic::BatchMixMessageSender;
 use crate::client::real_messages_control::acknowledgement_control::SentPacketNotificationSender;
 use crate::client::topology_control::TopologyAccessor;
 use client_connections::{
-    ClosedConnectionReceiver, ConnectionCommand, ConnectionId, LaneQueueLengths, TransmissionLane,
+    ConnectionCommandReceiver, ConnectionCommand, ConnectionId, LaneQueueLengths, TransmissionLane,
 };
 use futures::task::{Context, Poll};
 use futures::{Future, Stream, StreamExt};
@@ -134,7 +134,7 @@ where
 
     /// Incoming channel for being notified of closed connections, so that we can close lanes
     /// corresponding to connections. To avoid sending traffic unnecessary
-    closed_connection_rx: ClosedConnectionReceiver,
+    closed_connection_rx: ConnectionCommandReceiver,
 
     /// Report queue lengths so that upstream can backoff sending data, and keep connections open.
     lane_queue_lengths: LaneQueueLengths,
@@ -182,7 +182,7 @@ where
         our_full_destination: Recipient,
         topology_access: TopologyAccessor,
         lane_queue_lengths: LaneQueueLengths,
-        closed_connection_rx: ClosedConnectionReceiver,
+        closed_connection_rx: ConnectionCommandReceiver,
     ) -> Self {
         OutQueueControl {
             config,

--- a/clients/native/src/client/mod.rs
+++ b/clients/native/src/client/mod.rs
@@ -299,6 +299,7 @@ impl NymClient {
         &self,
         buffer_requester: ReceivedBufferRequestSender,
         msg_input: InputMessageSender,
+        shared_lane_queue_lengths: LaneQueueLengths,
         closed_connection_tx: ClosedConnectionSender,
     ) {
         info!("Starting websocket listener...");
@@ -308,6 +309,7 @@ impl NymClient {
             closed_connection_tx,
             buffer_requester,
             &self.as_mix_recipient(),
+            shared_lane_queue_lengths,
         );
 
         websocket::Listener::new(self.config.get_listening_port()).start(websocket_handler);
@@ -453,7 +455,7 @@ impl NymClient {
 
         // Shared queue length data. Published by the `OutQueueController` in the client, and used
         // primarily to throttle incoming connections (e.g socks5 for attached network-requesters)
-        let shared_lane_queue_length = LaneQueueLengths::new();
+        let shared_lane_queue_lengths = LaneQueueLengths::new();
 
         self.start_real_traffic_controller(
             shared_topology_accessor.clone(),
@@ -461,7 +463,7 @@ impl NymClient {
             ack_receiver,
             input_receiver,
             sphinx_message_sender.clone(),
-            shared_lane_queue_length,
+            shared_lane_queue_lengths.clone(),
             closed_connection_rx,
             shutdown.subscribe(),
         );
@@ -482,6 +484,7 @@ impl NymClient {
             SocketType::WebSocket => self.start_websocket_listener(
                 received_buffer_request_sender,
                 input_sender,
+                shared_lane_queue_lengths,
                 closed_connection_tx,
             ),
             SocketType::None => {

--- a/clients/native/src/client/mod.rs
+++ b/clients/native/src/client/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use client_connections::{
-    ClosedConnectionReceiver, ClosedConnectionSender, LaneQueueLengths, TransmissionLane,
+    ConnectionCommandReceiver, ConnectionCommandSender, LaneQueueLengths, TransmissionLane,
 };
 use client_core::client::cover_traffic_stream::LoopCoverTrafficStream;
 use client_core::client::inbound_messages::{
@@ -123,7 +123,7 @@ impl NymClient {
         input_receiver: InputMessageReceiver,
         mix_sender: BatchMixMessageSender,
         lane_queue_lengths: LaneQueueLengths,
-        closed_connection_rx: ClosedConnectionReceiver,
+        closed_connection_rx: ConnectionCommandReceiver,
         shutdown: ShutdownListener,
     ) {
         let mut controller_config = real_messages_control::Config::new(
@@ -300,7 +300,7 @@ impl NymClient {
         buffer_requester: ReceivedBufferRequestSender,
         msg_input: InputMessageSender,
         shared_lane_queue_lengths: LaneQueueLengths,
-        closed_connection_tx: ClosedConnectionSender,
+        closed_connection_tx: ConnectionCommandSender,
     ) {
         info!("Starting websocket listener...");
 

--- a/clients/native/src/websocket/handler.rs
+++ b/clients/native/src/websocket/handler.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use client_connections::{ClosedConnectionSender, TransmissionLane};
+use client_connections::{ClosedConnectionSender, LaneQueueLengths, TransmissionLane};
 use client_core::client::{
     inbound_messages::{InputMessage, InputMessageSender},
     received_buffer::{
@@ -40,6 +40,7 @@ pub(crate) struct Handler {
     self_full_address: Recipient,
     socket: Option<WebSocketStream<TcpStream>>,
     received_response_type: ReceivedResponseType,
+    lane_queue_lengths: LaneQueueLengths,
 }
 
 // clone is used to use handler on a new connection, which initially is `None`
@@ -52,6 +53,7 @@ impl Clone for Handler {
             self_full_address: self.self_full_address,
             socket: None,
             received_response_type: Default::default(),
+            lane_queue_lengths: self.lane_queue_lengths.clone(),
         }
     }
 }
@@ -70,6 +72,7 @@ impl Handler {
         closed_connection_tx: ClosedConnectionSender,
         buffer_requester: ReceivedBufferRequestSender,
         self_full_address: &Recipient,
+        lane_queue_lengths: LaneQueueLengths,
     ) -> Self {
         Handler {
             msg_input,
@@ -78,6 +81,7 @@ impl Handler {
             self_full_address: *self_full_address,
             socket: None,
             received_response_type: Default::default(),
+            lane_queue_lengths,
         }
     }
 
@@ -95,6 +99,15 @@ impl Handler {
             panic!();
         }
 
+        // on receiving a send, we reply back the current lane queue length for that connection id.
+        // Note that this does _NOT_ take into account the packets that have been received but not
+        // yet reach `OutQueueControl`, so it might be a tad low.
+        if let Ok(lane_queue_lengths) = self.lane_queue_lengths.lock() {
+            let queue_length = lane_queue_lengths.get(&lane).unwrap_or(0);
+            return Some(ServerResponse::LaneQueueLength(connection_id, queue_length));
+        }
+
+        log::warn!("Failed to get the lane queue length lock, not responding back with the current queue length");
         None
     }
 

--- a/clients/native/src/websocket/handler.rs
+++ b/clients/native/src/websocket/handler.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use client_connections::{
-    ClosedConnectionSender, ConnectionCommand, LaneQueueLengths, TransmissionLane,
+    ConnectionCommandSender, ConnectionCommand, LaneQueueLengths, TransmissionLane,
 };
 use client_core::client::{
     inbound_messages::{InputMessage, InputMessageSender},
@@ -37,7 +37,7 @@ impl Default for ReceivedResponseType {
 
 pub(crate) struct Handler {
     msg_input: InputMessageSender,
-    closed_connection_tx: ClosedConnectionSender,
+    closed_connection_tx: ConnectionCommandSender,
     buffer_requester: ReceivedBufferRequestSender,
     self_full_address: Recipient,
     socket: Option<WebSocketStream<TcpStream>>,
@@ -71,7 +71,7 @@ impl Drop for Handler {
 impl Handler {
     pub(crate) fn new(
         msg_input: InputMessageSender,
-        closed_connection_tx: ClosedConnectionSender,
+        closed_connection_tx: ConnectionCommandSender,
         buffer_requester: ReceivedBufferRequestSender,
         self_full_address: &Recipient,
         lane_queue_lengths: LaneQueueLengths,

--- a/clients/socks5/src/client/mod.rs
+++ b/clients/socks5/src/client/mod.rs
@@ -9,7 +9,7 @@ use crate::socks::{
     authentication::{AuthenticationMethods, Authenticator, User},
     server::SphinxSocksServer,
 };
-use client_connections::{ClosedConnectionReceiver, ClosedConnectionSender, LaneQueueLengths};
+use client_connections::{ConnectionCommandReceiver, ConnectionCommandSender, LaneQueueLengths};
 use client_core::client::cover_traffic_stream::LoopCoverTrafficStream;
 use client_core::client::inbound_messages::{
     InputMessage, InputMessageReceiver, InputMessageSender,
@@ -120,7 +120,7 @@ impl NymClient {
         ack_receiver: AcknowledgementReceiver,
         input_receiver: InputMessageReceiver,
         mix_sender: BatchMixMessageSender,
-        closed_connection_rx: ClosedConnectionReceiver,
+        closed_connection_rx: ConnectionCommandReceiver,
         lane_queue_lengths: LaneQueueLengths,
         shutdown: ShutdownListener,
     ) {
@@ -297,7 +297,7 @@ impl NymClient {
         &self,
         buffer_requester: ReceivedBufferRequestSender,
         msg_input: InputMessageSender,
-        closed_connection_tx: ClosedConnectionSender,
+        closed_connection_tx: ConnectionCommandSender,
         lane_queue_lengths: LaneQueueLengths,
         shutdown: ShutdownListener,
     ) {

--- a/clients/socks5/src/client/mod.rs
+++ b/clients/socks5/src/client/mod.rs
@@ -120,7 +120,7 @@ impl NymClient {
         ack_receiver: AcknowledgementReceiver,
         input_receiver: InputMessageReceiver,
         mix_sender: BatchMixMessageSender,
-        closed_connection_rx: ConnectionCommandReceiver,
+        client_connection_rx: ConnectionCommandReceiver,
         lane_queue_lengths: LaneQueueLengths,
         shutdown: ShutdownListener,
     ) {
@@ -152,7 +152,7 @@ impl NymClient {
             topology_accessor,
             reply_key_storage,
             lane_queue_lengths,
-            closed_connection_rx,
+            client_connection_rx,
         )
         .start_with_shutdown(shutdown);
     }
@@ -297,7 +297,7 @@ impl NymClient {
         &self,
         buffer_requester: ReceivedBufferRequestSender,
         msg_input: InputMessageSender,
-        closed_connection_tx: ConnectionCommandSender,
+        client_connection_tx: ConnectionCommandSender,
         lane_queue_lengths: LaneQueueLengths,
         shutdown: ShutdownListener,
     ) {
@@ -316,7 +316,7 @@ impl NymClient {
         );
         tokio::spawn(async move {
             sphinx_socks
-                .serve(msg_input, buffer_requester, closed_connection_tx)
+                .serve(msg_input, buffer_requester, client_connection_tx)
                 .await
         });
     }
@@ -426,7 +426,7 @@ impl NymClient {
 
         // Channel for announcing closed (socks5) connections by the controller.
         // This will be forwarded to `OutQueueControl`
-        let (closed_connection_tx, closed_connection_rx) = mpsc::unbounded();
+        let (client_connection_tx, client_connection_rx) = mpsc::unbounded();
 
         // Shared queue length data. Published by the `OutQueueController` in the client, and used
         // primarily to throttle incoming connections
@@ -438,7 +438,7 @@ impl NymClient {
             ack_receiver,
             input_receiver,
             sphinx_message_sender.clone(),
-            closed_connection_rx,
+            client_connection_rx,
             shared_lane_queue_lengths.clone(),
             shutdown.subscribe(),
         );
@@ -458,7 +458,7 @@ impl NymClient {
         self.start_socks5_listener(
             received_buffer_request_sender,
             input_sender,
-            closed_connection_tx,
+            client_connection_tx,
             shared_lane_queue_lengths,
             shutdown.subscribe(),
         );

--- a/clients/socks5/src/socks/server.rs
+++ b/clients/socks5/src/socks/server.rs
@@ -62,7 +62,7 @@ impl SphinxSocksServer {
 
         // controller for managing all active connections
         let (mut active_streams_controller, controller_sender) =
-            Controller::new(closed_connection_tx, self.shutdown.clone());
+            Controller::new(closed_connection_tx, false, self.shutdown.clone());
         tokio::spawn(async move {
             active_streams_controller.run().await;
         });

--- a/clients/socks5/src/socks/server.rs
+++ b/clients/socks5/src/socks/server.rs
@@ -4,7 +4,7 @@ use super::{
     mixnet_responses::MixnetResponseListener,
     types::{ResponseCode, SocksProxyError},
 };
-use client_connections::{ClosedConnectionSender, LaneQueueLengths};
+use client_connections::{ConnectionCommandSender, LaneQueueLengths};
 use client_core::client::{
     inbound_messages::InputMessageSender, received_buffer::ReceivedBufferRequestSender,
 };
@@ -55,7 +55,7 @@ impl SphinxSocksServer {
         &mut self,
         input_sender: InputMessageSender,
         buffer_requester: ReceivedBufferRequestSender,
-        closed_connection_tx: ClosedConnectionSender,
+        closed_connection_tx: ConnectionCommandSender,
     ) -> Result<(), SocksProxyError> {
         let listener = TcpListener::bind(self.listening_address).await.unwrap();
         info!("Serving Connections...");

--- a/clients/socks5/src/socks/server.rs
+++ b/clients/socks5/src/socks/server.rs
@@ -10,7 +10,7 @@ use client_core::client::{
 };
 use log::*;
 use nymsphinx::addressing::clients::Recipient;
-use proxy_helpers::connection_controller::Controller;
+use proxy_helpers::connection_controller::{BroadcastActiveConnections, Controller};
 use std::net::SocketAddr;
 use task::ShutdownListener;
 use tokio::net::TcpListener;
@@ -61,8 +61,11 @@ impl SphinxSocksServer {
         info!("Serving Connections...");
 
         // controller for managing all active connections
-        let (mut active_streams_controller, controller_sender) =
-            Controller::new(client_connection_tx, false, self.shutdown.clone());
+        let (mut active_streams_controller, controller_sender) = Controller::new(
+            client_connection_tx,
+            BroadcastActiveConnections::Off,
+            self.shutdown.clone(),
+        );
         tokio::spawn(async move {
             active_streams_controller.run().await;
         });

--- a/clients/socks5/src/socks/server.rs
+++ b/clients/socks5/src/socks/server.rs
@@ -55,14 +55,14 @@ impl SphinxSocksServer {
         &mut self,
         input_sender: InputMessageSender,
         buffer_requester: ReceivedBufferRequestSender,
-        closed_connection_tx: ConnectionCommandSender,
+        client_connection_tx: ConnectionCommandSender,
     ) -> Result<(), SocksProxyError> {
         let listener = TcpListener::bind(self.listening_address).await.unwrap();
         info!("Serving Connections...");
 
         // controller for managing all active connections
         let (mut active_streams_controller, controller_sender) =
-            Controller::new(closed_connection_tx, false, self.shutdown.clone());
+            Controller::new(client_connection_tx, false, self.shutdown.clone());
         tokio::spawn(async move {
             active_streams_controller.run().await;
         });

--- a/clients/webassembly/src/client/mod.rs
+++ b/clients/webassembly/src/client/mod.rs
@@ -128,7 +128,7 @@ impl NymClient {
         ack_receiver: AcknowledgementReceiver,
         input_receiver: InputMessageReceiver,
         mix_sender: BatchMixMessageSender,
-        closed_connection_rx: ClosedConnectionReceiver,
+        client_connection_rx: ClosedConnectionReceiver,
         lane_queue_lengths: LaneQueueLengths,
     ) {
         let mut controller_config = real_messages_control::Config::new(
@@ -155,7 +155,7 @@ impl NymClient {
             mix_sender,
             topology_accessor,
             lane_queue_lengths,
-            closed_connection_rx,
+            client_connection_rx,
         )
         .start();
     }
@@ -334,7 +334,7 @@ impl NymClient {
 
         // Channel that the real traffix controller can listed to for closing connections.
         // Currently unused in the wasm client.
-        let (_closed_connection_tx, closed_connection_rx) = mpsc::unbounded();
+        let (_client_connection_tx, client_connection_rx) = mpsc::unbounded();
 
         // the components are started in very specific order. Unless you know what you are doing,
         // do not change that.
@@ -364,7 +364,7 @@ impl NymClient {
             ack_receiver,
             input_receiver,
             sphinx_message_sender.clone(),
-            closed_connection_rx,
+            client_connection_rx,
             shared_lane_queue_lengths,
         );
 

--- a/clients/webassembly/src/client/mod.rs
+++ b/clients/webassembly/src/client/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use self::config::Config;
-use client_connections::{ClosedConnectionReceiver, LaneQueueLengths, TransmissionLane};
+use client_connections::{ConnectionCommandReceiver, LaneQueueLengths, TransmissionLane};
 use client_core::client::{
     cover_traffic_stream::LoopCoverTrafficStream,
     inbound_messages::{InputMessage, InputMessageReceiver, InputMessageSender},
@@ -128,7 +128,7 @@ impl NymClient {
         ack_receiver: AcknowledgementReceiver,
         input_receiver: InputMessageReceiver,
         mix_sender: BatchMixMessageSender,
-        client_connection_rx: ClosedConnectionReceiver,
+        client_connection_rx: ConnectionCommandReceiver,
         lane_queue_lengths: LaneQueueLengths,
     ) {
         let mut controller_config = real_messages_control::Config::new(

--- a/common/client-connections/src/lib.rs
+++ b/common/client-connections/src/lib.rs
@@ -16,11 +16,9 @@ pub enum TransmissionLane {
     ConnectionId(ConnectionId),
 }
 
-/// Announce connections that are closed, for whoever is interested.
-/// One usecase is that the network-requester and socks5-client wants to know about this, so that
-/// they can forward this to the `OutQueueControl` (via `ClientRequest` for the network-requester)
-pub type ClosedConnectionSender = mpsc::UnboundedSender<ConnectionCommand>;
-pub type ClosedConnectionReceiver = mpsc::UnboundedReceiver<ConnectionCommand>;
+/// Used by the connection controller to report current state for client connections.
+pub type ConnectionCommandSender = mpsc::UnboundedSender<ConnectionCommand>;
+pub type ConnectionCommandReceiver = mpsc::UnboundedReceiver<ConnectionCommand>;
 
 pub enum ConnectionCommand {
     // Announce that at a connection was closed. E.g the `OutQueueControl` uses this to discard

--- a/common/client-connections/src/lib.rs
+++ b/common/client-connections/src/lib.rs
@@ -19,8 +19,20 @@ pub enum TransmissionLane {
 /// Announce connections that are closed, for whoever is interested.
 /// One usecase is that the network-requester and socks5-client wants to know about this, so that
 /// they can forward this to the `OutQueueControl` (via `ClientRequest` for the network-requester)
-pub type ClosedConnectionSender = mpsc::UnboundedSender<ConnectionId>;
-pub type ClosedConnectionReceiver = mpsc::UnboundedReceiver<ConnectionId>;
+pub type ClosedConnectionSender = mpsc::UnboundedSender<ConnectionCommand>;
+pub type ClosedConnectionReceiver = mpsc::UnboundedReceiver<ConnectionCommand>;
+
+pub enum ConnectionCommand {
+    // Announce that at a connection was closed. E.g the `OutQueueControl` uses this to discard
+    // transmission lanes.
+    Close(ConnectionId),
+
+    // In the network requester for example, we usually want to broadcast active connections
+    // regularly, so we know what connections we need to request lane queue lengths for from the
+    // client.
+    // In the socks5-client, this is not needed since have direct access to the lane queue lengths.
+    ActiveConnections(Vec<ConnectionId>),
+}
 
 // The `OutQueueControl` publishes the backlog per lane, primarily so that upstream can slow down
 // if needed.

--- a/common/socks5/proxy-helpers/src/connection_controller.rs
+++ b/common/socks5/proxy-helpers/src/connection_controller.rs
@@ -1,14 +1,18 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use client_connections::ClosedConnectionSender;
+use client_connections::{ClosedConnectionSender, ConnectionCommand};
 use futures::channel::mpsc;
 use futures::StreamExt;
 use log::*;
 use ordered_buffer::{OrderedMessage, OrderedMessageBuffer, ReadContiguousData};
 use socks5_requests::ConnectionId;
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 use task::ShutdownListener;
+use tokio::time;
 
 /// A generic message produced after reading from a socket/connection. It includes data that was
 /// actually read alongside boolean indicating whether the connection got closed so that
@@ -77,6 +81,8 @@ pub struct Controller {
     // Broadcast closed connections
     closed_connection_tx: ClosedConnectionSender,
 
+    broadcast_connections: bool,
+
     // TODO: this can potentially be abused to ddos and kill provider. Not sure at this point
     // how to handle it more gracefully
 
@@ -90,6 +96,7 @@ pub struct Controller {
 impl Controller {
     pub fn new(
         closed_connection_tx: ClosedConnectionSender,
+        broadcast_connections: bool,
         shutdown: ShutdownListener,
     ) -> (Self, ControllerSender) {
         let (sender, receiver) = mpsc::unbounded();
@@ -99,6 +106,7 @@ impl Controller {
                 receiver,
                 recently_closed: HashSet::new(),
                 closed_connection_tx,
+                broadcast_connections,
                 pending_messages: HashMap::new(),
                 shutdown,
             },
@@ -137,13 +145,25 @@ impl Controller {
         self.recently_closed.insert(conn_id);
 
         // Announce closed connections, currently used by the `OutQueueControl`.
-        if let Err(err) = self.closed_connection_tx.unbounded_send(conn_id) {
+        if let Err(err) = self
+            .closed_connection_tx
+            .unbounded_send(ConnectionCommand::Close(conn_id))
+        {
             if self.shutdown.is_shutdown_poll() {
                 log::debug!("Failed to send: {}", err);
             } else {
                 log::error!("Failed to send: {}", err);
             }
         }
+    }
+
+    fn broadcast_active_connections(&mut self) {
+        // What about the recently closed ones? Hopefully we can ignore them ...
+        let conn_ids = self.active_connections.keys().copied().collect();
+
+        self.closed_connection_tx
+            .unbounded_send(ConnectionCommand::ActiveConnections(conn_ids))
+            .unwrap();
     }
 
     fn send_to_connection(&mut self, conn_id: ConnectionId, payload: Vec<u8>, is_closed: bool) {
@@ -202,6 +222,8 @@ impl Controller {
     }
 
     pub async fn run(&mut self) {
+        let mut interval = time::interval(Duration::from_millis(500));
+
         loop {
             tokio::select! {
                 command = self.receiver.next() => match command {
@@ -216,7 +238,12 @@ impl Controller {
                         log::trace!("SOCKS5 Controller: Stopping since channel closed");
                         break;
                     }
-                }
+                },
+                _ = interval.tick() => {
+                    if self.broadcast_connections {
+                        self.broadcast_active_connections();
+                    }
+                },
             }
         }
         assert!(self.shutdown.is_shutdown_poll());

--- a/common/socks5/proxy-helpers/src/connection_controller.rs
+++ b/common/socks5/proxy-helpers/src/connection_controller.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use client_connections::{ClosedConnectionSender, ConnectionCommand};
+use client_connections::{ConnectionCommandSender, ConnectionCommand};
 use futures::channel::mpsc;
 use futures::StreamExt;
 use log::*;
@@ -79,7 +79,7 @@ pub struct Controller {
     recently_closed: HashSet<ConnectionId>,
 
     // Broadcast closed connections
-    closed_connection_tx: ClosedConnectionSender,
+    closed_connection_tx: ConnectionCommandSender,
 
     broadcast_connections: bool,
 
@@ -95,7 +95,7 @@ pub struct Controller {
 
 impl Controller {
     pub fn new(
-        closed_connection_tx: ClosedConnectionSender,
+        closed_connection_tx: ConnectionCommandSender,
         broadcast_connections: bool,
         shutdown: ShutdownListener,
     ) -> (Self, ControllerSender) {

--- a/common/socks5/proxy-helpers/src/proxy_runner/inbound.rs
+++ b/common/socks5/proxy-helpers/src/proxy_runner/inbound.rs
@@ -107,7 +107,7 @@ where
 
 async fn wait_until_lane_empty(lane_queue_lengths: LaneQueueLengths, connection_id: u64) {
     if tokio::time::timeout(
-        Duration::from_secs(15),
+        Duration::from_secs(2 * 60),
         wait_for_lane(
             lane_queue_lengths,
             connection_id,
@@ -124,7 +124,7 @@ async fn wait_until_lane_empty(lane_queue_lengths: LaneQueueLengths, connection_
 
 async fn wait_until_lane_almost_empty(lane_queue_lengths: LaneQueueLengths, connection_id: u64) {
     if tokio::time::timeout(
-        Duration::from_secs(15),
+        Duration::from_secs(2 * 60),
         wait_for_lane(
             lane_queue_lengths,
             connection_id,
@@ -135,7 +135,7 @@ async fn wait_until_lane_almost_empty(lane_queue_lengths: LaneQueueLengths, conn
     .await
     .is_err()
     {
-        log::warn!("Wait until lane almost empty timed out");
+        log::debug!("Wait until lane almost empty timed out");
     }
 }
 

--- a/common/socks5/proxy-helpers/src/proxy_runner/inbound.rs
+++ b/common/socks5/proxy-helpers/src/proxy_runner/inbound.rs
@@ -106,23 +106,37 @@ where
 }
 
 async fn wait_until_lane_empty(lane_queue_lengths: LaneQueueLengths, connection_id: u64) {
-    wait_for_lane(
-        lane_queue_lengths,
-        connection_id,
-        0,
-        Duration::from_millis(500),
+    if tokio::time::timeout(
+        Duration::from_secs(15),
+        wait_for_lane(
+            lane_queue_lengths,
+            connection_id,
+            0,
+            Duration::from_millis(500),
+        ),
     )
     .await
+    .is_err()
+    {
+        log::warn!("Wait until lane empty timed out");
+    }
 }
 
 async fn wait_until_lane_almost_empty(lane_queue_lengths: LaneQueueLengths, connection_id: u64) {
-    wait_for_lane(
-        lane_queue_lengths,
-        connection_id,
-        10,
-        Duration::from_millis(100),
+    if tokio::time::timeout(
+        Duration::from_secs(15),
+        wait_for_lane(
+            lane_queue_lengths,
+            connection_id,
+            10,
+            Duration::from_millis(100),
+        ),
     )
     .await
+    .is_err()
+    {
+        log::warn!("Wait until lane almost empty timed out");
+    }
 }
 
 async fn wait_for_lane(

--- a/service-providers/network-requester/src/connection.rs
+++ b/service-providers/network-requester/src/connection.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use client_connections::LaneQueueLengths;
 use nymsphinx::addressing::clients::Recipient;
 use proxy_helpers::connection_controller::ConnectionReceiver;
 use proxy_helpers::proxy_runner::{MixProxySender, ProxyRunner};
@@ -40,6 +41,7 @@ impl Connection {
         &mut self,
         mix_receiver: ConnectionReceiver,
         mix_sender: MixProxySender<(Socks5Message, Recipient)>,
+        lane_queue_lengths: LaneQueueLengths,
         shutdown: ShutdownListener,
     ) {
         let stream = self.conn.take().unwrap();
@@ -53,7 +55,7 @@ impl Connection {
             mix_receiver,
             mix_sender,
             connection_id,
-            None,
+            Some(lane_queue_lengths),
             shutdown,
         )
         .run(move |conn_id, read_data, socket_closed| {

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -8,7 +8,7 @@ use crate::statistics::ServiceStatisticsCollector;
 use crate::websocket;
 use crate::websocket::TSWebsocketStream;
 use client_connections::{
-    ClosedConnectionReceiver, ConnectionCommand, LaneQueueLengths, TransmissionLane,
+    ConnectionCommandReceiver, ConnectionCommand, LaneQueueLengths, TransmissionLane,
 };
 use futures::channel::mpsc;
 use futures::stream::{SplitSink, SplitStream};
@@ -72,7 +72,7 @@ impl ServiceProvider {
         mut websocket_writer: SplitSink<TSWebsocketStream, Message>,
         mut mix_reader: MixProxyReader<(Socks5Message, Recipient)>,
         stats_collector: Option<ServiceStatisticsCollector>,
-        mut closed_connection_rx: ClosedConnectionReceiver,
+        mut closed_connection_rx: ConnectionCommandReceiver,
     ) {
         loop {
             tokio::select! {

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -284,7 +284,6 @@ impl ServiceProvider {
     }
 
     fn handle_proxy_send(
-        &self,
         controller_sender: &mut ControllerSender,
         conn_id: ConnectionId,
         data: Vec<u8>,
@@ -348,7 +347,7 @@ impl ServiceProvider {
                                 .processed(remote_addr, data.len() as u32);
                         }
                     }
-                    self.handle_proxy_send(controller_sender, conn_id, data, closed)
+                    Self::handle_proxy_send(controller_sender, conn_id, data, closed)
                 }
             },
             Socks5Message::Response(_) | Socks5Message::NetworkRequesterResponse(_) => {}


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1934
Part of: https://github.com/nymtech/nym/issues/1960

Let the network requester query the client for current lane queue lengths, which it uses to throttle inbound connections.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
