### PR TITLE
Fix clippy::derive-partial-eq-without-eq

### DIFF
--- a/common/crypto/dkg/src/bte/keys.rs
+++ b/common/crypto/dkg/src/bte/keys.rs
@@ -135,7 +135,7 @@ impl PublicKeyWithProof {
 
 #[derive(Debug, Zeroize)]
 #[zeroize(drop)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct DecryptionKey {
     // g1^rho
     pub(crate) a: G1Projective,


### PR DESCRIPTION
# Description

Fix `clippy::derive-partial-eq-without-eq`

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
