### PR TITLE
Add step to release GH actions

### DIFF
--- a/.github/workflows/contracts-build.yml
+++ b/.github/workflows/contracts-build.yml
@@ -1,6 +1,8 @@
 name: Build release of Nym smart contracts
 on:
   workflow_dispatch:
+  release:
+    types: [created]
 
 defaults:
   run:
@@ -36,3 +38,11 @@ jobs:
           name: vesting_contract.wasm
           path: contracts/target/wasm32-unknown-unknown/release/vesting_contract.wasm
           retention-days: 5
+
+      - name: Upload to release based on tag name
+        uses: softprops/action-gh-release@v1
+        if: github.event_name == 'release'
+        with:
+          files: |
+            mixnet_contract.wasm 
+            vesting_contract.wasm

--- a/.github/workflows/contracts-build.yml
+++ b/.github/workflows/contracts-build.yml
@@ -4,10 +4,6 @@ on:
   release:
     types: [created]
 
-defaults:
-  run:
-    working-directory: contracts
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,7 +19,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Build release contracts
-        run: RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown
+        run: make wasm
 
       - name: Upload Mixnet Contract Artifact
         uses: actions/upload-artifact@v3
@@ -44,5 +40,5 @@ jobs:
         if: github.event_name == 'release'
         with:
           files: |
-            mixnet_contract.wasm 
-            vesting_contract.wasm
+            contracts/target/wasm32-unknown-unknown/release/vesting_contract.wasm
+            contracts/target/wasm32-unknown-unknown/release/mixnet_contract.wasm


### PR DESCRIPTION
# Description

This task is a part of our Sandbox v2 initiative. By releasing mixnet contracts on GH releases we will be able to wget them instead of having to compile them every time.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
