### PR TITLE
Feature/gateway client protocol version

### DIFF
--- a/common/client-libs/gateway-client/src/client.rs
+++ b/common/client-libs/gateway-client/src/client.rs
@@ -443,7 +443,7 @@ impl GatewayClient {
         // right now there are no failure cases here, but this might change in the future
         match gateway_protocol {
             None => {
-                warn!("the gateway we're connected to has not specified it's protocol version. It's probably running version < 1.1.X, but that's still fine for now. It will become a hard error in 1.2.0");
+                warn!("the gateway we're connected to has not specified its protocol version. It's probably running version < 1.1.X, but that's still fine for now. It will become a hard error in 1.2.0");
                 // note: in 1.2.0 we will have to return a hard error here
                 Ok(())
             }

--- a/common/client-libs/gateway-client/src/client.rs
+++ b/common/client-libs/gateway-client/src/client.rs
@@ -20,7 +20,7 @@ use futures::{FutureExt, SinkExt, StreamExt};
 use gateway_requests::authentication::encrypted_address::EncryptedAddressBytes;
 use gateway_requests::iv::IV;
 use gateway_requests::registration::handshake::{client_handshake, SharedKeys};
-use gateway_requests::{BinaryRequest, ClientControlRequest, ServerResponse};
+use gateway_requests::{BinaryRequest, ClientControlRequest, ServerResponse, PROTOCOL_VERSION};
 use log::*;
 use network_defaults::{REMAINING_BANDWIDTH_THRESHOLD, TOKENS_TO_BURN};
 use nymsphinx::forwarding::packet::MixPacket;
@@ -436,6 +436,33 @@ impl GatewayClient {
         }
     }
 
+    fn check_gateway_protocol(
+        &self,
+        gateway_protocol: Option<u8>,
+    ) -> Result<(), GatewayClientError> {
+        // right now there are no failure cases here, but this might change in the future
+        match gateway_protocol {
+            None => {
+                warn!("the gateway we're connected to has not specified it's protocol version. It's probably running version < 1.1.X, but that's still fine for now. It will become a hard error in 1.2.0");
+                // note: in 1.2.0 we will have to return a hard error here
+                Ok(())
+            }
+            Some(v) if v != PROTOCOL_VERSION => {
+                let err = GatewayClientError::IncompatibleProtocol {
+                    gateway: Some(v),
+                    current: PROTOCOL_VERSION,
+                };
+                error!("{err}");
+                Err(err)
+            }
+
+            Some(_) => {
+                info!("the gateway is using exactly the same protocol version as we are. We're good to continue!");
+                Ok(())
+            }
+        }
+    }
+
     async fn register(&mut self) -> Result<(), GatewayClientError> {
         if !self.connection.is_established() {
             return Err(GatewayClientError::ConnectionNotEstablished);
@@ -458,11 +485,20 @@ impl GatewayClient {
             .map_err(GatewayClientError::RegistrationFailure),
             _ => unreachable!(),
         }?;
-        self.authenticated = match self.read_control_response().await? {
-            ServerResponse::Register { status } => Ok(status),
-            ServerResponse::Error { message } => Err(GatewayClientError::GatewayError(message)),
-            _ => Err(GatewayClientError::UnexpectedResponse),
-        }?;
+        let (authentication_status, gateway_protocol) = match self.read_control_response().await? {
+            ServerResponse::Register {
+                protocol_version,
+                status,
+            } => (status, protocol_version),
+            ServerResponse::Error { message } => {
+                return Err(GatewayClientError::GatewayError(message))
+            }
+            _ => return Err(GatewayClientError::UnexpectedResponse),
+        };
+
+        self.check_gateway_protocol(gateway_protocol)?;
+        self.authenticated = authentication_status;
+
         if self.authenticated {
             self.shared_key = Some(Arc::new(shared_key));
         }
@@ -501,9 +537,11 @@ impl GatewayClient {
 
         match self.send_websocket_message(msg).await? {
             ServerResponse::Authenticate {
+                protocol_version,
                 status,
                 bandwidth_remaining,
             } => {
+                self.check_gateway_protocol(protocol_version)?;
                 self.authenticated = status;
                 self.bandwidth_remaining = bandwidth_remaining;
                 Ok(())

--- a/common/client-libs/gateway-client/src/error.rs
+++ b/common/client-libs/gateway-client/src/error.rs
@@ -85,6 +85,9 @@ pub enum GatewayClientError {
 
     #[error("Failed to send mixnet message")]
     MixnetMsgSenderFailedToSend,
+
+    #[error("Attempted to negotiate connection with gateway using incompatible protocol version. Ours is {current} and the gateway reports {gateway:?}")]
+    IncompatibleProtocol { gateway: Option<u8>, current: u8 },
 }
 
 impl GatewayClientError {

--- a/common/topology/src/lib.rs
+++ b/common/topology/src/lib.rs
@@ -209,18 +209,14 @@ impl NymTopology {
 
     #[must_use]
     pub fn filter_system_version(&self, expected_version: &str) -> Self {
-        self.filter_node_versions(expected_version, expected_version)
+        self.filter_node_versions(expected_version)
     }
 
     #[must_use]
-    pub fn filter_node_versions(
-        &self,
-        expected_mix_version: &str,
-        expected_gateway_version: &str,
-    ) -> Self {
+    pub fn filter_node_versions(&self, expected_mix_version: &str) -> Self {
         NymTopology {
             mixes: self.mixes.filter_by_version(expected_mix_version),
-            gateways: self.gateways.filter_by_version(expected_gateway_version),
+            gateways: self.gateways.clone(),
         }
     }
 }

--- a/gateway/gateway-requests/src/lib.rs
+++ b/gateway/gateway-requests/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 - Nym Technologies SA <contact@nymtech.net>
+// Copyright 2020-2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
 pub use crypto::generic_array;
@@ -11,6 +11,10 @@ pub mod authentication;
 pub mod iv;
 pub mod registration;
 pub mod types;
+
+/// Defines the current version of the communication protocol between gateway and clients.
+/// It has to be incremented for any breaking change.
+pub const PROTOCOL_VERSION: u8 = 1;
 
 pub type GatewayMac = HmacOutput<GatewayIntegrityHmacAlgorithm>;
 

--- a/gateway/gateway-requests/src/registration/handshake/state.rs
+++ b/gateway/gateway-requests/src/registration/handshake/state.rs
@@ -210,7 +210,10 @@ impl<'a, S> State<'a, S> {
                     match msg {
                         WsMessage::Text(ws_msg) => match types::RegistrationHandshake::try_from(ws_msg) {
                             Ok(reg_handshake_msg) => return match reg_handshake_msg {
-                                types::RegistrationHandshake::HandshakePayload { data } => Ok(data),
+                                // hehe, that's a bit disgusting that the type system requires we explicitly ignore the
+                                // protocol_version field that we actually never attach at this point
+                                // yet another reason for the overdue refactor
+                                types::RegistrationHandshake::HandshakePayload {  data, .. } => Ok(data),
                                 types::RegistrationHandshake::HandshakeError { message } => Err(HandshakeError::RemoteError(message)),
                             },
                             Err(_) => error!("Received a non-handshake message during the registration handshake! It's getting dropped."),

--- a/gateway/gateway-requests/src/types.rs
+++ b/gateway/gateway-requests/src/types.rs
@@ -399,14 +399,37 @@ mod tests {
     #[test]
     fn handshake_payload_can_be_deserialized_into_register_handshake_init_request() {
         let handshake_data = vec![1, 2, 3, 4, 5, 6];
-        let handshake_payload = RegistrationHandshake::HandshakePayload {
+        let handshake_payload_with_protocol = RegistrationHandshake::HandshakePayload {
+            protocol_version: Some(42),
             data: handshake_data.clone(),
         };
-        let serialized = serde_json::to_string(&handshake_payload).unwrap();
+        let serialized = serde_json::to_string(&handshake_payload_with_protocol).unwrap();
         let deserialized = ClientControlRequest::try_from(serialized).unwrap();
 
         match deserialized {
-            ClientControlRequest::RegisterHandshakeInitRequest { data } => {
+            ClientControlRequest::RegisterHandshakeInitRequest {
+                protocol_version,
+                data,
+            } => {
+                assert_eq!(protocol_version, Some(42));
+                assert_eq!(data, handshake_data)
+            }
+            _ => unreachable!("this branch shouldn't have been reached!"),
+        }
+
+        let handshake_payload_without_protocol = RegistrationHandshake::HandshakePayload {
+            protocol_version: None,
+            data: handshake_data.clone(),
+        };
+        let serialized = serde_json::to_string(&handshake_payload_without_protocol).unwrap();
+        let deserialized = ClientControlRequest::try_from(serialized).unwrap();
+
+        match deserialized {
+            ClientControlRequest::RegisterHandshakeInitRequest {
+                protocol_version,
+                data,
+            } => {
+                assert!(protocol_version.is_none());
                 assert_eq!(data, handshake_data)
             }
             _ => unreachable!("this branch shouldn't have been reached!"),

--- a/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
@@ -349,7 +349,7 @@ where
         // right now there are no failure cases here, but this might change in the future
         match client_protocol {
             None => {
-                warn!("the client we're connected to has not specified it's protocol version. It's probably running version < 1.1.X, but that's still fine for now. It will become a hard error in 1.2.0");
+                warn!("the client we're connected to has not specified its protocol version. It's probably running version < 1.1.X, but that's still fine for now. It will become a hard error in 1.2.0");
                 // note: in 1.2.0 we will have to return a hard error here
                 Ok(())
             }

--- a/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
@@ -18,7 +18,7 @@ use gateway_requests::iv::{IVConversionError, IV};
 use gateway_requests::registration::handshake::error::HandshakeError;
 use gateway_requests::registration::handshake::{gateway_handshake, SharedKeys};
 use gateway_requests::types::{ClientControlRequest, ServerResponse};
-use gateway_requests::BinaryResponse;
+use gateway_requests::{BinaryResponse, PROTOCOL_VERSION};
 use log::*;
 use mixnet_client::forwarder::MixForwardingSender;
 use nymsphinx::DestinationAddressBytes;
@@ -55,6 +55,9 @@ enum InitialAuthenticationError {
 
     #[error("Experienced connection error - {0}")]
     ConnectionError(#[from] WsError),
+
+    #[error("Attempted to negotiate connection with client using incompatible protocol version. Ours is {current} and the client reports {client:?}")]
+    IncompatibleProtocol { client: Option<u8>, current: u8 },
 }
 
 impl InitialAuthenticationError {
@@ -279,10 +282,7 @@ where
 
             // push them to the client
             if let Err(err) = self.push_packets_to_client(shared_keys, messages).await {
-                warn!(
-                    "We failed to send stored messages to fresh client - {}",
-                    err
-                );
+                warn!("We failed to send stored messages to fresh client - {err}",);
                 return Err(InitialAuthenticationError::ConnectionError(err));
             } else {
                 // if it was successful - remove them from the store
@@ -342,6 +342,33 @@ where
         }
     }
 
+    fn check_client_protocol(
+        &self,
+        client_protocol: Option<u8>,
+    ) -> Result<(), InitialAuthenticationError> {
+        // right now there are no failure cases here, but this might change in the future
+        match client_protocol {
+            None => {
+                warn!("the client we're connected to has not specified it's protocol version. It's probably running version < 1.1.X, but that's still fine for now. It will become a hard error in 1.2.0");
+                // note: in 1.2.0 we will have to return a hard error here
+                Ok(())
+            }
+            Some(v) if v != PROTOCOL_VERSION => {
+                let err = InitialAuthenticationError::IncompatibleProtocol {
+                    client: Some(v),
+                    current: PROTOCOL_VERSION,
+                };
+                error!("{err}");
+                Err(err)
+            }
+
+            Some(_) => {
+                info!("the client is using exactly the same protocol version as we are. We're good to continue!");
+                Ok(())
+            }
+        }
+    }
+
     /// Using the received challenge data, i.e. client's address as well the ciphertext of it plus
     /// a fresh IV, attempts to authenticate the client by checking whether the ciphertext matches
     /// the expected value if encrypted with the shared key.
@@ -389,6 +416,7 @@ where
     /// * `iv`: fresh IV received with the request.
     async fn handle_authenticate(
         &mut self,
+        client_protocol_version: Option<u8>,
         address: String,
         enc_address: String,
         iv: String,
@@ -396,6 +424,8 @@ where
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
+        self.check_client_protocol(client_protocol_version)?;
+
         let address = DestinationAddressBytes::try_from_base58_string(address)
             .map_err(|err| InitialAuthenticationError::MalformedClientAddress(err.to_string()))?;
         let encrypted_address = EncryptedAddressBytes::try_from_base58_string(enc_address)?;
@@ -420,6 +450,7 @@ where
         Ok(InitialAuthResult::new(
             client_details,
             ServerResponse::Authenticate {
+                protocol_version: Some(PROTOCOL_VERSION),
                 status,
                 bandwidth_remaining,
             },
@@ -474,11 +505,14 @@ where
     /// * `init_data`: init payload of the registration handshake.
     async fn handle_register(
         &mut self,
+        client_protocol_version: Option<u8>,
         init_data: Vec<u8>,
     ) -> Result<InitialAuthResult, InitialAuthenticationError>
     where
         S: AsyncRead + AsyncWrite + Unpin + Send,
     {
+        self.check_client_protocol(client_protocol_version)?;
+
         let remote_identity = Self::extract_remote_identity_from_register_init(&init_data)?;
         let remote_address = remote_identity.derive_destination_address();
 
@@ -493,7 +527,10 @@ where
 
         Ok(InitialAuthResult::new(
             Some(client_details),
-            ServerResponse::Register { status },
+            ServerResponse::Register {
+                protocol_version: Some(PROTOCOL_VERSION),
+                status,
+            },
         ))
     }
 
@@ -513,13 +550,18 @@ where
         if let Ok(request) = ClientControlRequest::try_from(raw_request) {
             match request {
                 ClientControlRequest::Authenticate {
+                    protocol_version,
                     address,
                     enc_address,
                     iv,
-                } => self.handle_authenticate(address, enc_address, iv).await,
-                ClientControlRequest::RegisterHandshakeInitRequest { data } => {
-                    self.handle_register(data).await
+                } => {
+                    self.handle_authenticate(protocol_version, address, enc_address, iv)
+                        .await
                 }
+                ClientControlRequest::RegisterHandshakeInitRequest {
+                    protocol_version,
+                    data,
+                } => self.handle_register(protocol_version, data).await,
                 // won't accept anything else (like bandwidth) without prior authentication
                 _ => Err(InitialAuthenticationError::InvalidRequest),
             }


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1917

Introduces simple `protocol_version` field exchanged for each `authenticate` and `register` message between client and the gateway. Currently it's fully optional and if one party doesn't specify it, everything proceeds without a problem. However, once we release a breaking change (like a 1.2.0) this behaviour should change.


# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
