### PR TITLE
Make connection_id optional in ClientRequest::Send

### DIFF
--- a/clients/native/examples/websocket_binarysend.rs
+++ b/clients/native/examples/websocket_binarysend.rs
@@ -43,7 +43,7 @@ async fn send_file_with_reply() {
         recipient,
         message: read_data,
         with_reply_surb: true,
-        connection_id: 0,
+        connection_id: Some(0),
     };
 
     println!("sending content of 'dummy_file' over the mix network...");
@@ -92,7 +92,7 @@ async fn send_file_without_reply() {
         recipient,
         message: read_data,
         with_reply_surb: false,
-        connection_id: 0,
+        connection_id: Some(0),
     };
 
     println!("sending content of 'dummy_file' over the mix network...");

--- a/clients/native/src/websocket/handler.rs
+++ b/clients/native/src/websocket/handler.rs
@@ -92,25 +92,41 @@ impl Handler {
         recipient: &Recipient,
         message: Vec<u8>,
         with_reply_surb: bool,
-        connection_id: u64,
+        connection_id: Option<u64>,
     ) -> Option<ServerResponse> {
+        // We map the absence of a connection id as going into the general lane.
+        let lane = connection_id.map_or(TransmissionLane::General, |id| {
+            TransmissionLane::ConnectionId(id)
+        });
+
         // the ack control is now responsible for chunking, etc.
-        let lane = TransmissionLane::ConnectionId(connection_id);
         let input_msg = InputMessage::new_fresh(*recipient, message, with_reply_surb, lane);
         if self.msg_input.send(input_msg).await.is_err() {
             panic!();
         }
 
+        // Only reply back with a `LaneQueueLength` if the sender providided a connection id
+        let connection_id = match lane {
+            TransmissionLane::General
+            | TransmissionLane::Reply
+            | TransmissionLane::Retransmission
+            | TransmissionLane::Control => return None,
+            TransmissionLane::ConnectionId(id) => id,
+        };
+
         // on receiving a send, we reply back the current lane queue length for that connection id.
         // Note that this does _NOT_ take into account the packets that have been received but not
         // yet reach `OutQueueControl`, so it might be a tad low.
-        if let Ok(lane_queue_lengths) = self.lane_queue_lengths.lock() {
-            let queue_length = lane_queue_lengths.get(&lane).unwrap_or(0);
-            return Some(ServerResponse::LaneQueueLength(connection_id, queue_length));
-        }
+        let Ok(lane_queue_lengths) = self.lane_queue_lengths.lock() else {
+            log::warn!(
+                "Failed to get the lane queue length lock, \
+                not responding back with the current queue length"
+            );
+            return None;
+        };
 
-        log::warn!("Failed to get the lane queue length lock, not responding back with the current queue length");
-        None
+        let queue_length = lane_queue_lengths.get(&lane).unwrap_or(0);
+        Some(ServerResponse::LaneQueueLength(connection_id, queue_length))
     }
 
     async fn handle_reply(
@@ -119,7 +135,13 @@ impl Handler {
         message: Vec<u8>,
     ) -> Option<ServerResponse> {
         if message.len() > ReplySurb::max_msg_len(Default::default()) {
-            return Some(ServerResponse::new_error(format!("too long message to put inside a reply SURB. Received: {} bytes and maximum is {} bytes", message.len(), ReplySurb::max_msg_len(Default::default()))));
+            return Some(
+                ServerResponse::new_error(
+                    format!(
+                        "too long message to put inside a reply SURB. Received: {} bytes and maximum is {} bytes",
+                        message.len(), ReplySurb::max_msg_len(Default::default()))
+                    )
+                );
         }
 
         let input_msg = InputMessage::new_reply(reply_surb, message);

--- a/clients/native/websocket-requests/src/text.rs
+++ b/clients/native/websocket-requests/src/text.rs
@@ -20,7 +20,7 @@ pub(super) enum ClientRequestText {
         message: String,
         recipient: String,
         with_reply_surb: bool,
-        connection_id: u64,
+        connection_id: Option<u64>,
     },
     SelfAddress,
     #[serde(rename_all = "camelCase")]

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -102,7 +102,7 @@ impl ServiceProvider {
                             recipient: return_address,
                             message: msg.into_bytes(),
                             with_reply_surb: false,
-                            connection_id: conn_id,
+                            connection_id: Some(conn_id),
                         };
 
                         let message = Message::Binary(response_message.serialize());


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1916

Make `connection_id` optional in `ClientRequest::Send`

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
