### PR TITLE
Using Display implementation of MessageRecoveryError when logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 -clients: ability to use multi-reply SURBs to send arbitrarily long messages fully anonymously whilst requesting additional reply blocks whenever they're about to run out ([#1796])
 
+### Changed
+
+- clients: improve message logging when received message fails to get reconstructed ([#1803])
+
 [#1796]: https://github.com/nymtech/nym/pull/1796
+[#1803]: https://github.com/nymtech/nym/pull/1803
 
 ## Unreleased
 

--- a/clients/client-core/src/client/received_buffer.rs
+++ b/clients/client-core/src/client/received_buffer.rs
@@ -53,8 +53,8 @@ impl ReceivedMessagesBufferInner {
         }
 
         let fragment = match self.message_receiver.recover_fragment(fragment_data) {
-            Err(e) => {
-                warn!("failed to recover fragment from raw data: {:?}. The whole underlying message might be corrupted and unrecoverable!", e);
+            Err(err) => {
+                warn!("failed to recover fragment from raw data: {err}. The whole underlying message might be corrupted and unrecoverable!");
                 return None;
             }
             Ok(frag) => frag,
@@ -116,8 +116,8 @@ impl ReceivedMessagesBufferInner {
             self.local_encryption_keypair.private_key(),
             &mut raw_fragment,
         ) {
-            Err(e) => {
-                warn!("failed to recover fragment data: {:?}. The whole underlying message might be corrupted and unrecoverable!", e);
+            Err(err) => {
+                warn!("failed to recover fragment data: {err}. The whole underlying message might be corrupted and unrecoverable!");
                 return None;
             }
             Ok(frag_data) => frag_data,
@@ -302,7 +302,7 @@ impl ReceivedMessagesBuffer {
         if let Some(sender) = &inner_guard.message_sender {
             trace!("Sending reconstructed messages to announced sender");
             if let Err(err) = sender.unbounded_send(reconstructed_messages) {
-                warn!("The reconstructed message receiver went offline without explicit notification (relevant error: - {:?})", err);
+                warn!("The reconstructed message receiver went offline without explicit notification (relevant error: - {err})");
                 inner_guard.message_sender = None;
                 inner_guard.messages.extend(err.into_inner());
             }


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
