### PR TITLE
Defined socks5 client startup flag to enable reply-surb communication

### DIFF
--- a/clients/socks5/src/client/config/mod.rs
+++ b/clients/socks5/src/client/config/mod.rs
@@ -130,9 +130,11 @@ pub struct Socks5 {
     /// The mix address of the provider to which all requests are going to be sent.
     provider_mix_address: String,
 
-    /// Flag to indicate whether this client shall send reply surbs with each request
-    /// and expect to receive any replies using those.
-    /// Note that it almost doubles bandwidth requirements.
+    /// Specifies whether this client is going to use an anonymous sender tag for communication with the service provider.
+    /// While this is going to hide its actual address information, it will make the actual communication
+    /// slower and consume nearly double the bandwidth as it will require sending reply SURBs.
+    ///
+    /// Note that some service providers might not support this.
     send_anonymously: bool,
 }
 

--- a/clients/socks5/src/client/config/template.rs
+++ b/clients/socks5/src/client/config/template.rs
@@ -92,9 +92,11 @@ provider_mix_address = '{{ socks5.provider_mix_address }}'
 # The port on which the client will be listening for incoming requests
 listening_port = {{ socks5.listening_port }}
 
-# Flag to indicate whether this client shall send reply surbs with each request
-# and expect to receive any replies using those.
-# Note that it almost doubles bandwidth requirements.
+# Specifies whether this client is going to use an anonymous sender tag for communication with the service provider.
+# While this is going to hide its actual address information, it will make the actual communication
+# slower and consume nearly double the bandwidth as it will require sending reply SURBs.
+#
+# Note that some service providers might not support this.
 send_anonymously = {{ socks5.send_anonymously }}
 
 ##### logging configuration options #####

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -20,6 +20,14 @@ pub(crate) struct Init {
     #[clap(long)]
     provider: String,
 
+    /// Specifies whether this client is going to use an anonymous sender tag for communication with the service provider.
+    /// While this is going to hide its actual address information, it will make the actual communication
+    /// slower and consume nearly double the bandwidth as it will require sending reply SURBs.
+    ///
+    /// Note that some service providers might not support this.
+    #[clap(long)]
+    use_anonymous_sender_tag: bool,
+
     /// Id of the gateway we are going to connect to.
     #[clap(long)]
     gateway: Option<String>,
@@ -59,7 +67,9 @@ impl From<Init> for OverrideConfig {
             nymd_validators: init_config.nymd_validators,
             api_validators: init_config.api_validators,
             port: init_config.port,
+            use_anonymous_sender_tag: init_config.use_anonymous_sender_tag,
             fastmode: init_config.fastmode,
+
             #[cfg(feature = "coconut")]
             enabled_credentials_mode: init_config.enabled_credentials_mode,
         }

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -81,6 +81,7 @@ pub(crate) struct OverrideConfig {
     nymd_validators: Option<String>,
     api_validators: Option<String>,
     port: Option<u16>,
+    use_anonymous_sender_tag: bool,
     fastmode: bool,
 
     #[cfg(feature = "coconut")]
@@ -118,6 +119,10 @@ pub(crate) fn override_config(mut config: Config, args: OverrideConfig) -> Confi
         config
             .get_base_mut()
             .set_custom_validator_apis(parse_validators(&raw_validators));
+    }
+
+    if args.use_anonymous_sender_tag {
+        config = config.with_anonymous_replies(true)
     }
 
     if let Some(port) = args.port {

--- a/clients/socks5/src/commands/run.rs
+++ b/clients/socks5/src/commands/run.rs
@@ -22,6 +22,14 @@ pub(crate) struct Run {
     #[clap(long)]
     config: Option<String>,
 
+    /// Specifies whether this client is going to use an anonymous sender tag for communication with the service provider.
+    /// While this is going to hide its actual address information, it will make the actual communication
+    /// slower and consume nearly double the bandwidth as it will require sending reply SURBs.
+    ///
+    /// Note that some service providers might not support this.
+    #[clap(long)]
+    use_anonymous_sender_tag: bool,
+
     /// Address of the socks5 provider to send messages to.
     #[clap(long)]
     provider: Option<String>,
@@ -56,6 +64,7 @@ impl From<Run> for OverrideConfig {
             nymd_validators: run_config.nymd_validators,
             api_validators: run_config.api_validators,
             port: run_config.port,
+            use_anonymous_sender_tag: run_config.use_anonymous_sender_tag,
             fastmode: false,
 
             #[cfg(feature = "coconut")]


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1913

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
