### PR TITLE
Bug fix - Vesting schedule display

### DIFF
--- a/nym-wallet/src/pages/balance/index.tsx
+++ b/nym-wallet/src/pages/balance/index.tsx
@@ -9,24 +9,8 @@ import { TransferModal } from './components/TransferModal';
 
 export const Balance = () => {
   const [showTransferModal, setShowTransferModal] = useState(false);
-  const [showVestingCard, setShowVestingCard] = useState(false);
 
   const { userBalance } = useContext(AppContext);
-
-  useEffect(() => {
-    const { originalVesting, currentVestingPeriod, tokenAllocation } = userBalance;
-    if (
-      originalVesting &&
-      currentVestingPeriod === 'After' &&
-      tokenAllocation?.locked === '0' &&
-      tokenAllocation?.vesting === '0' &&
-      tokenAllocation?.spendable === '0'
-    ) {
-      setShowVestingCard(false);
-    } else if (originalVesting) {
-      setShowVestingCard(true);
-    }
-  }, [userBalance]);
 
   const handleShowTransferModal = async () => {
     await userBalance.refreshBalances();
@@ -37,7 +21,7 @@ export const Balance = () => {
     <PageLayout>
       <Box display="flex" flexDirection="column" gap={2}>
         <BalanceCard />
-        {showVestingCard && <VestingCard onTransfer={handleShowTransferModal} />}
+        <VestingCard onTransfer={handleShowTransferModal} />
         {showTransferModal && <TransferModal onClose={() => setShowTransferModal(false)} />}
       </Box>
     </PageLayout>


### PR DESCRIPTION
# Description

Currently a vesting schedule is only displayed if a number of conditions are met.

```
      originalVesting &&
      currentVestingPeriod === 'After' &&
      tokenAllocation?.locked === '0' &&
      tokenAllocation?.vesting === '0' &&
      tokenAllocation?.spendable === '0'
```

To avoid (and fix) potential bugs in the displaying ther schedule, we are reverting back to using only one condition 

```
originalVesting ! == undefined
```

Closes: https://github.com/nymtech/nym/issues/2170
