### PR TITLE
client-core: allow increasing sending rate with number of connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,7 @@ dependencies = [
  "humantime-serde",
  "log",
  "nonexhaustive-delayqueue",
+ "num-rational",
  "nymsphinx",
  "pemstore",
  "rand 0.7.3",
@@ -3057,6 +3058,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,6 +3086,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg 1.1.0",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 

--- a/clients/client-core/Cargo.toml
+++ b/clients/client-core/Cargo.toml
@@ -32,6 +32,7 @@ pemstore = { path = "../../common/pemstore" }
 topology = { path = "../../common/topology" }
 validator-client = { path = "../../common/client-libs/validator-client", default-features = false }
 task = { path = "../../common/task" }
+num-rational = "0.4.1"
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio-stream]
 version = "0.1.9"

--- a/clients/client-core/src/client/base_client/mod.rs
+++ b/clients/client-core/src/client/base_client/mod.rs
@@ -185,6 +185,7 @@ impl<'a> BaseClientBuilder<'a> {
             self.debug_config.ack_wait_addition,
             self.debug_config.average_ack_delay,
             self.debug_config.message_sending_average_delay,
+            self.debug_config.scale_sending_rate_with_no_connections,
             self.debug_config.average_packet_delay,
             self.debug_config.disable_main_poisson_packet_distribution,
             self.as_mix_recipient(),

--- a/clients/client-core/src/client/real_messages_control/mod.rs
+++ b/clients/client-core/src/client/real_messages_control/mod.rs
@@ -50,6 +50,8 @@ pub struct Config {
     /// Average delay between sending subsequent packets from this client.
     average_message_sending_delay: Duration,
 
+    scale_sending_rate_with_no_connections: bool,
+
     /// Average delay a data packet is going to get delayed at a single mixnode.
     average_packet_delay_duration: Duration,
 
@@ -73,6 +75,7 @@ impl Config {
         ack_wait_addition: Duration,
         average_ack_delay_duration: Duration,
         average_message_sending_delay: Duration,
+        scale_sending_rate_with_no_connections: bool,
         average_packet_delay_duration: Duration,
         disable_main_poisson_packet_distribution: bool,
         self_recipient: Recipient,
@@ -83,6 +86,7 @@ impl Config {
             ack_wait_multiplier,
             self_recipient,
             average_message_sending_delay,
+            scale_sending_rate_with_no_connections,
             average_packet_delay_duration,
             average_ack_delay_duration,
             disable_main_poisson_packet_distribution,
@@ -152,6 +156,7 @@ impl RealMessagesController<OsRng> {
             config.average_ack_delay_duration,
             config.average_packet_delay_duration,
             config.average_message_sending_delay,
+            config.scale_sending_rate_with_no_connections,
             config.disable_main_poisson_packet_distribution,
         )
         .with_custom_cover_packet_size(config.packet_size);

--- a/clients/client-core/src/config/mod.rs
+++ b/clients/client-core/src/config/mod.rs
@@ -474,6 +474,9 @@ pub struct DebugConfig {
     #[serde(with = "humantime_serde")]
     pub message_sending_average_delay: Duration,
 
+    /// Controls if we should increase the sending rate with the number of connections
+    pub scale_sending_rate_with_no_connections: bool,
+
     /// How long we're willing to wait for a response to a message sent to the gateway,
     /// before giving up on it.
     #[serde(with = "humantime_serde")]
@@ -519,6 +522,7 @@ impl Default for DebugConfig {
             ack_wait_addition: DEFAULT_ACK_WAIT_ADDITION,
             loop_cover_traffic_average_delay: DEFAULT_LOOP_COVER_STREAM_AVERAGE_DELAY,
             message_sending_average_delay: DEFAULT_MESSAGE_STREAM_AVERAGE_DELAY,
+            scale_sending_rate_with_no_connections: false,
             gateway_response_timeout: DEFAULT_GATEWAY_RESPONSE_TIMEOUT,
             topology_refresh_rate: DEFAULT_TOPOLOGY_REFRESH_RATE,
             topology_resolution_timeout: DEFAULT_TOPOLOGY_RESOLUTION_TIMEOUT,


### PR DESCRIPTION
# Description

Closes: #XXXX

Add flag to client that enables setting the minimum avg delay to 1 / N where N is the number of active connections.

This is currently only for testing and evaluation. Not for production use.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
