### PR TITLE
Fix a few errors in socks5 client and network-requester

### DIFF
--- a/clients/socks5/src/socks/client.rs
+++ b/clients/socks5/src/socks/client.rs
@@ -285,10 +285,15 @@ impl SocksClient {
             .await;
 
         let stream = self.stream.run_proxy();
-        let local_stream_remote = stream
-            .peer_addr()
-            .expect("failed to extract peer address")
-            .to_string();
+        let peer_addr = match stream.peer_addr() {
+            Ok(peer_addr) => peer_addr,
+            Err(err) => {
+                log::error!("Unable to extract the remote peer address: {err}");
+                return;
+            }
+        };
+        let local_stream_remote = peer_addr.to_string();
+
         let connection_id = self.connection_id;
         let input_sender = self.input_sender.clone();
 

--- a/clients/socks5/src/socks/client.rs
+++ b/clients/socks5/src/socks/client.rs
@@ -167,9 +167,13 @@ impl SocksClient {
         controller_sender: ControllerSender,
         self_address: &Recipient,
         lane_queue_lengths: LaneQueueLengths,
-        shutdown_listener: ShutdownListener,
+        mut shutdown_listener: ShutdownListener,
     ) -> Self {
+        // If this task fails and exits, we don't want to send shutdown signal
+        shutdown_listener.mark_as_success();
+
         let connection_id = Self::generate_random();
+
         SocksClient {
             controller_sender,
             connection_id,
@@ -369,7 +373,6 @@ impl SocksClient {
             SocksCommand::UdpAssociate => unimplemented!(), // not handled
         };
 
-        self.shutdown_listener.mark_as_success();
         Ok(())
     }
 

--- a/clients/socks5/src/socks/client.rs
+++ b/clients/socks5/src/socks/client.rs
@@ -197,10 +197,10 @@ impl SocksClient {
 
     pub async fn send_error(&mut self, err: SocksProxyError) -> Result<(), SocksProxyError> {
         let error_text = format!("{}", err);
-        let version = self
-            .socks_version
-            .as_ref()
-            .expect("Trying to send error without knowing the version");
+        let Some(ref version) = self.socks_version else {
+            log::error!("Trying to send error without knowing the version");
+            return Ok(());
+        };
 
         match version {
             SocksVersion::V4 => {

--- a/clients/socks5/src/socks/server.rs
+++ b/clients/socks5/src/socks/server.rs
@@ -100,7 +100,7 @@ impl SphinxSocksServer {
                         if let Err(err) = client.run().await {
                             error!("Error! {}", err);
                             if client.send_error(err).await.is_err() {
-                                warn!("Failed to error code");
+                                warn!("Failed to send error code");
                             };
                             if client.shutdown().await.is_err() {
                                 warn!("Failed to shutdown TcpStream");

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -157,9 +157,13 @@ impl ServiceProvider {
         lane_queue_lengths: LaneQueueLengths,
     ) -> Option<ReconstructedMessage> {
         while let Some(msg) = websocket_reader.next().await {
-            let data = msg
-                .expect("we failed to read from the websocket!")
-                .into_data();
+            let data = match msg {
+                Ok(msg) => msg.into_data(),
+                Err(err) => {
+                    log::error!("Failed to read from the websocket: {err}");
+                    continue;
+                }
+            };
 
             // try to recover the actual message from the mix network...
             let deserialized_message = match ServerResponse::deserialize(&data) {


### PR DESCRIPTION
# Description

Fix a few errors noticed during regular usage

- Never shutdown proxy if connection handler fails
- Don't panic on unable to read websocket
- Don't panic on unable to read peer address
- Don't panic on getting the socks5 version when sending error back

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
