### PR TITLE
validator-api: add missing short form for --config-env-file

### DIFF
--- a/validator-api/src/main.rs
+++ b/validator-api/src/main.rs
@@ -121,6 +121,7 @@ fn parse_args() -> ArgMatches {
             Arg::with_name(CONFIG_ENV_FILE)
                 .help("Path pointing to an env file that configures the validator API")
                 .long(CONFIG_ENV_FILE)
+                .short('c')
                 .takes_value(true)
         )
         .arg(


### PR DESCRIPTION
# Description

Add missing `-c` to validator-api for `--config-env-file`

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
