### PR TITLE
nym-connect: append error to failed message

### DIFF
--- a/nym-connect/CHANGELOG.md
+++ b/nym-connect/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- nym-connect: fix issue with actual socks5 error message not being appened to the error message sent to the frontend.
+
 ## [nym-connect-v1.1.1](https://github.com/nymtech/nym/tree/nym-connect-v1.1.1) (2022-11-29)
 
 - socks5-client: fix multiplex concurrent connections ([#1720], [#1777])

--- a/nym-connect/src-tauri/src/tasks.rs
+++ b/nym-connect/src-tauri/src/tasks.rs
@@ -19,7 +19,7 @@ pub enum Socks5StatusMessage {
     /// The SOCKS5 task successfully stopped
     Stopped,
     /// The SOCKS5 task failed to start
-    FailedToStart,
+    Failed(Box<dyn std::error::Error + Send>),
 }
 
 /// The main SOCKS5 client task. It loads the configuration from file determined by the `id`.
@@ -56,7 +56,7 @@ pub fn start_nym_socks5_client(
         if let Err(err) = result {
             log::error!("SOCKS5 proxy failed: {err}");
             socks5_status_tx
-                .send(Socks5StatusMessage::FailedToStart)
+                .send(Socks5StatusMessage::Failed(err))
                 .expect("Failed to send status message back to main task");
             return;
         }
@@ -98,14 +98,14 @@ pub fn start_disconnect_listener(
                     )
                     .unwrap();
             }
-            Ok(Socks5StatusMessage::FailedToStart) => {
-                log::info!("SOCKS5 task reported it failed to start");
+            Ok(Socks5StatusMessage::Failed(err)) => {
+                log::info!("SOCKS5 task reported error: {}", err);
                 window
                     .emit(
                         "socks5-event",
                         Payload {
                             title: "SOCKS5 error".into(),
-                            message: "SOCKS5 failed to start".into(),
+                            message: format!("SOCKS5 failed: {}", err),
                         },
                     )
                     .unwrap();


### PR DESCRIPTION
# Description

Fix issue where the error message generated in the socks5-client was not appended to the error that was sent to nym-connect.

*Before*: nym-connect would disconnect with the error: "SOCKS5 task reported it failed to start"

*Now* (example):

![image](https://user-images.githubusercontent.com/1894054/205652510-4e380ae3-8901-46e7-9e55-6c87274d6bba.png)

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
