### PR TITLE
Enabled mixnode packet versioning

### DIFF
--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -491,9 +491,6 @@ struct Debug {
     maximum_connection_buffer_size: usize,
 
     /// Specifies whether the mixnode should be using the legacy framing for the sphinx packets.
-    // it's set to true by default. The reason for that decision is to preserve compatibility with the
-    // existing nodes whilst everyone else is upgrading and getting the code for handling the new field.
-    // It shall be disabled in the subsequent releases.
     use_legacy_framed_packet_version: bool,
 }
 
@@ -506,8 +503,7 @@ impl Default for Debug {
             packet_forwarding_maximum_backoff: DEFAULT_PACKET_FORWARDING_MAXIMUM_BACKOFF,
             initial_connection_timeout: DEFAULT_INITIAL_CONNECTION_TIMEOUT,
             maximum_connection_buffer_size: DEFAULT_MAXIMUM_CONNECTION_BUFFER_SIZE,
-            // TODO: remember to change it in one of future releases!!
-            use_legacy_framed_packet_version: true,
+            use_legacy_framed_packet_version: false,
         }
     }
 }


### PR DESCRIPTION
# Description

I think at this point it's safe to assume that all mixnodes are on 1.1.X version and thus we could enable the packet versioning. It's going to make our lives easier for any future breaking changes.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
