### PR TITLE
use mix_id for account to get correct pending cost event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6537,7 +6537,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vesting-contract"
-version = "1.1.0"
+version = "1.1.2"
 dependencies = [
  "contracts-common",
  "cosmwasm-std",

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -5497,7 +5497,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vesting-contract"
-version = "1.1.0"
+version = "1.1.2"
 dependencies = [
  "contracts-common",
  "cosmwasm-std",

--- a/nym-wallet/src/pages/bonding/node-settings/settings-pages/general-settings/ParametersSettings.tsx
+++ b/nym-wallet/src/pages/bonding/node-settings/settings-pages/general-settings/ParametersSettings.tsx
@@ -88,7 +88,11 @@ export const ParametersSettings = ({ bondedNode }: { bondedNode: TBondedMixnode 
 
   const getPendingEvents = async () => {
     const events = await getPendingIntervalEvents();
-    const latestEvent = events.reverse().find((evt) => 'ChangeMixCostParams' in evt.event) as unknown as
+    const latestEvent = events
+      .reverse()
+      .find(
+        (evt) => 'ChangeMixCostParams' in evt.event && evt.event.ChangeMixCostParams.mix_id === bondedNode.mixId,
+      ) as unknown as
       | {
           id: number;
           event: {


### PR DESCRIPTION
# Description

Bug fix - Show users their own most recent pending cost update event NOT most recent of all the pending cost update events

Closes: https://github.com/nymtech/nym/issues/2136
