### PR TITLE
Client: dedup setup gateway during init

### DIFF
--- a/clients/client-core/src/error.rs
+++ b/clients/client-core/src/error.rs
@@ -26,6 +26,8 @@ pub enum ClientCoreError {
     NoGatewayWithId(String),
     #[error("No gateways on network")]
     NoGatewaysOnNetwork,
+    #[error("Failed to setup gateway")]
+    FailedToSetupGateway,
     #[error("List of validator apis is empty")]
     ListOfValidatorApisIsEmpty,
     #[error("Could not load existing gateway configuration: {0}")]

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -133,12 +133,20 @@ pub(crate) async fn execute(args: &Init) {
     let override_config_fields = OverrideConfig::from(args.clone());
     config = override_config(config, override_config_fields);
 
-    let gateway = setup_gateway(id, register_gateway, user_chosen_gateway_id, &config)
+    let gateway = if !register_gateway && user_chosen_gateway_id.is_none() {
+        reuse_gateway_config(id)
+    } else {
+        client_core::init::setup_gateway(
+            register_gateway,
+            user_chosen_gateway_id,
+            config.get_base(),
+        )
         .await
-        .unwrap_or_else(|err| {
-            eprintln!("Failed to setup gateway\nError: {err}");
-            std::process::exit(1)
-        });
+    }
+    .unwrap_or_else(|err| {
+        eprintln!("Failed to setup gateway\nError: {err}");
+        std::process::exit(1)
+    });
     config.get_base_mut().with_gateway_endpoint(gateway);
 
     let config_save_location = config.get_config_file_save_location();
@@ -179,45 +187,11 @@ pub(crate) async fn execute(args: &Init) {
     println!("\nThe address of this client is: {}\n", address);
 }
 
-async fn setup_gateway(
-    id: &str,
-    register: bool,
-    user_chosen_gateway_id: Option<&str>,
-    config: &Config,
-) -> Result<GatewayEndpointConfig, ClientCoreError> {
-    if register {
-        // Get the gateway details by querying the validator-api. Either pick one at random or use
-        // the chosen one if it's among the available ones.
-        println!("Configuring gateway");
-        let gateway = client_core::init::query_gateway_details(
-            config.get_base().get_validator_api_endpoints(),
-            user_chosen_gateway_id,
-        )
-        .await?;
-        log::debug!("Querying gateway gives: {}", gateway);
-
-        // Registering with gateway by setting up and writing shared keys to disk
-        log::trace!("Registering gateway");
-        client_core::init::register_with_gateway_and_store_keys(gateway.clone(), config.get_base())
-            .await?;
-        println!("Saved all generated keys");
-
-        Ok(gateway.into())
-    } else if user_chosen_gateway_id.is_some() {
-        // Just set the config, don't register or create any keys
-        // This assumes that the user knows what they are doing, and that the existing keys are
-        // valid for the gateway being used
-        println!("Using gateway provided by user, keeping existing keys");
-        let gateway = client_core::init::query_gateway_details(
-            config.get_base().get_validator_api_endpoints(),
-            user_chosen_gateway_id,
-        )
-        .await?;
-        log::debug!("Querying gateway gives: {}", gateway);
-        Ok(gateway.into())
-    } else {
-        println!("Not registering gateway, will reuse existing config and keys");
-        let existing_config = Config::load_from_file(Some(id)).map_err(|err| {
+fn reuse_gateway_config(id: &str) -> Result<GatewayEndpointConfig, ClientCoreError> {
+    println!("Not registering gateway, will reuse existing config and keys");
+    Config::load_from_file(Some(id))
+        .map(|existing_config| existing_config.get_base().get_gateway_endpoint().clone())
+        .map_err(|err| {
             log::error!(
                 "Unable to configure gateway: {err}. \n
                 Seems like the client was already initialized but it was not possible to read \
@@ -226,7 +200,5 @@ async fn setup_gateway(
                 removing the existing configuration and starting over."
             );
             ClientCoreError::CouldNotLoadExistingGatewayConfiguration(err)
-        })?;
-        Ok(existing_config.get_base().get_gateway_endpoint().clone())
-    }
+        })
 }

--- a/nym-connect/src-tauri/src/config/mod.rs
+++ b/nym-connect/src-tauri/src/config/mod.rs
@@ -135,12 +135,22 @@ pub async fn init_socks5_config(provider_address: String, chosen_gateway_id: Str
 
     config.get_base_mut().with_gateway_endpoint(gateway);
 
-    let config_save_location = config.get_socks5().get_config_file_save_location();
     config.get_socks5().save_to_file(None).tap_err(|_| {
         log::error!("Failed to save the config file");
     })?;
 
-    log::info!("Saved configuration file to {:?}", config_save_location);
+    print_save_config(&config);
+
+    let address = client_core::init::get_client_address(config.get_base())?;
+    log::info!("The address of this client is: {}", address);
+    Ok(())
+}
+
+fn print_save_config(config: &Config) {
+    log::info!(
+        "Saved configuration file to {:?}",
+        config.get_socks5().get_config_file_save_location()
+    );
     log::info!("Gateway id: {}", config.get_base().get_gateway_id());
     log::info!("Gateway owner: {}", config.get_base().get_gateway_owner());
     log::info!(
@@ -157,8 +167,4 @@ pub async fn init_socks5_config(provider_address: String, chosen_gateway_id: Str
         config.get_socks5().get_listening_port()
     );
     log::info!("Client configuration completed.");
-
-    let address = client_core::init::get_client_address(config.get_base())?;
-    println!("\nThe address of this client is: {}\n", address);
-    Ok(())
 }


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1892

Moves code that was duplicated in client, socks5-client and nym-connect to client-core

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
