### PR TITLE
network-requester: return error on socket close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 - validator-api: can recover from shutdown during DKG process ([#1872])
 
+### Fixed
+
+- network-requester: fix bug where websocket connection disconnect resulted in success error code
+
 [#1872]: https://github.com/nymtech/nym/pull/1872
+
 
 ## [v1.1.2]
 

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -447,7 +447,7 @@ impl ServiceProvider {
                 .await
             else {
                 log::error!("The websocket stream has finished!");
-                return Ok(());
+                return Err(NetworkRequesterError::ConnectionClosed);
             };
 
             let raw_message = received.message;

--- a/service-providers/network-requester/src/error.rs
+++ b/service-providers/network-requester/src/error.rs
@@ -7,4 +7,7 @@ pub enum NetworkRequesterError {
 
     #[error("Websocket error")]
     WebsocketConnectionError(#[from] WebsocketConnectionError),
+
+    #[error("Websocket connection closed")]
+    ConnectionClosed,
 }


### PR DESCRIPTION
# Description

Fix bug where the network-requester returned success when the websocket was closed

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
