### PR TITLE
client: pick from old lanes probabilisticlly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 - validator-api: can recover from shutdown during DKG process ([#1872])
 - client-core: deduplicate gateway inititialization, part of work towards a rust-sdk
+- clients: keep all transmission lanes going at all times by making priority probabilistic
 
 ### Fixed
 

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream/transmission_buffer.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream/transmission_buffer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use client_connections::TransmissionLane;
-use rand::seq::SliceRandom;
+use rand::{seq::SliceRandom, Rng};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     time::Duration,
@@ -116,9 +116,15 @@ impl TransmissionBuffer {
         lanes.choose(&mut rand::thread_rng()).copied()
     }
 
+    // 2/3 chance to pick from the old lanes
     fn pick_random_old_lane(&self) -> Option<TransmissionLane> {
-        let lanes = self.get_oldest_set();
-        lanes.choose(&mut rand::thread_rng()).copied()
+        let rand = &mut rand::thread_rng();
+        if rand.gen_ratio(2, 3) {
+            let lanes = self.get_oldest_set();
+            lanes.choose(rand).copied()
+        } else {
+            self.pick_random_lane().copied()
+        }
     }
 
     fn pop_front_from_lane(&mut self, lane: &TransmissionLane) -> Option<RealMessage> {


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1890

The client should pick lane to send from probabilistically instead of strictly picking from old lanes. We want to keep all connection going at all time (even if the older ones move faster)

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
