### PR TITLE
socks5: rework waiting in inbound.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - network-requester: fix bug where websocket connection disconnect resulted in success error code
 - clients: fix a few panics handling the gateway-client
 - mixnode, gateway, validator-api: Use mainnet values as defaults for URLs and mixnet contract  ([#1884])
+- socks5: fixed bug where connections sometimes where closed too early
 
 [#1872]: https://github.com/nymtech/nym/pull/1872
 [#1884]: https://github.com/nymtech/nym/pull/1884

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream/transmission_buffer.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream/transmission_buffer.rs
@@ -17,7 +17,7 @@ use wasm_timer;
 use super::{get_time_now, RealMessage};
 
 // The number of lanes included in the oldest set. Used when we need to prioritize traffic.
-const OLDEST_LANE_SET_SIZE: usize = 5;
+const OLDEST_LANE_SET_SIZE: usize = 4;
 // As a way of prune connections we also check for timeouts.
 const MSG_CONSIDERED_STALE_AFTER_SECS: u64 = 10 * 60;
 


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1845

Rework how we handle backpressure in the `inbound.rs` to make sure we really wait until the last data is sent

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
