### PR TITLE
nym-connect: send status messages from socks5 task to tauri backend

### DIFF
--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -459,7 +459,9 @@ where
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn log_status(&self) {
+    async fn log_status(&self, shutdown: &mut task::ShutdownListener) {
+        use crate::error::ClientCoreStatusMessage;
+
         let packets = self.transmission_buffer.total_size();
         let backlog = self.transmission_buffer.total_size_in_bytes() as f64 / 1024.0;
         let lanes = self.transmission_buffer.num_lanes();
@@ -482,6 +484,17 @@ where
             log::info!("{status_str}");
         } else {
             log::debug!("{status_str}");
+        }
+
+        // Send status message to whoever is listening (possibly UI)
+        if mult == self.sending_delay_controller.max_multiplier() {
+            shutdown
+                .send_status_msg(Box::new(ClientCoreStatusMessage::GatewayIsVerySlow))
+                .await;
+        } else if mult > self.sending_delay_controller.min_multiplier() {
+            shutdown
+                .send_status_msg(Box::new(ClientCoreStatusMessage::GatewayIsSlow))
+                .await;
         }
     }
 
@@ -510,7 +523,7 @@ where
                         log::trace!("OutQueueControl: Received shutdown");
                     }
                     _ = status_timer.tick() => {
-                        self.log_status();
+                        self.log_status(&mut shutdown).await;
                     }
                     _ = infrequent_status_timer.tick() => {
                         self.log_status_infrequent();

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -459,7 +459,7 @@ where
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    async fn log_status(&self, shutdown: &mut task::ShutdownListener) {
+    fn log_status(&self, shutdown: &mut task::ShutdownListener) {
         use crate::error::ClientCoreStatusMessage;
 
         let packets = self.transmission_buffer.total_size();
@@ -488,13 +488,9 @@ where
 
         // Send status message to whoever is listening (possibly UI)
         if mult == self.sending_delay_controller.max_multiplier() {
-            shutdown
-                .send_status_msg(Box::new(ClientCoreStatusMessage::GatewayIsVerySlow))
-                .await;
+            shutdown.send_status_msg(Box::new(ClientCoreStatusMessage::GatewayIsVerySlow));
         } else if mult > self.sending_delay_controller.min_multiplier() {
-            shutdown
-                .send_status_msg(Box::new(ClientCoreStatusMessage::GatewayIsSlow))
-                .await;
+            shutdown.send_status_msg(Box::new(ClientCoreStatusMessage::GatewayIsSlow));
         }
     }
 
@@ -523,7 +519,7 @@ where
                         log::trace!("OutQueueControl: Received shutdown");
                     }
                     _ = status_timer.tick() => {
-                        self.log_status(&mut shutdown).await;
+                        self.log_status(&mut shutdown);
                     }
                     _ = infrequent_status_timer.tick() => {
                         self.log_status_infrequent();

--- a/clients/client-core/src/client/real_messages_control/real_traffic_stream/sending_delay_controller.rs
+++ b/clients/client-core/src/client/real_messages_control/real_traffic_stream/sending_delay_controller.rs
@@ -77,6 +77,14 @@ impl SendingDelayController {
         self.current_multiplier
     }
 
+    pub(crate) fn min_multiplier(&self) -> u32 {
+        self.lower_bound
+    }
+
+    pub(crate) fn max_multiplier(&self) -> u32 {
+        self.upper_bound
+    }
+
     pub(crate) fn increase_delay_multiplier(&mut self) {
         if self.current_multiplier < self.upper_bound {
             self.current_multiplier =

--- a/clients/client-core/src/error.rs
+++ b/clients/client-core/src/error.rs
@@ -48,3 +48,12 @@ pub enum ClientCoreError {
     #[error("Unexpected exit")]
     UnexpectedExit,
 }
+
+/// Set of messages that the client can send to listeners via the task manager
+#[derive(thiserror::Error, Debug)]
+pub enum ClientCoreStatusMessage {
+    #[error("The connected gateway is slow, or the connection to it is slow")]
+    GatewayIsSlow,
+    #[error("The connected gateway is very slow, or the connection to it is very slow")]
+    GatewayIsVerySlow,
+}

--- a/clients/socks5/src/client/mod.rs
+++ b/clients/socks5/src/client/mod.rs
@@ -150,10 +150,15 @@ impl NymClient {
     pub async fn run_and_listen(
         self,
         mut receiver: Socks5ControlMessageReceiver,
+        sender: task::StatusSender,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
         // Start the main task
         let mut shutdown = self.start().await?;
 
+        // Listen to status messages from task, that we forward back to the caller
+        shutdown.start_status_listener(sender);
+
+        // Listen for conditions to stop
         let res = tokio::select! {
             biased;
             message = receiver.next() => {

--- a/common/task/src/lib.rs
+++ b/common/task/src/lib.rs
@@ -6,7 +6,8 @@ pub mod shutdown;
 pub mod signal;
 pub mod spawn;
 
-pub use shutdown::{ShutdownListener, ShutdownNotifier};
+// WIP(JON): those both need to be public?
+pub use shutdown::{ShutdownListener, ShutdownNotifier, StatusReceiver, StatusSender};
 #[cfg(not(target_arch = "wasm32"))]
 pub use signal::{wait_for_signal, wait_for_signal_and_error};
 

--- a/common/task/src/shutdown.rs
+++ b/common/task/src/shutdown.rs
@@ -106,7 +106,7 @@ impl ShutdownNotifier {
     pub fn start_status_listener(&mut self, mut sender: StatusSender) {
         if let Some(mut task_status_rx) = self.task_status_rx.take() {
             log::info!("Starting status message listener");
-            tokio::spawn(async move {
+            crate::spawn::spawn(async move {
                 loop {
                     if let Some(msg) = task_status_rx.next().await {
                         log::trace!("Got msg: {}", msg);

--- a/nym-connect/Cargo.lock
+++ b/nym-connect/Cargo.lock
@@ -3332,6 +3332,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tap",
+ "task",
  "tauri",
  "tauri-build",
  "tauri-codegen",

--- a/nym-connect/src-tauri/Cargo.toml
+++ b/nym-connect/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ client-core = { path = "../../clients/client-core" }
 config-common = { path = "../../common/config", package = "config" }
 logging = { path = "../../common/logging"}
 nym-socks5-client = { path = "../../clients/socks5" }
+task = { path = "../../common/task" }
 topology = { path = "../../common/topology" }
 
 [dev-dependencies]

--- a/nym-connect/src-tauri/src/operations/connection/connect.rs
+++ b/nym-connect/src-tauri/src/operations/connection/connect.rs
@@ -11,14 +11,14 @@ pub async fn start_connecting(
     state: tauri::State<'_, Arc<RwLock<State>>>,
     window: tauri::Window<tauri::Wry>,
 ) -> Result<ConnectResult> {
-    let (msg_receiver, status_receiver) = {
+    let (msg_receiver, exit_status_receiver) = {
         let mut state_w = state.write().await;
         state_w.start_connecting(&window).await?
     };
 
     // Setup task for checking status
     let state = state.inner().clone();
-    tasks::start_disconnect_listener(state, window.clone(), status_receiver);
+    tasks::start_disconnect_listener(state, window.clone(), exit_status_receiver);
     tasks::start_status_listener(window, msg_receiver);
 
     Ok(ConnectResult {

--- a/nym-connect/src-tauri/src/operations/connection/connect.rs
+++ b/nym-connect/src-tauri/src/operations/connection/connect.rs
@@ -11,14 +11,15 @@ pub async fn start_connecting(
     state: tauri::State<'_, Arc<RwLock<State>>>,
     window: tauri::Window<tauri::Wry>,
 ) -> Result<ConnectResult> {
-    let status_receiver = {
+    let (msg_receiver, status_receiver) = {
         let mut state_w = state.write().await;
         state_w.start_connecting(&window).await?
     };
 
     // Setup task for checking status
     let state = state.inner().clone();
-    tasks::start_disconnect_listener(state, window, status_receiver);
+    tasks::start_disconnect_listener(state, window.clone(), status_receiver);
+    tasks::start_status_listener(window, msg_receiver);
 
     Ok(ConnectResult {
         address: "PLACEHOLDER".to_string(),

--- a/nym-connect/src-tauri/src/state.rs
+++ b/nym-connect/src-tauri/src/state.rs
@@ -16,7 +16,7 @@ use crate::{
         AppEventConnectionStatusChangedPayload, ConnectionStatusKind,
         APP_EVENT_CONNECTION_STATUS_CHANGED,
     },
-    tasks::{self, StatusReceiver},
+    tasks::{self, ExitStatusReceiver},
 };
 
 pub struct State {
@@ -96,7 +96,7 @@ impl State {
     pub async fn start_connecting(
         &mut self,
         window: &tauri::Window<tauri::Wry>,
-    ) -> Result<StatusReceiver> {
+    ) -> Result<(task::StatusReceiver, ExitStatusReceiver)> {
         self.set_state(ConnectionStatusKind::Connecting, window);
 
         // Setup configuration by writing to file
@@ -111,9 +111,9 @@ impl State {
         }
 
         // Kick off the main task and get the channel for controlling it
-        let status_receiver = self.start_nym_socks5_client().await?;
+        let (msg_receiver, status_receiver) = self.start_nym_socks5_client()?;
         self.set_state(ConnectionStatusKind::Connected, window);
-        Ok(status_receiver)
+        Ok((msg_receiver, status_receiver))
     }
 
     /// Create a configuration file
@@ -133,12 +133,12 @@ impl State {
     }
 
     /// Spawn a new thread running the SOCKS5 client
-    async fn start_nym_socks5_client(&mut self) -> Result<StatusReceiver> {
+    fn start_nym_socks5_client(&mut self) -> Result<(task::StatusReceiver, ExitStatusReceiver)> {
         let id = self.get_config_id()?;
-        let (control_tx, status_rx, used_gateway) = tasks::start_nym_socks5_client(&id)?;
+        let (control_tx, msg_rx, status_rx, used_gateway) = tasks::start_nym_socks5_client(&id)?;
         self.socks5_client_sender = Some(control_tx);
         self.gateway = Some(used_gateway.gateway_id);
-        Ok(status_rx)
+        Ok((msg_rx, status_rx))
     }
 
     /// Disconnect by sending a message to the SOCKS5 client thread. Once it has finished and is

--- a/nym-connect/src-tauri/src/state.rs
+++ b/nym-connect/src-tauri/src/state.rs
@@ -111,9 +111,9 @@ impl State {
         }
 
         // Kick off the main task and get the channel for controlling it
-        let (msg_receiver, status_receiver) = self.start_nym_socks5_client()?;
+        let (msg_receiver, exit_status_receiver) = self.start_nym_socks5_client()?;
         self.set_state(ConnectionStatusKind::Connected, window);
-        Ok((msg_receiver, status_receiver))
+        Ok((msg_receiver, exit_status_receiver))
     }
 
     /// Create a configuration file
@@ -135,10 +135,11 @@ impl State {
     /// Spawn a new thread running the SOCKS5 client
     fn start_nym_socks5_client(&mut self) -> Result<(task::StatusReceiver, ExitStatusReceiver)> {
         let id = self.get_config_id()?;
-        let (control_tx, msg_rx, status_rx, used_gateway) = tasks::start_nym_socks5_client(&id)?;
+        let (control_tx, msg_rx, exit_status_rx, used_gateway) =
+            tasks::start_nym_socks5_client(&id)?;
         self.socks5_client_sender = Some(control_tx);
         self.gateway = Some(used_gateway.gateway_id);
-        Ok((msg_rx, status_rx))
+        Ok((msg_rx, exit_status_rx))
     }
 
     /// Disconnect by sending a message to the SOCKS5 client thread. Once it has finished and is

--- a/nym-connect/src-tauri/src/tasks.rs
+++ b/nym-connect/src-tauri/src/tasks.rs
@@ -1,5 +1,5 @@
 use client_core::config::{ClientCoreConfigTrait, GatewayEndpointConfig};
-use futures::channel::mpsc;
+use futures::{channel::mpsc, StreamExt};
 use std::sync::Arc;
 use tap::TapFallible;
 use tokio::sync::RwLock;
@@ -11,11 +11,11 @@ use nym_socks5::client::{config::Config as Socks5Config, Socks5ControlMessageSen
 
 use crate::{error::Result, state::State};
 
-pub type StatusReceiver = futures::channel::oneshot::Receiver<Socks5StatusMessage>;
+pub type ExitStatusReceiver = futures::channel::oneshot::Receiver<Socks5ExitStatusMessage>;
 
 /// Status messages sent by the SOCKS5 client task to the main tauri task.
 #[derive(Debug)]
-pub enum Socks5StatusMessage {
+pub enum Socks5ExitStatusMessage {
     /// The SOCKS5 task successfully stopped
     Stopped,
     /// The SOCKS5 task failed to start
@@ -27,7 +27,8 @@ pub fn start_nym_socks5_client(
     id: &str,
 ) -> Result<(
     Socks5ControlMessageSender,
-    StatusReceiver,
+    task::StatusReceiver,
+    ExitStatusReceiver,
     GatewayEndpointConfig,
 )> {
     log::info!("Loading config from file: {id}");
@@ -41,8 +42,11 @@ pub fn start_nym_socks5_client(
     // Channel to send control messages to the socks5 client
     let (socks5_ctrl_tx, socks5_ctrl_rx) = mpsc::unbounded();
 
+    // Channel to send status update messages from the background socks5 task to the frontend.
+    let (socks5_status_tx, socks5_status_rx) = mpsc::unbounded();
+
     // Channel to signal back to the main task when the socks5 client finishes, and why
-    let (socks5_status_tx, socks5_status_rx) = futures::channel::oneshot::channel();
+    let (socks5_exit_tx, socks5_exit_rx) = futures::channel::oneshot::channel();
 
     // Spawn a separate runtime for the socks5 client so we can forcefully terminate.
     // Once we can gracefully shutdown the socks5 client we can get rid of this.
@@ -51,23 +55,32 @@ pub fn start_nym_socks5_client(
     std::thread::spawn(|| {
         let result = tokio::runtime::Runtime::new()
             .expect("Failed to create runtime for SOCKS5 client")
-            .block_on(async move { socks5_client.run_and_listen(socks5_ctrl_rx).await });
+            .block_on(async move {
+                socks5_client
+                    .run_and_listen(socks5_ctrl_rx, socks5_status_tx)
+                    .await
+            });
 
         if let Err(err) = result {
             log::error!("SOCKS5 proxy failed: {err}");
-            socks5_status_tx
-                .send(Socks5StatusMessage::Failed(err))
+            socks5_exit_tx
+                .send(Socks5ExitStatusMessage::Failed(err))
                 .expect("Failed to send status message back to main task");
             return;
         }
 
         log::info!("SOCKS5 task finished");
-        socks5_status_tx
-            .send(Socks5StatusMessage::Stopped)
+        socks5_exit_tx
+            .send(Socks5ExitStatusMessage::Stopped)
             .expect("Failed to send status message back to main task");
     });
 
-    Ok((socks5_ctrl_tx, socks5_status_rx, used_gateway))
+    Ok((
+        socks5_ctrl_tx,
+        socks5_status_rx,
+        socks5_exit_rx,
+        used_gateway,
+    ))
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -76,17 +89,39 @@ struct Payload {
     message: String,
 }
 
+/// The status listener listens for non-exit status messages from the background socks5 proxy task.
+pub fn start_status_listener(
+    window: tauri::Window<tauri::Wry>,
+    mut msg_receiver: task::StatusReceiver,
+) {
+    log::info!("Starting status listener");
+    tokio::spawn(async move {
+        while let Some(msg) = msg_receiver.next().await {
+            log::info!("SOCKS5 proxy sent status message: {}", msg);
+            window
+                .emit(
+                    "socks5-event",
+                    Payload {
+                        title: "SOCKS5 update".into(),
+                        message: msg.to_string(),
+                    },
+                )
+                .unwrap();
+        }
+    });
+}
+
 /// The disconnect listener listens to the channel setup between the socks5 proxy task and the main
 /// tauri task. Primarily it listens for shutdown messages, and updates the state accordingly.
 pub fn start_disconnect_listener(
     state: Arc<RwLock<State>>,
     window: tauri::Window<tauri::Wry>,
-    status_receiver: StatusReceiver,
+    status_receiver: ExitStatusReceiver,
 ) {
     log::trace!("Starting disconnect listener");
     tokio::spawn(async move {
         match status_receiver.await {
-            Ok(Socks5StatusMessage::Stopped) => {
+            Ok(Socks5ExitStatusMessage::Stopped) => {
                 log::info!("SOCKS5 task reported it has finished");
                 window
                     .emit(
@@ -98,7 +133,7 @@ pub fn start_disconnect_listener(
                     )
                     .unwrap();
             }
-            Ok(Socks5StatusMessage::Failed(err)) => {
+            Ok(Socks5ExitStatusMessage::Failed(err)) => {
                 log::info!("SOCKS5 task reported error: {}", err);
                 window
                     .emit(

--- a/nym-connect/src-tauri/src/tasks.rs
+++ b/nym-connect/src-tauri/src/tasks.rs
@@ -116,11 +116,11 @@ pub fn start_status_listener(
 pub fn start_disconnect_listener(
     state: Arc<RwLock<State>>,
     window: tauri::Window<tauri::Wry>,
-    status_receiver: ExitStatusReceiver,
+    exit_status_receiver: ExitStatusReceiver,
 ) {
     log::trace!("Starting disconnect listener");
     tokio::spawn(async move {
-        match status_receiver.await {
+        match exit_status_receiver.await {
             Ok(Socks5ExitStatusMessage::Stopped) => {
                 log::info!("SOCKS5 task reported it has finished");
                 window

--- a/nym-connect/src-tauri/src/tasks.rs
+++ b/nym-connect/src-tauri/src/tasks.rs
@@ -43,7 +43,7 @@ pub fn start_nym_socks5_client(
     let (socks5_ctrl_tx, socks5_ctrl_rx) = mpsc::unbounded();
 
     // Channel to send status update messages from the background socks5 task to the frontend.
-    let (socks5_status_tx, socks5_status_rx) = mpsc::unbounded();
+    let (socks5_status_tx, socks5_status_rx) = mpsc::channel(128);
 
     // Channel to signal back to the main task when the socks5 client finishes, and why
     let (socks5_exit_tx, socks5_exit_rx) = futures::channel::oneshot::channel();


### PR DESCRIPTION
# Description

Part of: https://github.com/nymtech/nym/issues/2160

Send status messages from the background socks5 proxy task to the nym-connect tauri backend, and then emit events for the frontend to handle.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
