### PR TITLE
Set default values for urls and mixnet address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 - network-requester: fix bug where websocket connection disconnect resulted in success error code
 - clients: fix a few panics handling the gateway-client
+- mixnode, gateway, validator-api: Use mainnet values as defaults for URLs and mixnet contract  ([#1884])
 
 [#1872]: https://github.com/nymtech/nym/pull/1872
+[#1884]: https://github.com/nymtech/nym/pull/1884
 
 
 ## [v1.1.2]

--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -9,7 +9,7 @@ pub(crate) const BECH32_PREFIX: &str = "n";
 pub const MIX_DENOM: DenomDetails = DenomDetails::new("unym", "nym", 6);
 pub const STAKE_DENOM: DenomDetails = DenomDetails::new("unyx", "nyx", 6);
 
-pub(crate) const MIXNET_CONTRACT_ADDRESS: &str =
+pub const MIXNET_CONTRACT_ADDRESS: &str =
     "n17srjznxl9dvzdkpwpw24gg668wc73val88a6m5ajg6ankwvz9wtst0cznr";
 pub(crate) const VESTING_CONTRACT_ADDRESS: &str =
     "n1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrq73f2nw";
@@ -25,7 +25,7 @@ pub(crate) const _ETH_ERC20_CONTRACT_ADDRESS: [u8; 20] =
     hex_literal::hex!("0000000000000000000000000000000000000000");
 pub(crate) const REWARDING_VALIDATOR_ADDRESS: &str = "n10yyd98e2tuwu0f7ypz9dy3hhjw7v772q6287gy";
 
-pub(crate) const STATISTICS_SERVICE_DOMAIN_ADDRESS: &str = "https://mainnet-stats.nymte.ch:8090/";
+pub const STATISTICS_SERVICE_DOMAIN_ADDRESS: &str = "https://mainnet-stats.nymte.ch:8090/";
 pub const NYMD_VALIDATOR: &str = "https://rpc.nymtech.net";
 pub const API_VALIDATOR: &str = "https://validator.nymtech.net/api/";
 pub(crate) fn validators() -> Vec<ValidatorDetails> {

--- a/gateway/src/config/mod.rs
+++ b/gateway/src/config/mod.rs
@@ -5,6 +5,7 @@ use crate::config::template::config_template;
 use config::defaults::{DEFAULT_CLIENT_LISTENING_PORT, DEFAULT_MIX_LISTENING_PORT};
 use config::NymConfig;
 use log::error;
+use network_defaults::mainnet::{API_VALIDATOR, NYMD_VALIDATOR, STATISTICS_SERVICE_DOMAIN_ADDRESS};
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -416,9 +417,9 @@ impl Default for Gateway {
             private_sphinx_key_file: Default::default(),
             public_sphinx_key_file: Default::default(),
             enabled_statistics: false,
-            statistics_service_url: Url::from_str("http://127.0.0.1").unwrap(),
-            validator_api_urls: vec![],
-            validator_nymd_urls: vec![],
+            statistics_service_url: Url::from_str(STATISTICS_SERVICE_DOMAIN_ADDRESS).expect("Invalid default statistics service URL"),
+            validator_api_urls: vec![Url::from_str(API_VALIDATOR).expect("Invalid default API URL")],
+            validator_nymd_urls: vec![Url::from_str(NYMD_VALIDATOR).expect("Invalid default nymd URL")],
             cosmos_mnemonic: bip39::Mnemonic::from_str("exact antique hybrid width raise anchor puzzle degree fee quit long crack net vague hip despair write put useless civil mechanic broom music day").unwrap(),
             nym_root_directory: Config::default_root_directory(),
             persistent_storage: Default::default(),

--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::template::config_template;
+use config::defaults::mainnet::API_VALIDATOR;
 use config::defaults::{
     DEFAULT_HTTP_API_LISTENING_PORT, DEFAULT_MIX_LISTENING_PORT, DEFAULT_VERLOC_LISTENING_PORT,
 };
@@ -411,7 +412,7 @@ impl Default for MixNode {
             public_identity_key_file: Default::default(),
             private_sphinx_key_file: Default::default(),
             public_sphinx_key_file: Default::default(),
-            validator_api_urls: vec![],
+            validator_api_urls: vec![Url::from_str(API_VALIDATOR).expect("Invalid default API URL")],
             nym_root_directory: Config::default_root_directory(),
             wallet_address: "nymXXXXXXXX".to_string(),
         }

--- a/validator-api/src/config/mod.rs
+++ b/validator-api/src/config/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::template::config_template;
+use config::defaults::mainnet::MIXNET_CONTRACT_ADDRESS;
 use config::defaults::DEFAULT_VALIDATOR_API_PORT;
 use config::NymConfig;
 use serde::{Deserialize, Serialize};
@@ -119,7 +120,7 @@ impl Default for Base {
             id: String::default(),
             local_validator: default_validator,
             announce_address: default_announce_address,
-            mixnet_contract_address: String::default(),
+            mixnet_contract_address: MIXNET_CONTRACT_ADDRESS.to_string(),
             mnemonic: "exact antique hybrid width raise anchor puzzle degree fee quit long crack net vague hip despair write put useless civil mechanic broom music day".to_string(),
         }
     }


### PR DESCRIPTION
# Description

<!-- If appropriate, insert relevant description here -->

When neither cli options and env files are not passed, we still need to use the default values for api/nymd URLs and mixnet address.

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
