### PR TITLE
socks5: send additional status messages available for the frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 ## [Unreleased]
 
+### Added
+
+- socks5: send status message for service ready, and network-requester error response
+
 ### Changed
 
 - all-binaries: improved error logging ([#2686])

--- a/clients/socks5/src/client/mod.rs
+++ b/clients/socks5/src/client/mod.rs
@@ -166,7 +166,7 @@ impl NymClient {
         let mut shutdown = self.start().await?;
 
         // Listen to status messages from task, that we forward back to the caller
-        shutdown.start_status_listener(sender);
+        shutdown.start_status_listener(sender).await;
 
         let res = tokio::select! {
             biased;

--- a/clients/socks5/src/error.rs
+++ b/clients/socks5/src/error.rs
@@ -1,6 +1,7 @@
 use crate::socks::types::SocksProxyError;
 use client_core::client::replies::reply_storage::fs_backend;
 use client_core::error::ClientCoreError;
+use socks5_requests::ConnectionId;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Socks5ClientError {
@@ -21,4 +22,10 @@ pub enum Socks5ClientError {
 
     #[error("Fail to bind address")]
     FailToBindAddress,
+
+    #[error("{connection_id}: {error}")]
+    NetworkRequesterError {
+        connection_id: ConnectionId,
+        error: String,
+    },
 }

--- a/clients/socks5/src/error.rs
+++ b/clients/socks5/src/error.rs
@@ -23,7 +23,7 @@ pub enum Socks5ClientError {
     #[error("Fail to bind address")]
     FailToBindAddress,
 
-    #[error("{connection_id}: {error}")]
+    #[error("Network requester: connection id {connection_id}: {error}")]
     NetworkRequesterError {
         connection_id: ConnectionId,
         error: String,

--- a/clients/socks5/src/socks/mixnet_responses.rs
+++ b/clients/socks5/src/socks/mixnet_responses.rs
@@ -11,6 +11,8 @@ use proxy_helpers::connection_controller::{ControllerCommand, ControllerSender};
 use socks5_requests::Message;
 use task::TaskClient;
 
+use crate::error::Socks5ClientError;
+
 pub(crate) struct MixnetResponseListener {
     buffer_requester: ReceivedBufferRequestSender,
     mix_response_receiver: ReconstructedMessagesReceiver,
@@ -52,7 +54,10 @@ impl MixnetResponseListener {
         }
     }
 
-    async fn on_message(&self, reconstructed_message: ReconstructedMessage) {
+    async fn on_message(
+        &self,
+        reconstructed_message: ReconstructedMessage,
+    ) -> Result<(), Socks5ClientError> {
         let raw_message = reconstructed_message.message;
         if reconstructed_message.sender_tag.is_some() {
             warn!("this message was sent anonymously - it couldn't have come from the service provider");
@@ -61,11 +66,11 @@ impl MixnetResponseListener {
         let response = match Message::try_from_bytes(&raw_message) {
             Err(err) => {
                 warn!("failed to parse received response - {err}");
-                return;
+                return Ok(());
             }
             Ok(Message::Request(_)) => {
                 warn!("unexpected request");
-                return;
+                return Ok(());
             }
             Ok(Message::Response(data)) => data,
             Ok(Message::NetworkRequesterResponse(r)) => {
@@ -73,7 +78,10 @@ impl MixnetResponseListener {
                     "Network requester failed on connection id {} with error: {}",
                     r.connection_id, r.network_requester_error
                 );
-                return;
+                return Err(Socks5ClientError::NetworkRequesterError {
+                    connection_id: r.connection_id,
+                    error: r.network_requester_error,
+                });
             }
         };
 
@@ -84,6 +92,8 @@ impl MixnetResponseListener {
                 response.is_closed,
             ))
             .unwrap();
+
+        Ok(())
     }
 
     pub(crate) async fn run(&mut self) {
@@ -92,7 +102,9 @@ impl MixnetResponseListener {
                 received_responses = self.mix_response_receiver.next() => match received_responses {
                     Some(received_responses) => {
                         for reconstructed_message in received_responses {
-                            self.on_message(reconstructed_message).await;
+                            if let Err(err) = self.on_message(reconstructed_message).await {
+                                self.shutdown.send_status_msg(Box::new(err));
+                            }
                         }
                     },
                     None => {

--- a/common/socks5/requests/src/network_requester_response.rs
+++ b/common/socks5/requests/src/network_requester_response.rs
@@ -63,7 +63,7 @@ impl NetworkRequesterResponse {
         self.connection_id
             .to_be_bytes()
             .iter()
-            .cloned()
+            .copied()
             .chain(self.network_requester_error.into_bytes().into_iter())
             .collect()
     }

--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -28,6 +28,13 @@ enum TaskError {
     UnexpectedHalt,
 }
 
+// TODO: possibly we should create a `Status` trait instead of reusing `Error`
+#[derive(thiserror::Error, Debug)]
+pub enum TaskStatus {
+    #[error("Ready")]
+    Ready,
+}
+
 /// Listens to status and error messages from tasks, as well as notifying them to gracefully
 /// shutdown. Keeps track of if task stop unexpectedly, such as in a panic.
 #[derive(Debug)]
@@ -101,15 +108,21 @@ impl TaskManager {
         self.notify_tx.send(())
     }
 
-    pub fn start_status_listener(&mut self, mut sender: StatusSender) {
+    pub async fn start_status_listener(&mut self, mut sender: StatusSender) {
+        // Announce that we are operational. This means that in the application where this is used,
+        // everything is up and running and ready to go.
+        if let Err(msg) = sender.send(Box::new(TaskStatus::Ready)).await {
+            log::error!("Error sending status message: {}", msg);
+        };
+
         if let Some(mut task_status_rx) = self.task_status_rx.take() {
             log::info!("Starting status message listener");
             crate::spawn::spawn(async move {
                 loop {
                     if let Some(msg) = task_status_rx.next().await {
                         log::trace!("Got msg: {}", msg);
-                        if sender.send(msg).await.is_err() {
-                            log::error!("Error sending status message");
+                        if let Err(msg) = sender.send(msg).await {
+                            log::error!("Error sending status message: {}", msg);
                         }
                     } else {
                         log::trace!("Stopping since channel closed");

--- a/nym-api/src/coconut/tests.rs
+++ b/nym-api/src/coconut/tests.rs
@@ -282,7 +282,7 @@ impl super::client::Client for DummyClient {
         self.dealer_details.write().unwrap().insert(
             self.validator_address.to_string(),
             DealerDetails {
-                address: Addr::unchecked(&self.validator_address.to_string()),
+                address: Addr::unchecked(self.validator_address.to_string()),
                 bte_public_key_with_proof,
                 announce_address,
                 assigned_index,

--- a/nym-connect/src-tauri/src/tasks.rs
+++ b/nym-connect/src-tauri/src/tasks.rs
@@ -100,7 +100,7 @@ pub fn start_status_listener(
             log::info!("SOCKS5 proxy sent status message: {}", msg);
             window
                 .emit(
-                    "socks5-event",
+                    "socks5-status-event",
                     Payload {
                         title: "SOCKS5 update".into(),
                         message: msg.to_string(),


### PR DESCRIPTION
# Description

By popular request, the socks5-proxy learned how to send status messages for

- service ready
- network-requester responding with error

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
