### PR TITLE
bugfix: don't start rewarding unless `rewarding.enabled` is explicitly set to `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 - native client: bring shutdown logic up to the same level as socks5-client
 - nym-api, coconut-dkg contract: automatic, time-based dkg epoch state advancement ([#2670])
 
+### Fixed
+
+- nym-api: should now correctly use `rewarding.enabled` config flag ([#2753])
+
 [#2686]: https://github.com/nymtech/nym/pull/2686
 [#2670]: https://github.com/nymtech/nym/pull/2670
+[#2753]: https://github.com/nymtech/nym/pull/2753
 
 ## [v1.1.4] (2022-12-20)
 

--- a/nym-api/src/config/mod.rs
+++ b/nym-api/src/config/mod.rs
@@ -446,8 +446,6 @@ impl Config {
         self.network_monitor.credentials_database_path.clone()
     }
 
-    // TODO: Remove if still unused
-    #[allow(dead_code)]
     pub fn get_rewarding_enabled(&self) -> bool {
         self.rewarding.enabled
     }

--- a/nym-api/src/main.rs
+++ b/nym-api/src/main.rs
@@ -584,11 +584,13 @@ async fn run_nym_api(matches: ArgMatches) -> Result<()> {
         tokio::spawn(async move { validator_cache_refresher.run(shutdown_listener).await });
 
         // spawn rewarded set updater
-        let mut rewarded_set_updater =
-            RewardedSetUpdater::new(signing_nymd_client, validator_cache.clone(), storage).await?;
-        let shutdown_listener = shutdown.subscribe();
-        tokio::spawn(async move { rewarded_set_updater.run(shutdown_listener).await.unwrap() });
-
+        if config.get_rewarding_enabled() {
+            let mut rewarded_set_updater =
+                RewardedSetUpdater::new(signing_nymd_client, validator_cache.clone(), storage)
+                    .await?;
+            let shutdown_listener = shutdown.subscribe();
+            tokio::spawn(async move { rewarded_set_updater.run(shutdown_listener).await.unwrap() });
+        }
         validator_cache_listener
     } else {
         // Spawn the validator cache refresher.


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/1925

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
