### PR TITLE
bugfix: set default value for nym-api (and nyxd) for clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,6 +3067,7 @@ dependencies = [
  "futures",
  "humantime-serde",
  "log",
+ "network-defaults",
  "nymsphinx-acknowledgements",
  "nymsphinx-addressing",
  "nymsphinx-forwarding",

--- a/common/mixnode-common/Cargo.toml
+++ b/common/mixnode-common/Cargo.toml
@@ -19,6 +19,7 @@ url = "2.2"
 thiserror = "1.0.37"
 
 crypto =  { path = "../crypto" }
+network-defaults = { path = "../network-defaults" }
 nymsphinx-acknowledgements = { path = "../nymsphinx/acknowledgements" }
 nymsphinx-addressing = { path = "../nymsphinx/addressing" }
 nymsphinx-forwarding = { path = "../nymsphinx/forwarding" }

--- a/common/mixnode-common/src/verloc/mod.rs
+++ b/common/mixnode-common/src/verloc/mod.rs
@@ -7,6 +7,7 @@ use crypto::asymmetric::identity;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use log::*;
+use network_defaults::mainnet::NYM_API;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use std::net::SocketAddr;
@@ -160,7 +161,7 @@ impl Default for ConfigBuilder {
             tested_nodes_batch_size: DEFAULT_BATCH_SIZE,
             testing_interval: DEFAULT_TESTING_INTERVAL,
             retry_timeout: DEFAULT_RETRY_TIMEOUT,
-            nym_api_urls: vec![],
+            nym_api_urls: vec![NYM_API.parse().expect("Invalid default API URL")],
         })
     }
 }


### PR DESCRIPTION
# Description

if neither an argument flag nor a custom environmental variable was provided, clients should now correctly default to mainnet values of nyxd and nym-api urls

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
