### PR TITLE
connect and wallet: make fern use same colors as pretty_env_logger

### DIFF
--- a/nym-connect/src-tauri/src/logging.rs
+++ b/nym-connect/src-tauri/src/logging.rs
@@ -1,12 +1,17 @@
 use std::str::FromStr;
 
-use fern::colors::ColoredLevelConfig;
+use fern::colors::{Color, ColoredLevelConfig};
 use serde::Serialize;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use tauri::Manager;
 
 pub fn setup_logging(app_handle: tauri::AppHandle) -> Result<(), log::SetLoggerError> {
-    let colors = ColoredLevelConfig::new();
+    let colors = ColoredLevelConfig::new()
+        .trace(Color::Magenta)
+        .debug(Color::Blue)
+        .info(Color::Green)
+        .warn(Color::Yellow)
+        .error(Color::Red);
     let base_config = fern::Dispatch::new()
         .level(global_level())
         .filter_lowlevel_external_components()

--- a/nym-wallet/src-tauri/src/log.rs
+++ b/nym-wallet/src-tauri/src/log.rs
@@ -1,12 +1,17 @@
 use std::str::FromStr;
 
-use fern::colors::ColoredLevelConfig;
+use fern::colors::{Color, ColoredLevelConfig};
 use serde::Serialize;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use tauri::Manager;
 
 pub fn setup_logging(app_handle: tauri::AppHandle) -> Result<(), log::SetLoggerError> {
-    let colors = ColoredLevelConfig::new();
+    let colors = ColoredLevelConfig::new()
+        .trace(Color::Magenta)
+        .debug(Color::Blue)
+        .info(Color::Green)
+        .warn(Color::Yellow)
+        .error(Color::Red);
     let base_config = fern::Dispatch::new()
         .level(global_level())
         .filter_lowlevel_external_components()


### PR DESCRIPTION
# Description

Use the same logging colors in `fern` as we use in `pretty_env_logger`.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
