### PR TITLE
nym-api: add endpoint for a list of GatewayBondAnnotated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 - nym-sdk: added initial version of a Rust client sdk
 - nym-api: added `/circulating-supply` endpoint ([#2814])
+- nym-api: add endpoint listing detailed gateway info by @octol in https://github.com/nymtech/nym/pull/2833
 
 ### Changed
 

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -7,7 +7,7 @@ use mixnet_contract_common::mixnode::MixNodeDetails;
 use mixnet_contract_common::reward_params::{Performance, RewardingParams};
 use mixnet_contract_common::rewarding::RewardEstimate;
 use mixnet_contract_common::{
-    IdentityKey, Interval, MixId, MixNode, Percent, RewardedSetNodeStatus,
+    GatewayBond, IdentityKey, Interval, MixId, MixNode, Percent, RewardedSetNodeStatus,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -112,6 +112,12 @@ impl MixNodeBondAnnotated {
     pub fn mix_id(&self) -> MixId {
         self.mixnode_details.mix_id()
     }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct GatewayBondAnnotated {
+    pub gateway_bond: GatewayBond,
+    pub performance: Performance,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/nym-api/src/node_status_api/cache/data.rs
+++ b/nym-api/src/node_status_api/cache/data.rs
@@ -1,4 +1,4 @@
-use nym_api_requests::models::MixNodeBondAnnotated;
+use nym_api_requests::models::{GatewayBondAnnotated, MixNodeBondAnnotated};
 
 use crate::support::caching::Cache;
 
@@ -9,6 +9,8 @@ pub(crate) struct NodeStatusCacheData {
     pub(crate) mixnodes_annotated: Cache<Vec<MixNodeBondAnnotated>>,
     pub(crate) rewarded_set_annotated: Cache<Vec<MixNodeBondAnnotated>>,
     pub(crate) active_set_annotated: Cache<Vec<MixNodeBondAnnotated>>,
+
+    pub(crate) gateways_annotated: Cache<Vec<GatewayBondAnnotated>>,
 
     // Estimated active set inclusion probabilities from Monte Carlo simulation
     pub(crate) inclusion_probabilities: Cache<InclusionProbabilities>,

--- a/nym-api/src/node_status_api/cache/mod.rs
+++ b/nym-api/src/node_status_api/cache/mod.rs
@@ -6,7 +6,7 @@ use crate::support::caching::Cache;
 use self::data::NodeStatusCacheData;
 use self::inclusion_probabilities::InclusionProbabilities;
 use mixnet_contract_common::MixId;
-use nym_api_requests::models::{MixNodeBondAnnotated, MixnodeStatus};
+use nym_api_requests::models::{GatewayBondAnnotated, MixNodeBondAnnotated, MixnodeStatus};
 use rocket::fairing::AdHoc;
 use std::{sync::Arc, time::Duration};
 use thiserror::Error;
@@ -58,6 +58,7 @@ impl NodeStatusCache {
         mixnodes: Vec<MixNodeBondAnnotated>,
         rewarded_set: Vec<MixNodeBondAnnotated>,
         active_set: Vec<MixNodeBondAnnotated>,
+        gateways: Vec<GatewayBondAnnotated>,
         inclusion_probabilities: InclusionProbabilities,
     ) {
         match time::timeout(Duration::from_millis(CACHE_TIMEOUT_MS), self.inner.write()).await {
@@ -65,6 +66,7 @@ impl NodeStatusCache {
                 cache.mixnodes_annotated.update(mixnodes);
                 cache.rewarded_set_annotated.update(rewarded_set);
                 cache.active_set_annotated.update(active_set);
+                cache.gateways_annotated.update(gateways);
                 cache
                     .inclusion_probabilities
                     .update(inclusion_probabilities);
@@ -97,6 +99,10 @@ impl NodeStatusCache {
 
     pub(crate) async fn active_set_annotated(&self) -> Option<Cache<Vec<MixNodeBondAnnotated>>> {
         self.get(|c| c.active_set_annotated.clone()).await
+    }
+
+    pub(crate) async fn gateways_annotated(&self) -> Option<Cache<Vec<GatewayBondAnnotated>>> {
+        self.get(|c| c.gateways_annotated.clone()).await
     }
 
     pub(crate) async fn inclusion_probabilities(&self) -> Option<Cache<InclusionProbabilities>> {

--- a/nym-api/src/node_status_api/helpers.rs
+++ b/nym-api/src/node_status_api/helpers.rs
@@ -9,10 +9,10 @@ use cosmwasm_std::Decimal;
 use mixnet_contract_common::reward_params::Performance;
 use mixnet_contract_common::{Interval, MixId, RewardedSetNodeStatus};
 use nym_api_requests::models::{
-    AllInclusionProbabilitiesResponse, ComputeRewardEstParam, InclusionProbabilityResponse,
-    MixNodeBondAnnotated, MixnodeCoreStatusResponse, MixnodeStatusReportResponse,
-    MixnodeStatusResponse, MixnodeUptimeHistoryResponse, RewardEstimationResponse,
-    StakeSaturationResponse, UptimeResponse,
+    AllInclusionProbabilitiesResponse, ComputeRewardEstParam, GatewayBondAnnotated,
+    InclusionProbabilityResponse, MixNodeBondAnnotated, MixnodeCoreStatusResponse,
+    MixnodeStatusReportResponse, MixnodeStatusResponse, MixnodeUptimeHistoryResponse,
+    RewardEstimationResponse, StakeSaturationResponse, UptimeResponse,
 };
 use rocket::http::Status;
 use rocket::State;
@@ -315,6 +315,14 @@ pub(crate) async fn _get_rewarded_set_detailed(
 pub(crate) async fn _get_active_set_detailed(cache: &NodeStatusCache) -> Vec<MixNodeBondAnnotated> {
     cache
         .active_set_annotated()
+        .await
+        .unwrap_or_default()
+        .into_inner()
+}
+
+pub(crate) async fn _get_gateways_detailed(cache: &NodeStatusCache) -> Vec<GatewayBondAnnotated> {
+    cache
+        .gateways_annotated()
         .await
         .unwrap_or_default()
         .into_inner()

--- a/nym-api/src/node_status_api/mod.rs
+++ b/nym-api/src/node_status_api/mod.rs
@@ -49,6 +49,7 @@ pub(crate) fn node_status_routes(
             routes::get_mixnodes_detailed,
             routes::get_rewarded_set_detailed,
             routes::get_active_set_detailed,
+            routes::get_gateways_detailed,
         ]
     } else {
         // in the minimal variant we would not have access to endpoints relying on existence

--- a/nym-api/src/node_status_api/routes.rs
+++ b/nym-api/src/node_status_api/routes.rs
@@ -1,6 +1,7 @@
 // Copyright 2021-2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use super::helpers::_get_gateways_detailed;
 use super::NodeStatusCache;
 use crate::node_status_api::helpers::{
     _compute_mixnode_reward_estimation, _get_active_set_detailed, _get_mixnode_avg_uptime,
@@ -14,11 +15,11 @@ use crate::storage::NymApiStorage;
 use crate::NymContractCache;
 use mixnet_contract_common::MixId;
 use nym_api_requests::models::{
-    AllInclusionProbabilitiesResponse, ComputeRewardEstParam, GatewayCoreStatusResponse,
-    GatewayStatusReportResponse, GatewayUptimeHistoryResponse, InclusionProbabilityResponse,
-    MixNodeBondAnnotated, MixnodeCoreStatusResponse, MixnodeStatusReportResponse,
-    MixnodeStatusResponse, MixnodeUptimeHistoryResponse, RewardEstimationResponse,
-    StakeSaturationResponse, UptimeResponse,
+    AllInclusionProbabilitiesResponse, ComputeRewardEstParam, GatewayBondAnnotated,
+    GatewayCoreStatusResponse, GatewayStatusReportResponse, GatewayUptimeHistoryResponse,
+    InclusionProbabilityResponse, MixNodeBondAnnotated, MixnodeCoreStatusResponse,
+    MixnodeStatusReportResponse, MixnodeStatusResponse, MixnodeUptimeHistoryResponse,
+    RewardEstimationResponse, StakeSaturationResponse, UptimeResponse,
 };
 use rocket::http::Status;
 use rocket::serde::json::Json;
@@ -207,4 +208,12 @@ pub async fn get_active_set_detailed(
     cache: &State<NodeStatusCache>,
 ) -> Json<Vec<MixNodeBondAnnotated>> {
     Json(_get_active_set_detailed(cache).await)
+}
+
+#[openapi(tag = "status")]
+#[get("/gateways/detailed")]
+pub async fn get_gateways_detailed(
+    cache: &State<NodeStatusCache>,
+) -> Json<Vec<GatewayBondAnnotated>> {
+    Json(_get_gateways_detailed(cache).await)
 }

--- a/nym-api/src/support/storage/manager.rs
+++ b/nym-api/src/support/storage/manager.rs
@@ -388,7 +388,7 @@ impl StorageManager {
         .await
     }
 
-    pub(crate) async fn get_average_reliability_in_interval(
+    pub(crate) async fn get_mixnode_average_reliability_in_interval(
         &self,
         id: i64,
         start: i64,
@@ -398,6 +398,26 @@ impl StorageManager {
             r#"
             SELECT AVG(reliability) as "reliability: f32" FROM mixnode_status
             WHERE mixnode_details_id= ? AND timestamp >= ? AND timestamp <= ?
+            "#,
+            id,
+            start,
+            end
+        )
+        .fetch_one(&self.connection_pool)
+        .await?;
+        Ok(result.reliability)
+    }
+
+    pub(super) async fn get_gateway_average_reliability_in_interval(
+        &self,
+        id: i64,
+        start: i64,
+        end: i64,
+    ) -> Result<Option<f32>, sqlx::Error> {
+        let result = sqlx::query!(
+            r#"
+            SELECT AVG(reliability) as "reliability: f32" FROM gateway_status
+            WHERE gateway_details_id= ? AND timestamp >= ? AND timestamp <= ?
             "#,
             id,
             start,

--- a/nym-api/src/support/storage/mod.rs
+++ b/nym-api/src/support/storage/mod.rs
@@ -307,6 +307,16 @@ impl NymApiStorage {
             .await
     }
 
+    pub(crate) async fn get_average_gateway_uptime_in_the_last_24hrs(
+        &self,
+        identity: &str,
+        end_ts_secs: i64,
+    ) -> Result<Uptime, NymApiStorageError> {
+        let start = end_ts_secs - 86400;
+        self.get_average_gateway_uptime_in_time_interval(identity, start, end_ts_secs)
+            .await
+    }
+
     /// Based on the data available in the validator API, determines the average uptime of particular
     /// mixnode during the specified time interval.
     ///
@@ -328,7 +338,38 @@ impl NymApiStorage {
 
         let reliability = self
             .manager
-            .get_average_reliability_in_interval(mixnode_database_id, start, end)
+            .get_mixnode_average_reliability_in_interval(mixnode_database_id, start, end)
+            .await?;
+
+        if let Some(reliability) = reliability {
+            Ok(Uptime::new(reliability))
+        } else {
+            Ok(Uptime::zero())
+        }
+    }
+
+    /// Based on the data available in the validator API, determines the average uptime of particular
+    /// gateway during the specified time interval.
+    ///
+    /// # Arguments
+    ///
+    /// * `identity`: base58-encoded identity of the gateway.
+    /// * `since`: unix timestamp indicating the lower bound interval of the selection.
+    /// * `end`: unix timestamp indicating the upper bound interval of the selection.
+    pub(crate) async fn get_average_gateway_uptime_in_time_interval(
+        &self,
+        identity: &str,
+        start: i64,
+        end: i64,
+    ) -> Result<Uptime, NymApiStorageError> {
+        let gateway_database_id = match self.manager.get_gateway_id(identity).await? {
+            Some(id) => id,
+            None => return Ok(Uptime::zero()),
+        };
+
+        let reliability = self
+            .manager
+            .get_gateway_average_reliability_in_interval(gateway_database_id, start, end)
             .await?;
 
         if let Some(reliability) = reliability {


### PR DESCRIPTION
# Description

Part of: https://github.com/nymtech/nym/issues/2186

Add endpoint for detailed gateway info: `status/gateways/detailed`.
This is like the usual contract cache endpoints that lists all the gateway bonds, but annotates it with more data from the node info storage. In this case it's the `performance`.

# Checklist:

- [x] added a changelog entry to `CHANGELOG.md`
