### PR TITLE
chore: added --all-targets --all-features to clippy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace -- -D warnings
+          args: --workspace --all-targets --all-features -- -D warnings
 
       # COCONUT stuff
 


### PR DESCRIPTION
# Description

Follow up to the discussion on the daily yesterday, I've run a couple of benchmarks on my machine (ignore the bad formatting of the output).

`WITH --all-targets` and `WITHOUT --all-targets`actually has `--all-features` flag as well enabled.

So the outputs are:
- `--workspace --all-features --all-targets`
- `--workspace --all-features`
- `--workspace --all-targets`
- `--workspace`

![paste](https://user-images.githubusercontent.com/36734176/212286635-64f99455-2367-4d8e-a9cd-44dcf2b557e8.png)
![paste (1)](https://user-images.githubusercontent.com/36734176/212286640-eab3de29-4c9d-453d-8270-522a85ff92cb.png)

We currently use the last case, without `--all-targets` and without `--all-features`. The increase in run time is ~30 seconds if we enable both. That is a 60% increase, but it's still not a lot while we may get the info of what's failing faster.

In CI the differences are even smaller. Look at the `Run clippy` step.

![paste (3)](https://user-images.githubusercontent.com/36734176/212287550-5b391a31-194d-4138-8af0-fda3ebd9c30b.png)

![paste (2)](https://user-images.githubusercontent.com/36734176/212287557-9fa84488-7a63-4363-a826-20bea4d51df4.png)

It's 37s vs 18s, a 19s increase.

The question is however, would this be useful to you guys? If you wouldn't have any benefits from this then it doesn't make sense to increase the time it takes to run the CI.