### PR TITLE
upgrade tauri to 1.2.3

### DIFF
--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -4732,9 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "tauri"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ea1d785ab2164373703817bff144c4610a69ad3f659becaca0e1ea004b98d8"
+checksum = "5b48820ee3bb6a5031a83b2b6e11f8630bdc5a2f68cb841ab8ebc7a15a916679"
 dependencies = [
  "anyhow",
  "attohttpc",

--- a/nym-wallet/src-tauri/Cargo.toml
+++ b/nym-wallet/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_repr = "0.1"
 strum = { version = "0.23", features = ["derive"] }
-tauri = { version = "=1.2.2", features = ["clipboard-all", "shell-open", "updater", "window-maximize"] }
+tauri = { version = "=1.2.3", features = ["clipboard-all", "shell-open", "updater", "window-maximize"] }
 tendermint-rpc = "0.23.0"
 thiserror = "1.0"
 tokio = { version = "1.10", features = ["full"] }


### PR DESCRIPTION
# Description

Upgrade Tauri to 1.2.3

Closes: #2841

Dependabot reference - https://github.com/nymtech/nym/pull/2748