### PR TITLE
Fix typescript examples

### DIFF
--- a/sdk/typescript/examples/react-webpack-with-theme-example/src/typings/FC.d.ts
+++ b/sdk/typescript/examples/react-webpack-with-theme-example/src/typings/FC.d.ts
@@ -1,0 +1,1 @@
+declare type FCWithChildren<P = {}> = React.FC<React.PropsWithChildren<P>>;

--- a/sdk/typescript/packages/sdk/src/mixnet/wasm/worker.ts
+++ b/sdk/typescript/packages/sdk/src/mixnet/wasm/worker.ts
@@ -82,12 +82,10 @@ class ClientWrapper {
       return;
     }
 
-    this.client = await this.clientBuilder.start_client();
-
     // this is current limitation of wasm in rust - for async methods you can't take self by reference...
     // I'm trying to figure out if I can somehow hack my way around it, but for time being you have to re-assign
     // the object (it's the same one)
-    // this.client = await this.client.start();
+    this.client = await this.clientBuilder.start_client();
   };
 
   sendMessage = async ({ payload, recipient }: { recipient: string; payload: string }) => {

--- a/sdk/typescript/packages/sdk/src/mixnet/wasm/worker.ts
+++ b/sdk/typescript/packages/sdk/src/mixnet/wasm/worker.ts
@@ -47,7 +47,7 @@ class ClientWrapper {
   /**
    * Creates the WASM client and initialises it.
    */
-  init = async (
+  init = (
     config: wasm_bindgen.Config,
     onMessageHandler: OnBinaryMessageFn,
   ) => {


### PR DESCRIPTION
Both `plain-html` and `react-webpack-with-theme-example` are broken on the develop branch.

- `plain-html` is calling removed methods.
- `react-webpack-with-theme-example` is referencing an undefined type.