### PR TITLE
gateway: don't shutdown on connection handler drop

### DIFF
--- a/gateway/src/node/client_handling/websocket/connection_handler/mod.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/mod.rs
@@ -77,6 +77,9 @@ pub(crate) async fn handle_connection<R, S, St>(
     S: AsyncRead + AsyncWrite + Unpin + Send,
     St: Storage,
 {
+    // If the connection handler abruptly stops, we shouldn't signal global shutdown
+    shutdown.mark_as_success();
+
     match shutdown
         .run_future(handle.perform_websocket_handshake())
         .await


### PR DESCRIPTION
# Description

Fix gateway graceful shutdown by making sure connection handlers that drop don't signal global shutdown.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
