### PR TITLE
a bunch of systemd service files

### DIFF
--- a/scripts/systemd/nym-client-sp.service
+++ b/scripts/systemd/nym-client-sp.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=NYM Client
+
+[Service]
+User=nym
+ExecStart=/usr/local/bin/nym-client run --id service-provider -p 1978
+LimitNOFILE=65535
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+

--- a/scripts/systemd/nym-client.service
+++ b/scripts/systemd/nym-client.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=NYM Client
+
+[Service]
+User=nym
+ExecStart=/usr/local/bin/nym-client run --id client
+LimitNOFILE=65535
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+

--- a/scripts/systemd/nym-gateway.service
+++ b/scripts/systemd/nym-gateway.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=NYM Gateway
+
+[Service]
+User=nym
+ExecStart=/usr/local/bin/nym-gateway --id gateway -p 1789,1790,9000
+LimitNOFILE=65535
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+

--- a/scripts/systemd/nym-service-provider.service
+++ b/scripts/systemd/nym-service-provider.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NYM Client
+
+[Service]
+User=nym
+ExecStart=/usr/local/bin/nym-service-provider run --id service-provider
+LimitNOFILE=65535
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd/nym-socks5-client.service
+++ b/scripts/systemd/nym-socks5-client.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=NYM Client
+
+[Service]
+User=nym
+ExecStart=/usr/local/bin/nym-client run --id nymstr 
+LimitNOFILE=65535
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
This should make life much easier to automate stuff. I used a chatgpt with some manual edits, so please check it out also yourself but it all works for me.

The nym-client there is twice just if there is a need to run two instances on one box. I kept the README port 1978 for that service.

Cheers.

# Description

Closes: #XXXX

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
