### PR TITLE
Bugfix/verloc send shutdown

### DIFF
--- a/common/mixnode-common/src/verloc/sender.rs
+++ b/common/mixnode-common/src/verloc/sender.rs
@@ -84,6 +84,7 @@ impl PacketSender {
         tested_node: TestedNode,
     ) -> Result<Measurement, RttError> {
         let mut shutdown_listener = self.shutdown_listener.clone();
+        shutdown_listener.mark_as_success();
 
         let mut conn = match tokio::time::timeout(
             self.connection_timeout,


### PR DESCRIPTION
# Description

Fixes an issue where `TaskClient` in verloc would send an `UnexpectedHalt` after (even successfully) finishing sending measurement packets

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
