### PR TITLE
removed migrated vesting contract code

### DIFF
--- a/common/cosmwasm-smart-contracts/vesting-contract/src/messages.rs
+++ b/common/cosmwasm-smart-contracts/vesting-contract/src/messages.rs
@@ -17,10 +17,7 @@ pub struct InitMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {
-    // I'm making it explicit so that we wouldn't accidentally forget about it
-    pub manually_verified_no_staking_addresses: bool,
-}
+pub struct MigrateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default)]
 pub struct VestingSpecification {

--- a/contracts/vesting/src/contract.rs
+++ b/contracts/vesting/src/contract.rs
@@ -51,16 +51,7 @@ pub fn instantiate(
 }
 
 #[entry_point]
-pub fn migrate(_deps: DepsMut<'_>, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
-    // we can't perform this check inside the migrate function since there are 12k addresses to check
-    // and this invariant MUST hold, otherwise we're gonna have bad time
-    if !msg.manually_verified_no_staking_addresses {
-        return Err(ContractError::Other {
-            message:
-                "the assumption that nobody has set a staking address hasn't been manually verified"
-                    .to_string(),
-        });
-    }
+pub fn migrate(_deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     Ok(Response::new())
 }
 


### PR DESCRIPTION
# Description

Removes the migration that was already run on mainnet

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
