### PR TITLE
Don't drop in mixnet connection handler

### DIFF
--- a/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
+++ b/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
@@ -181,6 +181,7 @@ impl<St: Storage> ConnectionHandler<St> {
         mut shutdown: TaskClient,
     ) {
         debug!("Starting connection handler for {:?}", remote);
+        shutdown.mark_as_success();
         let mut framed_conn = Framed::new(conn, SphinxCodec);
         while !shutdown.is_shutdown() {
             tokio::select! {

--- a/mixnode/src/node/listener/connection_handler/mod.rs
+++ b/mixnode/src/node/listener/connection_handler/mod.rs
@@ -77,6 +77,7 @@ impl ConnectionHandler {
         mut shutdown: TaskClient,
     ) {
         debug!("Starting connection handler for {:?}", remote);
+        shutdown.mark_as_success();
         let mut framed_conn = Framed::new(conn, SphinxCodec);
         while !shutdown.is_shutdown() {
             tokio::select! {


### PR DESCRIPTION
# Description

Fixes: https://github.com/nymtech/nym/issues/3017

Fixes mixnode going down if the connection is corrupted

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
