### PR TITLE
Feature/stabilize credential deposit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,6 +1053,7 @@ dependencies = [
  "credential-storage",
  "credentials",
  "crypto",
+ "log",
  "network-defaults",
  "pemstore",
  "rand 0.7.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,15 +291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bip32"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3915,7 +3906,6 @@ dependencies = [
 name = "nymcoconut"
 version = "0.5.0"
 dependencies = [
- "bincode",
  "bls12_381 0.6.0",
  "bs58",
  "criterion 0.3.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,7 @@ dependencies = [
  "credentials",
  "crypto",
  "log",
+ "logging",
  "network-defaults",
  "pemstore",
  "rand 0.7.3",

--- a/clients/credential/Cargo.toml
+++ b/clients/credential/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 bip39 = "1.0.1"
 clap = { version = "4.0", features = ["cargo", "derive"] }
+log = "0.4"
 rand = "0.7.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"

--- a/clients/credential/Cargo.toml
+++ b/clients/credential/Cargo.toml
@@ -21,6 +21,7 @@ completions = { path = "../../common/completions" }
 credentials = { path = "../../common/credentials" }
 credential-storage = { path = "../../common/credential-storage" }
 crypto = { path = "../../common/crypto", features = ["rand", "asymmetric", "symmetric", "aes", "hashing"] }
+logging = { path = "../../common/logging"}
 network-defaults = { path = "../../common/network-defaults" }
 pemstore = { path = "../../common/pemstore" }
 validator-client = { path = "../../common/client-libs/validator-client", features = ["nyxd-client"] }

--- a/clients/credential/src/commands.rs
+++ b/clients/credential/src/commands.rs
@@ -93,11 +93,7 @@ pub(crate) async fn deposit(nyxd_url: &str, mnemonic: &str, amount: u64) -> Resu
         encryption::PrivateKey::from_base58_string(&encryption_keypair.private_key)?,
     );
 
-    let state = State {
-        amount,
-        voucher,
-        params,
-    };
+    let state = State { voucher, params };
 
     Ok(state)
 }
@@ -125,7 +121,7 @@ pub(crate) async fn get_credential<C: Clone + CosmWasmClient + Send + Sync>(
     println!("Signature: {:?}", signature.to_bs58());
     shared_storage
         .insert_coconut_credential(
-            state.amount.to_string(),
+            state.voucher.get_voucher_value(),
             VOUCHER_INFO.to_string(),
             state.voucher.get_private_attributes()[0].to_bs58(),
             state.voucher.get_private_attributes()[1].to_bs58(),
@@ -144,7 +140,6 @@ pub(crate) async fn recover_credentials<C: Clone + CosmWasmClient + Send + Sync>
 ) -> Result<()> {
     for voucher in recovery_storage.unconsumed_vouchers()? {
         let state = State {
-            amount: 0,
             voucher,
             params: Parameters::new(TOTAL_ATTRIBUTES).unwrap(),
         };

--- a/clients/credential/src/commands.rs
+++ b/clients/credential/src/commands.rs
@@ -51,6 +51,10 @@ pub(crate) struct Run {
     /// The amount of utokens the credential will hold
     #[clap(long)]
     pub(crate) amount: u64,
+
+    /// Path to a file used to recover in case of unconsumed deposits
+    #[clap(long)]
+    pub(crate) recovery_file_path: std::path::PathBuf,
 }
 
 pub(crate) async fn deposit(nyxd_url: &str, mnemonic: &str, amount: u64) -> Result<State> {

--- a/clients/credential/src/commands.rs
+++ b/clients/credential/src/commands.rs
@@ -12,10 +12,11 @@ use credential_storage::PersistentStorage;
 use credentials::coconut::bandwidth::{BandwidthVoucher, TOTAL_ATTRIBUTES};
 use credentials::coconut::utils::obtain_aggregate_signature;
 use crypto::asymmetric::{encryption, identity};
-use network_defaults::{NymNetworkDetails, VOUCHER_INFO};
+use network_defaults::VOUCHER_INFO;
 use validator_client::nyxd::traits::DkgQueryClient;
 use validator_client::nyxd::tx::Hash;
-use validator_client::{CoconutApiClient, Config};
+use validator_client::nyxd::CosmWasmClient;
+use validator_client::CoconutApiClient;
 
 use crate::client::Client;
 use crate::error::{CredentialClientError, Result};
@@ -77,10 +78,11 @@ pub(crate) async fn deposit(nyxd_url: &str, mnemonic: &str, amount: u64) -> Resu
     Ok(state)
 }
 
-pub(crate) async fn get_credential(state: &State, shared_storage: PersistentStorage) -> Result<()> {
-    let network_details = NymNetworkDetails::new_from_env();
-    let config = Config::try_from_nym_network_details(&network_details)?;
-    let client = validator_client::Client::new_query(config)?;
+pub(crate) async fn get_credential<C: Clone + CosmWasmClient + Send + Sync>(
+    state: &State,
+    client: validator_client::Client<C>,
+    shared_storage: PersistentStorage,
+) -> Result<()> {
     let epoch_id = client.nyxd.get_current_epoch().await?.epoch_id;
     let threshold = client
         .nyxd

--- a/clients/credential/src/commands.rs
+++ b/clients/credential/src/commands.rs
@@ -3,6 +3,7 @@
 
 use clap::{ArgGroup, Args, Subcommand};
 use completions::ArgShell;
+use log::*;
 use rand::rngs::OsRng;
 use std::str::FromStr;
 
@@ -118,7 +119,7 @@ pub(crate) async fn get_credential<C: Clone + CosmWasmClient + Send + Sync>(
         threshold,
     )
     .await?;
-    println!("Signature: {:?}", signature.to_bs58());
+    info!("Signature: {:?}", signature.to_bs58());
     shared_storage
         .insert_coconut_credential(
             state.voucher.get_voucher_value(),
@@ -144,18 +145,18 @@ pub(crate) async fn recover_credentials<C: Clone + CosmWasmClient + Send + Sync>
             params: Parameters::new(TOTAL_ATTRIBUTES).unwrap(),
         };
         if let Err(e) = get_credential(&state, client.clone(), shared_storage.clone()).await {
-            println!(
+            error!(
                 "Could not recover deposit {} due to {:?}, try again later",
                 state.voucher.tx_hash(),
                 e
             )
         } else {
-            println!(
+            info!(
                 "Converted deposit {} to a credential, removing recovery data for it",
                 state.voucher.tx_hash()
             );
             if let Err(e) = recovery_storage.remove_voucher(state.voucher.tx_hash().to_string()) {
-                println!("Could not remove recovery data - {:?}", e);
+                warn!("Could not remove recovery data - {:?}", e);
             }
         }
     }

--- a/clients/credential/src/commands.rs
+++ b/clients/credential/src/commands.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::{Args, Subcommand};
+use clap::{ArgGroup, Args, Subcommand};
 use completions::ArgShell;
 use rand::rngs::OsRng;
 use std::str::FromStr;
@@ -20,11 +20,12 @@ use validator_client::CoconutApiClient;
 
 use crate::client::Client;
 use crate::error::{CredentialClientError, Result};
+use crate::recovery_storage::RecoveryStorage;
 use crate::state::{KeyPair, State};
 
 #[derive(Subcommand)]
 pub(crate) enum Command {
-    /// Run the binary
+    /// Run the binary to obtain a credential
     Run(Run),
 
     /// Generate shell completions
@@ -35,6 +36,11 @@ pub(crate) enum Command {
 }
 
 #[derive(Args)]
+#[clap(group(
+ArgGroup::new("recov")
+.required(true)
+.args(&["amount", "recovery_mode"]),
+))]
 pub(crate) struct Run {
     /// Home directory of the client that is supposed to use the credential.
     #[clap(long)]
@@ -48,19 +54,24 @@ pub(crate) struct Run {
     #[clap(long)]
     pub(crate) mnemonic: String,
 
-    /// The amount of utokens the credential will hold
+    /// The amount of utokens the credential will hold. If recovery mode is enabled, this
     #[clap(long)]
     pub(crate) amount: u64,
 
-    /// Path to a file used to recover in case of unconsumed deposits
+    /// Path to a directory used to store recovery files for unconsumed deposits
     #[clap(long)]
-    pub(crate) recovery_file_path: std::path::PathBuf,
+    pub(crate) recovery_dir: std::path::PathBuf,
+
+    /// Recovery mode, when enabled, tries to recover any deposit data dumped in recovery_dir
+    #[clap(long)]
+    pub(crate) recovery_mode: bool,
 }
 
 pub(crate) async fn deposit(nyxd_url: &str, mnemonic: &str, amount: u64) -> Result<State> {
     let mut rng = OsRng;
     let signing_keypair = KeyPair::from(identity::KeyPair::new(&mut rng));
     let encryption_keypair = KeyPair::from(encryption::KeyPair::new(&mut rng));
+    let params = Parameters::new(TOTAL_ATTRIBUTES).unwrap();
 
     let client = Client::new(nyxd_url, mnemonic);
     let tx_hash = client
@@ -72,11 +83,19 @@ pub(crate) async fn deposit(nyxd_url: &str, mnemonic: &str, amount: u64) -> Resu
         )
         .await?;
 
+    let voucher = BandwidthVoucher::new(
+        &params,
+        amount.to_string(),
+        VOUCHER_INFO.to_string(),
+        Hash::from_str(&tx_hash).map_err(|_| CredentialClientError::InvalidTxHash)?,
+        identity::PrivateKey::from_base58_string(&signing_keypair.private_key)?,
+        encryption::PrivateKey::from_base58_string(&encryption_keypair.private_key)?,
+    );
+
     let state = State {
         amount,
-        tx_hash,
-        signing_keypair,
-        encryption_keypair,
+        voucher,
+        params,
     };
 
     Ok(state)
@@ -95,19 +114,9 @@ pub(crate) async fn get_credential<C: Clone + CosmWasmClient + Send + Sync>(
         .ok_or(CredentialClientError::NoThreshold)?;
     let coconut_api_clients = CoconutApiClient::all_coconut_api_clients(&client, epoch_id).await?;
 
-    let params = Parameters::new(TOTAL_ATTRIBUTES).unwrap();
-    let bandwidth_credential_attributes = BandwidthVoucher::new(
-        &params,
-        state.amount.to_string(),
-        VOUCHER_INFO.to_string(),
-        Hash::from_str(&state.tx_hash).map_err(|_| CredentialClientError::InvalidTxHash)?,
-        identity::PrivateKey::from_base58_string(&state.signing_keypair.private_key)?,
-        encryption::PrivateKey::from_base58_string(&state.encryption_keypair.private_key)?,
-    );
-
     let signature = obtain_aggregate_signature(
-        &params,
-        &bandwidth_credential_attributes,
+        &state.params,
+        &state.voucher,
         &coconut_api_clients,
         threshold,
     )
@@ -117,12 +126,43 @@ pub(crate) async fn get_credential<C: Clone + CosmWasmClient + Send + Sync>(
         .insert_coconut_credential(
             state.amount.to_string(),
             VOUCHER_INFO.to_string(),
-            bandwidth_credential_attributes.get_private_attributes()[0].to_bs58(),
-            bandwidth_credential_attributes.get_private_attributes()[1].to_bs58(),
+            state.voucher.get_private_attributes()[0].to_bs58(),
+            state.voucher.get_private_attributes()[1].to_bs58(),
             signature.to_bs58(),
             epoch_id.to_string(),
         )
         .await?;
+
+    Ok(())
+}
+
+pub(crate) async fn recover_credentials<C: Clone + CosmWasmClient + Send + Sync>(
+    client: validator_client::Client<C>,
+    recovery_storage: &RecoveryStorage,
+    shared_storage: PersistentStorage,
+) -> Result<()> {
+    for voucher in recovery_storage.unconsumed_vouchers()? {
+        let state = State {
+            amount: 0,
+            voucher,
+            params: Parameters::new(TOTAL_ATTRIBUTES).unwrap(),
+        };
+        if let Err(e) = get_credential(&state, client.clone(), shared_storage.clone()).await {
+            println!(
+                "Could not recover deposit {} due to {:?}, try again later",
+                state.voucher.tx_hash(),
+                e
+            )
+        } else {
+            println!(
+                "Converted deposit {} to a credential, removing recovery data for it",
+                state.voucher.tx_hash()
+            );
+            if let Err(e) = recovery_storage.remove_voucher(state.voucher.tx_hash().to_string()) {
+                println!("Could not remove recovery data - {:?}", e);
+            }
+        }
+    }
 
     Ok(())
 }

--- a/clients/credential/src/commands.rs
+++ b/clients/credential/src/commands.rs
@@ -54,8 +54,9 @@ pub(crate) struct Run {
     #[clap(long)]
     pub(crate) mnemonic: String,
 
-    /// The amount of utokens the credential will hold. If recovery mode is enabled, this
-    #[clap(long)]
+    /// The amount of utokens the credential will hold. If recovery mode is enabled, this value
+    /// is not needed
+    #[clap(long, default_value = "0")]
     pub(crate) amount: u64,
 
     /// Path to a directory used to store recovery files for unconsumed deposits

--- a/clients/credential/src/error.rs
+++ b/clients/credential/src/error.rs
@@ -15,6 +15,9 @@ pub type Result<T> = std::result::Result<T, CredentialClientError>;
 
 #[derive(Error, Debug)]
 pub enum CredentialClientError {
+    #[error("IO error: {0}")]
+    IOError(#[from] std::io::Error),
+
     #[error("Nyxd error: {0}")]
     Nyxd(#[from] NyxdError),
 

--- a/clients/credential/src/error.rs
+++ b/clients/credential/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::SystemTimeError;
 use thiserror::Error;
 
 use credential_storage::error::StorageError;
@@ -34,6 +35,9 @@ pub enum CredentialClientError {
 
     #[error("Could not use shared storage")]
     SharedStorageError(#[from] StorageError),
+
+    #[error("Could not get system time")]
+    SysTimeError(#[from] SystemTimeError),
 
     #[error("Threshold not set yet")]
     NoThreshold,

--- a/clients/credential/src/main.rs
+++ b/clients/credential/src/main.rs
@@ -17,6 +17,7 @@ use std::process::exit;
 use std::time::{Duration, SystemTime};
 
 use clap::{CommandFactory, Parser};
+use logging::setup_logging;
 use validator_client::nyxd::traits::DkgQueryClient;
 use validator_client::nyxd::CosmWasmClient;
 use validator_client::Config;
@@ -50,7 +51,8 @@ async fn block_until_coconut_is_available<C: Clone + CosmWasmClient + Send + Syn
 
             break;
         } else {
-            let secs_until_final = epoch.final_timestamp_secs() - current_timestamp_secs;
+            // Use 10 additional seconds to avoid the exact moment of going into the final epoch state
+            let secs_until_final = epoch.final_timestamp_secs() + 10 - current_timestamp_secs;
             info!("Approximately {} seconds until coconut is available. Sleeping until then. You can safely kill the process at any moment.", secs_until_final);
             std::thread::sleep(Duration::from_secs(secs_until_final));
         }
@@ -62,6 +64,7 @@ async fn block_until_coconut_is_available<C: Clone + CosmWasmClient + Send + Syn
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Cli::parse();
+    setup_logging();
     setup_env(args.config_env_file.as_ref());
     let bin_name = "nym-credential-client";
 

--- a/clients/credential/src/main.rs
+++ b/clients/credential/src/main.rs
@@ -43,7 +43,7 @@ async fn block_until_coconut_is_available<C: Clone + CosmWasmClient + Send + Syn
             .as_secs();
         if epoch.state.is_final() {
             if current_timestamp_secs + SAFETY_BUFFER_SECS >= epoch.finish_timestamp.seconds() {
-                println!("In the next {} minutes, a transition will take place in the coconut system. Deposits should be halted in this time for safety reasons.", SAFETY_BUFFER_SECS / 60);
+                println!("In the next {} minute(s), a transition will take place in the coconut system. Deposits should be halted in this time for safety reasons.", SAFETY_BUFFER_SECS / 60);
                 exit(0);
             }
 
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
             let client = validator_client::Client::new_query(config)?;
 
             block_until_coconut_is_available(&client).await?;
-            println!("Finished sleeping, starting depositing funds, don't kill the process");
+            println!("Starting depositing funds, don't kill the process");
 
             if !r.recovery_mode {
                 let state = deposit(&r.nyxd_url, &r.mnemonic, r.amount).await?;

--- a/clients/credential/src/main.rs
+++ b/clients/credential/src/main.rs
@@ -10,9 +10,13 @@ use commands::*;
 use completions::fig_generate;
 use config::{DATA_DIR, DB_FILE_NAME};
 use error::Result;
-use network_defaults::setup_env;
+use network_defaults::{setup_env, NymNetworkDetails};
+use std::time::Duration;
 
 use clap::{CommandFactory, Parser};
+use validator_client::nyxd::traits::DkgQueryClient;
+use validator_client::nyxd::CosmWasmClient;
+use validator_client::Config;
 
 #[derive(Parser)]
 #[clap(author = "Nymtech", version, about)]
@@ -23,6 +27,23 @@ struct Cli {
 
     #[clap(subcommand)]
     pub(crate) command: Command,
+}
+
+async fn block_until_coconut_is_available<C: Clone + CosmWasmClient + Send + Sync>(
+    client: &validator_client::Client<C>,
+) -> Result<()> {
+    loop {
+        let epoch = client.nyxd.get_current_epoch().await?;
+        if epoch.state.is_final() {
+            break;
+        } else {
+            let secs_until_final = epoch.secs_until_final();
+            println!("Approximately {} seconds until coconut is available. Sleeping until then. You can safely kill the process at any moment.", secs_until_final);
+            std::thread::sleep(Duration::from_secs(secs_until_final));
+        }
+    }
+
+    Ok(())
 }
 
 #[tokio::main]
@@ -36,8 +57,16 @@ async fn main() -> Result<()> {
             let db_path = r.client_home_directory.join(DATA_DIR).join(DB_FILE_NAME);
             let shared_storage = credential_storage::initialise_storage(db_path).await;
 
+            let network_details = NymNetworkDetails::new_from_env();
+            let config = Config::try_from_nym_network_details(&network_details)?;
+            let client = validator_client::Client::new_query(config)?;
+
+            block_until_coconut_is_available(&client).await?;
+            println!("Finished sleeping, starting depositing funds, don't kill the process");
+
             let state = deposit(&r.nyxd_url, &r.mnemonic, r.amount).await?;
-            get_credential(&state, shared_storage).await?;
+
+            get_credential(&state, client, shared_storage).await?;
         }
         Command::Completions(c) => c.generate(&mut crate::Cli::command(), bin_name),
         Command::GenerateFigSpec => fig_generate(&mut crate::Cli::command(), bin_name),

--- a/clients/credential/src/main.rs
+++ b/clients/credential/src/main.rs
@@ -20,7 +20,7 @@ use validator_client::nyxd::traits::DkgQueryClient;
 use validator_client::nyxd::CosmWasmClient;
 use validator_client::Config;
 
-const SAFETY_BUFFER_SECS: u64 = 10 * 60; // 10 minutes
+const SAFETY_BUFFER_SECS: u64 = 1 * 60; // 1 minute
 
 #[derive(Parser)]
 #[clap(author = "Nymtech", version, about)]

--- a/clients/credential/src/main.rs
+++ b/clients/credential/src/main.rs
@@ -21,7 +21,7 @@ use validator_client::nyxd::traits::DkgQueryClient;
 use validator_client::nyxd::CosmWasmClient;
 use validator_client::Config;
 
-const SAFETY_BUFFER_SECS: u64 = 1 * 60; // 1 minute
+const SAFETY_BUFFER_SECS: u64 = 60; // 1 minute
 
 #[derive(Parser)]
 #[clap(author = "Nymtech", version, about)]

--- a/clients/credential/src/main.rs
+++ b/clients/credential/src/main.rs
@@ -51,8 +51,8 @@ async fn block_until_coconut_is_available<C: Clone + CosmWasmClient + Send + Syn
 
             break;
         } else {
-            // Use 10 additional seconds to avoid the exact moment of going into the final epoch state
-            let secs_until_final = epoch.final_timestamp_secs() + 10 - current_timestamp_secs;
+            // Use 20 additional seconds to avoid the exact moment of going into the final epoch state
+            let secs_until_final = epoch.final_timestamp_secs() + 20 - current_timestamp_secs;
             info!("Approximately {} seconds until coconut is available. Sleeping until then. You can safely kill the process at any moment.", secs_until_final);
             std::thread::sleep(Duration::from_secs(secs_until_final));
         }

--- a/clients/credential/src/recovery_storage.rs
+++ b/clients/credential/src/recovery_storage.rs
@@ -1,0 +1,56 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use credentials::coconut::bandwidth::BandwidthVoucher;
+use std::fs::{create_dir_all, read_dir, File};
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+pub struct RecoveryStorage {
+    recovery_dir: PathBuf,
+}
+
+impl RecoveryStorage {
+    pub fn new(recovery_dir: PathBuf) -> std::io::Result<Self> {
+        create_dir_all(&recovery_dir)?;
+        Ok(Self { recovery_dir })
+    }
+
+    pub fn unconsumed_vouchers(&self) -> std::io::Result<impl Iterator<Item = BandwidthVoucher>> {
+        Ok(read_dir(&self.recovery_dir)?
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| {
+                let path = entry.path();
+                if path.is_file() {
+                    Some(path)
+                } else {
+                    None
+                }
+            })
+            .filter_map(|path| File::open(path).ok())
+            .filter_map(|mut f| {
+                let mut buff = Vec::new();
+                if f.read_to_end(&mut buff).is_ok() {
+                    Some(buff)
+                } else {
+                    None
+                }
+            })
+            .filter_map(|buff| BandwidthVoucher::try_from_bytes(&buff).ok()))
+    }
+
+    pub fn insert_voucher(&self, voucher: &BandwidthVoucher) -> std::io::Result<PathBuf> {
+        let file_name = voucher.tx_hash().to_string();
+        let file_path = self.recovery_dir.join(file_name);
+        let mut file = File::create(&file_path)?;
+        let buff = voucher.to_bytes();
+        file.write_all(&buff)?;
+
+        Ok(file_path)
+    }
+
+    pub fn remove_voucher(&self, file_name: String) -> std::io::Result<()> {
+        let file_path = self.recovery_dir.join(file_name);
+        std::fs::remove_file(file_path)
+    }
+}

--- a/clients/credential/src/state.rs
+++ b/clients/credential/src/state.rs
@@ -1,11 +1,11 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::{Deserialize, Serialize};
+use coconut_interface::Parameters;
+use credentials::coconut::bandwidth::BandwidthVoucher;
 
 use crypto::asymmetric::{encryption, identity};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct KeyPair {
     pub public_key: String,
     pub private_key: String,
@@ -29,10 +29,8 @@ impl From<encryption::KeyPair> for KeyPair {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct State {
     pub amount: u64,
-    pub tx_hash: String,
-    pub signing_keypair: KeyPair,
-    pub encryption_keypair: KeyPair,
+    pub voucher: BandwidthVoucher,
+    pub params: Parameters,
 }

--- a/clients/credential/src/state.rs
+++ b/clients/credential/src/state.rs
@@ -30,7 +30,6 @@ impl From<encryption::KeyPair> for KeyPair {
 }
 
 pub(crate) struct State {
-    pub amount: u64,
     pub voucher: BandwidthVoucher,
     pub params: Parameters,
 }

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -934,16 +934,6 @@ impl NymApiClient {
         Ok(self.nym_api_client.blind_sign(request_body).await?)
     }
 
-    pub async fn partial_bandwidth_credential(
-        &self,
-        request_body: &str,
-    ) -> Result<BlindedSignatureResponse, ValidatorClientError> {
-        Ok(self
-            .nym_api_client
-            .partial_bandwidth_credential(request_body)
-            .await?)
-    }
-
     pub async fn verify_bandwidth_credential(
         &self,
         request_body: &VerifyCredentialBody,

--- a/common/client-libs/validator-client/src/nym_api/mod.rs
+++ b/common/client-libs/validator-client/src/nym_api/mod.rs
@@ -449,23 +449,6 @@ impl Client {
         .await
     }
 
-    pub async fn partial_bandwidth_credential(
-        &self,
-        request_body: &str,
-    ) -> Result<BlindedSignatureResponse, NymAPIError> {
-        self.post_nym_api(
-            &[
-                routes::API_VERSION,
-                routes::COCONUT_ROUTES,
-                routes::BANDWIDTH,
-                routes::COCONUT_PARTIAL_BANDWIDTH_CREDENTIAL,
-            ],
-            NO_PARAMS,
-            request_body,
-        )
-        .await
-    }
-
     pub async fn verify_bandwidth_credential(
         &self,
         request_body: &VerifyCredentialBody,

--- a/common/client-libs/validator-client/src/nym_api/routes.rs
+++ b/common/client-libs/validator-client/src/nym_api/routes.rs
@@ -14,7 +14,6 @@ pub const COCONUT_ROUTES: &str = "coconut";
 pub const BANDWIDTH: &str = "bandwidth";
 
 pub const COCONUT_BLIND_SIGN: &str = "blind-sign";
-pub const COCONUT_PARTIAL_BANDWIDTH_CREDENTIAL: &str = "partial-bandwidth-credential";
 pub const COCONUT_VERIFY_BANDWIDTH_CREDENTIAL: &str = "verify-bandwidth-credential";
 
 pub const STATUS_ROUTES: &str = "status";

--- a/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
+++ b/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
@@ -115,7 +115,7 @@ impl Epoch {
         }
     }
 
-    pub fn secs_until_final(&self) -> u64 {
+    pub fn final_timestamp_secs(&self) -> u64 {
         let mut finish = self.finish_timestamp.seconds();
         let time_configuration = self.time_configuration;
         let mut curr_epoch_state = self.state;

--- a/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
+++ b/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
@@ -114,6 +114,33 @@ impl Epoch {
             finish_timestamp: current_timestamp.plus_seconds(duration),
         }
     }
+
+    pub fn secs_until_final(&self) -> u64 {
+        let mut finish = self.finish_timestamp.seconds();
+        let time_configuration = self.time_configuration;
+        let mut curr_epoch_state = self.state;
+        while let Some(state) = curr_epoch_state.next() {
+            curr_epoch_state = state;
+            let adding = match curr_epoch_state {
+                EpochState::PublicKeySubmission { .. } => {
+                    time_configuration.public_key_submission_time_secs
+                }
+                EpochState::DealingExchange { .. } => time_configuration.dealing_exchange_time_secs,
+                EpochState::VerificationKeySubmission { .. } => {
+                    time_configuration.verification_key_submission_time_secs
+                }
+                EpochState::VerificationKeyValidation { .. } => {
+                    time_configuration.verification_key_validation_time_secs
+                }
+                EpochState::VerificationKeyFinalization { .. } => {
+                    time_configuration.verification_key_finalization_time_secs
+                }
+                EpochState::InProgress { .. } => 0,
+            };
+            finish += adding;
+        }
+        finish
+    }
 }
 
 // currently (it is still extremely likely to change, we might be able to get rid of verification key-related complaints),
@@ -194,5 +221,9 @@ impl EpochState {
         }
 
         states
+    }
+
+    pub fn is_final(&self) -> bool {
+        *self == EpochState::InProgress
     }
 }

--- a/common/credentials/src/coconut/bandwidth.rs
+++ b/common/credentials/src/coconut/bandwidth.rs
@@ -239,6 +239,10 @@ impl BandwidthVoucher {
         &self.blind_sign_request
     }
 
+    pub fn get_voucher_value(&self) -> String {
+        self.voucher_value_plain.clone()
+    }
+
     pub fn get_public_attributes_plain(&self) -> Vec<String> {
         vec![
             self.voucher_value_plain.clone(),

--- a/common/credentials/src/coconut/bandwidth.rs
+++ b/common/credentials/src/coconut/bandwidth.rs
@@ -94,15 +94,15 @@ impl BandwidthVoucher {
 
         ret.extend_from_slice(&serial_number_b);
         ret.extend_from_slice(&binding_number_b);
-        ret.extend_from_slice(&tx_hash_b);
+        ret.extend_from_slice(tx_hash_b);
         ret.extend_from_slice(&signing_key_b);
         ret.extend_from_slice(&encryption_key_b);
         ret.extend_from_slice(&(voucher_value_plain_b.len() as u64).to_be_bytes());
         ret.extend_from_slice(&(voucher_info_plain_b.len() as u64).to_be_bytes());
         ret.extend_from_slice(&(blind_sign_request_b.len() as u64).to_be_bytes());
         ret.extend_from_slice(&(self.pedersen_commitments_openings.len() as u64).to_be_bytes());
-        ret.extend_from_slice(&voucher_value_plain_b);
-        ret.extend_from_slice(&voucher_info_plain_b);
+        ret.extend_from_slice(voucher_value_plain_b);
+        ret.extend_from_slice(voucher_info_plain_b);
         ret.extend_from_slice(&blind_sign_request_b);
         for commitment in self.pedersen_commitments_openings.iter() {
             ret.extend_from_slice(&commitment.to_bytes());
@@ -131,16 +131,12 @@ impl BandwidthVoucher {
         buff.copy_from_slice(&bytes[2 * 32..3 * 32]);
         let tx_hash = Hash::new(buff);
         buff.copy_from_slice(&bytes[3 * 32..4 * 32]);
-        let signing_key = identity::PrivateKey::from_bytes(&buff).or_else(|_| {
-            Err(Error::BandwidthVoucherDeserializationError(String::from(
-                "Invalid key",
-            )))
+        let signing_key = identity::PrivateKey::from_bytes(&buff).map_err(|_| {
+            Error::BandwidthVoucherDeserializationError(String::from("Invalid key"))
         })?;
         buff.copy_from_slice(&bytes[4 * 32..5 * 32]);
-        let encryption_key = encryption::PrivateKey::from_bytes(&buff).or_else(|_| {
-            Err(Error::BandwidthVoucherDeserializationError(String::from(
-                "Invalid key",
-            )))
+        let encryption_key = encryption::PrivateKey::from_bytes(&buff).map_err(|_| {
+            Error::BandwidthVoucherDeserializationError(String::from("Invalid key"))
         })?;
         small_buff.copy_from_slice(&bytes[5 * 32..5 * 32 + 8]);
         let voucher_value_plain_no = u64::from_be_bytes(small_buff) as usize;
@@ -159,8 +155,7 @@ impl BandwidthVoucher {
             + pedersen_commitments_openings_no * 32;
         if bytes.len() != total_length {
             return Err(Error::BandwidthVoucherDeserializationError(format!(
-                "Expected {} bytes",
-                total_length
+                "Expected {total_length} bytes",
             )));
         }
 

--- a/common/credentials/src/coconut/bandwidth.rs
+++ b/common/credentials/src/coconut/bandwidth.rs
@@ -42,41 +42,9 @@ pub struct BandwidthVoucher {
     encryption_key: encryption::PrivateKey,
     pedersen_commitments_openings: Vec<Attribute>,
     blind_sign_request: BlindSignRequest,
-    use_request: bool,
 }
 
 impl BandwidthVoucher {
-    pub fn new_with_blind_sign_req(
-        private_attributes: [PrivateAttribute; PRIVATE_ATTRIBUTES as usize],
-        public_attributes_plain: [&str; PUBLIC_ATTRIBUTES as usize],
-        tx_hash: Hash,
-        signing_key: identity::PrivateKey,
-        encryption_key: encryption::PrivateKey,
-        pedersen_commitments_openings: Vec<Attribute>,
-        blind_sign_request: BlindSignRequest,
-    ) -> Self {
-        let voucher_value = public_attributes_plain[0];
-        let voucher_info = public_attributes_plain[1];
-        let voucher_value_plain = voucher_value.to_string();
-        let voucher_info_plain = voucher_info.to_string();
-        let voucher_value = hash_to_scalar(voucher_value.as_bytes());
-        let voucher_info = hash_to_scalar(voucher_info.as_bytes());
-
-        BandwidthVoucher {
-            serial_number: private_attributes[0],
-            binding_number: private_attributes[1],
-            voucher_value,
-            voucher_value_plain,
-            voucher_info,
-            voucher_info_plain,
-            tx_hash,
-            signing_key,
-            encryption_key,
-            pedersen_commitments_openings,
-            blind_sign_request,
-            use_request: false,
-        }
-    }
     pub fn new(
         params: &Parameters,
         voucher_value: String,
@@ -109,8 +77,138 @@ impl BandwidthVoucher {
             encryption_key,
             pedersen_commitments_openings,
             blind_sign_request,
-            use_request: true,
         }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let serial_number_b = self.serial_number.to_bytes();
+        let binding_number_b = self.binding_number.to_bytes();
+        let voucher_value_plain_b = self.voucher_value_plain.as_bytes();
+        let voucher_info_plain_b = self.voucher_info_plain.as_bytes();
+        let tx_hash_b = self.tx_hash.as_bytes();
+        let signing_key_b = self.signing_key.to_bytes();
+        let encryption_key_b = self.encryption_key.to_bytes();
+        let blind_sign_request_b = self.blind_sign_request.to_bytes();
+
+        let mut ret = Vec::new();
+
+        ret.extend_from_slice(&serial_number_b);
+        ret.extend_from_slice(&binding_number_b);
+        ret.extend_from_slice(&tx_hash_b);
+        ret.extend_from_slice(&signing_key_b);
+        ret.extend_from_slice(&encryption_key_b);
+        ret.extend_from_slice(&(voucher_value_plain_b.len() as u64).to_be_bytes());
+        ret.extend_from_slice(&(voucher_info_plain_b.len() as u64).to_be_bytes());
+        ret.extend_from_slice(&(blind_sign_request_b.len() as u64).to_be_bytes());
+        ret.extend_from_slice(&(self.pedersen_commitments_openings.len() as u64).to_be_bytes());
+        ret.extend_from_slice(&voucher_value_plain_b);
+        ret.extend_from_slice(&voucher_info_plain_b);
+        ret.extend_from_slice(&blind_sign_request_b);
+        for commitment in self.pedersen_commitments_openings.iter() {
+            ret.extend_from_slice(&commitment.to_bytes());
+        }
+
+        ret
+    }
+
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        if bytes.len() < 32 * 5 + 4 * 8 {
+            return Err(Error::BandwidthVoucherDeserializationError(format!(
+                "Less then {} bytes needed",
+                32 * 5 + 4 * 8
+            )));
+        }
+        let mut buff = [0u8; 32];
+        let mut small_buff = [0u8; 8];
+        let scalar_err =
+            || Error::BandwidthVoucherDeserializationError(String::from("Invalid Scalar"));
+        buff.copy_from_slice(&bytes[..32]);
+        let serial_number = Option::<PrivateAttribute>::from(PrivateAttribute::from_bytes(&buff))
+            .ok_or_else(scalar_err)?;
+        buff.copy_from_slice(&bytes[32..2 * 32]);
+        let binding_number = Option::<PrivateAttribute>::from(PrivateAttribute::from_bytes(&buff))
+            .ok_or_else(scalar_err)?;
+        buff.copy_from_slice(&bytes[2 * 32..3 * 32]);
+        let tx_hash = Hash::new(buff);
+        buff.copy_from_slice(&bytes[3 * 32..4 * 32]);
+        let signing_key = identity::PrivateKey::from_bytes(&buff).or_else(|_| {
+            Err(Error::BandwidthVoucherDeserializationError(String::from(
+                "Invalid key",
+            )))
+        })?;
+        buff.copy_from_slice(&bytes[4 * 32..5 * 32]);
+        let encryption_key = encryption::PrivateKey::from_bytes(&buff).or_else(|_| {
+            Err(Error::BandwidthVoucherDeserializationError(String::from(
+                "Invalid key",
+            )))
+        })?;
+        small_buff.copy_from_slice(&bytes[5 * 32..5 * 32 + 8]);
+        let voucher_value_plain_no = u64::from_be_bytes(small_buff) as usize;
+        small_buff.copy_from_slice(&bytes[5 * 32 + 8..5 * 32 + 2 * 8]);
+        let voucher_info_plain_no = u64::from_be_bytes(small_buff) as usize;
+        small_buff.copy_from_slice(&bytes[5 * 32 + 2 * 8..5 * 32 + 3 * 8]);
+        let blind_sign_request_no = u64::from_be_bytes(small_buff) as usize;
+        small_buff.copy_from_slice(&bytes[5 * 32 + 3 * 8..5 * 32 + 4 * 8]);
+        let pedersen_commitments_openings_no = u64::from_be_bytes(small_buff) as usize;
+
+        let total_length = 32 * 5
+            + 4 * 8
+            + voucher_value_plain_no
+            + voucher_info_plain_no
+            + blind_sign_request_no
+            + pedersen_commitments_openings_no * 32;
+        if bytes.len() != total_length {
+            return Err(Error::BandwidthVoucherDeserializationError(format!(
+                "Expected {} bytes",
+                total_length
+            )));
+        }
+
+        let utf_err = |_| {
+            Err(Error::BandwidthVoucherDeserializationError(String::from(
+                "Invalid UTF8 string",
+            )))
+        };
+        let mut var_length_pointer = 5 * 32 + 4 * 8;
+        let voucher_value_plain = String::from_utf8(
+            bytes[var_length_pointer..var_length_pointer + voucher_value_plain_no].to_vec(),
+        )
+        .or_else(utf_err)?;
+        let voucher_value = hash_to_scalar(&voucher_value_plain);
+        var_length_pointer += voucher_value_plain_no;
+        let voucher_info_plain = String::from_utf8(
+            bytes[var_length_pointer..var_length_pointer + voucher_info_plain_no].to_vec(),
+        )
+        .or_else(utf_err)?;
+        let voucher_info = hash_to_scalar(&voucher_info_plain);
+        var_length_pointer += voucher_info_plain_no;
+        let blind_sign_request = BlindSignRequest::from_bytes(
+            &bytes[var_length_pointer..var_length_pointer + blind_sign_request_no],
+        )?;
+        var_length_pointer += blind_sign_request_no;
+
+        let mut pedersen_commitments_openings = Vec::new();
+        for _ in 0..pedersen_commitments_openings_no {
+            buff.copy_from_slice(&bytes[var_length_pointer..var_length_pointer + 32]);
+            let commitment =
+                Option::<Attribute>::from(Attribute::from_bytes(&buff)).ok_or_else(scalar_err)?;
+            var_length_pointer += 32;
+            pedersen_commitments_openings.push(commitment);
+        }
+
+        Ok(Self {
+            serial_number,
+            binding_number,
+            voucher_value,
+            voucher_value_plain,
+            voucher_info,
+            voucher_info_plain,
+            tx_hash,
+            signing_key,
+            encryption_key,
+            pedersen_commitments_openings,
+            blind_sign_request,
+        })
     }
 
     /// Check if the plain values correspond to the PublicAttributes
@@ -139,10 +237,6 @@ impl BandwidthVoucher {
 
     pub fn blind_sign_request(&self) -> &BlindSignRequest {
         &self.blind_sign_request
-    }
-
-    pub fn use_request(&self) -> bool {
-        self.use_request
     }
 
     pub fn get_public_attributes_plain(&self) -> Vec<String> {
@@ -189,13 +283,13 @@ pub fn prepare_for_spending(
 #[cfg(test)]
 mod test {
     use super::*;
+    use coconut_interface::Base58;
     use rand::rngs::OsRng;
 
-    #[test]
-    fn voucher_consistency() {
+    fn voucher_fixture() -> BandwidthVoucher {
         let params = Parameters::new(4).unwrap();
         let mut rng = OsRng;
-        let voucher = BandwidthVoucher::new(
+        BandwidthVoucher::new(
             &params,
             "1234".to_string(),
             "voucher info".to_string(),
@@ -210,7 +304,48 @@ mod test {
                 &encryption::KeyPair::new(&mut rng).private_key().to_bytes(),
             )
             .unwrap(),
+        )
+    }
+
+    #[test]
+    fn serde_voucher() {
+        let voucher = voucher_fixture();
+        let bytes = voucher.to_bytes();
+        let deserialized_voucher = BandwidthVoucher::try_from_bytes(&bytes).unwrap();
+        assert_eq!(voucher.serial_number, deserialized_voucher.serial_number);
+        assert_eq!(voucher.binding_number, deserialized_voucher.binding_number);
+        assert_eq!(voucher.voucher_value, deserialized_voucher.voucher_value);
+        assert_eq!(
+            voucher.voucher_value_plain,
+            deserialized_voucher.voucher_value_plain
         );
+        assert_eq!(voucher.voucher_info, deserialized_voucher.voucher_info);
+        assert_eq!(
+            voucher.voucher_info_plain,
+            deserialized_voucher.voucher_info_plain
+        );
+        assert_eq!(voucher.tx_hash, deserialized_voucher.tx_hash);
+        assert_eq!(
+            voucher.signing_key.to_string(),
+            deserialized_voucher.signing_key.to_string()
+        );
+        assert_eq!(
+            voucher.encryption_key.to_string(),
+            deserialized_voucher.encryption_key.to_string()
+        );
+        assert_eq!(
+            voucher.pedersen_commitments_openings,
+            deserialized_voucher.pedersen_commitments_openings
+        );
+        assert_eq!(
+            voucher.blind_sign_request.to_bs58(),
+            deserialized_voucher.blind_sign_request.to_bs58()
+        );
+    }
+
+    #[test]
+    fn voucher_consistency() {
+        let voucher = voucher_fixture();
         assert!(!BandwidthVoucher::verify_against_plain(
             &[],
             &voucher.get_public_attributes_plain()

--- a/common/credentials/src/coconut/utils.rs
+++ b/common/credentials/src/coconut/utils.rs
@@ -128,7 +128,7 @@ pub async fn obtain_aggregate_signature(
     attributes.extend_from_slice(&public_attributes);
 
     aggregate_signature_shares(params, &verification_key, &attributes, &shares)
-        .map_err(|e| Error::SignatureAggregationError(e))
+        .map_err(Error::SignatureAggregationError)
 }
 
 // TODO: better type flow

--- a/common/credentials/src/coconut/utils.rs
+++ b/common/credentials/src/coconut/utils.rs
@@ -45,21 +45,15 @@ async fn obtain_partial_credential(
     let private_attributes = attributes.get_private_attributes();
     let blind_sign_request = attributes.blind_sign_request();
 
-    let response = if attributes.use_request() {
-        let blind_sign_request_body = BlindSignRequestBody::new(
-            blind_sign_request,
-            attributes.tx_hash().to_string(),
-            attributes.sign(blind_sign_request).to_base58_string(),
-            &public_attributes,
-            public_attributes_plain,
-            (public_attributes.len() + private_attributes.len()) as u32,
-        );
-        client.blind_sign(&blind_sign_request_body).await?
-    } else {
-        client
-            .partial_bandwidth_credential(&attributes.tx_hash().to_string())
-            .await?
-    };
+    let blind_sign_request_body = BlindSignRequestBody::new(
+        blind_sign_request,
+        attributes.tx_hash().to_string(),
+        attributes.sign(blind_sign_request).to_base58_string(),
+        &public_attributes,
+        public_attributes_plain,
+        (public_attributes.len() + private_attributes.len()) as u32,
+    );
+    let response = client.blind_sign(&blind_sign_request_body).await?;
     let encrypted_signature = response.encrypted_signature;
     let remote_key = PublicKey::from_bytes(&response.remote_key)?;
 
@@ -109,6 +103,8 @@ pub async fn obtain_aggregate_signature(
         .iter()
         .map(|api_client| api_client.node_id)
         .collect();
+    let verification_key =
+        aggregate_verification_keys(&validators_partial_vks, Some(indices.as_ref()))?;
 
     for coconut_api_client in coconut_api_clients.iter() {
         if let Ok(signature) = obtain_partial_credential(
@@ -131,15 +127,8 @@ pub async fn obtain_aggregate_signature(
     attributes.extend_from_slice(&private_attributes);
     attributes.extend_from_slice(&public_attributes);
 
-    let verification_key =
-        aggregate_verification_keys(&validators_partial_vks, Some(indices.as_ref()))?;
-
-    Ok(aggregate_signature_shares(
-        params,
-        &verification_key,
-        &attributes,
-        &shares,
-    )?)
+    aggregate_signature_shares(params, &verification_key, &attributes, &shares)
+        .map_err(|e| Error::SignatureAggregationError(e))
 }
 
 // TODO: better type flow

--- a/common/credentials/src/error.rs
+++ b/common/credentials/src/error.rs
@@ -9,6 +9,9 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("IO error")]
+    IOError(#[from] std::io::Error),
+
     #[error("The detailed description is yet to be determined")]
     BandwidthCredentialError,
 

--- a/common/credentials/src/error.rs
+++ b/common/credentials/src/error.rs
@@ -30,6 +30,12 @@ pub enum Error {
     #[error("Could not parse the key - {0}")]
     ParsePublicKey(#[from] KeyRecoveryError),
 
-    #[error("Could not gather enough signature shares")]
+    #[error("Could not gather enough signature shares. Try again using the recovery command")]
     NotEnoughShares,
+
+    #[error("Could not aggregate signature shares - {0}. Try again using the recovery command")]
+    SignatureAggregationError(CoconutError),
+
+    #[error("Could not deserialize bandwidth voucher - {0}")]
+    BandwidthVoucherDeserializationError(String),
 }

--- a/common/nymcoconut/Cargo.toml
+++ b/common/nymcoconut/Cargo.toml
@@ -33,9 +33,6 @@ criterion = { version="0.3", features=["html_reports"] }
 doc-comment = "0.3"
 rand_chacha = "0.3"
 
-[dev-dependencies.bincode]
-version = "1"
-
 [[bench]]
 name = "benchmarks"
 harness = false

--- a/nym-api/src/coconut/error.rs
+++ b/nym-api/src/coconut/error.rs
@@ -70,9 +70,6 @@ pub enum CoconutError {
     )]
     DifferentPublicAttributes(String, String),
 
-    #[error("No signature found")]
-    NoSignature,
-
     #[error("Error in coconut interface - {0}")]
     CoconutInterfaceError(#[from] coconut_interface::error::CoconutInterfaceError),
 

--- a/nym-api/src/coconut/mod.rs
+++ b/nym-api/src/coconut/mod.rs
@@ -182,11 +182,7 @@ impl InternalSignRequest {
             rocket.manage(state).mount(
                 // this format! is so ugly...
                 format!("/{}/{}/{}", NYM_API_VERSION, COCONUT_ROUTES, BANDWIDTH),
-                routes![
-                    post_blind_sign,
-                    post_partial_bandwidth_credential,
-                    verify_bandwidth_credential
-                ],
+                routes![post_blind_sign, verify_bandwidth_credential],
             )
         })
     }
@@ -240,18 +236,6 @@ pub async fn post_blind_sign(
         .await?;
 
     Ok(Json(response))
-}
-
-#[post("/partial-bandwidth-credential", data = "<tx_hash>")]
-pub async fn post_partial_bandwidth_credential(
-    tx_hash: Json<String>,
-    state: &RocketState<State>,
-) -> Result<Json<BlindedSignatureResponse>> {
-    let v = state
-        .signed_before(&tx_hash)
-        .await?
-        .ok_or(CoconutError::NoSignature)?;
-    Ok(Json(v))
 }
 
 #[post("/verify-bandwidth-credential", data = "<verify_credential_body>")]


### PR DESCRIPTION
# Description

Closes: #2991 

List of improvements for the `credential` client that does the acquirement of bandwidth credentials:
- a deposit is only attempted when DKG is in `InProgress` stage
- a sleep is triggered attempting to wait until `InProgress` is reached; the process can be safely killed during this sleep
- deposits are softly disallowed by the client (not enforced in the smart contracts) in the last minute of `InProgress`, to prevent inconsistencies
- a recovery mode is introduced, that allows the run of the credential in two ways:
  - deposit and get a credential; if failure appears (e.g. less then `threshold` `nym-api`s are running) , dump recovery data to disk
  - try and recover as much as possible from previous deposits that resulted in failures