### PR TITLE
2023-01-13-OAK-11

### DIFF
--- a/common/client-libs/validator-client/src/nyxd/traits/mixnet_query_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/traits/mixnet_query_client.rs
@@ -18,13 +18,13 @@ use mixnet_contract_common::rewarding::{
 };
 use mixnet_contract_common::{
     delegation, ContractBuildInformation, ContractState, ContractStateParams,
-    CurrentIntervalResponse, EpochEventId, GatewayBondResponse, GatewayOwnershipResponse,
-    IdentityKey, IntervalEventId, LayerDistribution, MixId, MixOwnershipResponse,
-    MixnodeDetailsResponse, NumberOfPendingEventsResponse, PagedAllDelegationsResponse,
-    PagedDelegatorDelegationsResponse, PagedFamiliesResponse, PagedGatewayResponse,
-    PagedMembersResponse, PagedMixNodeDelegationsResponse, PagedMixnodeBondsResponse,
-    PagedRewardedSetResponse, PendingEpochEventsResponse, PendingIntervalEventsResponse,
-    QueryMsg as MixnetQueryMsg,
+    CurrentIntervalResponse, EpochEventId, EpochStatus, GatewayBondResponse,
+    GatewayOwnershipResponse, IdentityKey, IntervalEventId, LayerDistribution, MixId,
+    MixOwnershipResponse, MixnodeDetailsResponse, NumberOfPendingEventsResponse,
+    PagedAllDelegationsResponse, PagedDelegatorDelegationsResponse, PagedFamiliesResponse,
+    PagedGatewayResponse, PagedMembersResponse, PagedMixNodeDelegationsResponse,
+    PagedMixnodeBondsResponse, PagedRewardedSetResponse, PendingEpochEventsResponse,
+    PendingIntervalEventsResponse, QueryMsg as MixnetQueryMsg,
 };
 use serde::Deserialize;
 
@@ -58,6 +58,11 @@ pub trait MixnetQueryClient {
 
     async fn get_rewarding_parameters(&self) -> Result<RewardingParams, NyxdError> {
         self.query_mixnet_contract(MixnetQueryMsg::GetRewardingParams {})
+            .await
+    }
+
+    async fn get_current_epoch_status(&self) -> Result<EpochStatus, NyxdError> {
+        self.query_mixnet_contract(MixnetQueryMsg::GetEpochStatus {})
             .await
     }
 

--- a/common/client-libs/validator-client/src/nyxd/traits/mixnet_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/traits/mixnet_signing_client.rs
@@ -106,6 +106,11 @@ pub trait MixnetSigningClient {
         .await
     }
 
+    async fn begin_epoch_transition(&self, fee: Option<Fee>) -> Result<ExecuteResult, NyxdError> {
+        self.execute_mixnet_contract(fee, MixnetExecuteMsg::BeginEpochTransition {}, vec![])
+            .await
+    }
+
     async fn advance_current_epoch(
         &self,
         new_rewarded_set: Vec<LayerAssignment>,

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/error.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{IdentityKey, MixId};
+use crate::{EpochState, IdentityKey, MixId};
 use cosmwasm_std::{Addr, Coin, Decimal};
 use thiserror::Error;
 
@@ -188,6 +188,30 @@ pub enum MixnetContractError {
 
     #[error("epoch duration must be > 0")]
     EpochDurationZero,
+
+    #[error("this validator ({current_validator}) is not the one responsible for advancing this epoch. It's responsibility of {chosen_validator}.")]
+    RewardingValidatorMismatch {
+        current_validator: Addr,
+        chosen_validator: Addr,
+    },
+
+    #[error("the epoch is currently in the process of being advanced. (the state is {current_state}) Please try sending your transaction again once this has finished")]
+    EpochAdvancementInProgress { current_state: EpochState },
+
+    #[error("the epoch is in an unexpected state. expected 'mix rewarding' state, but we're in {current_state} instead.")]
+    UnexpectedNonRewardingEpochState { current_state: EpochState },
+
+    #[error("attempted to reward mixnode out of order. Attempted to reward {attempted_to_reward} while last rewarded was {last_rewarded}.")]
+    RewardingOutOfOrder {
+        last_rewarded: MixId,
+        attempted_to_reward: MixId,
+    },
+
+    #[error("the epoch is currently not in the 'event reconciliation' state. (the state is {current_state})")]
+    EpochNotInEventReconciliationState { current_state: EpochState },
+
+    #[error("the epoch is currently not in the 'epoch advancement' state. (the state is {current_state})")]
+    EpochNotInAdvancementState { current_state: EpochState },
 
     #[error("failed to parse {value} into a valid SemVer version: {error_message}")]
     SemVerFailure {

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/events.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/events.rs
@@ -35,6 +35,7 @@ pub enum MixnetEventType {
     Undelegation,
     ContractSettingsUpdate,
     RewardingValidatorUpdate,
+    BeginEpochTransition,
     AdvanceEpoch,
     ExecutePendingEpochEvents,
     ExecutePendingIntervalEvents,
@@ -77,6 +78,7 @@ impl ToString for MixnetEventType {
             MixnetEventType::Undelegation => "undelegation",
             MixnetEventType::ContractSettingsUpdate => "settings_update",
             MixnetEventType::RewardingValidatorUpdate => "rewarding_validator_address_update",
+            MixnetEventType::BeginEpochTransition => "beginning_epoch_transition",
             MixnetEventType::AdvanceEpoch => "advance_epoch",
             MixnetEventType::ExecutePendingEpochEvents => "execute_pending_epoch_events",
             MixnetEventType::ExecutePendingIntervalEvents => "execute_pending_interval_events",
@@ -139,6 +141,7 @@ pub const ZERO_PERFORMANCE_VALUE: &str = "zero_performance";
 // rewarded set update
 pub const ACTIVE_SET_SIZE_KEY: &str = "active_set_size";
 
+pub const CURRENT_EPOCH_KEY: &str = "current_epoch";
 pub const NEW_CURRENT_EPOCH_KEY: &str = "new_current_epoch";
 
 // interval
@@ -498,6 +501,13 @@ pub fn new_mix_rewarding_event(
             DELEGATES_REWARD_KEY,
             reward_distribution.delegates.to_string(),
         )
+}
+
+pub fn new_epoch_transition_start_event(current_interval: Interval) -> Event {
+    Event::new(MixnetEventType::BeginEpochTransition).add_attribute(
+        CURRENT_EPOCH_KEY,
+        current_interval.current_epoch_absolute_id().to_string(),
+    )
 }
 
 pub fn new_advance_epoch_event(interval: Interval, rewarded_nodes: u32) -> Event {

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
@@ -61,7 +61,7 @@ pub(crate) mod string_rfc3339_offset_date_time {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct EpochStatus {
     // TODO: introduce mechanism to allow another validator to take over if no progress has been made in X blocks / Y seconds
     /// Specifies either, which validator is currently performing progression into the following epoch (if the epoch is currently being progressed),
@@ -87,7 +87,7 @@ impl EpochStatus {
                 ref mut last_rewarded,
                 final_node_id,
             } => {
-                if new_last_rewarded < *last_rewarded {
+                if new_last_rewarded <= *last_rewarded {
                     return Err(MixnetContractError::RewardingOutOfOrder {
                         last_rewarded: *last_rewarded,
                         attempted_to_reward: new_last_rewarded,

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
@@ -133,6 +133,18 @@ impl EpochStatus {
     pub fn is_in_progress(&self) -> bool {
         matches!(self.state, EpochState::InProgress)
     }
+
+    pub fn is_rewarding(&self) -> bool {
+        matches!(self.state, EpochState::Rewarding { .. })
+    }
+
+    pub fn is_reconciling(&self) -> bool {
+        matches!(self.state, EpochState::ReconcilingEvents)
+    }
+
+    pub fn is_advancing(&self) -> bool {
+        matches!(self.state, EpochState::AdvancingEpoch)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
@@ -129,6 +129,10 @@ impl EpochStatus {
         }
         Ok(())
     }
+
+    pub fn is_in_progress(&self) -> bool {
+        matches!(self.state, EpochState::InProgress)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/interval.rs
@@ -1,9 +1,10 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::error::MixnetContractError;
 use crate::pending_events::{PendingEpochEvent, PendingIntervalEvent};
-use crate::{EpochId, IntervalId};
-use cosmwasm_std::Env;
+use crate::{EpochId, IntervalId, MixId};
+use cosmwasm_std::{Addr, Env};
 use schemars::gen::SchemaGenerator;
 use schemars::schema::{InstanceType, Schema, SchemaObject};
 use schemars::JsonSchema;
@@ -57,6 +58,117 @@ pub(crate) mod string_rfc3339_offset_date_time {
             .format(&Rfc3339)
             .map_err(S::Error::custom)?
             .serialize(serializer)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EpochStatus {
+    // TODO: introduce mechanism to allow another validator to take over if no progress has been made in X blocks / Y seconds
+    /// Specifies either, which validator is currently performing progression into the following epoch (if the epoch is currently being progressed),
+    /// or which validator was responsible for progressing into the current epoch (if the epoch is currently in progress)
+    pub being_advanced_by: Addr,
+    pub state: EpochState,
+}
+
+impl EpochStatus {
+    pub fn new(being_advanced_by: Addr) -> Self {
+        EpochStatus {
+            being_advanced_by,
+            state: EpochState::InProgress,
+        }
+    }
+
+    pub fn update_last_rewarded(
+        &mut self,
+        new_last_rewarded: MixId,
+    ) -> Result<bool, MixnetContractError> {
+        match &mut self.state {
+            EpochState::Rewarding {
+                ref mut last_rewarded,
+                final_node_id,
+            } => {
+                if new_last_rewarded < *last_rewarded {
+                    return Err(MixnetContractError::RewardingOutOfOrder {
+                        last_rewarded: *last_rewarded,
+                        attempted_to_reward: new_last_rewarded,
+                    });
+                }
+
+                *last_rewarded = new_last_rewarded;
+                Ok(new_last_rewarded == *final_node_id)
+            }
+            state => Err(MixnetContractError::UnexpectedNonRewardingEpochState {
+                current_state: *state,
+            }),
+        }
+    }
+
+    pub fn last_rewarded(&self) -> Result<MixId, MixnetContractError> {
+        match self.state {
+            EpochState::Rewarding { last_rewarded, .. } => Ok(last_rewarded),
+            state => Err(MixnetContractError::UnexpectedNonRewardingEpochState {
+                current_state: state,
+            }),
+        }
+    }
+
+    pub fn ensure_is_in_event_reconciliation_state(&self) -> Result<(), MixnetContractError> {
+        if !matches!(self.state, EpochState::ReconcilingEvents) {
+            return Err(MixnetContractError::EpochNotInEventReconciliationState {
+                current_state: self.state,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn ensure_is_in_advancement_state(&self) -> Result<(), MixnetContractError> {
+        if !matches!(self.state, EpochState::AdvancingEpoch) {
+            return Err(MixnetContractError::EpochNotInAdvancementState {
+                current_state: self.state,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
+pub enum EpochState {
+    /// Represents the state of an epoch that's in progress (well, duh.)
+    /// All actions are allowed to be issued.
+    InProgress,
+
+    /// Represents the state of an epoch when the rewarding entity has been decided on,
+    /// and the mixnodes are in the process of being rewarded for their work in this epoch.
+    Rewarding {
+        last_rewarded: MixId,
+
+        final_node_id: MixId,
+        // total_rewarded: u32,
+    },
+
+    /// Represents the state of an epoch when all mixnodes have already been rewarded for their work in this epoch
+    /// and all issued actions should now get resolved before being allowed to advance into the next epoch.
+    ReconcilingEvents,
+
+    /// Represents the state of an epoch when all mixnodes have already been rewarded for their work in this epoch,
+    /// all issued actions got resolved and the epoch should now be advanced whilst assigning new rewarded set.
+    AdvancingEpoch,
+}
+
+impl Display for EpochState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EpochState::InProgress => write!(f, "in progress"),
+            EpochState::Rewarding {
+                last_rewarded,
+                final_node_id,
+            } => write!(
+                f,
+                "mix rewarding (last rewarded: {last_rewarded}, final node: {final_node_id})"
+            ),
+            EpochState::ReconcilingEvents => write!(f, "event reconciliation"),
+            EpochState::AdvancingEpoch => write!(f, "advancing epoch"),
+        }
     }
 }
 

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/lib.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
+// Copyright 2021-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
 #![warn(clippy::expect_used)]
@@ -29,8 +29,8 @@ pub use gateway::{
     Gateway, GatewayBond, GatewayBondResponse, GatewayOwnershipResponse, PagedGatewayResponse,
 };
 pub use interval::{
-    CurrentIntervalResponse, Interval, NumberOfPendingEventsResponse, PendingEpochEventsResponse,
-    PendingIntervalEventsResponse,
+    CurrentIntervalResponse, EpochState, EpochStatus, Interval, NumberOfPendingEventsResponse,
+    PendingEpochEventsResponse, PendingIntervalEventsResponse,
 };
 pub use mixnode::{
     Layer, MixNode, MixNodeBond, MixNodeConfigUpdate, MixNodeCostParams, MixNodeDetails,

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
@@ -375,6 +375,7 @@ pub enum QueryMsg {
     GetStateParams {},
     GetState {},
     GetRewardingParams {},
+    GetEpochStatus {},
     GetCurrentIntervalDetails {},
     GetRewardedSet {
         limit: Option<u32>,

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
@@ -139,6 +139,7 @@ pub enum ExecuteMsg {
         epoch_duration_secs: u64,
         force_immediately: bool,
     },
+    BeginEpochTransition,
     AdvanceCurrentEpoch {
         new_rewarded_set: Vec<LayerAssignment>,
         // families_in_layer: HashMap<String, Layer>,
@@ -282,6 +283,7 @@ impl ExecuteMsg {
             ExecuteMsg::UpdateIntervalConfig {
                 force_immediately, ..
             } => format!("updating mixnet interval configuration. forced: {force_immediately}"),
+            ExecuteMsg::BeginEpochTransition => "beginning epoch transition".into(),
             ExecuteMsg::AdvanceCurrentEpoch { .. } => "advancing current epoch".into(),
             ExecuteMsg::ReconcileEpochEvents { .. } => "reconciling epoch events".into(),
             ExecuteMsg::BondMixnode { mix_node, .. } => {

--- a/contracts/mixnet/src/constants.rs
+++ b/contracts/mixnet/src/constants.rs
@@ -47,6 +47,7 @@ pub(crate) const GATEWAYS_PK_NAMESPACE: &str = "gt";
 pub(crate) const GATEWAYS_OWNER_IDX_NAMESPACE: &str = "gto";
 
 pub(crate) const REWARDED_SET_KEY: &str = "rs";
+pub(crate) const CURRENT_EPOCH_STATUS_KEY: &str = "ces";
 pub(crate) const CURRENT_INTERVAL_KEY: &str = "ci";
 pub(crate) const EPOCH_EVENT_ID_COUNTER_KEY: &str = "eic";
 pub(crate) const INTERVAL_EVENT_ID_COUNTER_KEY: &str = "iic";

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -408,6 +408,9 @@ pub fn query(
         QueryMsg::GetRewardingParams {} => {
             to_binary(&crate::rewards::queries::query_rewarding_params(deps)?)
         }
+        QueryMsg::GetEpochStatus {} => {
+            to_binary(&crate::interval::queries::query_epoch_status(deps)?)
+        }
         QueryMsg::GetCurrentIntervalDetails {} => to_binary(
             &crate::interval::queries::query_current_interval_details(deps, env)?,
         ),

--- a/contracts/mixnet/src/delegations/helpers.rs
+++ b/contracts/mixnet/src/delegations/helpers.rs
@@ -38,10 +38,10 @@ mod tests {
         test.add_immediate_delegation(delegator, og_amount, mix_id);
 
         test.skip_to_next_epoch_end();
-        test.update_rewarded_set(vec![mix_id]);
-        let dist1 = test.reward_with_distribution(mix_id, performance(100.0));
+        test.force_change_rewarded_set(vec![mix_id]);
+        let dist1 = test.reward_with_distribution_with_state_bypass(mix_id, performance(100.0));
         test.skip_to_next_epoch_end();
-        let dist2 = test.reward_with_distribution(mix_id, performance(100.0));
+        let dist2 = test.reward_with_distribution_with_state_bypass(mix_id, performance(100.0));
 
         let mix_rewarding = test.mix_rewarding(mix_id);
         let delegation = test.delegation(mix_id, delegator, &None);

--- a/contracts/mixnet/src/interval/pending_events.rs
+++ b/contracts/mixnet/src/interval/pending_events.rs
@@ -603,19 +603,31 @@ mod tests {
             let delegation_coin_new = coin(delegation_new, TEST_COIN_DENOM);
 
             // perform some rewarding here to advance the unit delegation beyond the initial value
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let owner = "delegator";
             test.add_immediate_delegation(owner, delegation_og, mix_id);
 
             test.skip_to_next_epoch_end();
-            let dist1 = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            let dist1 = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             test.skip_to_next_epoch_end();
-            let dist2 = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            let dist2 = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let storage_key =
                 Delegation::generate_storage_key(mix_id, &Addr::unchecked(owner), None);
@@ -674,11 +686,17 @@ mod tests {
             let delegation_coin = coin(120_000_000u128, TEST_COIN_DENOM);
 
             // perform some rewarding here to advance the unit delegation beyond the initial value
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let storage_key =
                 Delegation::generate_storage_key(mix_id, &Addr::unchecked(owner), None);
@@ -863,18 +881,30 @@ mod tests {
             let delegation = 120_000_000u128;
 
             // perform some rewarding here to advance the unit delegation beyond the initial value
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             test.add_immediate_delegation(owner, delegation, mix_id);
 
             test.skip_to_next_epoch_end();
-            let dist1 = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            let dist1 = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             test.skip_to_next_epoch_end();
-            let dist2 = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            let dist2 = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let expected_reward = dist1.delegates + dist2.delegates;
             let truncated_reward = truncate_reward_amount(expected_reward);
@@ -1032,11 +1062,17 @@ mod tests {
                 .unwrap();
             let layer = mix_details.layer;
 
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
             test.skip_to_next_epoch_end();
-            let dist1 = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            let dist1 = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             test.skip_to_next_epoch_end();
-            let dist2 = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            let dist2 = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let expected_reward = dist1.operator + dist2.operator;
             let truncated_reward = truncate_reward_amount(expected_reward);
@@ -1217,12 +1253,16 @@ mod tests {
             test.add_immediate_delegation("carol", 111_111_111u128, mix_id_full_pledge);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id_repledge, mix_id_full_pledge]);
+            test.force_change_rewarded_set(vec![mix_id_repledge, mix_id_full_pledge]);
 
-            let dist1 =
-                test.reward_with_distribution(mix_id_repledge, test_helpers::performance(100.0));
-            let dist2 =
-                test.reward_with_distribution(mix_id_full_pledge, test_helpers::performance(100.0));
+            let dist1 = test.reward_with_distribution_with_state_bypass(
+                mix_id_repledge,
+                test_helpers::performance(100.0),
+            );
+            let dist2 = test.reward_with_distribution_with_state_bypass(
+                mix_id_full_pledge,
+                test_helpers::performance(100.0),
+            );
 
             assert_eq!(dist1, dist2)
         }
@@ -1240,10 +1280,12 @@ mod tests {
             test.add_immediate_delegation("carol", 111_111_111_000u128, mix_id_repledge);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id_repledge]);
+            test.force_change_rewarded_set(vec![mix_id_repledge]);
 
-            let dist =
-                test.reward_with_distribution(mix_id_repledge, test_helpers::performance(100.0));
+            let dist = test.reward_with_distribution_with_state_bypass(
+                mix_id_repledge,
+                test_helpers::performance(100.0),
+            );
 
             let increase = test.coin(pledge2.u128());
             increase_pledge(test.deps_mut(), 123, mix_id_repledge, increase).unwrap();
@@ -1279,15 +1321,19 @@ mod tests {
             );
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id_repledge, mix_id_full_pledge]);
+            test.force_change_rewarded_set(vec![mix_id_repledge, mix_id_full_pledge]);
 
             // go through few epochs of rewarding
             for _ in 0..500 {
                 test.skip_to_next_epoch_end();
-                let dist1 = test
-                    .reward_with_distribution(mix_id_repledge, test_helpers::performance(100.0));
-                let dist2 = test
-                    .reward_with_distribution(mix_id_full_pledge, test_helpers::performance(100.0));
+                let dist1 = test.reward_with_distribution_with_state_bypass(
+                    mix_id_repledge,
+                    test_helpers::performance(100.0),
+                );
+                let dist2 = test.reward_with_distribution_with_state_bypass(
+                    mix_id_full_pledge,
+                    test_helpers::performance(100.0),
+                );
 
                 assert_eq!(dist1, dist2)
             }
@@ -1306,7 +1352,7 @@ mod tests {
             test.add_immediate_delegation("carol", 111_111_111_000u128, mix_id_repledge);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id_repledge]);
+            test.force_change_rewarded_set(vec![mix_id_repledge]);
 
             let mut cumulative_op_reward = Decimal::zero();
             let mut cumulative_del_reward = Decimal::zero();
@@ -1314,8 +1360,10 @@ mod tests {
             // go few epochs of rewarding before adding more pledge
             for _ in 0..500 {
                 test.skip_to_next_epoch_end();
-                let dist = test
-                    .reward_with_distribution(mix_id_repledge, test_helpers::performance(100.0));
+                let dist = test.reward_with_distribution_with_state_bypass(
+                    mix_id_repledge,
+                    test_helpers::performance(100.0),
+                );
                 cumulative_op_reward += dist.operator;
                 cumulative_del_reward += dist.delegates;
             }
@@ -1355,15 +1403,19 @@ mod tests {
             );
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id_repledge, mix_id_full_pledge]);
+            test.force_change_rewarded_set(vec![mix_id_repledge, mix_id_full_pledge]);
 
             // go through few more epochs of rewarding
             for _ in 0..500 {
                 test.skip_to_next_epoch_end();
-                let dist1 = test
-                    .reward_with_distribution(mix_id_repledge, test_helpers::performance(100.0));
-                let dist2 = test
-                    .reward_with_distribution(mix_id_full_pledge, test_helpers::performance(100.0));
+                let dist1 = test.reward_with_distribution_with_state_bypass(
+                    mix_id_repledge,
+                    test_helpers::performance(100.0),
+                );
+                let dist2 = test.reward_with_distribution_with_state_bypass(
+                    mix_id_full_pledge,
+                    test_helpers::performance(100.0),
+                );
 
                 assert_eq!(dist1, dist2)
             }

--- a/contracts/mixnet/src/interval/queries.rs
+++ b/contracts/mixnet/src/interval/queries.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
+// Copyright 2022-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::constants::{
@@ -207,7 +207,7 @@ mod tests {
 
         fn set_rewarded_set_to_n_nodes(test: &mut TestSetup, n: usize) {
             let set = (1u32..).take(n).collect::<Vec<_>>();
-            test.update_rewarded_set(set)
+            test.force_change_rewarded_set(set)
         }
 
         #[test]

--- a/contracts/mixnet/src/interval/queries.rs
+++ b/contracts/mixnet/src/interval/queries.rs
@@ -12,9 +12,14 @@ use cw_storage_plus::Bound;
 use mixnet_contract_common::error::MixnetContractError;
 use mixnet_contract_common::pending_events::{PendingEpochEvent, PendingIntervalEvent};
 use mixnet_contract_common::{
-    CurrentIntervalResponse, EpochEventId, IntervalEventId, MixId, NumberOfPendingEventsResponse,
-    PagedRewardedSetResponse, PendingEpochEventsResponse, PendingIntervalEventsResponse,
+    CurrentIntervalResponse, EpochEventId, EpochStatus, IntervalEventId, MixId,
+    NumberOfPendingEventsResponse, PagedRewardedSetResponse, PendingEpochEventsResponse,
+    PendingIntervalEventsResponse,
 };
+
+pub fn query_epoch_status(deps: Deps<'_>) -> StdResult<EpochStatus> {
+    storage::current_epoch_status(deps.storage)
+}
 
 pub fn query_current_interval_details(
     deps: Deps<'_>,

--- a/contracts/mixnet/src/interval/storage.rs
+++ b/contracts/mixnet/src/interval/storage.rs
@@ -1,21 +1,23 @@
-// Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
+// Copyright 2022-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::constants::{
-    CURRENT_INTERVAL_KEY, EPOCH_EVENT_ID_COUNTER_KEY, INTERVAL_EVENT_ID_COUNTER_KEY,
-    LAST_EPOCH_EVENT_ID_KEY, LAST_INTERVAL_EVENT_ID_KEY, PENDING_EPOCH_EVENTS_NAMESPACE,
-    PENDING_INTERVAL_EVENTS_NAMESPACE, REWARDED_SET_KEY,
+    CURRENT_EPOCH_STATUS_KEY, CURRENT_INTERVAL_KEY, EPOCH_EVENT_ID_COUNTER_KEY,
+    INTERVAL_EVENT_ID_COUNTER_KEY, LAST_EPOCH_EVENT_ID_KEY, LAST_INTERVAL_EVENT_ID_KEY,
+    PENDING_EPOCH_EVENTS_NAMESPACE, PENDING_INTERVAL_EVENTS_NAMESPACE, REWARDED_SET_KEY,
 };
-use cosmwasm_std::{Env, Order, StdResult, Storage};
+use cosmwasm_std::{Addr, Env, Order, StdResult, Storage};
 use cw_storage_plus::{Item, Map};
 use mixnet_contract_common::pending_events::{
     PendingEpochEventData, PendingEpochEventKind, PendingIntervalEventData,
 };
 use mixnet_contract_common::{
-    EpochEventId, Interval, IntervalEventId, MixId, PendingIntervalEventKind, RewardedSetNodeStatus,
+    EpochEventId, EpochStatus, Interval, IntervalEventId, MixId, PendingIntervalEventKind,
+    RewardedSetNodeStatus,
 };
 use std::collections::HashMap;
 
+pub(crate) const CURRENT_EPOCH_STATUS: Item<'_, EpochStatus> = Item::new(CURRENT_EPOCH_STATUS_KEY);
 pub(crate) const CURRENT_INTERVAL: Item<'_, Interval> = Item::new(CURRENT_INTERVAL_KEY);
 pub(crate) const REWARDED_SET: Map<MixId, RewardedSetNodeStatus> = Map::new(REWARDED_SET_KEY);
 
@@ -38,6 +40,17 @@ pub(crate) const PENDING_EPOCH_EVENTS: Map<EpochEventId, PendingEpochEventData> 
 /// Contains operations that should get resolved at the end of the current interval.
 pub(crate) const PENDING_INTERVAL_EVENTS: Map<IntervalEventId, PendingIntervalEventData> =
     Map::new(PENDING_INTERVAL_EVENTS_NAMESPACE);
+
+pub(crate) fn current_epoch_status(storage: &dyn Storage) -> StdResult<EpochStatus> {
+    CURRENT_EPOCH_STATUS.load(storage)
+}
+
+pub(crate) fn save_current_epoch_status(
+    storage: &mut dyn Storage,
+    status: &EpochStatus,
+) -> StdResult<()> {
+    CURRENT_EPOCH_STATUS.save(storage, status)
+}
 
 pub(crate) fn current_interval(storage: &dyn Storage) -> StdResult<Interval> {
     CURRENT_INTERVAL.load(storage)
@@ -69,6 +82,12 @@ pub(crate) fn push_new_epoch_event(
     env: &Env,
     event: PendingEpochEventKind,
 ) -> StdResult<()> {
+    // not included in non-test code as it messes with our return types as we expected `StdResult`
+    // from all storage-related operations.
+    // However, the callers MUST HAVE ensured the below invariant
+    #[cfg(test)]
+    crate::support::helpers::ensure_epoch_in_progress_state(storage).unwrap();
+
     let event_id = next_epoch_event_id_counter(storage)?;
     let event_data = event.attach_source_height(env.block.height);
     PENDING_EPOCH_EVENTS.save(storage, event_id, &event_data)
@@ -79,6 +98,12 @@ pub(crate) fn push_new_interval_event(
     env: &Env,
     event: PendingIntervalEventKind,
 ) -> StdResult<()> {
+    // not included in non-test code as it messes with our return types as we expected `StdResult`
+    // from all storage-related operations.
+    // However, the callers MUST HAVE ensured the below invariant
+    #[cfg(test)]
+    crate::support::helpers::ensure_epoch_in_progress_state(storage).unwrap();
+
     let event_id = next_interval_event_id_counter(storage)?;
     let event_data = event.attach_source_height(env.block.height);
     PENDING_INTERVAL_EVENTS.save(storage, event_id, &event_data)
@@ -130,12 +155,14 @@ pub(crate) fn update_rewarded_set(
 pub(crate) fn initialise_storage(
     storage: &mut dyn Storage,
     starting_interval: Interval,
+    rewarding_validator: Addr,
 ) -> StdResult<()> {
     save_interval(storage, &starting_interval)?;
     LAST_PROCESSED_EPOCH_EVENT.save(storage, &0)?;
     LAST_PROCESSED_INTERVAL_EVENT.save(storage, &0)?;
     EPOCH_EVENT_ID_COUNTER.save(storage, &0)?;
-    INTERVAL_EVENT_ID_COUNTER.save(storage, &0)
+    INTERVAL_EVENT_ID_COUNTER.save(storage, &0)?;
+    CURRENT_EPOCH_STATUS.save(storage, &EpochStatus::new(rewarding_validator))
 }
 
 #[cfg(test)]

--- a/contracts/mixnet/src/interval/transactions.rs
+++ b/contracts/mixnet/src/interval/transactions.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
+// Copyright 2022-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
 use super::storage;
@@ -14,9 +14,9 @@ use crate::support::helpers::{
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Order, Response, Storage};
 use mixnet_contract_common::error::MixnetContractError;
 use mixnet_contract_common::events::{
-    new_advance_epoch_event, new_pending_epoch_events_execution_event,
-    new_pending_interval_config_update_event, new_pending_interval_events_execution_event,
-    new_reconcile_pending_events,
+    new_advance_epoch_event, new_epoch_transition_start_event,
+    new_pending_epoch_events_execution_event, new_pending_interval_config_update_event,
+    new_pending_interval_events_execution_event, new_reconcile_pending_events,
 };
 use mixnet_contract_common::pending_events::PendingIntervalEventKind;
 use mixnet_contract_common::{EpochState, EpochStatus, LayerAssignment, MixId};
@@ -163,7 +163,18 @@ pub fn try_reconcile_epoch_events(
 
     // if there are no more events to clear, go into the next state
     let pending_events = super::queries::query_number_of_pending_events(deps.as_ref())?;
-    if pending_events.epoch_events == 0 && pending_events.interval_events == 0 {
+    // we can only progress if there are no epoch events AND if the interval has finished, that there are no interval events
+    let progress = if pending_events.epoch_events == 0 {
+        if interval.is_current_interval_over(&env) {
+            pending_events.interval_events == 0
+        } else {
+            true
+        }
+    } else {
+        false
+    };
+
+    if progress {
         current_epoch_status.state = EpochState::AdvancingEpoch;
         storage::save_current_epoch_status(deps.storage, &current_epoch_status)?;
     }
@@ -238,23 +249,29 @@ pub fn try_begin_epoch_transition(
         .range(deps.storage, None, None, Order::Ascending)
         .map(|kv| kv.map(|kv| kv.0))
         .collect::<Result<Vec<_>, _>>()?;
-    let last = rewarded_set.last().copied().unwrap_or_default();
+
+    // if there are no nodes to reward (i.e. empty rewarded set), we go straight into event reconciliation
+    let new_epoch_state = if let Some(last) = rewarded_set.last() {
+        EpochState::Rewarding {
+            last_rewarded: 0,
+            final_node_id: *last,
+        }
+    } else {
+        EpochState::ReconcilingEvents
+    };
 
     // progress into the first stage of epoch progression
     let new_epoch_status = EpochStatus {
         being_advanced_by: info.sender,
-        state: EpochState::Rewarding {
-            last_rewarded: 0,
-            final_node_id: last,
-        },
+        state: new_epoch_state,
     };
 
     storage::save_current_epoch_status(deps.storage, &new_epoch_status)?;
-    Ok(Response::new())
+    Ok(Response::new().add_event(new_epoch_transition_start_event(current_interval)))
 }
 
 pub fn try_advance_epoch(
-    mut deps: DepsMut<'_>,
+    deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
     layer_assignments: Vec<LayerAssignment>,
@@ -263,8 +280,6 @@ pub fn try_advance_epoch(
     // Only rewarding validator can attempt to advance epoch
     let mut current_epoch_status = ensure_can_advance_epoch(&info.sender, deps.storage)?;
     current_epoch_status.ensure_is_in_advancement_state()?;
-
-    let mut response = Response::new();
 
     // we must make sure that we roll into new epoch / interval with up to date state
     // with no pending actions (like somebody wanting to update their profit margin)
@@ -277,32 +292,8 @@ pub fn try_advance_epoch(
         });
     }
 
-    // NO PENDING EVENTS!!
-    assert!(true);
-
-    // } else {
-    //     let (mut sub_response, executed) =
-    //         perform_pending_epoch_actions(deps.branch(), &env, None)?;
-    //     response.messages.append(&mut sub_response.messages);
-    //     response.attributes.append(&mut sub_response.attributes);
-    //     response.events.append(&mut sub_response.events);
-    //     response
-    //         .events
-    //         .push(new_pending_epoch_events_execution_event(executed));
-    // }
-
-    // first clear epoch events queue and then touch the interval actions
+    // if the current interval is over, apply reward pool changes
     if current_interval.is_current_interval_over(&env) {
-        // // the interval has finished -> we can change things such as the profit margin
-        // let (mut sub_response, executed) =
-        //     perform_pending_interval_actions(deps.branch(), &env, None)?;
-        // response.messages.append(&mut sub_response.messages);
-        // response.attributes.append(&mut sub_response.attributes);
-        // response.events.append(&mut sub_response.events);
-        // response
-        //     .events
-        //     .push(new_pending_interval_events_execution_event(executed));
-
         // this one is a very important one!
         rewards::helpers::apply_reward_pool_changes(deps.storage)?;
     }
@@ -323,7 +314,7 @@ pub fn try_advance_epoch(
     current_epoch_status.state = EpochState::InProgress;
     storage::save_current_epoch_status(deps.storage, &current_epoch_status)?;
 
-    Ok(response.add_event(new_advance_epoch_event(updated_interval, num_nodes as u32)))
+    Ok(Response::new().add_event(new_advance_epoch_event(updated_interval, num_nodes as u32)))
 }
 
 pub(crate) fn try_update_interval_config(
@@ -874,10 +865,130 @@ mod tests {
     #[cfg(test)]
     mod beginning_epoch_transition {
         use super::*;
+        use cosmwasm_std::testing::mock_info;
 
         #[test]
-        fn epoch_state_is_correctly_updated() {
-            todo!()
+        fn returns_error_if_epoch_is_in_progress() {
+            let mut test = TestSetup::new();
+            let env = test.env();
+            let rewarding_validator = test.rewarding_validator();
+
+            let res = try_begin_epoch_transition(test.deps_mut(), env, rewarding_validator);
+            assert!(matches!(
+                res,
+                Err(MixnetContractError::EpochInProgress { .. })
+            ))
+        }
+
+        #[test]
+        fn can_only_be_performed_if_in_progress_state() {
+            let bad_states = vec![
+                EpochState::Rewarding {
+                    last_rewarded: 0,
+                    final_node_id: 0,
+                },
+                EpochState::ReconcilingEvents,
+                EpochState::AdvancingEpoch,
+            ];
+
+            for bad_state in bad_states {
+                let mut test = TestSetup::new();
+                let rewarding_validator = test.rewarding_validator();
+
+                let mut status = EpochStatus::new(test.rewarding_validator().sender);
+                status.state = bad_state;
+                storage::save_current_epoch_status(test.deps_mut().storage, &status).unwrap();
+
+                test.skip_to_current_epoch_end();
+                let env = test.env();
+
+                let res = try_begin_epoch_transition(test.deps_mut(), env, rewarding_validator);
+                assert_eq!(
+                    res,
+                    Err(MixnetContractError::EpochAdvancementInProgress {
+                        current_state: bad_state
+                    })
+                );
+            }
+        }
+
+        #[test]
+        fn returns_error_if_not_performed_by_the_rewarding_validator() {
+            let mut test = TestSetup::new();
+            let env = test.env();
+
+            test.skip_to_current_epoch_end();
+
+            let random = mock_info("alice", &[]);
+            let owner = test.owner();
+
+            let res = try_begin_epoch_transition(test.deps_mut(), env.clone(), random);
+            assert!(matches!(res, Err(MixnetContractError::Unauthorized)));
+
+            let res = try_begin_epoch_transition(test.deps_mut(), env, owner);
+            assert!(matches!(res, Err(MixnetContractError::Unauthorized)));
+        }
+
+        #[test]
+        fn returns_error_if_epoch_is_already_being_advanced() {
+            let mut test = TestSetup::new();
+            let rewarding_validator = test.rewarding_validator();
+
+            test.skip_to_current_epoch_end();
+            let env = test.env();
+
+            try_begin_epoch_transition(test.deps_mut(), env.clone(), rewarding_validator.clone())
+                .unwrap();
+
+            let res = try_begin_epoch_transition(test.deps_mut(), env, rewarding_validator);
+            assert!(matches!(
+                res,
+                Err(MixnetContractError::EpochAdvancementInProgress { .. })
+            ));
+        }
+
+        #[test]
+        fn epoch_state_is_correctly_updated_for_empty_rewarded_set() {
+            let mut test = TestSetup::new();
+            let rewarding_validator = test.rewarding_validator();
+
+            test.skip_to_current_epoch_end();
+            let env = test.env();
+
+            try_begin_epoch_transition(test.deps_mut(), env, rewarding_validator).unwrap();
+
+            let expected = EpochStatus {
+                being_advanced_by: test.rewarding_validator().sender,
+                state: EpochState::ReconcilingEvents,
+            };
+            assert_eq!(
+                expected,
+                storage::current_epoch_status(test.deps().storage).unwrap()
+            )
+        }
+
+        #[test]
+        fn epoch_state_is_correctly_updated_for_nonempty_rewarded_set() {
+            let mut test = TestSetup::new();
+            let rewarding_validator = test.rewarding_validator();
+
+            test.force_change_rewarded_set(vec![1, 2, 3, 4, 5]);
+            test.skip_to_current_epoch_end();
+            let env = test.env();
+
+            try_begin_epoch_transition(test.deps_mut(), env, rewarding_validator).unwrap();
+
+            let expected = EpochStatus {
+                being_advanced_by: test.rewarding_validator().sender,
+                state: EpochState::Rewarding {
+                    last_rewarded: 0,
+                    final_node_id: 5,
+                },
+            };
+            assert_eq!(
+                expected,
+                storage::current_epoch_status(test.deps().storage).unwrap()
+            )
         }
     }
 
@@ -894,8 +1005,130 @@ mod tests {
         use mixnet_contract_common::reward_params::IntervalRewardingParamsUpdate;
 
         #[test]
-        fn epoch_state_is_correctly_updated() {
-            todo!()
+        fn can_only_be_performed_if_in_reconciling_state() {
+            let bad_states = vec![
+                EpochState::InProgress,
+                EpochState::Rewarding {
+                    last_rewarded: 0,
+                    final_node_id: 0,
+                },
+                EpochState::AdvancingEpoch,
+            ];
+
+            for bad_state in bad_states {
+                let mut test = TestSetup::new();
+                let rewarding_validator = test.rewarding_validator();
+
+                let mut status = EpochStatus::new(test.rewarding_validator().sender);
+                status.state = bad_state;
+                storage::save_current_epoch_status(test.deps_mut().storage, &status).unwrap();
+
+                test.skip_to_current_epoch_end();
+                let env = test.env();
+
+                let res =
+                    try_reconcile_epoch_events(test.deps_mut(), env, rewarding_validator, None);
+                assert_eq!(
+                    res,
+                    Err(MixnetContractError::EpochNotInEventReconciliationState {
+                        current_state: bad_state
+                    })
+                );
+            }
+        }
+
+        #[test]
+        fn epoch_state_is_correctly_updated_if_there_are_no_events() {
+            let mut test = TestSetup::new();
+            let rewarding_validator = test.rewarding_validator();
+
+            test.skip_to_current_epoch_end();
+            test.set_epoch_reconciliation_state();
+            let env = test.env();
+
+            try_reconcile_epoch_events(test.deps_mut(), env, rewarding_validator, None).unwrap();
+
+            let expected = EpochStatus {
+                being_advanced_by: test.rewarding_validator().sender,
+                state: EpochState::AdvancingEpoch,
+            };
+            assert_eq!(
+                expected,
+                storage::current_epoch_status(test.deps().storage).unwrap()
+            )
+        }
+
+        #[test]
+        fn epoch_state_is_not_updated_if_some_events_are_cleared() {
+            let mut test = TestSetup::new();
+            let rewarding_validator = test.rewarding_validator();
+
+            test.skip_to_current_epoch_end();
+            let env = test.env();
+
+            push_n_dummy_epoch_actions(&mut test, 10);
+            push_n_dummy_interval_actions(&mut test, 10);
+            test.set_epoch_reconciliation_state();
+
+            try_reconcile_epoch_events(test.deps_mut(), env, rewarding_validator, Some(5)).unwrap();
+
+            let expected = EpochStatus {
+                being_advanced_by: test.rewarding_validator().sender,
+                state: EpochState::ReconcilingEvents,
+            };
+            assert_eq!(
+                expected,
+                storage::current_epoch_status(test.deps().storage).unwrap()
+            )
+        }
+
+        #[test]
+        fn epoch_state_is_correctly_updated_if_even_with_leftover_interval_events_if_interval_is_not_over(
+        ) {
+            let mut test = TestSetup::new();
+            let rewarding_validator = test.rewarding_validator();
+
+            test.skip_to_current_epoch_end();
+            let env = test.env();
+
+            push_n_dummy_epoch_actions(&mut test, 10);
+            push_n_dummy_interval_actions(&mut test, 10);
+            test.set_epoch_reconciliation_state();
+
+            try_reconcile_epoch_events(test.deps_mut(), env, rewarding_validator, None).unwrap();
+
+            let expected = EpochStatus {
+                being_advanced_by: test.rewarding_validator().sender,
+                state: EpochState::AdvancingEpoch,
+            };
+            assert_eq!(
+                expected,
+                storage::current_epoch_status(test.deps().storage).unwrap()
+            )
+        }
+
+        #[test]
+        fn epoch_state_is_correctly_updated_if_all_events_are_cleared() {
+            let mut test = TestSetup::new();
+            let rewarding_validator = test.rewarding_validator();
+
+            test.skip_to_current_interval_end();
+            let env = test.env();
+
+            push_n_dummy_epoch_actions(&mut test, 10);
+            push_n_dummy_interval_actions(&mut test, 10);
+            test.set_epoch_reconciliation_state();
+
+            try_reconcile_epoch_events(test.deps_mut(), env, rewarding_validator, None).unwrap();
+
+            let expected = EpochStatus {
+                being_advanced_by: test.rewarding_validator().sender,
+                state: EpochState::AdvancingEpoch,
+            };
+            assert_eq!(
+                expected,
+                storage::current_epoch_status(test.deps().storage).unwrap()
+            )
         }
 
         #[test]
@@ -904,6 +1137,7 @@ mod tests {
             let env = test.env();
             let rewarding_validator = test.rewarding_validator();
 
+            test.set_epoch_reconciliation_state();
             let res = try_reconcile_epoch_events(test.deps_mut(), env, rewarding_validator, None);
             assert!(matches!(
                 res,
@@ -917,6 +1151,7 @@ mod tests {
             let env = test.env();
 
             test.skip_to_current_epoch_end();
+            test.set_epoch_reconciliation_state();
 
             let random = mock_info("alice", &[]);
             let owner = test.owner();
@@ -935,6 +1170,7 @@ mod tests {
             push_n_dummy_epoch_actions(&mut test, 10);
             push_n_dummy_interval_actions(&mut test, 10);
             test.skip_to_current_epoch_end();
+            test.set_epoch_reconciliation_state();
 
             let env = test.env();
             let rewarding_validator = test.rewarding_validator();
@@ -954,6 +1190,7 @@ mod tests {
             push_n_dummy_epoch_actions(&mut test, 10);
             push_n_dummy_interval_actions(&mut test, 10);
             test.skip_to_current_interval_end();
+            test.set_epoch_reconciliation_state();
             let rewarding_validator = test.rewarding_validator();
 
             let env = test.env();
@@ -982,6 +1219,7 @@ mod tests {
             // all test cases are using the same one
             let rewarding_validator = test1.rewarding_validator();
 
+            test1.set_epoch_reconciliation_state();
             try_reconcile_epoch_events(
                 test1.deps_mut(),
                 env.clone(),
@@ -1030,6 +1268,7 @@ mod tests {
             assert!(epoch_events.is_empty());
             assert!(interval_events.is_empty());
 
+            test2.set_epoch_reconciliation_state();
             try_reconcile_epoch_events(
                 test2.deps_mut(),
                 env.clone(),
@@ -1054,6 +1293,7 @@ mod tests {
             assert!(epoch_events.is_empty());
             assert!(interval_events.is_empty());
 
+            test3.set_epoch_reconciliation_state();
             try_reconcile_epoch_events(
                 test3.deps_mut(),
                 env.clone(),
@@ -1066,6 +1306,7 @@ mod tests {
             assert!(epoch_events.is_empty());
             assert!(interval_events.is_empty());
 
+            test4.set_epoch_reconciliation_state();
             try_reconcile_epoch_events(test4.deps_mut(), env, rewarding_validator, Some(100))
                 .unwrap();
             let epoch_events = test4.pending_epoch_events();
@@ -1122,6 +1363,7 @@ mod tests {
             expected_events.push(new_pending_interval_events_execution_event(1));
 
             test.skip_to_current_interval_end();
+            test.set_epoch_reconciliation_state();
             let env = test.env();
             let rewarding_validator = test.rewarding_validator();
 
@@ -1224,18 +1466,95 @@ mod tests {
         use super::*;
         use crate::mixnodes::queries::query_mixnode_details;
         use crate::rewards::models::RewardPoolChange;
-        use crate::support::tests::fixtures::TEST_COIN_DENOM;
         use cosmwasm_std::testing::mock_info;
-        use cosmwasm_std::{coin, coins, BankMsg, Decimal, Empty, SubMsg, Uint128};
-        use mixnet_contract_common::events::{
-            new_delegation_on_unbonded_node_event, new_rewarding_params_update_event,
-        };
+        use cosmwasm_std::{Decimal, Uint128};
         use mixnet_contract_common::reward_params::IntervalRewardingParamsUpdate;
         use mixnet_contract_common::{Layer, RewardedSetNodeStatus};
 
         #[test]
+        fn can_only_be_performed_if_in_advancing_epoch_state() {
+            let bad_states = vec![
+                EpochState::InProgress,
+                EpochState::Rewarding {
+                    last_rewarded: 0,
+                    final_node_id: 0,
+                },
+                EpochState::ReconcilingEvents,
+            ];
+
+            for bad_state in bad_states {
+                let mut test = TestSetup::new();
+                test.add_dummy_mixnode("1", Some(Uint128::new(100000000)));
+                test.add_dummy_mixnode("2", Some(Uint128::new(100000000)));
+                test.add_dummy_mixnode("3", Some(Uint128::new(100000000)));
+                let current_active_set = test.rewarding_params().active_set_size;
+
+                test.skip_to_current_epoch_end();
+
+                let mut status = EpochStatus::new(test.rewarding_validator().sender);
+                status.state = bad_state;
+                storage::save_current_epoch_status(test.deps_mut().storage, &status).unwrap();
+
+                let layer_assignments = vec![
+                    LayerAssignment::new(1, Layer::One),
+                    LayerAssignment::new(2, Layer::Two),
+                    LayerAssignment::new(3, Layer::Three),
+                ];
+
+                let env = test.env();
+                let sender = test.rewarding_validator();
+                let res = try_advance_epoch(
+                    test.deps_mut(),
+                    env,
+                    sender,
+                    layer_assignments,
+                    current_active_set,
+                );
+                assert_eq!(
+                    res,
+                    Err(MixnetContractError::EpochNotInAdvancementState {
+                        current_state: bad_state
+                    })
+                );
+            }
+        }
+
+        #[test]
         fn epoch_state_is_correctly_updated() {
-            todo!()
+            let mut test = TestSetup::new();
+            test.add_dummy_mixnode("1", Some(Uint128::new(100000000)));
+            test.add_dummy_mixnode("2", Some(Uint128::new(100000000)));
+            test.add_dummy_mixnode("3", Some(Uint128::new(100000000)));
+            let current_active_set = test.rewarding_params().active_set_size;
+
+            test.skip_to_current_epoch_end();
+            test.set_epoch_advancement_state();
+
+            let layer_assignments = vec![
+                LayerAssignment::new(1, Layer::One),
+                LayerAssignment::new(2, Layer::Two),
+                LayerAssignment::new(3, Layer::Three),
+            ];
+
+            let env = test.env();
+            let sender = test.rewarding_validator();
+            try_advance_epoch(
+                test.deps_mut(),
+                env,
+                sender,
+                layer_assignments,
+                current_active_set,
+            )
+            .unwrap();
+
+            let expected = EpochStatus {
+                being_advanced_by: test.rewarding_validator().sender,
+                state: EpochState::InProgress,
+            };
+            assert_eq!(
+                expected,
+                storage::current_epoch_status(test.deps().storage).unwrap()
+            )
         }
 
         #[test]
@@ -1248,6 +1567,7 @@ mod tests {
             let some_sender = mock_info("foomper", &[]);
 
             test.skip_to_current_epoch_end();
+            test.set_epoch_advancement_state();
 
             let layer_assignments = vec![
                 LayerAssignment::new(1, Layer::One),
@@ -1281,6 +1601,8 @@ mod tests {
         #[test]
         fn can_only_be_performed_if_epoch_is_over() {
             let mut test = TestSetup::new();
+            test.set_epoch_advancement_state();
+
             let current_active_set = test.rewarding_params().active_set_size;
 
             test.add_dummy_mixnode("1", Some(Uint128::new(100000000)));
@@ -1327,6 +1649,7 @@ mod tests {
 
             // sanity check
             test.skip_to_current_epoch_end();
+
             let env = test.env();
             let res = try_advance_epoch(
                 test.deps_mut(),
@@ -1339,170 +1662,10 @@ mod tests {
         }
 
         #[test]
-        fn only_clears_epoch_events_if_interval_is_in_progress() {
-            let mut test = TestSetup::new();
-            let current_active_set = test.rewarding_params().active_set_size;
-
-            test.add_dummy_mixnode("1", Some(Uint128::new(100000000)));
-            test.add_dummy_mixnode("2", Some(Uint128::new(100000000)));
-            test.add_dummy_mixnode("3", Some(Uint128::new(100000000)));
-
-            push_n_dummy_epoch_actions(&mut test, 10);
-            push_n_dummy_interval_actions(&mut test, 10);
-            test.skip_to_current_epoch_end();
-
-            let layer_assignments = vec![
-                LayerAssignment::new(1, Layer::One),
-                LayerAssignment::new(2, Layer::Two),
-                LayerAssignment::new(3, Layer::Three),
-            ];
-
-            let env = test.env();
-            let sender = test.rewarding_validator();
-            try_advance_epoch(
-                test.deps_mut(),
-                env,
-                sender,
-                layer_assignments,
-                current_active_set,
-            )
-            .unwrap();
-
-            let epoch_events = test.pending_epoch_events();
-            let interval_events = test.pending_interval_events();
-            assert!(epoch_events.is_empty());
-            assert_eq!(interval_events.len(), 10);
-        }
-
-        #[test]
-        fn clears_both_epoch_and_interval_events_if_interval_has_finished() {
-            let mut test = TestSetup::new();
-            let current_active_set = test.rewarding_params().active_set_size;
-
-            test.add_dummy_mixnode("1", Some(Uint128::new(100000000)));
-            test.add_dummy_mixnode("2", Some(Uint128::new(100000000)));
-            test.add_dummy_mixnode("3", Some(Uint128::new(100000000)));
-
-            push_n_dummy_epoch_actions(&mut test, 10);
-            push_n_dummy_interval_actions(&mut test, 10);
-            test.skip_to_current_interval_end();
-
-            let layer_assignments = vec![
-                LayerAssignment::new(1, Layer::One),
-                LayerAssignment::new(2, Layer::Two),
-                LayerAssignment::new(3, Layer::Three),
-            ];
-
-            let env = test.env();
-            let sender = test.rewarding_validator();
-            try_advance_epoch(
-                test.deps_mut(),
-                env,
-                sender,
-                layer_assignments,
-                current_active_set,
-            )
-            .unwrap();
-
-            let epoch_events = test.pending_epoch_events();
-            let interval_events = test.pending_interval_events();
-            assert!(epoch_events.is_empty());
-            assert!(interval_events.is_empty());
-        }
-
-        #[test]
-        fn if_executes_any_events_it_propagates_responses() {
-            let mut test = TestSetup::new();
-            let env = test.env();
-            let current_active_set = test.rewarding_params().active_set_size;
-
-            test.add_dummy_mixnode("1", Some(Uint128::new(100000000)));
-            test.add_dummy_mixnode("2", Some(Uint128::new(100000000)));
-            test.add_dummy_mixnode("3", Some(Uint128::new(100000000)));
-
-            let mut expected_events = Vec::new();
-            let mut expected_messages: Vec<SubMsg<Empty>> = Vec::new();
-
-            let non_existent_delegation = PendingEpochEventKind::Delegate {
-                owner: Addr::unchecked("foomp"),
-                mix_id: 123,
-                amount: coin(123, TEST_COIN_DENOM),
-                proxy: None,
-            };
-            storage::push_new_epoch_event(test.deps_mut().storage, &env, non_existent_delegation)
-                .unwrap();
-            expected_events.push(new_delegation_on_unbonded_node_event(
-                &Addr::unchecked("foomp"),
-                &None,
-                123,
-            ));
-            expected_messages.push(SubMsg::new(BankMsg::Send {
-                to_address: "foomp".to_string(),
-                amount: coins(123, TEST_COIN_DENOM),
-            }));
-            expected_events.push(new_pending_epoch_events_execution_event(1));
-
-            // interval event
-            let update = IntervalRewardingParamsUpdate {
-                rewarded_set_size: Some(500),
-                ..Default::default()
-            };
-            let change_params = PendingIntervalEventKind::UpdateRewardingParams { update };
-            storage::push_new_interval_event(test.deps_mut().storage, &env, change_params).unwrap();
-            let interval = test.current_interval();
-            let mut expected_updated = test.rewarding_params();
-            expected_updated
-                .try_apply_updates(update, interval.epochs_in_interval())
-                .unwrap();
-            expected_events.push(new_rewarding_params_update_event(
-                env.block.height,
-                update,
-                expected_updated.interval,
-            ));
-            expected_events.push(new_pending_interval_events_execution_event(1));
-            let current_interval = test.current_interval();
-            let expected = current_interval.advance_epoch();
-            expected_events.push(new_advance_epoch_event(expected, 3));
-
-            test.skip_to_current_interval_end();
-
-            let layer_assignments = vec![
-                LayerAssignment::new(1, Layer::One),
-                LayerAssignment::new(2, Layer::Two),
-                LayerAssignment::new(3, Layer::Three),
-            ];
-
-            let env = test.env();
-            let sender = test.rewarding_validator();
-            let res = try_advance_epoch(
-                test.deps_mut(),
-                env,
-                sender,
-                layer_assignments,
-                current_active_set,
-            )
-            .unwrap();
-
-            let mut expected = Response::new().add_events(expected_events);
-            expected.messages = expected_messages;
-            assert_eq!(res, expected);
-            assert_eq!(
-                1,
-                storage::LAST_PROCESSED_EPOCH_EVENT
-                    .load(test.deps().storage)
-                    .unwrap()
-            );
-            assert_eq!(
-                1,
-                storage::LAST_PROCESSED_INTERVAL_EVENT
-                    .load(test.deps().storage)
-                    .unwrap()
-            );
-        }
-
-        #[test]
         fn if_interval_is_over_applies_reward_pool_changes() {
             let mut test = TestSetup::new();
+            test.set_epoch_advancement_state();
+
             let current_active_set = test.rewarding_params().active_set_size;
 
             test.add_dummy_mixnode("1", Some(Uint128::new(100000000)));
@@ -1532,6 +1695,7 @@ mod tests {
             // end of epoch - nothing has happened
             let sender = test.rewarding_validator();
             test.skip_to_current_epoch_end();
+
             let env = test.env();
             try_advance_epoch(
                 test.deps_mut(),
@@ -1551,6 +1715,8 @@ mod tests {
 
             let sender = test.rewarding_validator();
             test.skip_to_current_interval_end();
+            test.set_epoch_advancement_state();
+
             let env = test.env();
             try_advance_epoch(
                 test.deps_mut(),
@@ -1583,6 +1749,8 @@ mod tests {
         #[test]
         fn updates_rewarded_set_and_interval_data() {
             let mut test = TestSetup::new();
+            test.set_epoch_advancement_state();
+
             let current_active_set = test.rewarding_params().active_set_size;
 
             test.add_dummy_mixnode("1", Some(Uint128::new(100000000)));
@@ -1636,7 +1804,48 @@ mod tests {
 
         #[test]
         fn cant_be_performed_if_epoch_transition_is_in_progress_unless_forced() {
-            todo!()
+            let bad_states = vec![
+                EpochState::Rewarding {
+                    last_rewarded: 0,
+                    final_node_id: 0,
+                },
+                EpochState::ReconcilingEvents,
+                EpochState::AdvancingEpoch,
+            ];
+
+            for bad_state in bad_states {
+                let mut test = TestSetup::new();
+                let owner = test.owner();
+                let env = test.env();
+
+                let mut status = EpochStatus::new(test.rewarding_validator().sender);
+                status.state = bad_state;
+
+                storage::save_current_epoch_status(test.deps_mut().storage, &status).unwrap();
+
+                let res = try_update_interval_config(
+                    test.deps_mut(),
+                    env.clone(),
+                    owner.clone(),
+                    100,
+                    1000,
+                    false,
+                );
+                assert!(matches!(
+                    res,
+                    Err(MixnetContractError::EpochAdvancementInProgress { .. })
+                ));
+
+                let res_forced = try_update_interval_config(
+                    test.deps_mut(),
+                    env.clone(),
+                    owner,
+                    100,
+                    1000,
+                    true,
+                );
+                assert!(res_forced.is_ok())
+            }
         }
 
         #[test]

--- a/contracts/mixnet/src/lib.rs
+++ b/contracts/mixnet/src/lib.rs
@@ -12,6 +12,7 @@ mod gateways;
 mod interval;
 mod mixnet_contract_settings;
 mod mixnodes;
+mod queued_migrations;
 mod rewards;
 mod support;
 

--- a/contracts/mixnet/src/queued_migrations.rs
+++ b/contracts/mixnet/src/queued_migrations.rs
@@ -1,2 +1,18 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
+
+use crate::interval::storage as interval_storage;
+use cosmwasm_std::Storage;
+use mixnet_contract_common::error::MixnetContractError;
+use mixnet_contract_common::EpochStatus;
+
+pub(crate) fn create_epoch_status(storage: &mut dyn Storage) -> Result<(), MixnetContractError> {
+    let current_rewarding_validator =
+        crate::mixnet_contract_settings::storage::rewarding_validator_address(storage)?;
+    interval_storage::save_current_epoch_status(
+        storage,
+        &EpochStatus::new(current_rewarding_validator),
+    )?;
+
+    Ok(())
+}

--- a/contracts/mixnet/src/rewards/helpers.rs
+++ b/contracts/mixnet/src/rewards/helpers.rs
@@ -228,14 +228,14 @@ mod tests {
         assert_eq!(res.amount, Uint128::zero());
 
         test.skip_to_next_epoch_end();
-        test.update_rewarded_set(vec![mix_id]);
-        let dist1 = test.reward_with_distribution(mix_id, performance(100.0));
+        test.force_change_rewarded_set(vec![mix_id]);
+        let dist1 = test.reward_with_distribution_with_state_bypass(mix_id, performance(100.0));
 
         test.skip_to_next_epoch_end();
-        let dist2 = test.reward_with_distribution(mix_id, performance(100.0));
+        let dist2 = test.reward_with_distribution_with_state_bypass(mix_id, performance(100.0));
 
         test.skip_to_next_epoch_end();
-        let dist3 = test.reward_with_distribution(mix_id, performance(100.0));
+        let dist3 = test.reward_with_distribution_with_state_bypass(mix_id, performance(100.0));
 
         let mix_details = get_mixnode_details_by_id(test.deps().storage, mix_id)
             .unwrap()
@@ -267,14 +267,14 @@ mod tests {
         assert_eq!(res.amount, Uint128::zero());
 
         test.skip_to_next_epoch_end();
-        test.update_rewarded_set(vec![mix_id]);
-        let dist1 = test.reward_with_distribution(mix_id, performance(100.0));
+        test.force_change_rewarded_set(vec![mix_id]);
+        let dist1 = test.reward_with_distribution_with_state_bypass(mix_id, performance(100.0));
 
         test.skip_to_next_epoch_end();
-        let dist2 = test.reward_with_distribution(mix_id, performance(100.0));
+        let dist2 = test.reward_with_distribution_with_state_bypass(mix_id, performance(100.0));
 
         test.skip_to_next_epoch_end();
-        let dist3 = test.reward_with_distribution(mix_id, performance(100.0));
+        let dist3 = test.reward_with_distribution_with_state_bypass(mix_id, performance(100.0));
 
         let delegation_pre = test.delegation(mix_id, delegator, &None);
         let mix_rewarding = test.mix_rewarding(mix_id);

--- a/contracts/mixnet/src/rewards/queries.rs
+++ b/contracts/mixnet/src/rewards/queries.rs
@@ -297,10 +297,13 @@ mod tests {
             let mix_id = test.add_dummy_mixnode(owner, Some(initial_stake));
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
 
             let mut total_earned = Decimal::zero();
-            let dist = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            let dist = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             total_earned += dist.operator;
 
             let res = query_pending_operator_reward(test.deps(), owner.into()).unwrap();
@@ -317,7 +320,10 @@ mod tests {
             // reward it few more times for good measure
             for _ in 0..10 {
                 test.skip_to_next_epoch_end();
-                let dist = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+                let dist = test.reward_with_distribution_with_state_bypass(
+                    mix_id,
+                    test_helpers::performance(100.0),
+                );
                 total_earned += dist.operator;
 
                 let res = query_pending_operator_reward(test.deps(), owner.into()).unwrap();
@@ -341,10 +347,13 @@ mod tests {
             let mix_id = test.add_dummy_mixnode(owner, Some(initial_stake));
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
 
             let mut total_earned = Decimal::zero();
-            let dist = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            let dist = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             total_earned += dist.operator;
 
             let sender = mock_info(owner, &[]);
@@ -370,9 +379,12 @@ mod tests {
             let mix_id = test.add_dummy_mixnode(owner, Some(initial_stake));
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
 
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let sender = mock_info(owner, &[]);
             let env = test.env();
@@ -447,10 +459,13 @@ mod tests {
             test.add_immediate_delegation(owner, initial_stake, mix_id);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
 
             let mut total_earned = Decimal::zero();
-            let dist = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            let dist = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             total_earned += dist.delegates;
 
             let res =
@@ -466,7 +481,10 @@ mod tests {
             // reward it few more times for good measure
             for _ in 0..10 {
                 test.skip_to_next_epoch_end();
-                let dist = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+                let dist = test.reward_with_distribution_with_state_bypass(
+                    mix_id,
+                    test_helpers::performance(100.0),
+                );
                 total_earned += dist.delegates;
 
                 let res = query_pending_delegator_reward(test.deps(), owner.into(), mix_id, None)
@@ -491,10 +509,13 @@ mod tests {
             test.add_immediate_delegation(owner, initial_stake, mix_id);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
 
             let mut total_earned = Decimal::zero();
-            let dist = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            let dist = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             total_earned += dist.delegates;
 
             let sender = mock_info("mix-owner", &[]);
@@ -521,10 +542,13 @@ mod tests {
             test.add_immediate_delegation(owner, initial_stake, mix_id);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
 
             let mut total_earned = Decimal::zero();
-            let dist = test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            let dist = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             total_earned += dist.delegates;
 
             let sender = mock_info("mix-owner", &[]);
@@ -557,34 +581,58 @@ mod tests {
             test.add_immediate_delegation(del2, 150_000_000u32, mix_id);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
 
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             test.add_immediate_delegation(del3, 500_000_000u32, mix_id);
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(85.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(85.0),
+            );
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(5.0));
+            test.reward_with_distribution_with_state_bypass(mix_id, test_helpers::performance(5.0));
 
             test.add_immediate_delegation(del4, 5_000_000u32, mix_id);
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             test.add_immediate_delegation(del2, 250_000_000u32, mix_id);
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(98.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(98.0),
+            );
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             test.remove_immediate_delegation(del3, mix_id);
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(98.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(98.0),
+            );
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let pending1 =
                 query_pending_delegator_reward(test.deps(), del1.into(), mix_id, None).unwrap();
@@ -660,8 +708,11 @@ mod tests {
             let mix_id = test.add_dummy_mixnode(owner, Some(initial_stake));
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.force_change_rewarded_set(vec![mix_id]);
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let sender = mock_info(owner, &[]);
             let env = test.env();
@@ -686,8 +737,11 @@ mod tests {
             let mix_id = test.add_dummy_mixnode(owner, Some(initial_stake));
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.force_change_rewarded_set(vec![mix_id]);
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let sender = mock_info(owner, &[]);
             let env = test.env();
@@ -710,9 +764,12 @@ mod tests {
             let mix_id = test.add_dummy_mixnode("mix-owner", Some(initial_stake));
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
-            test.update_rewarded_set(vec![]);
+            test.force_change_rewarded_set(vec![mix_id]);
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
+            test.force_change_rewarded_set(vec![]);
 
             let res = query_estimated_current_epoch_operator_reward(
                 test.deps(),
@@ -732,8 +789,11 @@ mod tests {
             let mix_id = test.add_dummy_mixnode("mix-owner", Some(initial_stake));
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.force_change_rewarded_set(vec![mix_id]);
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let res = query_estimated_current_epoch_operator_reward(
                 test.deps(),
@@ -753,8 +813,11 @@ mod tests {
             let mix_id = test.add_dummy_mixnode("mix-owner", Some(initial_stake));
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.force_change_rewarded_set(vec![mix_id]);
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let mix_rewarding = test.mix_rewarding(mix_id);
             let res = query_estimated_current_epoch_operator_reward(
@@ -765,7 +828,10 @@ mod tests {
             .unwrap();
 
             test.skip_to_next_epoch_end();
-            let dist = test.reward_with_distribution(mix_id, test_helpers::performance(95.0));
+            let dist = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(95.0),
+            );
 
             let expected = EstimatedCurrentEpochRewardResponse {
                 original_stake: Some(coin(initial_stake.u128(), TEST_COIN_DENOM)),
@@ -816,8 +882,11 @@ mod tests {
             let mix_id = test.add_dummy_mixnode("mix-owner", None);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.force_change_rewarded_set(vec![mix_id]);
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let res = query_estimated_current_epoch_delegator_reward(
                 test.deps(),
@@ -841,8 +910,11 @@ mod tests {
             test.add_immediate_delegation(owner, initial_stake, mix_id);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.force_change_rewarded_set(vec![mix_id]);
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let sender = mock_info("mix-owner", &[]);
             let env = test.env();
@@ -871,8 +943,11 @@ mod tests {
             test.add_immediate_delegation(owner, initial_stake, mix_id);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.force_change_rewarded_set(vec![mix_id]);
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let sender = mock_info("mix-owner", &[]);
             let env = test.env();
@@ -902,9 +977,12 @@ mod tests {
             test.add_immediate_delegation(owner, initial_stake, mix_id);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
-            test.update_rewarded_set(vec![]);
+            test.force_change_rewarded_set(vec![mix_id]);
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
+            test.force_change_rewarded_set(vec![]);
 
             let res = query_estimated_current_epoch_delegator_reward(
                 test.deps(),
@@ -929,8 +1007,11 @@ mod tests {
             test.add_immediate_delegation(owner, initial_stake, mix_id);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
-            test.reward_with_distribution(mix_id, test_helpers::performance(100.0));
+            test.force_change_rewarded_set(vec![mix_id]);
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(100.0),
+            );
 
             let res = query_estimated_current_epoch_delegator_reward(
                 test.deps(),
@@ -955,7 +1036,7 @@ mod tests {
             test.add_immediate_delegation(owner, initial_stake, mix_id);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
+            test.force_change_rewarded_set(vec![mix_id]);
 
             let mix_rewarding = test.mix_rewarding(mix_id);
             let res = query_estimated_current_epoch_delegator_reward(
@@ -968,7 +1049,10 @@ mod tests {
             .unwrap();
 
             test.skip_to_next_epoch_end();
-            let dist = test.reward_with_distribution(mix_id, test_helpers::performance(95.0));
+            let dist = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(95.0),
+            );
 
             let expected = EstimatedCurrentEpochRewardResponse {
                 original_stake: Some(coin(initial_stake.u128(), TEST_COIN_DENOM)),
@@ -1003,12 +1087,18 @@ mod tests {
             test.add_immediate_delegation(del2, initial_stake2, mix_id);
 
             test.skip_to_next_epoch_end();
-            test.update_rewarded_set(vec![mix_id]);
-            test.reward_with_distribution(mix_id, test_helpers::performance(95.0));
+            test.force_change_rewarded_set(vec![mix_id]);
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(95.0),
+            );
 
             test.add_immediate_delegation(del3, initial_stake3, mix_id);
             test.skip_to_next_epoch_end();
-            test.reward_with_distribution(mix_id, test_helpers::performance(85.0));
+            test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(85.0),
+            );
 
             let mix_rewarding = test.mix_rewarding(mix_id);
 
@@ -1045,7 +1135,10 @@ mod tests {
             let cur3 = initial_stake3_dec + est3;
 
             test.skip_to_next_epoch_end();
-            let dist = test.reward_with_distribution(mix_id, test_helpers::performance(95.0));
+            let dist = test.reward_with_distribution_with_state_bypass(
+                mix_id,
+                test_helpers::performance(95.0),
+            );
 
             let share1 = cur1 / mix_rewarding.delegates * dist.delegates;
             let share2 = cur2 / mix_rewarding.delegates * dist.delegates;

--- a/contracts/mixnet/src/support/tests/mod.rs
+++ b/contracts/mixnet/src/support/tests/mod.rs
@@ -19,7 +19,7 @@ pub mod test_helpers {
     use crate::gateways::storage as gateways_storage;
     use crate::gateways::transactions::{try_add_gateway, try_add_gateway_on_behalf};
     use crate::interval::transactions::{
-        perform_pending_epoch_actions, perform_pending_interval_actions,
+        perform_pending_epoch_actions, perform_pending_interval_actions, try_begin_epoch_transition,
     };
     use crate::interval::{pending_events, storage as interval_storage};
     use crate::mixnet_contract_settings::storage as mixnet_params_storage;
@@ -61,8 +61,8 @@ pub mod test_helpers {
     use mixnet_contract_common::rewarding::simulator::Simulator;
     use mixnet_contract_common::rewarding::RewardDistribution;
     use mixnet_contract_common::{
-        Delegation, Gateway, IdentityKey, InitialRewardingParams, InstantiateMsg, Interval, MixId,
-        MixNode, MixNodeBond, Percent, RewardedSetNodeStatus,
+        Delegation, EpochState, EpochStatus, Gateway, IdentityKey, InitialRewardingParams,
+        InstantiateMsg, Interval, MixId, MixNode, MixNodeBond, Percent, RewardedSetNodeStatus,
     };
     use rand_chacha::rand_core::{CryptoRng, RngCore, SeedableRng};
     use rand_chacha::ChaCha20Rng;
@@ -499,6 +499,48 @@ pub mod test_helpers {
             .unwrap();
         }
 
+        pub fn start_epoch_transition(&mut self) {
+            let env = self.env.clone();
+            let sender = self.rewarding_validator.clone();
+            try_begin_epoch_transition(self.deps_mut(), env, sender).unwrap();
+        }
+
+        pub fn set_epoch_in_progress_state(&mut self) {
+            let being_advanced_by = self.rewarding_validator.sender.clone();
+            interval_storage::save_current_epoch_status(
+                self.deps_mut().storage,
+                &EpochStatus {
+                    being_advanced_by,
+                    state: EpochState::InProgress,
+                },
+            )
+            .unwrap();
+        }
+
+        pub fn set_epoch_reconciliation_state(&mut self) {
+            let being_advanced_by = self.rewarding_validator.sender.clone();
+            interval_storage::save_current_epoch_status(
+                self.deps_mut().storage,
+                &EpochStatus {
+                    being_advanced_by,
+                    state: EpochState::ReconcilingEvents,
+                },
+            )
+            .unwrap();
+        }
+
+        pub fn set_epoch_advancement_state(&mut self) {
+            let being_advanced_by = self.rewarding_validator.sender.clone();
+            interval_storage::save_current_epoch_status(
+                self.deps_mut().storage,
+                &EpochStatus {
+                    being_advanced_by,
+                    state: EpochState::AdvancingEpoch,
+                },
+            )
+            .unwrap();
+        }
+
         #[allow(unused)]
         pub fn pending_operator_reward(&mut self, mix: MixId) -> Decimal {
             query_pending_mixnode_operator_reward(self.deps(), mix)
@@ -559,10 +601,12 @@ pub mod test_helpers {
                 )
             }
 
-            interval_storage::save_interval(self.deps_mut().storage, &advanced).unwrap()
+            interval_storage::save_interval(self.deps_mut().storage, &advanced).unwrap();
+            // if we're going into next epoch, we're back into in progress
+            self.set_epoch_in_progress_state();
         }
 
-        pub fn update_rewarded_set(&mut self, nodes: Vec<MixId>) {
+        pub fn force_change_rewarded_set(&mut self, nodes: Vec<MixId>) {
             let active_set_size = rewards_storage::REWARDING_PARAMS
                 .load(self.deps().storage)
                 .unwrap()
@@ -592,6 +636,20 @@ pub mod test_helpers {
                 .range(self.deps().storage, None, None, Order::Ascending)
                 .map(|res| res.unwrap().1)
                 .collect::<Vec<_>>()
+        }
+
+        pub fn reward_with_distribution_with_state_bypass(
+            &mut self,
+            mix_id: MixId,
+            performance: Performance,
+        ) -> RewardDistribution {
+            let initial_status =
+                interval_storage::current_epoch_status(self.deps().storage).unwrap();
+            self.start_epoch_transition();
+            let res = self.reward_with_distribution(mix_id, performance);
+            interval_storage::save_current_epoch_status(self.deps_mut().storage, &initial_status)
+                .unwrap();
+            res
         }
 
         pub fn reward_with_distribution(

--- a/nym-api/src/epoch_operations/error.rs
+++ b/nym-api/src/epoch_operations/error.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::node_status_api::models::NymApiStorageError;
+use mixnet_contract_common::EpochState;
 use thiserror::Error;
 use validator_client::nyxd::error::NyxdError;
 use validator_client::nyxd::AccountId;
@@ -13,6 +14,12 @@ pub enum RewardingError {
     Unauthorised {
         our_address: AccountId,
         allowed_address: AccountId,
+    },
+
+    #[error("the current epoch is in the wrong state ({current_state}) to perform the requested operation: {operation}")]
+    InvalidEpochState {
+        current_state: EpochState,
+        operation: String,
     },
 
     // #[error("There were no mixnodes to reward (network is dead)")]

--- a/nym-api/src/epoch_operations/event_reconciliation.rs
+++ b/nym-api/src/epoch_operations/event_reconciliation.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::epoch_operations::error::RewardingError;
+use crate::RewardedSetUpdater;
+
+impl RewardedSetUpdater {
+    pub(super) async fn reconcile_epoch_events(&self) -> Result<(), RewardingError> {
+        let pending_events = self.nyxd_client.get_pending_events_count().await?;
+        // if there's no pending events, job's done.
+        if pending_events == 0 {
+            return Ok(());
+        }
+
+        // be conservative about number of events we resolve at once.
+        // contract should be able to handle few hundred at once
+        // but keep it on the lower side.
+        let limit = 100;
+
+        let mut required_calls = pending_events / limit;
+        if pending_events % limit != 0 {
+            required_calls += 1;
+        }
+
+        for _ in 0..required_calls {
+            self.nyxd_client.reconcile_epoch_events(Some(limit)).await?;
+        }
+
+        // in the incredibly unlikely/borderline impossible scenario a HUGE number of events got pushed
+        // while we were reconciling the events, do it one more time
+        //
+        // note: it's perfectly fine if we don't clear EXACTLY everything,
+        // since when we execute transaction to actually advance the epoch,
+        // it will resolve all remaining events.
+        let pending_events = self.nyxd_client.get_pending_events_count().await?;
+        if pending_events > 20 {
+            self.nyxd_client.reconcile_epoch_events(Some(limit)).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/nym-api/src/epoch_operations/rewarded_set_assignment.rs
+++ b/nym-api/src/epoch_operations/rewarded_set_assignment.rs
@@ -1,0 +1,117 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::epoch_operations::error::RewardingError;
+use crate::epoch_operations::helpers::stake_to_f64;
+use crate::RewardedSetUpdater;
+use mixnet_contract_common::families::FamilyHead;
+use mixnet_contract_common::{IdentityKey, Layer, LayerAssignment, MixNodeDetails};
+use rand::prelude::SliceRandom;
+use rand::rngs::OsRng;
+use std::collections::HashMap;
+
+// Weight of a layer being chose is reciprocal to current count in layer
+fn layer_weight(l: &Layer, layer_assignments: &HashMap<Layer, f32>) -> f32 {
+    let total = layer_assignments.values().fold(0., |acc, i| acc + i);
+    if total == 0. {
+        1.
+    } else {
+        1. - (layer_assignments.get(l).unwrap_or(&0.) / total)
+    }
+}
+
+impl RewardedSetUpdater {
+    async fn determine_layers(
+        &self,
+        rewarded_set: &[MixNodeDetails],
+    ) -> Result<(Vec<LayerAssignment>, HashMap<String, Layer>), RewardingError> {
+        let mut families_in_layer: HashMap<String, Layer> = HashMap::new();
+        let mut assignments = vec![];
+        let mut layer_assignments: HashMap<Layer, f32> = HashMap::new();
+        let mut rng = OsRng;
+        let layers = vec![Layer::One, Layer::Two, Layer::Three];
+
+        let mix_to_family = self.nym_contract_cache.mix_to_family().await.to_vec();
+
+        let mix_to_family = mix_to_family
+            .into_iter()
+            .collect::<HashMap<IdentityKey, FamilyHead>>();
+
+        for mix in rewarded_set {
+            let family = mix_to_family.get(&mix.bond_information.identity().to_owned());
+            // Get layer already assigned to nodes family, if any
+            let family_layer = family.and_then(|h| families_in_layer.get(h.identity()));
+
+            // Same node families are always assigned to the same layer, otherwise layer selected by a random weighted choice
+            let layer = if let Some(layer) = family_layer {
+                layer.to_owned()
+            } else {
+                layers
+                    .choose_weighted(&mut rng, |l| layer_weight(l, &layer_assignments))?
+                    .to_owned()
+            };
+
+            assignments.push(LayerAssignment::new(mix.mix_id(), layer));
+
+            // layer accounting
+            let layer_entry = layer_assignments.entry(layer).or_insert(0.);
+            *layer_entry += 1.;
+            if let Some(family) = family {
+                families_in_layer.insert(family.identity().to_string(), layer);
+            }
+        }
+
+        Ok((assignments, families_in_layer))
+    }
+
+    fn determine_rewarded_set(
+        &self,
+        mixnodes: &[MixNodeDetails],
+        nodes_to_select: u32,
+    ) -> Result<Vec<MixNodeDetails>, RewardingError> {
+        if mixnodes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut rng = OsRng;
+
+        // generate list of mixnodes and their relatively weight (by total stake)
+        let choices = mixnodes
+            .iter()
+            .map(|mix| {
+                let total_stake = stake_to_f64(mix.total_stake());
+                (mix.to_owned(), total_stake)
+            })
+            .collect::<Vec<_>>();
+
+        // the unwrap here is fine as an error can only be thrown under one of the following conditions:
+        // - our mixnode list is empty - we have already checked for that
+        // - we have invalid weights, i.e. less than zero or NaNs - it shouldn't happen in our case as we safely cast down from u128
+        // - all weights are zero - it's impossible in our case as the list of nodes is not empty and weight is proportional to stake. You must have non-zero stake in order to bond
+        // - we have more than u32::MAX values (which is incredibly unrealistic to have 4B mixnodes bonded... literally every other person on the planet would need one)
+        Ok(choices
+            .choose_multiple_weighted(&mut rng, nodes_to_select as usize, |item| item.1)?
+            .map(|(mix, _weight)| mix.to_owned())
+            .collect())
+    }
+
+    pub(super) async fn update_rewarded_set_and_advance_epoch(
+        &self,
+        all_mixnodes: &[MixNodeDetails],
+    ) -> Result<(), RewardingError> {
+        // we grab rewarding parameters here as they might have gotten updated when performing epoch actions
+        let rewarding_parameters = self.nyxd_client.get_current_rewarding_parameters().await?;
+
+        let new_rewarded_set =
+            self.determine_rewarded_set(all_mixnodes, rewarding_parameters.rewarded_set_size)?;
+
+        let (layer_assignments, _families_in_layer) =
+            self.determine_layers(&new_rewarded_set).await?;
+
+        self.nyxd_client
+            .advance_current_epoch(layer_assignments, rewarding_parameters.active_set_size)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/nym-api/src/epoch_operations/rewarding.rs
+++ b/nym-api/src/epoch_operations/rewarding.rs
@@ -1,0 +1,101 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::epoch_operations::error::RewardingError;
+use crate::support::storage::models::RewardingReport;
+use crate::RewardedSetUpdater;
+use mixnet_contract_common::reward_params::Performance;
+use mixnet_contract_common::{ExecuteMsg, Interval, MixId};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MixnodeToReward {
+    pub(crate) mix_id: MixId,
+
+    pub(crate) performance: Performance,
+}
+
+impl From<MixnodeToReward> for ExecuteMsg {
+    fn from(mix_reward: MixnodeToReward) -> Self {
+        ExecuteMsg::RewardMixnode {
+            mix_id: mix_reward.mix_id,
+            performance: mix_reward.performance,
+        }
+    }
+}
+
+impl RewardedSetUpdater {
+    pub(super) async fn reward_current_rewarded_set(
+        &self,
+        current_interval: Interval,
+    ) -> Result<(), RewardingError> {
+        let to_reward = self.nodes_to_reward(current_interval).await;
+
+        if let Some(existing_report) = self
+            .storage
+            .get_rewarding_report(current_interval.current_epoch_absolute_id())
+            .await?
+        {
+            warn!("We have already rewarded mixnodes for this rewarding epoch ({}). {} nodes should have gotten rewards", existing_report.absolute_epoch_id, existing_report.eligible_mixnodes);
+            return Ok(());
+        }
+
+        if to_reward.is_empty() {
+            info!("There are no nodes to reward in this epoch");
+        } else if let Err(err) = self.nyxd_client.send_rewarding_messages(&to_reward).await {
+            error!(
+                "failed to perform mixnode rewarding for epoch {}! Error encountered: {err}",
+                current_interval.current_epoch_absolute_id(),
+            );
+            return Err(err.into());
+        }
+
+        log::info!("rewarded {} mixnodes...", to_reward.len());
+
+        let rewarding_report = RewardingReport {
+            absolute_epoch_id: current_interval.current_epoch_absolute_id(),
+            eligible_mixnodes: to_reward.len() as u32,
+        };
+
+        self.storage
+            .insert_rewarding_report(rewarding_report)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn nodes_to_reward(&self, interval: Interval) -> Vec<MixnodeToReward> {
+        // try to get current up to date view of the network bypassing the cache
+        // in case the epochs were significantly shortened for the purposes of testing
+        let rewarded_set: Vec<MixId> = match self.nyxd_client.get_rewarded_set_mixnodes().await {
+            Ok(nodes) => nodes.into_iter().map(|(id, _)| id).collect::<Vec<_>>(),
+            Err(err) => {
+                warn!("failed to obtain the current rewarded set - {err}. falling back to the cached version");
+                self.nym_contract_cache
+                    .rewarded_set()
+                    .await
+                    .into_inner()
+                    .into_iter()
+                    .map(|node| node.mix_id())
+                    .collect::<Vec<_>>()
+            }
+        };
+
+        let mut eligible_nodes = Vec::with_capacity(rewarded_set.len());
+        for mix_id in rewarded_set {
+            let uptime = self
+                .storage
+                .get_average_mixnode_uptime_in_the_last_24hrs(
+                    mix_id,
+                    interval.current_epoch_end_unix_timestamp(),
+                )
+                .await
+                .unwrap_or_default();
+            eligible_nodes.push(MixnodeToReward {
+                mix_id,
+                performance: uptime.into(),
+            })
+        }
+
+        eligible_nodes
+    }
+}

--- a/nym-api/src/epoch_operations/rewarding.rs
+++ b/nym-api/src/epoch_operations/rewarding.rs
@@ -39,7 +39,7 @@ impl RewardedSetUpdater {
                 })
             }
             EpochState::ReconcilingEvents | EpochState::AdvancingEpoch => {
-                warn!("we seem to have crashed mid epoch operations... no need to reward mixnodes as we've already done that!");
+                warn!("we seem to have crashed mid epoch operations... no need to reward mixnodes as we've already done that! (or this could be a false positive if there were no nodes to reward - to fix this warning later)");
                 Ok(())
             }
             EpochState::Rewarding { .. } => {
@@ -59,7 +59,8 @@ impl RewardedSetUpdater {
         &self,
         current_interval: Interval,
     ) -> Result<(), RewardingError> {
-        let to_reward = self.nodes_to_reward(current_interval).await;
+        let mut to_reward = self.nodes_to_reward(current_interval).await;
+        to_reward.sort_by_key(|a| a.mix_id);
 
         if let Some(existing_report) = self
             .storage

--- a/nym-api/src/epoch_operations/transition_beginning.rs
+++ b/nym-api/src/epoch_operations/transition_beginning.rs
@@ -14,7 +14,7 @@ impl RewardedSetUpdater {
             let epoch_status = self.nyxd_client.get_current_epoch_status().await?;
             if !epoch_status.is_in_progress() {
                 log::error!("FAILED to begin epoch progression: {err}");
-                Err(err.into())
+                Err(err)
             } else {
                 error!("another nym-api ({}) is already advancing the epoch... but we shouldn't have other nym-apis yet!", epoch_status.being_advanced_by);
                 Ok(false)

--- a/nym-api/src/epoch_operations/transition_beginning.rs
+++ b/nym-api/src/epoch_operations/transition_beginning.rs
@@ -1,0 +1,31 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::epoch_operations::error::RewardingError;
+use crate::epoch_operations::RewardedSetUpdater;
+
+impl RewardedSetUpdater {
+    // returns boolean indicating whether we should bother continuing
+    pub(super) async fn begin_epoch_transition(&self) -> Result<bool, RewardingError> {
+        info!("starting the epoch transition...");
+        if let Err(err) = self._begin_epoch_transition().await {
+            // perform the state query again to make sure it's not because other nym-api (not yet applicable)
+            // wasn't faster than us
+            let epoch_status = self.nyxd_client.get_current_epoch_status().await?;
+            if !epoch_status.is_in_progress() {
+                log::error!("FAILED to begin epoch progression: {err}");
+                Err(err.into())
+            } else {
+                error!("another nym-api ({}) is already advancing the epoch... but we shouldn't have other nym-apis yet!", epoch_status.being_advanced_by);
+                Ok(false)
+            }
+        } else {
+            log::info!("Begun epoch transition... SUCCESS");
+            Ok(true)
+        }
+    }
+
+    async fn _begin_epoch_transition(&self) -> Result<(), RewardingError> {
+        Ok(self.nyxd_client.begin_epoch_transition().await?)
+    }
+}


### PR DESCRIPTION
# Description

Introduces strict `EpochState` ordering so that during `epoch_operations` transactions could not be sent in incorrect orders.

It should also deal with the issue described here: https://github.com/nymtech/nym/issues/2771

