### PR TITLE
mixnode: upgrade sysinfo dependency (fix win build)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
 dependencies = [
  "winapi",
 ]
@@ -6075,9 +6075,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.24.7"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cb4ebf3d49308b99e6e9dc95e989e2fdbdc210e4f67c39db0bb89ba927001c"
+checksum = "975fe381e0ecba475d4acff52466906d95b153a40324956552e027b2a9eaa89e"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/mixnode/Cargo.toml
+++ b/mixnode/Cargo.toml
@@ -32,7 +32,7 @@ rand = "0.7.3"
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
 serde = { version="1.0", features = ["derive"] }
 serde_json = "1.0"
-sysinfo = "0.24.1"
+sysinfo = "0.27.7"
 tokio = { version="1.21.2", features = ["rt-multi-thread", "net", "signal"] }
 tokio-util = { version="0.7.3", features = ["codec"] }
 toml = "0.5.8"


### PR DESCRIPTION
Upgrading the sysinfo crate fixes the build on windows with nightly rustc due to https://github.com/MSxDOS/ntapi/issues/11

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
