### PR TITLE
verloc: don't shutdown listener on corrupted connection

### DIFF
--- a/common/mixnode-common/src/verloc/listener.rs
+++ b/common/mixnode-common/src/verloc/listener.rs
@@ -56,7 +56,8 @@ impl PacketListener {
         while !shutdown_listener.is_shutdown() {
             // cloning the arc as each accepted socket is handled in separate task
             let connection_handler = Arc::clone(&self.connection_handler);
-            let handler_shutdown_listener = self.shutdown.clone();
+            let mut handler_shutdown_listener = self.shutdown.clone();
+            handler_shutdown_listener.mark_as_success();
 
             tokio::select! {
                 socket = listener.accept() => {


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/3038

Fix mixnode shutdown down unexpectedly after the verloc listener had it's connection corrupted.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
