### PR TITLE
nym-api: uptime rework

### DIFF
--- a/explorer/src/api/index.ts
+++ b/explorer/src/api/index.ts
@@ -94,9 +94,9 @@ export class Api {
   static fetchGateways = async (): Promise<GatewayBond[]> => {
     const res = await fetch(GATEWAYS_API);
     const gatewaysAnnotated: GatewayBondAnnotated[] = await res.json();
-    return gatewaysAnnotated.map(({ gateway_bond, performance }) => ({
+    return gatewaysAnnotated.map(({ gateway_bond, node_performance }) => ({
       ...gateway_bond,
-      performance: toPercentIntegerString(performance),
+      node_performance,
     }));
   };
 

--- a/explorer/src/api/index.ts
+++ b/explorer/src/api/index.ts
@@ -29,7 +29,6 @@ import {
   GatewayBondAnnotated,
   GatewayBond,
 } from '../typeDefs/explorer-api';
-import { toPercentIntegerString } from '../utils';
 
 function getFromCache(key: string) {
   const ts = Number(localStorage.getItem('ts'));

--- a/explorer/src/components/Gateways.ts
+++ b/explorer/src/components/Gateways.ts
@@ -1,4 +1,5 @@
 import { GatewayResponse, GatewayBond, GatewayReportResponse } from '../typeDefs/explorer-api';
+import { toPercentIntegerString } from '../utils';
 
 export type GatewayRowType = {
   id: string;
@@ -8,7 +9,7 @@ export type GatewayRowType = {
   host: string;
   location: string;
   version: string;
-  performance: string;
+  node_performance: string;
 };
 
 export type GatewayEnrichedRowType = GatewayRowType & {
@@ -29,7 +30,7 @@ export function gatewayToGridRow(arrayOfGateways: GatewayResponse): GatewayRowTy
         bond: gw.pledge_amount.amount || 0,
         host: gw.gateway.host || '',
         version: gw.gateway.version || '',
-        performance: gw.performance,
+        node_performance: toPercentIntegerString(gw.node_performance.last_24h),
       }));
 }
 
@@ -46,6 +47,6 @@ export function gatewayEnrichedToGridRow(gateway: GatewayBond, report: GatewayRe
     mixPort: gateway.gateway.mix_port || 0,
     routingScore: `${report.most_recent}%`,
     avgUptime: `${report.last_day || report.last_hour}%`,
-    performance: gateway.performance,
+    node_performance: toPercentIntegerString(gateway.node_performance.most_recent),
   };
 }

--- a/explorer/src/components/Universal-DataGrid.tsx
+++ b/explorer/src/components/Universal-DataGrid.tsx
@@ -38,7 +38,7 @@ const CustomPagination = () => {
       color="primary"
       count={state.pagination.pageCount}
       page={state.pagination.page + 1}
-      onChange={(event, value) => apiRef.current.setPage(value - 1)}
+      onChange={(_, value) => apiRef.current.setPage(value - 1)}
     />
   );
 };

--- a/explorer/src/pages/GatewayDetail/index.tsx
+++ b/explorer/src/pages/GatewayDetail/index.tsx
@@ -26,7 +26,7 @@ const columns: ColumnsType[] = [
     headerAlign: 'left',
   },
   {
-    field: 'routingScore',
+    field: 'node_performance',
     title: 'Routing Score',
     flex: 1,
     headerAlign: 'left',
@@ -130,13 +130,13 @@ const PageGatewayDetailsWithState = ({ selectedGateway }: { selectedGateway: Gat
  * Guard component to handle loading and not found states
  */
 const PageGatewayDetailGuard: FCWithChildren = () => {
-  const [selectedGateway, setSelectedGateway] = React.useState<GatewayBond | undefined>();
+  const [selectedGateway, setSelectedGateway] = React.useState<GatewayBond>();
   const { gateways } = useMainContext();
   const { id } = useParams<{ id: string | undefined }>();
 
   React.useEffect(() => {
     if (gateways?.data) {
-      setSelectedGateway(gateways.data.find((gateway) => gateway.gateway.identity_key === id));
+      setSelectedGateway(gateways.data.find((g) => g.gateway.identity_key === id));
     }
   }, [gateways, id]);
 

--- a/explorer/src/pages/Gateways/index.tsx
+++ b/explorer/src/pages/Gateways/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link as RRDLink } from 'react-router-dom';
-import { Box, Button, Card, Grid, Link as MuiLink } from '@mui/material';
+import { Box, Card, Grid, Link as MuiLink } from '@mui/material';
 import { CopyToClipboard } from '@nymproject/react/clipboard/CopyToClipboard';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { SelectChangeEvent } from '@mui/material/Select';
@@ -24,8 +24,6 @@ export const PageGateways: FCWithChildren = () => {
   const [pageSize, setPageSize] = React.useState<string>('50');
   const [searchTerm, setSearchTerm] = React.useState<string>('');
   const [versionFilter, setVersionFilter] = React.useState<VersionSelectOptions>(VersionSelectOptions.latestVersion);
-
-  console.log(gateways);
 
   const handleSearch = (str: string) => {
     setSearchTerm(str.toLowerCase());

--- a/explorer/src/pages/Gateways/index.tsx
+++ b/explorer/src/pages/Gateways/index.tsx
@@ -25,6 +25,8 @@ export const PageGateways: FCWithChildren = () => {
   const [searchTerm, setSearchTerm] = React.useState<string>('');
   const [versionFilter, setVersionFilter] = React.useState<VersionSelectOptions>(VersionSelectOptions.latestVersion);
 
+  console.log(gateways);
+
   const handleSearch = (str: string) => {
     setSearchTerm(str.toLowerCase());
   };
@@ -86,7 +88,6 @@ export const PageGateways: FCWithChildren = () => {
   const columns: GridColDef[] = [
     {
       field: 'identity_key',
-      headerName: 'Identity Key',
       renderHeader: () => <CustomColumnHeading headingTitle="Identity Key" />,
       headerClassName: 'MuiDataGrid-header-override',
       width: 380,
@@ -119,7 +120,7 @@ export const PageGateways: FCWithChildren = () => {
         <MuiLink
           sx={{ ...cellStyles }}
           component={RRDLink}
-          to={`/network-components/gateway/${params.row.identityKey}`}
+          to={`/network-components/gateway/${params.row.identity_key}`}
           data-testid="pledge-amount"
         >
           {unymToNym(params.value, 6)}
@@ -127,8 +128,7 @@ export const PageGateways: FCWithChildren = () => {
       ),
     },
     {
-      field: 'performance',
-      headerName: 'Routing Score',
+      field: 'node_performance',
       renderHeader: () => <CustomColumnHeading headingTitle="Routing Score" />,
       width: 150,
       headerAlign: 'left',
@@ -137,7 +137,7 @@ export const PageGateways: FCWithChildren = () => {
         <MuiLink
           sx={{ ...cellStyles }}
           component={RRDLink}
-          to={`/network-components/gateway/${params.row.identityKey}`}
+          to={`/network-components/gateway/${params.row.identity_key}`}
           data-testid="pledge-amount"
         >
           {`${params.value}%`}
@@ -154,7 +154,7 @@ export const PageGateways: FCWithChildren = () => {
         <MuiLink
           sx={{ ...cellStyles }}
           component={RRDLink}
-          to={`/network-components/gateway/${params.row.identityKey}`}
+          to={`/network-components/gateway/${params.row.identity_key}`}
           data-testid="host"
         >
           {params.value}
@@ -168,9 +168,9 @@ export const PageGateways: FCWithChildren = () => {
       headerAlign: 'left',
       headerClassName: 'MuiDataGrid-header-override',
       renderCell: (params: GridRenderCellParams) => (
-        <Button
+        <Box
           onClick={() => handleSearch(params.value as string)}
-          sx={{ ...cellStyles, justifyContent: 'flex-start' }}
+          sx={{ ...cellStyles, justifyContent: 'flex-start', cursor: 'pointer' }}
           data-testid="location-button"
         >
           <Tooltip text={params.value} id="gateway-location-text">
@@ -184,7 +184,7 @@ export const PageGateways: FCWithChildren = () => {
               {params.value}
             </Box>
           </Tooltip>
-        </Button>
+        </Box>
       ),
     },
     {
@@ -207,7 +207,6 @@ export const PageGateways: FCWithChildren = () => {
     },
     {
       field: 'version',
-      headerName: 'Version',
       renderHeader: () => <CustomColumnHeading headingTitle="Version" />,
       width: 150,
       headerAlign: 'left',

--- a/explorer/src/typeDefs/explorer-api.ts
+++ b/explorer/src/typeDefs/explorer-api.ts
@@ -114,6 +114,12 @@ export interface StatsResponse {
   packets_explicitly_dropped_since_last_update: number;
 }
 
+export interface NodePerformance {
+  most_recent: string;
+  last_hour: string;
+  last_24h: string;
+}
+
 export type MixNodeHistoryResponse = StatsResponse;
 
 export interface GatewayBond {
@@ -122,12 +128,12 @@ export interface GatewayBond {
   total_delegation: Amount;
   owner: string;
   gateway: Gateway;
-  performance: string;
+  node_performance: NodePerformance;
 }
 
 export interface GatewayBondAnnotated {
   gateway_bond: GatewayBond;
-  performance: string;
+  node_performance: NodePerformance;
 }
 
 export type GatewayResponse = GatewayBond[];

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -176,9 +176,9 @@ pub struct RewardEstimationResponse {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct UptimeResponse {
     pub mix_id: MixId,
-    // Deprecated in favour of `performance_last_24h`
+    // Deprecated in favour of `node_performance`
     pub avg_uptime: u8,
-    pub performance_last_24h: Performance,
+    pub node_performance: NodePerformance,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
@@ -285,18 +285,26 @@ pub struct MixnodeStatusReportResponse {
     pub mix_id: MixId,
     pub identity: IdentityKey,
     pub owner: String,
+    // Deprecated in favour of `node_performance`
     pub most_recent: Uptime,
+    // Deprecated in favour of `node_performance`
     pub last_hour: Uptime,
+    // Deprecated in favour of `node_performance`
     pub last_day: Uptime,
+    pub node_performance: NodePerformance,
 }
 
 #[derive(Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct GatewayStatusReportResponse {
     pub identity: String,
     pub owner: String,
+    // Deprecated in favour of `node_performance`
     pub most_recent: Uptime,
+    // Deprecated in favour of `node_performance`
     pub last_hour: Uptime,
+    // Deprecated in favour of `node_performance`
     pub last_day: Uptime,
+    pub node_performance: NodePerformance,
 }
 
 #[derive(Clone, Serialize, Deserialize, schemars::JsonSchema)]

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -156,7 +156,9 @@ pub struct RewardEstimationResponse {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct UptimeResponse {
     pub mix_id: MixId,
+    // Deprecated in favour of `performance_last_24h`
     pub avg_uptime: u8,
+    pub performance_last_24h: Performance,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use cosmwasm_std::{Coin, Decimal};
+use cosmwasm_std::{Addr, Coin, Decimal};
 use nym_mixnet_contract_common::families::FamilyHead;
 use nym_mixnet_contract_common::mixnode::MixNodeDetails;
 use nym_mixnet_contract_common::reward_params::{Performance, RewardingParams};
@@ -120,6 +120,14 @@ impl MixNodeBondAnnotated {
 
     pub fn mix_id(&self) -> MixId {
         self.mixnode_details.mix_id()
+    }
+
+    pub fn identity_key(&self) -> &str {
+        self.mixnode_details.bond_information.identity()
+    }
+
+    pub fn owner(&self) -> &Addr {
+        self.mixnode_details.bond_information.owner()
     }
 }
 

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -176,6 +176,7 @@ pub struct RewardEstimationResponse {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct UptimeResponse {
     pub mix_id: MixId,
+    // The same as node_performance.last_24h. Legacy
     pub avg_uptime: u8,
     pub node_performance: NodePerformance,
 }
@@ -183,6 +184,7 @@ pub struct UptimeResponse {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct GatewayUptimeResponse {
     pub identity: String,
+    // The same as node_performance.last_24h. Legacy
     pub avg_uptime: u8,
     pub node_performance: NodePerformance,
 }

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -176,7 +176,13 @@ pub struct RewardEstimationResponse {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct UptimeResponse {
     pub mix_id: MixId,
-    // Deprecated in favour of `node_performance`
+    pub avg_uptime: u8,
+    pub node_performance: NodePerformance,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct GatewayUptimeResponse {
+    pub identity: String,
     pub avg_uptime: u8,
     pub node_performance: NodePerformance,
 }
@@ -285,26 +291,18 @@ pub struct MixnodeStatusReportResponse {
     pub mix_id: MixId,
     pub identity: IdentityKey,
     pub owner: String,
-    // Deprecated in favour of `node_performance`
     pub most_recent: Uptime,
-    // Deprecated in favour of `node_performance`
     pub last_hour: Uptime,
-    // Deprecated in favour of `node_performance`
     pub last_day: Uptime,
-    pub node_performance: NodePerformance,
 }
 
 #[derive(Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct GatewayStatusReportResponse {
     pub identity: String,
     pub owner: String,
-    // Deprecated in favour of `node_performance`
     pub most_recent: Uptime,
-    // Deprecated in favour of `node_performance`
     pub last_hour: Uptime,
-    // Deprecated in favour of `node_performance`
     pub last_day: Uptime,
-    pub node_performance: NodePerformance,
 }
 
 #[derive(Clone, Serialize, Deserialize, schemars::JsonSchema)]

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -93,12 +93,21 @@ pub struct MixnodeStatusResponse {
     pub status: MixnodeStatus,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct NodePerformance {
+    pub most_recent: Performance,
+    pub last_hour: Performance,
+    pub last_24h: Performance,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct MixNodeBondAnnotated {
     pub mixnode_details: MixNodeDetails,
     pub stake_saturation: StakeSaturation,
     pub uncapped_stake_saturation: StakeSaturation,
+    // NOTE: the performance field is deprecated in favour of node_performance
     pub performance: Performance,
+    pub node_performance: NodePerformance,
     pub estimated_operator_apy: Decimal,
     pub estimated_delegators_apy: Decimal,
     pub family: Option<FamilyHead>,

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -134,7 +134,9 @@ impl MixNodeBondAnnotated {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct GatewayBondAnnotated {
     pub gateway_bond: GatewayBond,
+    // NOTE: the performance field is deprecated in favour of node_performance
     pub performance: Performance,
+    pub node_performance: NodePerformance,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -139,6 +139,16 @@ pub struct GatewayBondAnnotated {
     pub node_performance: NodePerformance,
 }
 
+impl GatewayBondAnnotated {
+    pub fn identity(&self) -> &String {
+        self.gateway_bond.identity()
+    }
+
+    pub fn owner(&self) -> &Addr {
+        self.gateway_bond.owner()
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ComputeRewardEstParam {
     pub performance: Option<Performance>,

--- a/nym-api/src/node_status_api/cache/node_sets.rs
+++ b/nym-api/src/node_status_api/cache/node_sets.rs
@@ -163,9 +163,21 @@ pub(crate) async fn annotate_gateways_with_details(
         .await
         .unwrap_or_default();
 
+        let node_performance = if let Some(storage) = storage {
+            storage
+                .construct_gateway_report(gateway_bond.identity())
+                .await
+                .map(NodePerformance::from)
+                .ok()
+        } else {
+            None
+        }
+        .unwrap_or_default();
+
         annotated.push(GatewayBondAnnotated {
             gateway_bond,
             performance,
+            node_performance,
         });
     }
     annotated

--- a/nym-api/src/node_status_api/helpers.rs
+++ b/nym-api/src/node_status_api/helpers.rs
@@ -9,9 +9,10 @@ use cosmwasm_std::Decimal;
 use nym_api_requests::models::{
     AllInclusionProbabilitiesResponse, ComputeRewardEstParam, GatewayBondAnnotated,
     GatewayCoreStatusResponse, GatewayStatusReportResponse, GatewayUptimeHistoryResponse,
-    InclusionProbabilityResponse, MixNodeBondAnnotated, MixnodeCoreStatusResponse,
-    MixnodeStatusReportResponse, MixnodeStatusResponse, MixnodeUptimeHistoryResponse,
-    RewardEstimationResponse, StakeSaturationResponse, UptimeResponse,
+    GatewayUptimeResponse, InclusionProbabilityResponse, MixNodeBondAnnotated,
+    MixnodeCoreStatusResponse, MixnodeStatusReportResponse, MixnodeStatusResponse,
+    MixnodeUptimeHistoryResponse, RewardEstimationResponse, StakeSaturationResponse,
+    UptimeResponse,
 };
 use nym_mixnet_contract_common::{MixId, RewardedSetNodeStatus};
 use rocket::http::Status;
@@ -333,6 +334,19 @@ pub(crate) async fn _get_mixnode_avg_uptime(
         mix_id,
         avg_uptime: mixnode.node_performance.last_24h.round_to_integer(),
         node_performance: mixnode.node_performance,
+    })
+}
+
+pub(crate) async fn _get_gateway_avg_uptime(
+    cache: &NodeStatusCache,
+    identity: &str,
+) -> Result<GatewayUptimeResponse, ErrorResponse> {
+    let gateway = get_gateway_bond_annotated(cache, identity).await?;
+
+    Ok(GatewayUptimeResponse {
+        identity: identity.to_string(),
+        avg_uptime: gateway.node_performance.last_24h.round_to_integer(),
+        node_performance: gateway.node_performance,
     })
 }
 

--- a/nym-api/src/node_status_api/helpers.rs
+++ b/nym-api/src/node_status_api/helpers.rs
@@ -332,7 +332,7 @@ pub(crate) async fn _get_mixnode_avg_uptime(
     Ok(UptimeResponse {
         mix_id,
         avg_uptime: mixnode.node_performance.last_24h.round_to_integer(),
-        performance_last_24h: mixnode.node_performance.last_24h,
+        node_performance: mixnode.node_performance,
     })
 }
 

--- a/nym-api/src/node_status_api/mod.rs
+++ b/nym-api/src/node_status_api/mod.rs
@@ -45,6 +45,7 @@ pub(crate) fn node_status_routes(
             routes::get_mixnode_stake_saturation,
             routes::get_mixnode_inclusion_probability,
             routes::get_mixnode_avg_uptime,
+            routes::get_gateway_avg_uptime,
             routes::get_mixnode_inclusion_probabilities,
             routes::get_mixnodes_detailed,
             routes::get_rewarded_set_detailed,

--- a/nym-api/src/node_status_api/models.rs
+++ b/nym-api/src/node_status_api/models.rs
@@ -238,6 +238,16 @@ impl From<GatewayStatusReport> for GatewayStatusReportResponse {
     }
 }
 
+impl From<GatewayStatusReport> for NodePerformance {
+    fn from(report: GatewayStatusReport) -> Self {
+        NodePerformance {
+            most_recent: report.most_recent.into(),
+            last_hour: report.last_hour.into(),
+            last_24h: report.last_day.into(),
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 pub struct MixnodeUptimeHistory {
     pub(crate) mix_id: MixId,

--- a/nym-api/src/node_status_api/models.rs
+++ b/nym-api/src/node_status_api/models.rs
@@ -5,7 +5,7 @@ use crate::node_status_api::utils::NodeUptimes;
 use crate::storage::models::NodeStatus;
 use nym_api_requests::models::{
     GatewayStatusReportResponse, GatewayUptimeHistoryResponse, HistoricalUptimeResponse,
-    MixnodeStatusReportResponse, MixnodeUptimeHistoryResponse, RequestError,
+    MixnodeStatusReportResponse, MixnodeUptimeHistoryResponse, NodePerformance, RequestError,
 };
 use nym_mixnet_contract_common::reward_params::Performance;
 use nym_mixnet_contract_common::{IdentityKey, MixId};
@@ -175,6 +175,16 @@ impl From<MixnodeStatusReport> for MixnodeStatusReportResponse {
             most_recent: status.most_recent.0,
             last_hour: status.last_hour.0,
             last_day: status.last_day.0,
+        }
+    }
+}
+
+impl From<MixnodeStatusReport> for NodePerformance {
+    fn from(report: MixnodeStatusReport) -> Self {
+        NodePerformance {
+            most_recent: report.most_recent.into(),
+            last_hour: report.last_hour.into(),
+            last_24h: report.last_day.into(),
         }
     }
 }

--- a/nym-api/src/node_status_api/routes.rs
+++ b/nym-api/src/node_status_api/routes.rs
@@ -171,11 +171,10 @@ pub(crate) async fn get_mixnode_inclusion_probability(
 #[openapi(tag = "status")]
 #[get("/mixnode/<mix_id>/avg_uptime")]
 pub(crate) async fn get_mixnode_avg_uptime(
-    cache: &State<NymContractCache>,
-    storage: &State<NymApiStorage>,
+    cache: &State<NodeStatusCache>,
     mix_id: MixId,
 ) -> Result<Json<UptimeResponse>, ErrorResponse> {
-    Ok(Json(_get_mixnode_avg_uptime(cache, storage, mix_id).await?))
+    Ok(Json(_get_mixnode_avg_uptime(cache, mix_id).await?))
 }
 
 #[openapi(tag = "status")]

--- a/nym-api/src/node_status_api/routes.rs
+++ b/nym-api/src/node_status_api/routes.rs
@@ -75,10 +75,10 @@ pub(crate) async fn gateway_core_status_count(
 #[openapi(tag = "status")]
 #[get("/mixnode/<mix_id>/report")]
 pub(crate) async fn mixnode_report(
-    storage: &State<NymApiStorage>,
+    cache: &State<NodeStatusCache>,
     mix_id: MixId,
 ) -> Result<Json<MixnodeStatusReportResponse>, ErrorResponse> {
-    Ok(Json(_mixnode_report(storage, mix_id).await?))
+    Ok(Json(_mixnode_report(cache, mix_id).await?))
 }
 
 #[openapi(tag = "status")]

--- a/nym-api/src/node_status_api/routes.rs
+++ b/nym-api/src/node_status_api/routes.rs
@@ -5,11 +5,12 @@ use super::helpers::_get_gateways_detailed;
 use super::NodeStatusCache;
 use crate::node_status_api::helpers::{
     _compute_mixnode_reward_estimation, _gateway_core_status_count, _gateway_report,
-    _gateway_uptime_history, _get_active_set_detailed, _get_mixnode_avg_uptime,
-    _get_mixnode_inclusion_probabilities, _get_mixnode_inclusion_probability,
-    _get_mixnode_reward_estimation, _get_mixnode_stake_saturation, _get_mixnode_status,
-    _get_mixnodes_detailed, _get_rewarded_set_detailed, _mixnode_core_status_count,
-    _mixnode_report, _mixnode_uptime_history,
+    _gateway_uptime_history, _get_active_set_detailed, _get_gateway_avg_uptime,
+    _get_mixnode_avg_uptime, _get_mixnode_inclusion_probabilities,
+    _get_mixnode_inclusion_probability, _get_mixnode_reward_estimation,
+    _get_mixnode_stake_saturation, _get_mixnode_status, _get_mixnodes_detailed,
+    _get_rewarded_set_detailed, _mixnode_core_status_count, _mixnode_report,
+    _mixnode_uptime_history,
 };
 use crate::node_status_api::models::ErrorResponse;
 use crate::storage::NymApiStorage;
@@ -17,9 +18,10 @@ use crate::NymContractCache;
 use nym_api_requests::models::{
     AllInclusionProbabilitiesResponse, ComputeRewardEstParam, GatewayBondAnnotated,
     GatewayCoreStatusResponse, GatewayStatusReportResponse, GatewayUptimeHistoryResponse,
-    InclusionProbabilityResponse, MixNodeBondAnnotated, MixnodeCoreStatusResponse,
-    MixnodeStatusReportResponse, MixnodeStatusResponse, MixnodeUptimeHistoryResponse,
-    RewardEstimationResponse, StakeSaturationResponse, UptimeResponse,
+    GatewayUptimeResponse, InclusionProbabilityResponse, MixNodeBondAnnotated,
+    MixnodeCoreStatusResponse, MixnodeStatusReportResponse, MixnodeStatusResponse,
+    MixnodeUptimeHistoryResponse, RewardEstimationResponse, StakeSaturationResponse,
+    UptimeResponse,
 };
 use nym_mixnet_contract_common::MixId;
 use rocket::serde::json::Json;
@@ -159,6 +161,15 @@ pub(crate) async fn get_mixnode_avg_uptime(
     mix_id: MixId,
 ) -> Result<Json<UptimeResponse>, ErrorResponse> {
     Ok(Json(_get_mixnode_avg_uptime(cache, mix_id).await?))
+}
+
+#[openapi(tag = "status")]
+#[get("/gateway/<identity>/avg_uptime")]
+pub(crate) async fn get_gateway_avg_uptime(
+    cache: &State<NodeStatusCache>,
+    identity: &str,
+) -> Result<Json<GatewayUptimeResponse>, ErrorResponse> {
+    Ok(Json(_get_gateway_avg_uptime(cache, identity).await?))
 }
 
 #[openapi(tag = "status")]


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/2978

- Cache the uptime data and add it to the detailes mixnode and gateway endpoints (as performance).
- Uptime report endpoints now just fetch cached data.
- Add gateway avg uptime endpoint for symmetry with the corresponding mixnode endpoint.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
