### PR TITLE
Use saturating_sub with an additional 1 second buffer

### DIFF
--- a/clients/credential/src/main.rs
+++ b/clients/credential/src/main.rs
@@ -51,8 +51,11 @@ async fn block_until_coconut_is_available<C: Clone + CosmWasmClient + Send + Syn
 
             break;
         } else {
-            // Use 20 additional seconds to avoid the exact moment of going into the final epoch state
-            let secs_until_final = epoch.final_timestamp_secs() + 20 - current_timestamp_secs;
+            // Use 1 additional second to not start the next iteration immediately and spam get_current_epoch queries
+            let secs_until_final = epoch
+                .final_timestamp_secs()
+                .saturating_sub(current_timestamp_secs)
+                + 1;
             info!("Approximately {} seconds until coconut is available. Sleeping until then. You can safely kill the process at any moment.", secs_until_final);
             std::thread::sleep(Duration::from_secs(secs_until_final));
         }


### PR DESCRIPTION
# Description

Closes: #3057

The panic on overflow is fixed, but a few (~10) ambiguous messages like `Approximately 1 seconds until coconut is available. Sleeping until then. You can safely kill the process at any moment.` will still be printed, due to some time discrepancies in epoch state updating. This shouldn't have much effect on the end-user, other then waiting a bit more for the credential to be generated.

<!-- If appropriate, insert relevant description here -->

