### PR TITLE
Feature/fix resharing

### DIFF
--- a/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
+++ b/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
@@ -21,7 +21,7 @@ pub const TOTAL_DEALINGS: usize = 2 + 2 + 1;
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct InitialReplacementData {
     pub initial_dealers: Vec<Addr>,
-    pub initial_height: Option<u64>,
+    pub initial_height: u64,
 }
 
 #[derive(

--- a/contracts/coconut-dkg/src/dealers/transactions.rs
+++ b/contracts/coconut-dkg/src/dealers/transactions.rs
@@ -22,7 +22,7 @@ fn verify_dealer(deps: DepsMut<'_>, dealer: &Addr, resharing: bool) -> Result<()
     let state = STATE.load(deps.storage)?;
 
     let height = if resharing {
-        INITIAL_REPLACEMENT_DATA.load(deps.storage)?.initial_height
+        Some(INITIAL_REPLACEMENT_DATA.load(deps.storage)?.initial_height)
     } else {
         None
     };
@@ -105,7 +105,7 @@ pub(crate) mod tests {
                     deps.as_mut().storage,
                     &InitialReplacementData {
                         initial_dealers: vec![details1.address, details2.address, details3.address],
-                        initial_height: Some(1),
+                        initial_height: 1,
                     },
                 )
                 .unwrap();
@@ -126,7 +126,7 @@ pub(crate) mod tests {
 
             INITIAL_REPLACEMENT_DATA
                 .update::<_, ContractError>(deps.as_mut().storage, |mut data| {
-                    data.initial_height = Some(2);
+                    data.initial_height = 2;
                     Ok(data)
                 })
                 .unwrap();

--- a/contracts/coconut-dkg/src/dealings/transactions.rs
+++ b/contracts/coconut-dkg/src/dealings/transactions.rs
@@ -110,7 +110,7 @@ pub(crate) mod tests {
                 deps.as_mut().storage,
                 &InitialReplacementData {
                     initial_dealers: vec![],
-                    initial_height: None,
+                    initial_height: 1,
                 },
             )
             .unwrap();

--- a/contracts/coconut-dkg/src/epoch_state/transactions.rs
+++ b/contracts/coconut-dkg/src/epoch_state/transactions.rs
@@ -21,7 +21,13 @@ fn reset_epoch_state(storage: &mut dyn Storage) -> Result<(), ContractError> {
     for dealer_addr in dealers {
         let details = current_dealers().load(storage, &dealer_addr)?;
         for dealings in DEALINGS_BYTES {
-            dealings.remove(storage, &details.address);
+            let dealing_keys: Vec<_> = dealings
+                .keys(storage, None, None, Order::Ascending)
+                .flatten()
+                .collect();
+            for key in dealing_keys {
+                dealings.remove(storage, &key);
+            }
         }
         current_dealers().remove(storage, &dealer_addr)?;
         past_dealers().save(storage, &dealer_addr, &details)?;

--- a/contracts/coconut-dkg/src/epoch_state/transactions.rs
+++ b/contracts/coconut-dkg/src/epoch_state/transactions.rs
@@ -8,7 +8,6 @@ use crate::epoch_state::utils::check_epoch_state;
 use crate::error::ContractError;
 use crate::state::STATE;
 use crate::verification_key_shares::storage::verified_dealers;
-use crate::verification_key_shares::storage::vk_shares;
 use cosmwasm_std::{Addr, Deps, DepsMut, Env, Order, Response, Storage};
 use nym_coconut_dkg_common::types::{Epoch, EpochState, InitialReplacementData};
 

--- a/contracts/coconut-dkg/src/epoch_state/transactions.rs
+++ b/contracts/coconut-dkg/src/epoch_state/transactions.rs
@@ -48,7 +48,7 @@ fn dealers_still_active(
 }
 
 fn dealers_eq_members(deps: &DepsMut<'_>) -> Result<bool, ContractError> {
-    let verified_dealers = verified_dealers(deps.storage);
+    let verified_dealers = verified_dealers(deps.storage)?;
     let all_dealers = verified_dealers.len();
     let dealers_still_active = dealers_still_active(&deps.as_ref(), verified_dealers.into_iter())?;
     let group_members = STATE
@@ -122,7 +122,7 @@ pub(crate) fn advance_epoch_state(deps: DepsMut<'_>, env: Env) -> Result<Respons
         )
     } else {
         let replacement_data = InitialReplacementData {
-            initial_dealers: verified_dealers(deps.storage),
+            initial_dealers: verified_dealers(deps.storage)?,
             initial_height: env.block.height,
         };
         INITIAL_REPLACEMENT_DATA.save(deps.storage, &replacement_data)?;
@@ -154,7 +154,7 @@ pub(crate) fn try_surpassed_threshold(
     check_epoch_state(deps.storage, EpochState::InProgress)?;
 
     let threshold = THRESHOLD.load(deps.storage)?;
-    let dealers = verified_dealers(deps.storage);
+    let dealers = verified_dealers(deps.storage)?;
     if dealers_still_active(&deps.as_ref(), dealers.into_iter())? < threshold as usize {
         reset_epoch_state(deps.storage)?;
         CURRENT_EPOCH.update::<_, ContractError>(deps.storage, |epoch| {

--- a/contracts/coconut-dkg/src/epoch_state/transactions.rs
+++ b/contracts/coconut-dkg/src/epoch_state/transactions.rs
@@ -7,6 +7,8 @@ use crate::epoch_state::storage::{CURRENT_EPOCH, INITIAL_REPLACEMENT_DATA, THRES
 use crate::epoch_state::utils::check_epoch_state;
 use crate::error::ContractError;
 use crate::state::STATE;
+use crate::verification_key_shares::storage::vk_shares;
+>>>>>>> bdf7487ea (Compare verified vks against current group instead of initial dealers)
 use cosmwasm_std::{Addr, Deps, DepsMut, Env, Order, Response, Storage};
 use nym_coconut_dkg_common::types::{Epoch, EpochState, InitialReplacementData};
 
@@ -158,9 +160,16 @@ pub(crate) fn try_surpassed_threshold(
     check_epoch_state(deps.storage, EpochState::InProgress)?;
 
     let threshold = THRESHOLD.load(deps.storage)?;
-    let dealers = current_dealers()
-        .keys(deps.storage, None, None, Order::Ascending)
-        .flatten();
+    let dealers = vk_shares()
+        .range(deps.storage, None, None, Order::Ascending)
+        .flatten()
+        .filter_map(|(_, share)| {
+            if share.verified {
+                Some(share.owner)
+            } else {
+                None
+            }
+        });
     if dealers_still_active(&deps.as_ref(), dealers)? < threshold as usize {
         reset_epoch_state(deps.storage)?;
         CURRENT_EPOCH.update::<_, ContractError>(deps.storage, |epoch| {
@@ -180,7 +189,7 @@ pub(crate) fn try_surpassed_threshold(
 pub(crate) mod tests {
     use super::*;
     use crate::error::ContractError::EarlyEpochStateAdvancement;
-    use crate::support::tests::fixtures::dealer_details_fixture;
+    use crate::support::tests::fixtures::{dealer_details_fixture, vk_share_fixture};
     use crate::support::tests::helpers::{init_contract, GROUP_MEMBERS};
     use cosmwasm_std::testing::mock_env;
     use cosmwasm_std::Addr;
@@ -676,6 +685,12 @@ pub(crate) mod tests {
             for details in all_details.iter() {
                 current_dealers()
                     .save(deps.as_mut().storage, &details.address, details)
+                    .unwrap();
+            }
+            let all_shares: [_; 3] = std::array::from_fn(|i| vk_share_fixture(&format!("owner{}", i + 1), 0));
+            for share in all_shares.iter() {
+                vk_shares()
+                    .save(deps.as_mut().storage, (&share.owner, share.epoch_id), share)
                     .unwrap();
             }
 

--- a/contracts/coconut-dkg/src/epoch_state/transactions.rs
+++ b/contracts/coconut-dkg/src/epoch_state/transactions.rs
@@ -200,11 +200,15 @@ pub(crate) mod tests {
 
             for n in [10, 25, 50, 100] {
                 let dealers: Vec<_> = (0..n).map(dealer_details_fixture).collect();
+                let shares: Vec<_> = (0..n).map(|idx| vk_share_fixture(&format!("owner{}", idx), 0)).collect();
                 let initial_dealers = dealers.iter().map(|d| d.address.clone()).collect();
                 let data = InitialReplacementData {
                     initial_dealers,
                     initial_height: 1,
                 };
+                for share in shares {
+                    vk_shares().save(deps.as_mut().storage, (&share.owner, 0), &share).unwrap();
+                }
                 for f in [two_thirds, three_fourths, ninty_pc] {
                     let threshold = f(n);
                     THRESHOLD.save(deps.as_mut().storage, &threshold).unwrap();
@@ -625,7 +629,7 @@ pub(crate) mod tests {
             advance_epoch_state(deps.as_mut(), env.clone()).unwrap();
             let curr_epoch = CURRENT_EPOCH.load(deps.as_mut().storage).unwrap();
             let expected_epoch = Epoch::new(
-                EpochState::PublicKeySubmission { resharing: false },
+                EpochState::PublicKeySubmission { resharing: true },
                 prev_epoch.epoch_id + 1,
                 prev_epoch.time_configuration,
                 env.block.time,

--- a/contracts/coconut-dkg/src/verification_key_shares/storage.rs
+++ b/contracts/coconut-dkg/src/verification_key_shares/storage.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::constants::{VK_SHARES_EPOCH_ID_IDX_NAMESPACE, VK_SHARES_PK_NAMESPACE};
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, Order, Storage};
 use cw_storage_plus::{Index, IndexList, IndexedMap, MultiIndex};
 use nym_coconut_dkg_common::types::EpochId;
 use nym_coconut_dkg_common::verification_key::ContractVKShare;
@@ -34,4 +34,18 @@ pub(crate) fn vk_shares<'a>() -> IndexedMap<'a, VKShareKey<'a>, ContractVKShare,
         ),
     };
     IndexedMap::new(VK_SHARES_PK_NAMESPACE, indexes)
+}
+
+pub(crate) fn verified_dealers(storage: &dyn Storage) -> Vec<Addr> {
+    vk_shares()
+        .range(storage, None, None, Order::Ascending)
+        .flatten()
+        .filter_map(|(_, share)| {
+            if share.verified {
+                Some(share.owner)
+            } else {
+                None
+            }
+        })
+        .collect()
 }

--- a/contracts/coconut-dkg/src/verification_key_shares/storage.rs
+++ b/contracts/coconut-dkg/src/verification_key_shares/storage.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::constants::{VK_SHARES_EPOCH_ID_IDX_NAMESPACE, VK_SHARES_PK_NAMESPACE};
+use crate::epoch_state::storage::CURRENT_EPOCH;
+use crate::error::ContractError;
 use cosmwasm_std::{Addr, Order, Storage};
 use cw_storage_plus::{Index, IndexList, IndexedMap, MultiIndex};
 use nym_coconut_dkg_common::types::EpochId;
@@ -36,8 +38,12 @@ pub(crate) fn vk_shares<'a>() -> IndexedMap<'a, VKShareKey<'a>, ContractVKShare,
     IndexedMap::new(VK_SHARES_PK_NAMESPACE, indexes)
 }
 
-pub(crate) fn verified_dealers(storage: &dyn Storage) -> Vec<Addr> {
-    vk_shares()
+pub(crate) fn verified_dealers(storage: &dyn Storage) -> Result<Vec<Addr>, ContractError> {
+    let epoch_id = CURRENT_EPOCH.load(storage)?.epoch_id;
+    Ok(vk_shares()
+        .idx
+        .epoch_id
+        .prefix(epoch_id)
         .range(storage, None, None, Order::Ascending)
         .flatten()
         .filter_map(|(_, share)| {
@@ -47,5 +53,5 @@ pub(crate) fn verified_dealers(storage: &dyn Storage) -> Vec<Addr> {
                 None
             }
         })
-        .collect()
+        .collect())
 }

--- a/nym-api/src/coconut/dkg/controller.rs
+++ b/nym-api/src/coconut/dkg/controller.rs
@@ -99,7 +99,7 @@ impl<R: RngCore + CryptoRng + Clone> DkgController<R> {
                     return;
                 }
                 if let Err(err) = self.state.is_consistent(epoch.state).await {
-                    error!("Epoch state is corrupted - {err}, the process should be terminated");
+                    debug!("Epoch state is corrupted - {err}. Awaiting for a DKG restart.");
                     return;
                 }
                 let ret = match epoch.state {

--- a/nym-api/src/coconut/dkg/controller.rs
+++ b/nym-api/src/coconut/dkg/controller.rs
@@ -100,56 +100,65 @@ impl<R: RngCore + CryptoRng + Clone> DkgController<R> {
                 }
                 if let Err(err) = self.state.is_consistent(epoch.state).await {
                     debug!("Epoch state is corrupted - {err}. Awaiting for a DKG restart.");
-                    return;
-                }
-                let ret = match epoch.state {
-                    EpochState::PublicKeySubmission { resharing } => {
-                        public_key_submission(&self.dkg_client, &mut self.state, resharing).await
-                    }
-                    EpochState::DealingExchange { resharing } => {
-                        dealing_exchange(
-                            &self.dkg_client,
-                            &mut self.state,
-                            self.rng.clone(),
-                            resharing,
-                        )
-                        .await
-                    }
-                    EpochState::VerificationKeySubmission { resharing } => {
-                        let keypair_path = nym_pemstore::KeyPairPath::new(
-                            self.secret_key_path.clone(),
-                            self.verification_key_path.clone(),
-                        );
-                        verification_key_submission(
-                            &self.dkg_client,
-                            &mut self.state,
-                            &keypair_path,
-                            resharing,
-                        )
-                        .await
-                    }
-                    EpochState::VerificationKeyValidation { resharing } => {
-                        verification_key_validation(&self.dkg_client, &mut self.state, resharing)
+                } else {
+                    let ret = match epoch.state {
+                        EpochState::PublicKeySubmission { resharing } => {
+                            public_key_submission(&self.dkg_client, &mut self.state, resharing)
+                                .await
+                        }
+                        EpochState::DealingExchange { resharing } => {
+                            dealing_exchange(
+                                &self.dkg_client,
+                                &mut self.state,
+                                self.rng.clone(),
+                                resharing,
+                            )
                             .await
-                    }
-                    EpochState::VerificationKeyFinalization { resharing } => {
-                        verification_key_finalization(&self.dkg_client, &mut self.state, resharing)
+                        }
+                        EpochState::VerificationKeySubmission { resharing } => {
+                            let keypair_path = nym_pemstore::KeyPairPath::new(
+                                self.secret_key_path.clone(),
+                                self.verification_key_path.clone(),
+                            );
+                            verification_key_submission(
+                                &self.dkg_client,
+                                &mut self.state,
+                                &keypair_path,
+                                resharing,
+                            )
                             .await
-                    }
-                    // Just wait, in case we need to redo dkg at some point
-                    EpochState::InProgress => {
-                        self.state.set_was_in_progress();
-                        Ok(())
-                    }
-                };
-                if let Err(err) = ret {
-                    warn!("Could not handle this iteration for the epoch state: {err}");
-                } else if epoch.state != EpochState::InProgress {
-                    let persistent_state = PersistentState::from(&self.state);
-                    if let Err(err) =
-                        persistent_state.save_to_file(self.state.persistent_state_path())
-                    {
-                        warn!("Could not backup the state for this iteration: {err}");
+                        }
+                        EpochState::VerificationKeyValidation { resharing } => {
+                            verification_key_validation(
+                                &self.dkg_client,
+                                &mut self.state,
+                                resharing,
+                            )
+                            .await
+                        }
+                        EpochState::VerificationKeyFinalization { resharing } => {
+                            verification_key_finalization(
+                                &self.dkg_client,
+                                &mut self.state,
+                                resharing,
+                            )
+                            .await
+                        }
+                        // Just wait, in case we need to redo dkg at some point
+                        EpochState::InProgress => {
+                            self.state.set_was_in_progress();
+                            Ok(())
+                        }
+                    };
+                    if let Err(err) = ret {
+                        warn!("Could not handle this iteration for the epoch state: {err}");
+                    } else if epoch.state != EpochState::InProgress {
+                        let persistent_state = PersistentState::from(&self.state);
+                        if let Err(err) =
+                            persistent_state.save_to_file(self.state.persistent_state_path())
+                        {
+                            warn!("Could not backup the state for this iteration: {err}");
+                        }
                     }
                 }
                 if let Ok(current_timestamp) =

--- a/nym-api/src/coconut/dkg/dealing.rs
+++ b/nym-api/src/coconut/dkg/dealing.rs
@@ -257,7 +257,7 @@ pub(crate) mod tests {
         let threshold_db = Arc::new(RwLock::new(Some(3)));
         let initial_dealers_db = Arc::new(RwLock::new(Some(InitialReplacementData {
             initial_dealers: vec![Addr::unchecked(TEST_VALIDATORS_ADDRESS[0])],
-            initial_height: Some(100),
+            initial_height: 100,
         })));
         let dkg_client = DkgClient::new(
             DummyClient::new(

--- a/nym-api/src/coconut/dkg/public_key.rs
+++ b/nym-api/src/coconut/dkg/public_key.rs
@@ -4,6 +4,7 @@
 use crate::coconut::dkg::client::DkgClient;
 use crate::coconut::dkg::state::State;
 use crate::coconut::error::CoconutError;
+use log::debug;
 use nym_coconut_dkg_common::dealer::DealerType;
 
 pub(crate) async fn public_key_submission(
@@ -19,9 +20,14 @@ pub(crate) async fn public_key_submission(
             .map(|data| data.initial_dealers.iter().any(|d| *d == own_address))
             .unwrap_or(false);
         let reset_coconut_keypair = !resharing || !is_initial_dealer;
+        debug!(
+            "Resetting state, with coconut keypair reset: {}",
+            reset_coconut_keypair
+        );
         state.reset_persistent(reset_coconut_keypair).await;
     }
     if state.node_index().is_some() {
+        debug!("Node index was set previously, nothing to do");
         return Ok(());
     }
 
@@ -30,12 +36,14 @@ pub(crate) async fn public_key_submission(
     let index = if let Some(details) = dealer_details.details {
         if dealer_details.dealer_type == DealerType::Past {
             // If it was a dealer in a previous epoch, re-register it for this epoch
+            debug!("Registering for the current DKG round, with keys from a previous epoch");
             dkg_client
                 .register_dealer(bte_key, state.announce_address().to_string(), resharing)
                 .await?;
         }
         details.assigned_index
     } else {
+        debug!("Registering for the first time to be a dealer");
         // First time registration
         dkg_client
             .register_dealer(bte_key, state.announce_address().to_string(), resharing)

--- a/nym-api/src/coconut/dkg/state.rs
+++ b/nym-api/src/coconut/dkg/state.rs
@@ -133,7 +133,7 @@ impl ConsistentState for State {
 
     fn proposal_id_value(&self) -> Result<u64, CoconutError> {
         self.proposal_id.ok_or(CoconutError::UnrecoverableState {
-            reason: String::from("Proposal id should have benn set"),
+            reason: String::from("Proposal id should have been set"),
         })
     }
 }

--- a/nym-api/src/coconut/dkg/state.rs
+++ b/nym-api/src/coconut/dkg/state.rs
@@ -5,6 +5,7 @@ use crate::coconut::dkg::complaints::ComplaintReason;
 use crate::coconut::error::CoconutError;
 use crate::coconut::keypair::KeyPair as CoconutKeyPair;
 use cosmwasm_std::Addr;
+use log::debug;
 use nym_coconut_dkg_common::dealer::DealerDetails;
 use nym_coconut_dkg_common::types::EpochState;
 use nym_dkg::bte::{keys::KeyPair as DkgKeyPair, PublicKey, PublicKeyWithProof};
@@ -360,6 +361,10 @@ impl State {
             .iter_mut()
             .find(|(addr, _)| *addr == dealer_addr)
         {
+            debug!(
+                "Dealer {} misbehaved: {:?}. It will be marked locally as bad dealer and ignored",
+                dealer_addr, reason
+            );
             *value = Err(reason);
         }
     }

--- a/nym-api/src/coconut/dkg/state.rs
+++ b/nym-api/src/coconut/dkg/state.rs
@@ -242,8 +242,8 @@ impl State {
         }
     }
 
-    pub async fn reset_persistent(&mut self, resharing: bool) {
-        if !resharing {
+    pub async fn reset_persistent(&mut self, reset_coconut_keypair: bool) {
+        if reset_coconut_keypair {
             self.coconut_keypair.set(None).await;
         }
         self.node_index = Default::default();

--- a/nym-api/src/coconut/dkg/verification_key.rs
+++ b/nym-api/src/coconut/dkg/verification_key.rs
@@ -471,7 +471,7 @@ pub(crate) mod tests {
         for (dkg_client, state) in clients_and_states.iter_mut().skip(1) {
             *db.initial_dealers_db.write().unwrap() = Some(InitialReplacementData {
                 initial_dealers: vec![Addr::unchecked(TEST_VALIDATORS_ADDRESS[0])],
-                initial_height: None,
+                initial_height: 1,
             });
             let filtered = deterministic_filter_dealers(dkg_client, state, 2, true)
                 .await
@@ -504,7 +504,7 @@ pub(crate) mod tests {
         for (dkg_client, state) in clients_and_states.iter_mut().skip(1) {
             *db.initial_dealers_db.write().unwrap() = Some(InitialReplacementData {
                 initial_dealers: vec![],
-                initial_height: None,
+                initial_height: 1,
             });
             let filtered = deterministic_filter_dealers(dkg_client, state, 2, true)
                 .await
@@ -851,7 +851,7 @@ pub(crate) mod tests {
                 Addr::unchecked(clients_and_states[1].0.get_address().await.as_ref()),
                 Addr::unchecked(clients_and_states[2].0.get_address().await.as_ref()),
             ],
-            initial_height: None,
+            initial_height: 1,
         });
         *clients_and_states.first_mut().unwrap() = (new_dkg_client, state);
         clients_and_states[1].1.set_was_in_progress();

--- a/nym-api/src/coconut/dkg/verification_key.rs
+++ b/nym-api/src/coconut/dkg/verification_key.rs
@@ -119,7 +119,7 @@ fn derive_partial_keypair(
             .unzip();
         debug!(
             "Recovering verification keys from dealings of dealers {:?} with receivers {:?}",
-            filtered_dealings,
+            filtered_dealers,
             filtered_receivers_by_idx.keys().collect::<Vec<_>>()
         );
         let recovered = try_recover_verification_keys(

--- a/nym-api/src/coconut/error.rs
+++ b/nym-api/src/coconut/error.rs
@@ -91,7 +91,7 @@ pub enum CoconutError {
     #[error("Failed to recover assigned node index: {reason}")]
     NodeIndexRecoveryError { reason: String },
 
-    #[error("Unrecoverable state: {reason}. Process should be restarted")]
+    #[error("Unrecoverable state: {reason}")]
     UnrecoverableState { reason: String },
 
     #[error("DKG has not finished yet in order to derive the coconut key")]

--- a/tools/nym-cli/src/validator/mixnet/delegators/mod.rs
+++ b/tools/nym-cli/src/validator/mixnet/delegators/mod.rs
@@ -38,7 +38,6 @@ pub(crate) async fn execute(
         nym_cli_commands::validator::mixnet::delegators::MixnetDelegatorsCommands::List(args) => {
             nym_cli_commands::validator::mixnet::delegators::query_for_delegations::execute(args, create_signing_client_with_nym_api(global_args, network_details)?).await
         }
-        _ => unreachable!(),
     }
     Ok(())
 }


### PR DESCRIPTION
# Description

Closes: #3138

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [x] Use the verified dealers (the ones that pushed correct coconut verification keys) instead of the ones that originally signed up to be a dealer, as some of them might fail on the way
- [x] Improve logging so that DKG errors don't flood the API console
- [x] Only enter `DealingExchange` state when all of the dealers from the group have signed up for being a dealer
- [x] In case DKG fails due to whatever reason, just re-run it in reset mode with the current group set, to ensure availability
- [x] Set list of initial dealer when going from `InProgress` to `PublicKeySubmission` in reshare mode instead of when going from `PublicKeySubmission` to `DealingExchange`