### PR TITLE
Fix docs.rs build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "1.2.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
+checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
 dependencies = [
  "enum-iterator-derive",
 ]
@@ -2187,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.16.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
 dependencies = [
  "bitflags",
  "libc",
@@ -2897,9 +2897,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.13.5+1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "51e5ea06c26926f1002dd553fded6cfcdc9784c1f60feeb58368b4d9b07b6dba"
 dependencies = [
  "cc",
  "libc",
@@ -6898,9 +6898,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "7.5.1"
+version = "7.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
+checksum = "447f9238a4553957277b3ee09d80babeae0811f1b3baefb093de1c0448437a37"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,31 +1713,11 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2953d1df47ac0eb70086ccabf0275aa8da8591a28bd358ee2b52bd9f9e3ff9e9"
-dependencies = [
- "enum-iterator-derive 0.8.1",
-]
-
-[[package]]
-name = "enum-iterator"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91a4ec26efacf4aeff80887a175a419493cb6f8b5480d26387eb0bd038976187"
 dependencies = [
- "enum-iterator-derive 1.1.0",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8958699f9359f0b04e691a13850d48b7de329138023876d07cbd024c2c820598"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "enum-iterator-derive",
 ]
 
 [[package]]
@@ -3371,7 +3351,7 @@ dependencies = [
  "pretty_env_logger",
  "semver 0.11.0",
  "serde",
- "vergen 7.5.1",
+ "vergen",
 ]
 
 [[package]]
@@ -4034,7 +4014,7 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
- "vergen 5.1.17",
+ "vergen",
 ]
 
 [[package]]
@@ -6918,30 +6898,13 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "5.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf88d94e969e7956d924ba70741316796177fa0c79a2c9f4ab04998d96e966e"
-dependencies = [
- "anyhow",
- "cfg-if",
- "chrono",
- "enum-iterator 0.8.1",
- "getset",
- "git2",
- "rustc_version 0.4.0",
- "rustversion",
- "thiserror",
-]
-
-[[package]]
-name = "vergen"
 version = "7.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
 dependencies = [
  "anyhow",
  "cfg-if",
- "enum-iterator 1.2.0",
+ "enum-iterator",
  "getset",
  "git2",
  "rustc_version 0.4.0",

--- a/contracts/mixnet/Cargo.toml
+++ b/contracts/mixnet/Cargo.toml
@@ -43,7 +43,7 @@ rand_chacha = "0.2"
 nym-crypto = { path = "../../common/crypto", features = ["asymmetric", "rand"] }
 
 [build-dependencies]
-vergen = { version = "7", default-features = false, features = ["build", "git", "rustc"] }
+vergen = { version = "=7.4.3", default-features = false, features = ["build", "git", "rustc"] }
 
 [features]
 default = []

--- a/contracts/mixnet/Cargo.toml
+++ b/contracts/mixnet/Cargo.toml
@@ -43,7 +43,7 @@ rand_chacha = "0.2"
 nym-crypto = { path = "../../common/crypto", features = ["asymmetric", "rand"] }
 
 [build-dependencies]
-vergen = { version = "5", default-features = false, features = ["build", "git", "rustc"] }
+vergen = { version = "7", default-features = false, features = ["build", "git", "rustc"] }
 
 [features]
 default = []

--- a/contracts/mixnet/build.rs
+++ b/contracts/mixnet/build.rs
@@ -4,5 +4,10 @@
 use vergen::{vergen, Config};
 
 fn main() {
-    vergen(Config::default()).expect("failed to extract build metadata")
+    let mut config = Config::default();
+    if std::env::var("DOCS_RS").is_ok() {
+        // If we don't have access to git information, such as in a docs.rs build, don't error
+        *config.git_mut().skip_if_error_mut() = true;
+    }
+    vergen(config).expect("failed to extract build metadata");
 }

--- a/contracts/mixnet/src/mixnet_contract_settings/queries.rs
+++ b/contracts/mixnet/src/mixnet_contract_settings/queries.rs
@@ -29,8 +29,12 @@ pub(crate) fn query_contract_version() -> ContractBuildInformation {
         build_timestamp: env!("VERGEN_BUILD_TIMESTAMP").to_string(),
         build_version: env!("VERGEN_BUILD_SEMVER").to_string(),
         commit_sha: option_env!("VERGEN_GIT_SHA").unwrap_or("NONE").to_string(),
-        commit_timestamp: option_env!("VERGEN_GIT_COMMIT_TIMESTAMP").unwrap_or("NONE").to_string(),
-        commit_branch: option_env!("VERGEN_GIT_BRANCH").unwrap_or("NONE").to_string(),
+        commit_timestamp: option_env!("VERGEN_GIT_COMMIT_TIMESTAMP")
+            .unwrap_or("NONE")
+            .to_string(),
+        commit_branch: option_env!("VERGEN_GIT_BRANCH")
+            .unwrap_or("NONE")
+            .to_string(),
         rustc_version: env!("VERGEN_RUSTC_SEMVER").to_string(),
     }
 }

--- a/contracts/mixnet/src/mixnet_contract_settings/queries.rs
+++ b/contracts/mixnet/src/mixnet_contract_settings/queries.rs
@@ -28,9 +28,9 @@ pub(crate) fn query_contract_version() -> ContractBuildInformation {
     ContractBuildInformation {
         build_timestamp: env!("VERGEN_BUILD_TIMESTAMP").to_string(),
         build_version: env!("VERGEN_BUILD_SEMVER").to_string(),
-        commit_sha: env!("VERGEN_GIT_SHA").to_string(),
-        commit_timestamp: env!("VERGEN_GIT_COMMIT_TIMESTAMP").to_string(),
-        commit_branch: env!("VERGEN_GIT_BRANCH").to_string(),
+        commit_sha: option_env!("VERGEN_GIT_SHA").unwrap_or("NONE").to_string(),
+        commit_timestamp: option_env!("VERGEN_GIT_COMMIT_TIMESTAMP").unwrap_or("NONE").to_string(),
+        commit_branch: option_env!("VERGEN_GIT_BRANCH").unwrap_or("NONE").to_string(),
         rustc_version: env!("VERGEN_RUSTC_SEMVER").to_string(),
     }
 }

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -38,4 +38,4 @@ hex = "0.4.3"
 serde_json = "1.0.66"
 
 [build-dependencies]
-vergen = { version = "7", default-features = false, features = ["build", "git", "rustc"] }
+vergen = { version = "=7.4.3", default-features = false, features = ["build", "git", "rustc"] }

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -38,4 +38,4 @@ hex = "0.4.3"
 serde_json = "1.0.66"
 
 [build-dependencies]
-vergen = { version = "5", default-features = false, features = ["build", "git", "rustc"] }
+vergen = { version = "7", default-features = false, features = ["build", "git", "rustc"] }

--- a/contracts/vesting/build.rs
+++ b/contracts/vesting/build.rs
@@ -4,5 +4,10 @@
 use vergen::{vergen, Config};
 
 fn main() {
+    let mut config = Config::default();
+    if std::env::var("DOCS_RS").is_ok() {
+        // If we don't have access to git information, such as in a docs.rs build, don't error
+        *config.git_mut().skip_if_error_mut() = true;
+    }
     vergen(Config::default()).expect("failed to extract build metadata")
 }

--- a/contracts/vesting/src/contract.rs
+++ b/contracts/vesting/src/contract.rs
@@ -743,9 +743,13 @@ pub fn get_contract_version() -> ContractBuildInformation {
     ContractBuildInformation {
         build_timestamp: env!("VERGEN_BUILD_TIMESTAMP").to_string(),
         build_version: env!("VERGEN_BUILD_SEMVER").to_string(),
-        commit_sha: env!("VERGEN_GIT_SHA").to_string(),
-        commit_timestamp: env!("VERGEN_GIT_COMMIT_TIMESTAMP").to_string(),
-        commit_branch: env!("VERGEN_GIT_BRANCH").to_string(),
+        commit_sha: option_env!("VERGEN_GIT_SHA").unwrap_or("NONE").to_string(),
+        commit_timestamp: option_env!("VERGEN_GIT_COMMIT_TIMESTAMP")
+            .unwrap_or("NONE")
+            .to_string(),
+        commit_branch: option_env!("VERGEN_GIT_BRANCH")
+            .unwrap_or("NONE")
+            .to_string(),
         rustc_version: env!("VERGEN_RUSTC_SEMVER").to_string(),
     }
 }


### PR DESCRIPTION
# Description

Closes: #3093

Fix the docs.rs build for the vesting and mixnet contracts, by making the build not fail on missing git info.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
