### PR TITLE
wallet_storage: fix clippy useless-conversion

### DIFF
--- a/nym-wallet/src-tauri/src/wallet_storage/mod.rs
+++ b/nym-wallet/src-tauri/src/wallet_storage/mod.rs
@@ -748,7 +748,7 @@ mod tests {
         assert!(matches!(
             store_login_with_multiple_accounts_at_file(
                 &wallet_file,
-                account2.into(),
+                account2,
                 hd_path,
                 id2,
                 &bad_password


### PR DESCRIPTION
# Description

Fix clippy warning for useless conversion in the wallet storage

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
