### PR TITLE
chore: simplify mnemonic zeroize story

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,22 +302,23 @@ dependencies = [
 
 [[package]]
 name = "bip39"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e89470017230c38e52b82b3ee3f530db1856ba1d434e3a67a3456a8a8dec5f"
+checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.6.5",
- "rand_core 0.4.2",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.9.7"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 
 [[package]]
 name = "bitflags"
@@ -2846,12 +2847,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4171,7 +4166,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.10.0",
+ "smallvec",
  "winapi",
 ]
 
@@ -4184,7 +4179,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.10.0",
+ "smallvec",
  "windows-sys 0.45.0",
 ]
 
@@ -5057,7 +5052,7 @@ dependencies = [
  "pin-project-lite",
  "ref-cast",
  "serde",
- "smallvec 1.10.0",
+ "smallvec",
  "stable-pattern",
  "state",
  "time 0.3.17",
@@ -5554,15 +5549,6 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
@@ -5725,7 +5711,7 @@ dependencies = [
  "percent-encoding",
  "rustls 0.19.1",
  "sha2 0.10.6",
- "smallvec 1.10.0",
+ "smallvec",
  "sqlformat 0.1.8",
  "sqlx-rt 0.5.13",
  "stringprep",
@@ -5773,7 +5759,7 @@ dependencies = [
  "rustls 0.20.8",
  "rustls-pemfile",
  "sha2 0.10.6",
- "smallvec 1.10.0",
+ "smallvec",
  "sqlformat 0.2.1",
  "sqlx-rt 0.6.2",
  "stringprep",
@@ -6199,6 +6185,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6495,7 +6496,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec 1.10.0",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -6661,11 +6662,11 @@ checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.9"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
- "smallvec 0.6.14",
+ "tinyvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 async-trait = "0.1.64"
+bip39 = { version = "2.0.0", features = ["zeroize"] }
 cfg-if = "1.0.0"
 dotenvy = "0.15.6"
 lazy_static = "1.4.0"

--- a/clients/credential/Cargo.toml
+++ b/clients/credential/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bip39 = "1.0.1"
+bip39 = { workspace = true }
 clap = { version = "4.0", features = ["cargo", "derive"] }
 log = "0.4"
 rand = "0.7.3"

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -37,7 +37,7 @@ nym-execute = { path = "../../execute" }
 # at some point it might be possible to make it wasm-compatible
 # perhaps after https://github.com/cosmos/cosmos-rust/pull/97 is resolved (and tendermint-rs is updated)
 async-trait = { workspace = true, optional = true }
-bip39 = { version = "1", features = ["rand"], optional = true }
+bip39 = { workspace = true, features = ["rand"], optional = true }
 nym-config = { path = "../../config", optional = true }
 cosmrs = { git = "https://github.com/neacsu/cosmos-rust", branch = "neacsu/feegrant_support", features = ["rpc", "bip32", "cosmwasm"], optional = true}
 cw3 = { version = "0.13.4", optional = true }
@@ -47,7 +47,7 @@ flate2 = { version = "1.0.20", optional = true }
 sha2 = { version = "0.9.5", optional = true }
 itertools = { version = "0.10", optional = true }
 cosmwasm-std = { version = "1.0.0", optional = true }
-zeroize = { version = "1.5.7", optional = true }
+zeroize = { version = "1.5.7", optional = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 ts-rs = "6.1.2"

--- a/common/commands/Cargo.toml
+++ b/common/commands/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.13.0"
-bip39 = "1.0.1"
+bip39 = { workspace = true }
 bs58 = "0.4"
 comfy-table = "6.0.0"
 cfg-if = "1.0.0"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.56"
 [dependencies]
 anyhow = "1.0.53"
 async-trait = { workspace = true }
-bip39 = "1.0.1"
+bip39 = { workspace = true }
 bs58 = "0.4.0"
 clap = { version = "4.0", features = ["cargo", "derive"] }
 colored = "2.0"

--- a/nym-api/Cargo.toml
+++ b/nym-api/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.56"
 [dependencies]
 async-trait = { workspace = true }
 bs58 = {version = "0.4.0" }
-bip39 = "1"
+bip39 = { workspace = true }
 cfg-if = "1.0"
 clap = { version = "4.0", features = ["cargo", "derive"] }
 console-subscriber = { version = "0.1.1", optional = true } # validator-api needs to be built with RUSTFLAGS="--cfg tokio_unstable"

--- a/nym-connect/desktop/src-tauri/Cargo.toml
+++ b/nym-connect/desktop/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri-macros = "^1.2.1"
 
 [dependencies]
 anyhow = "1.0"
-bip39 = "1.0"
+bip39 = { version = "2.0.0", features = ["zeroize"] }
 dirs = "4.0"
 eyre = "0.6.5"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", branch = "release"}

--- a/nym-connect/mobile/src-tauri/Cargo.toml
+++ b/nym-connect/mobile/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.0.0-alpha.1", features = [] }
 
 [dependencies]
 anyhow = "1.0"
-bip39 = "1.0"
+bip39 = { version = "2.0.0", features = ["zeroize"] }
 chrono = "0.4"
 dirs = "4.0"
 eyre = "0.6.5"

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -183,15 +183,6 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
-]
-
-[[package]]
-name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
@@ -240,22 +231,23 @@ dependencies = [
 
 [[package]]
 name = "bip39"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e89470017230c38e52b82b3ee3f530db1856ba1d434e3a67a3456a8a8dec5f"
+checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.6.5",
- "rand_core 0.4.2",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.9.7"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 
 [[package]]
 name = "bitflags"
@@ -476,7 +468,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3431df59f28accaf4cb4eed4a9acc66bea3f3c3753aa6cdc2f024174ef232af7"
 dependencies = [
- "smallvec 1.10.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -485,7 +477,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0357a6402b295ca3a86bc148e84df46c02e41f41fef186bda662557ef6328aa"
 dependencies = [
- "smallvec 1.10.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -567,15 +559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -869,7 +852,7 @@ dependencies = [
  "phf 0.8.0",
  "proc-macro2",
  "quote",
- "smallvec 1.10.0",
+ "smallvec",
  "syn",
 ]
 
@@ -1432,12 +1415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,7 +1739,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "once_cell",
- "smallvec 1.10.0",
+ "smallvec",
  "thiserror",
 ]
 
@@ -2248,7 +2225,7 @@ version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "hashbrown",
  "serde",
 ]
@@ -2508,7 +2485,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "scopeguard",
 ]
 
@@ -2582,12 +2559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,7 +2570,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -2729,7 +2700,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -2739,7 +2710,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2750,7 +2721,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "libm",
 ]
 
@@ -2879,6 +2850,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-crypto"
+version = "0.2.0"
+dependencies = [
+ "bs58",
+ "ed25519-dalek",
+ "nym-pemstore",
+ "nym-sphinx-types",
+ "rand 0.7.3",
+ "subtle-encoding",
+ "thiserror",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "nym-dkg"
 version = "0.1.0"
 dependencies = [
@@ -2897,20 +2882,6 @@ dependencies = [
  "sha2 0.9.9",
  "thiserror",
  "zeroize",
-]
-
-[[package]]
-name = "nym-crypto"
-version = "0.1.0"
-dependencies = [
- "bs58",
- "ed25519-dalek",
- "nym-pemstore",
- "nym-sphinx-types",
- "rand 0.7.3",
- "subtle-encoding",
- "thiserror",
- "x25519-dalek",
 ]
 
 [[package]]
@@ -2984,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "nym-sphinx-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "sphinx-packet",
 ]
@@ -3110,7 +3081,6 @@ dependencies = [
  "nym-wallet-types",
  "once_cell",
  "pretty_env_logger",
- "rand 0.6.5",
  "rand_chacha 0.2.2",
  "reqwest",
  "serde",
@@ -3258,7 +3228,7 @@ version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -3330,7 +3300,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.10.0",
+ "smallvec",
  "windows-sys 0.45.0",
 ]
 
@@ -3792,25 +3762,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.8",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg 0.1.2",
- "rand_xorshift",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -3819,8 +3770,8 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
- "rand_pcg 0.2.1",
+ "rand_hc",
+ "rand_pcg",
 ]
 
 [[package]]
@@ -3832,16 +3783,6 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3863,21 +3804,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3909,64 +3835,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.4.2",
 ]
 
 [[package]]
@@ -3979,30 +3852,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "raw-window-handle"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
 dependencies = [
  "cty",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4350,7 +4205,7 @@ dependencies = [
  "phf_codegen",
  "precomputed-hash",
  "servo_arc",
- "smallvec 1.10.0",
+ "smallvec",
  "thin-slice",
 ]
 
@@ -4605,16 +4460,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
- "autocfg 1.1.0",
-]
-
-[[package]]
-name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
+ "autocfg",
 ]
 
 [[package]]
@@ -5282,12 +5128,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -5434,7 +5295,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec 1.10.0",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -5517,11 +5378,11 @@ checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.9"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
- "smallvec 0.6.14",
+ "tinyvec",
 ]
 
 [[package]]
@@ -6228,6 +6089,7 @@ version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/nym-wallet/nym-wallet-recovery-cli/Cargo.toml
+++ b/nym-wallet/nym-wallet-recovery-cli/Cargo.toml
@@ -10,7 +10,7 @@ aes-gcm = "0.9"
 anyhow = "1.0"
 argon2 = "0.4"
 base64 = "0.13"
-bip39 = "1.0"
+bip39 = { version = "2.0.0", features = ["zeroize"] }
 clap = { version = "4.0", features = ["derive"] }
 log = "0.4"
 pretty_env_logger = "0.4"

--- a/nym-wallet/nym-wallet-types/Cargo.toml
+++ b/nym-wallet/nym-wallet-types/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = "1.0"
 strum = { version = "0.23", features = ["derive"] }
 ts-rs = "6.1.2"
 
-cosmwasm-std = "1.0.0-beta8"
+cosmwasm-std = "1.0.0"
 cosmrs = { git = "https://github.com/neacsu/cosmos-rust", branch = "neacsu/feegrant_support" }
 
 nym-config = { path = "../../common/config" }

--- a/nym-wallet/src-tauri/Cargo.toml
+++ b/nym-wallet/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri-macros = "=1.2.1"
 
 [dependencies]
 async-trait = "0.1.64"
-bip39 = "1.0"
+bip39 = { version = "2.0.0", features = ["zeroize", "rand"] }
 cfg-if = "1.0.0"
 colored = "2.0"
 dirs = "4.0"
@@ -32,7 +32,6 @@ itertools = "0.10"
 log = { version = "0.4", features = ["serde"] }
 once_cell = "1.7.2"
 pretty_env_logger = "0.4"
-rand = "0.6.5"
 reqwest = {version = "0.11.9", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -50,7 +49,7 @@ k256 = { version = "0.10", features = ["ecdsa", "sha256"] }
 aes-gcm = "0.9.4"
 argon2 = { version = "0.3.2", features = ["std"] }
 base64 = "0.13"
-zeroize = "1.4.3"
+zeroize = { version = "1.5", features = ["zeroize_derive", "serde"] }
 
 cosmwasm-std = "1.0.0"
 cosmrs = { git = "https://github.com/neacsu/cosmos-rust", branch = "neacsu/feegrant_support" }

--- a/nym-wallet/src-tauri/src/utils.rs
+++ b/nym-wallet/src-tauri/src/utils.rs
@@ -4,16 +4,14 @@
 use crate::error::BackendError;
 use crate::nyxd_client;
 use crate::state::WalletState;
-use bip39::Mnemonic;
 use cosmwasm_std::Decimal;
 use nym_mixnet_contract_common::{IdentityKey, MixId, Percent};
 use nym_types::currency::DecCoin;
 use nym_types::mixnode::MixNodeCostParams;
 use nym_wallet_types::app::AppEnv;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use validator_client::nyxd::traits::MixnetQueryClient;
 use validator_client::nyxd::{tx, Coin, CosmosCoin, Gas, GasPrice};
-use zeroize::Zeroize;
 
 fn get_env_as_option(key: &str) -> Option<String> {
     match ::std::env::var(key) {
@@ -193,95 +191,4 @@ pub async fn get_old_and_incorrect_hardcoded_fee(
     let coin: Coin = approximate_fee.amount.pop().unwrap().into();
     log::info!("hardcoded fee for {:?} is {:?}", operation, coin);
     guard.attempt_convert_to_display_dec_coin(coin)
-}
-
-#[derive(Zeroize)]
-#[zeroize(drop)]
-pub struct SensitiveStringWrapper(String);
-
-impl<'de> Deserialize<'de> for SensitiveStringWrapper {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(SensitiveStringWrapper(String::deserialize(deserializer)?))
-    }
-}
-
-impl Serialize for SensitiveStringWrapper {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        // unfortunately this serialized value will live on...
-        self.0.serialize(serializer)
-    }
-}
-
-impl From<String> for SensitiveStringWrapper {
-    fn from(value: String) -> Self {
-        SensitiveStringWrapper(value)
-    }
-}
-
-impl AsRef<str> for SensitiveStringWrapper {
-    fn as_ref(&self) -> &str {
-        self.0.as_ref()
-    }
-}
-
-#[derive(Clone)]
-// can't do it natively until https://github.com/rust-bitcoin/rust-bip39/pull/32 gets merged and released...
-pub(crate) struct ZeroizeMnemonicWrapper(bip39::Mnemonic);
-
-impl From<bip39::Mnemonic> for ZeroizeMnemonicWrapper {
-    fn from(value: Mnemonic) -> Self {
-        ZeroizeMnemonicWrapper(value)
-    }
-}
-
-impl Zeroize for ZeroizeMnemonicWrapper {
-    fn zeroize(&mut self) {
-        // overwrite the mnemonic value with a completely random one
-        // (a poor man's zeroize until bip39 crate does it properly...)
-        self.0 = Mnemonic::generate(self.0.word_count()).unwrap();
-    }
-}
-
-impl Drop for ZeroizeMnemonicWrapper {
-    fn drop(&mut self) {
-        self.zeroize()
-    }
-}
-
-impl AsRef<bip39::Mnemonic> for ZeroizeMnemonicWrapper {
-    fn as_ref(&self) -> &Mnemonic {
-        &self.0
-    }
-}
-
-impl ZeroizeMnemonicWrapper {
-    pub(crate) fn into_string(self) -> SensitiveStringWrapper {
-        SensitiveStringWrapper(self.0.to_string())
-    }
-
-    pub(crate) fn try_from_string(string: SensitiveStringWrapper) -> Result<Self, bip39::Error> {
-        let res = string.as_ref().parse()?;
-        Ok(ZeroizeMnemonicWrapper(res))
-    }
-
-    // special care must be taken when calling this method as the mnemonic will no longer get zeroized!
-    pub(crate) fn into_cloned_inner(self) -> bip39::Mnemonic {
-        self.0.clone()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn unchecked_clone_inner(&self) -> bip39::Mnemonic {
-        self.0.clone()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn generate_random() -> Self {
-        ZeroizeMnemonicWrapper(Mnemonic::generate(24).unwrap())
-    }
 }

--- a/nym-wallet/src-tauri/src/wallet_storage/password.rs
+++ b/nym-wallet/src-tauri/src/wallet_storage/password.rs
@@ -1,13 +1,12 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{Deserialize, Serialize};
 use std::fmt;
-
-use serde::{Deserialize, Deserializer, Serialize};
-use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+use zeroize::{Zeroize, Zeroizing};
 
 // The `LoginId` is the top level id in the wallet file, and is not stored encrypted
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Zeroize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct LoginId(String);
 
 impl LoginId {
@@ -81,25 +80,4 @@ impl fmt::Display for AccountId {
 }
 
 // simple wrapper for String that will get zeroized on drop
-#[derive(Zeroize, ZeroizeOnDrop)]
-pub struct UserPassword(Zeroizing<String>);
-
-impl UserPassword {
-    #[cfg(test)]
-    pub(crate) fn new(inner: String) -> Self {
-        UserPassword(Zeroizing::new(inner))
-    }
-
-    pub(crate) fn as_bytes(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-}
-
-impl<'de> Deserialize<'de> for UserPassword {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(UserPassword(Zeroizing::deserialize(deserializer)?))
-    }
-}
+pub type UserPassword = Zeroizing<String>;

--- a/tools/nym-cli/Cargo.toml
+++ b/tools/nym-cli/Cargo.toml
@@ -16,7 +16,7 @@ pretty_env_logger = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.11", features = [ "net", "rt-multi-thread", "macros", "signal"] }
-bip39 = "1.0.1"
+bip39 = { workspace = true }
 anyhow = "1"
 tap = "1"
 


### PR DESCRIPTION
Simplifies all zeroizing action in the wallet thanks to updates to bip39 and derived `Zeroize` trait

as for testing, it's just the case of can you still login, create new account, etc. no need to test any mixnet, vesting operations.
oh. you probably want to check `validate_mnemonic` method, i.e. try to provide an invalid mnemonic and make sure the UI works as expected, because I'm not sure whether it's going to throw an error or work as before due to parser changes.