### PR TITLE
mock-nym-api: fix .storybook lint error

### DIFF
--- a/ts-packages/mock-nym-api/package.json
+++ b/ts-packages/mock-nym-api/package.json
@@ -43,7 +43,7 @@
     "run:caddy": "caddy run",
     "build": "tsc --noEmit false",
     "watch": "tsc --noEmit false -w",
-    "lint": "eslint src .storybook",
-    "lint:fix": "eslint src .storybook --fix"
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix"
   }
 }


### PR DESCRIPTION
# Description

Fix `yarn lint` failing due to missing .storybook file in mock-nym-api

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
