### PR TITLE
disable sign-ext when using wasm-opt + update wasm-opt

### DIFF
--- a/.github/workflows/build-and-upload-binaries-ci.yml
+++ b/.github/workflows/build-and-upload-binaries-ci.yml
@@ -80,7 +80,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install wasm-opt
-        run: cargo install --version 0.110.0 wasm-opt
+        run: cargo install --version 0.112.0 wasm-opt
 
       - name: Build release contracts
         run: make wasm

--- a/.github/workflows/contracts-build.yml
+++ b/.github/workflows/contracts-build.yml
@@ -20,7 +20,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install wasm-opt
-        run: cargo install --version 0.110.0 wasm-opt
+        run: cargo install --version 0.112.0 wasm-opt
 
       - name: Build release contracts
         run: make wasm

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ build-nym-cli:
 
 wasm:
 	RUSTFLAGS='-C link-arg=-s' cargo build --manifest-path contracts/Cargo.toml --release --target wasm32-unknown-unknown
-	wasm-opt -Os contracts/target/wasm32-unknown-unknown/release/vesting_contract.wasm -o contracts/target/wasm32-unknown-unknown/release/vesting_contract.wasm
-	wasm-opt -Os contracts/target/wasm32-unknown-unknown/release/mixnet_contract.wasm -o contracts/target/wasm32-unknown-unknown/release/mixnet_contract.wasm
+	wasm-opt --disable-sign-ext -Os contracts/target/wasm32-unknown-unknown/release/vesting_contract.wasm -o contracts/target/wasm32-unknown-unknown/release/vesting_contract.wasm
+	wasm-opt --disable-sign-ext -Os contracts/target/wasm32-unknown-unknown/release/mixnet_contract.wasm -o contracts/target/wasm32-unknown-unknown/release/mixnet_contract.wasm
 
 # NOTE: this seems deprecated an not needed anymore?
 mixnet-opt: wasm

--- a/contracts/mixnet/Makefile
+++ b/contracts/mixnet/Makefile
@@ -1,5 +1,5 @@
 opt: wasm
-	wasm-opt -Os ../target/wasm32-unknown-unknown/release/mixnet_contract.wasm -o ../target/wasm32-unknown-unknown/release/mixnet_contract.wasm
+	wasm-opt --disable-sign-ext -Os ../target/wasm32-unknown-unknown/release/mixnet_contract.wasm -o ../target/wasm32-unknown-unknown/release/mixnet_contract.wasm
 
 wasm:
 	RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown


### PR DESCRIPTION
# Description

Explicitly disabling sign extension operators when running `wasm-opt` so that we could continue using most recent (v112) optimiser. 
~~Note: merge this after https://github.com/nymtech/nym/commit/1d2722f994a25d3d0dc94d890686c9138d670f8d is in develop so that we could remove dependency on `110`~~

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
