### PR TITLE
Feature/dual packet sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4058,6 +4058,7 @@ version = "0.1.0"
 dependencies = [
  "nym-crypto",
  "nym-sphinx-types",
+ "serde",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,7 @@ dependencies = [
  "nym-sphinx-types",
  "nym-topology",
  "rand 0.7.3",
+ "rand_chacha 0.2.2",
  "serde",
  "thiserror",
  "wasm-bindgen",

--- a/clients/native/src/client/config/mod.rs
+++ b/clients/native/src/client/config/mod.rs
@@ -94,6 +94,11 @@ impl Config {
         }
     }
 
+    pub fn validate(&self) -> bool {
+        // no other sections have explicit requirements (yet)
+        self.base.validate()
+    }
+
     pub fn with_socket(mut self, socket_type: SocketType) -> Self {
         self.socket.socket_type = socket_type;
         self

--- a/clients/native/src/commands/run.rs
+++ b/clients/native/src/commands/run.rs
@@ -112,6 +112,10 @@ pub(crate) async fn execute(args: &Run) -> Result<(), Box<dyn Error + Send + Syn
         }
     };
 
+    if !config.validate() {
+        return Err(Box::new(ClientError::ConfigValidationFailure))
+    }
+
     let override_config_fields = OverrideConfig::from(args.clone());
     config = override_config(config, override_config_fields);
 

--- a/clients/native/src/commands/run.rs
+++ b/clients/native/src/commands/run.rs
@@ -113,7 +113,7 @@ pub(crate) async fn execute(args: &Run) -> Result<(), Box<dyn Error + Send + Syn
     };
 
     if !config.validate() {
-        return Err(Box::new(ClientError::ConfigValidationFailure))
+        return Err(Box::new(ClientError::ConfigValidationFailure));
     }
 
     let override_config_fields = OverrideConfig::from(args.clone());

--- a/clients/native/src/error.rs
+++ b/clients/native/src/error.rs
@@ -11,6 +11,10 @@ pub enum ClientError {
     #[error("Failed to load config for: {0}")]
     FailedToLoadConfig(String),
 
+    // TODO: add more details here
+    #[error("Failed to validate the loaded config")]
+    ConfigValidationFailure,
+
     #[error("Failed local version check, client and config mismatch")]
     FailedLocalVersionCheck,
 

--- a/clients/socks5/src/commands/run.rs
+++ b/clients/socks5/src/commands/run.rs
@@ -122,6 +122,10 @@ pub(crate) async fn execute(args: &Run) -> Result<(), Box<dyn std::error::Error 
         }
     };
 
+    if !config.validate() {
+        return Err(Box::new(Socks5ClientError::ConfigValidationFailure))
+    }
+
     let override_config_fields = OverrideConfig::from(args.clone());
     config = override_config(config, override_config_fields);
 

--- a/clients/socks5/src/commands/run.rs
+++ b/clients/socks5/src/commands/run.rs
@@ -123,7 +123,7 @@ pub(crate) async fn execute(args: &Run) -> Result<(), Box<dyn std::error::Error 
     };
 
     if !config.validate() {
-        return Err(Box::new(Socks5ClientError::ConfigValidationFailure))
+        return Err(Box::new(Socks5ClientError::ConfigValidationFailure));
     }
 
     let override_config_fields = OverrideConfig::from(args.clone());

--- a/clients/socks5/src/error.rs
+++ b/clients/socks5/src/error.rs
@@ -8,6 +8,10 @@ pub enum Socks5ClientError {
     #[error("Failed to load config for: {0}")]
     FailedToLoadConfig(String),
 
+    // TODO: add more details here
+    #[error("Failed to validate the loaded config")]
+    ConfigValidationFailure,
+
     #[error("Failed local version check, client and config mismatch")]
     FailedLocalVersionCheck,
 

--- a/clients/webassembly/src/client/config.rs
+++ b/clients/webassembly/src/client/config.rs
@@ -8,10 +8,11 @@
 
 use nym_client_core::config::{
     Acknowledgements as ConfigAcknowledgements, CoverTraffic as ConfigCoverTraffic,
-    DebugConfig as ConfigDebug, ExtendedPacketSize, GatewayConnection as ConfigGatewayConnection,
+    DebugConfig as ConfigDebug, GatewayConnection as ConfigGatewayConnection,
     GatewayEndpointConfig, ReplySurbs as ConfigReplySurbs, Topology as ConfigTopology,
     Traffic as ConfigTraffic,
 };
+use nym_sphinx::params::PacketSize;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use url::Url;
@@ -82,7 +83,7 @@ impl From<Traffic> for ConfigTraffic {
     fn from(traffic: Traffic) -> Self {
         let use_extended_packet_size = traffic
             .use_extended_packet_size
-            .then(|| ExtendedPacketSize::Extended32);
+            .then(|| PacketSize::ExtendedPacket32);
 
         ConfigTraffic {
             average_packet_delay: Duration::from_millis(traffic.average_packet_delay_ms),
@@ -91,7 +92,8 @@ impl From<Traffic> for ConfigTraffic {
             ),
             disable_main_poisson_packet_distribution: traffic
                 .disable_main_poisson_packet_distribution,
-            use_extended_packet_size,
+            primary_packet_size: PacketSize::RegularPacket,
+            secondary_packet_size: use_extended_packet_size,
         }
     }
 }
@@ -104,7 +106,7 @@ impl From<ConfigTraffic> for Traffic {
                 as u64,
             disable_main_poisson_packet_distribution: traffic
                 .disable_main_poisson_packet_distribution,
-            use_extended_packet_size: traffic.use_extended_packet_size.is_some(),
+            use_extended_packet_size: traffic.secondary_packet_size.is_some(),
         }
     }
 }
@@ -115,6 +117,10 @@ pub struct CoverTraffic {
     /// The parameter of Poisson distribution determining how long, on average,
     /// it is going to take for another loop cover traffic message to be sent.
     pub loop_cover_traffic_average_delay_ms: u64,
+
+    /// Specifies the ratio of `primary_packet_size` to `secondary_packet_size` used in cover traffic.
+    /// Only applicable if `secondary_packet_size` is enabled.
+    pub cover_traffic_primary_size_ratio: f64,
 
     /// Controls whether the dedicated loop cover traffic stream should be enabled.
     /// (and sending packets, on average, every [Self::loop_cover_traffic_average_delay])
@@ -127,6 +133,7 @@ impl From<CoverTraffic> for ConfigCoverTraffic {
             loop_cover_traffic_average_delay: Duration::from_millis(
                 cover_traffic.loop_cover_traffic_average_delay_ms,
             ),
+            cover_traffic_primary_size_ratio: cover_traffic.cover_traffic_primary_size_ratio,
             disable_loop_cover_traffic_stream: cover_traffic.disable_loop_cover_traffic_stream,
         }
     }
@@ -138,6 +145,7 @@ impl From<ConfigCoverTraffic> for CoverTraffic {
             loop_cover_traffic_average_delay_ms: cover_traffic
                 .loop_cover_traffic_average_delay
                 .as_millis() as u64,
+            cover_traffic_primary_size_ratio: cover_traffic.cover_traffic_primary_size_ratio,
             disable_loop_cover_traffic_stream: cover_traffic.disable_loop_cover_traffic_stream,
         }
     }

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -235,7 +235,7 @@ where
     ) {
         info!("Starting loop cover traffic stream...");
 
-        let mut stream = LoopCoverTrafficStream::new(
+        let stream = LoopCoverTrafficStream::new(
             ack_key,
             debug_config.acknowledgements.average_ack_delay,
             debug_config.traffic.average_packet_delay,
@@ -244,11 +244,6 @@ where
             self_address,
             topology_accessor,
         );
-
-        if let Some(size) = debug_config.traffic.use_extended_packet_size {
-            log::debug!("Setting extended packet size: {:?}", size);
-            stream.set_custom_packet_size(size.into());
-        }
 
         stream.start_with_shutdown(shutdown);
     }

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -533,16 +533,11 @@ where
         // primarily to throttle incoming connections (e.g socks5 for attached network-requesters)
         let shared_lane_queue_lengths = LaneQueueLengths::new();
 
-        let mut controller_config = real_messages_control::Config::new(
+        let controller_config = real_messages_control::Config::new(
             self.debug_config,
             self.key_manager.ack_key(),
             self_address,
         );
-
-        if let Some(size) = self.debug_config.traffic.use_extended_packet_size {
-            log::debug!("Setting extended packet size: {:?}", size);
-            controller_config.set_custom_packet_size(size.into());
-        }
 
         Self::start_real_traffic_controller(
             controller_config,

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -238,11 +238,11 @@ where
         let stream = LoopCoverTrafficStream::new(
             ack_key,
             debug_config.acknowledgements.average_ack_delay,
-            debug_config.traffic.average_packet_delay,
-            debug_config.cover_traffic.loop_cover_traffic_average_delay,
             mix_tx,
             self_address,
             topology_accessor,
+            debug_config.traffic,
+            debug_config.cover_traffic,
         );
 
         stream.start_with_shutdown(shutdown);

--- a/common/client-core/src/client/cover_traffic_stream.rs
+++ b/common/client-core/src/client/cover_traffic_stream.rs
@@ -168,6 +168,7 @@ impl LoopCoverTrafficStream<OsRng> {
         trace!("next cover message!");
 
         let cover_traffic_packet_size = self.loop_cover_message_size();
+        trace!("the next loop cover message will be put in a {cover_traffic_packet_size} packet");
 
         // TODO for way down the line: in very rare cases (during topology update) we might have
         // to wait a really tiny bit before actually obtaining the permit hence messing with our

--- a/common/client-core/src/client/cover_traffic_stream.rs
+++ b/common/client-core/src/client/cover_traffic_stream.rs
@@ -3,7 +3,7 @@
 
 use crate::client::mix_traffic::BatchMixMessageSender;
 use crate::client::topology_control::TopologyAccessor;
-use crate::spawn_future;
+use crate::{config, spawn_future};
 use futures::task::{Context, Poll};
 use futures::{Future, Stream, StreamExt};
 use log::*;
@@ -34,11 +34,8 @@ where
     /// Average delay an acknowledgement packet is going to get delay at a single mixnode.
     average_ack_delay: Duration,
 
-    /// Average delay a data packet is going to get delay at a single mixnode.
-    average_packet_delay: Duration,
-
-    /// Average delay between sending subsequent cover packets.
-    average_cover_message_sending_delay: Duration,
+    /// Defines configuration options related to cover traffic.
+    cover_traffic: config::CoverTraffic,
 
     /// Internal state, determined by `average_message_sending_delay`,
     /// used to keep track of when a next packet should be sent out.
@@ -61,8 +58,11 @@ where
     /// Accessor to the common instance of network topology.
     topology_access: TopologyAccessor,
 
-    /// Predefined packet size used for the loop cover messages.
-    packet_size: PacketSize,
+    /// Primary predefined packet size used for the loop cover messages.
+    primary_packet_size: PacketSize,
+
+    /// Optional secondary predefined packet size used for the loop cover messages.
+    secondary_packet_size: Option<PacketSize>,
 }
 
 impl<R> Stream for LoopCoverTrafficStream<R>
@@ -83,7 +83,7 @@ where
 
         // we know it's time to send a message, so let's prepare delay for the next one
         // Get the `now` by looking at the current `delay` deadline
-        let avg_delay = self.average_cover_message_sending_delay;
+        let avg_delay = self.cover_traffic.loop_cover_traffic_average_delay;
         let next_poisson_delay = sample_poisson_duration(&mut self.rng, avg_delay);
 
         // The next interval value is `next_poisson_delay` after the one that just
@@ -107,15 +107,14 @@ where
 // obviously when we finally make shared rng that is on 'higher' level, this should become
 // generic `R`
 impl LoopCoverTrafficStream<OsRng> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ack_key: Arc<AckKey>,
         average_ack_delay: Duration,
-        average_packet_delay: Duration,
-        average_cover_message_sending_delay: Duration,
         mix_tx: BatchMixMessageSender,
         our_full_destination: Recipient,
         topology_access: TopologyAccessor,
+        traffic_config: config::Traffic,
+        cover_config: config::CoverTraffic,
     ) -> Self {
         let rng = OsRng;
 
@@ -128,19 +127,15 @@ impl LoopCoverTrafficStream<OsRng> {
         LoopCoverTrafficStream {
             ack_key,
             average_ack_delay,
-            average_packet_delay,
-            average_cover_message_sending_delay,
+            cover_traffic: cover_config,
             next_delay,
             mix_tx,
             our_full_destination,
             rng,
             topology_access,
-            packet_size: Default::default(),
+            primary_packet_size: traffic_config.primary_packet_size,
+            secondary_packet_size: traffic_config.secondary_packet_size,
         }
-    }
-
-    pub fn set_custom_packet_size(&mut self, packet_size: PacketSize) {
-        self.packet_size = packet_size;
     }
 
     fn set_next_delay(&mut self, amount: Duration) {
@@ -153,8 +148,26 @@ impl LoopCoverTrafficStream<OsRng> {
         self.next_delay = next_delay;
     }
 
+    fn loop_cover_message_size(&mut self) -> PacketSize {
+        let Some(secondary_packet_size) = self.secondary_packet_size else {
+            return self.primary_packet_size
+        };
+
+        let use_primary = self
+            .rng
+            .gen_bool(self.cover_traffic.cover_traffic_primary_size_ratio);
+
+        if use_primary {
+            self.primary_packet_size
+        } else {
+            secondary_packet_size
+        }
+    }
+
     async fn on_new_message(&mut self) {
         trace!("next cover message!");
+
+        let cover_traffic_packet_size = self.loop_cover_message_size();
 
         // TODO for way down the line: in very rare cases (during topology update) we might have
         // to wait a really tiny bit before actually obtaining the permit hence messing with our
@@ -178,8 +191,8 @@ impl LoopCoverTrafficStream<OsRng> {
             &self.ack_key,
             &self.our_full_destination,
             self.average_ack_delay,
-            self.average_packet_delay,
-            self.packet_size,
+            self.cover_traffic.loop_cover_traffic_average_delay,
+            cover_traffic_packet_size,
         )
         .expect("Somehow failed to generate a loop cover message with a valid topology");
 
@@ -214,9 +227,17 @@ impl LoopCoverTrafficStream<OsRng> {
     }
 
     pub fn start_with_shutdown(mut self, mut shutdown: nym_task::TaskClient) {
+        if self.cover_traffic.disable_loop_cover_traffic_stream {
+            // we should have never got here in the first place - the task should have never been created to begin with
+            // so panic and review the code that lead to this branch
+            panic!("attempted to start LoopCoverTrafficStream while config explicitly disabled it.")
+        }
+
         // we should set initial delay only when we actually start the stream
-        let sampled =
-            sample_poisson_duration(&mut self.rng, self.average_cover_message_sending_delay);
+        let sampled = sample_poisson_duration(
+            &mut self.rng,
+            self.cover_traffic.loop_cover_traffic_average_delay,
+        );
         self.set_next_delay(sampled);
 
         spawn_future(async move {

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -101,8 +101,11 @@ pub(crate) struct Config {
     /// Note that it does not include gateway hops.
     num_mix_hops: u8,
 
-    /// Predefined packet size used for the encapsulated messages.
-    packet_size: PacketSize,
+    /// Primary predefined packet size used for the encapsulated messages.
+    primary_packet_size: PacketSize,
+
+    /// Optional secondary predefined packet size used for the encapsulated messages.
+    secondary_packet_size: Option<PacketSize>,
 }
 
 impl Config {
@@ -118,7 +121,8 @@ impl Config {
             average_packet_delay,
             average_ack_delay,
             num_mix_hops: DEFAULT_NUM_MIX_HOPS,
-            packet_size: PacketSize::default(),
+            primary_packet_size: PacketSize::default(),
+            secondary_packet_size: None,
         }
     }
 
@@ -130,8 +134,14 @@ impl Config {
     }
 
     /// Allows setting non-default size of the sphinx packets sent out.
-    pub fn with_custom_packet_size(mut self, packet_size: PacketSize) -> Self {
-        self.packet_size = packet_size;
+    pub fn with_custom_primary_packet_size(mut self, packet_size: PacketSize) -> Self {
+        self.primary_packet_size = packet_size;
+        self
+    }
+
+    /// Allows setting non-default size of the sphinx packets sent out.
+    pub fn with_custom_secondary_packet_size(mut self, packet_size: Option<PacketSize>) -> Self {
+        self.secondary_packet_size = packet_size;
         self
     }
 }
@@ -170,7 +180,8 @@ where
             config.average_packet_delay,
             config.average_ack_delay,
         )
-        .with_custom_real_message_packet_size(config.packet_size)
+        .with_custom_primary_packet_size(config.primary_packet_size)
+        .with_custom_secondary_packet_size(config.secondary_packet_size)
         .with_mix_hops(config.num_mix_hops);
 
         MessageHandler {

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -270,6 +270,7 @@ where
     ) -> Result<(), SurbWrappedPreparationError> {
         let msg = NymMessage::new_reply(message);
         let packet_size = self.optimal_packet_size(&msg);
+        debug!("Using {packet_size} packets for {msg}");
 
         let mut fragment = self
             .message_preparer
@@ -325,6 +326,7 @@ where
     pub(crate) fn split_reply_message(&mut self, message: Vec<u8>) -> Vec<Fragment> {
         let msg = NymMessage::new_reply(ReplyMessage::new_data_message(message));
         let packet_size = self.optimal_packet_size(&msg);
+        debug!("Using {packet_size} packets for {msg}");
 
         self.message_preparer
             .pad_and_split_message(msg, packet_size)
@@ -424,6 +426,7 @@ where
         let topology = self.get_topology(&topology_permit)?;
 
         let packet_size = self.optimal_packet_size(&message);
+        debug!("Using {packet_size} packets for {message}");
         let fragments = self
             .message_preparer
             .pad_and_split_message(message, packet_size);

--- a/common/client-core/src/client/real_messages_control/mod.rs
+++ b/common/client-core/src/client/real_messages_control/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
+// Copyright 2021-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
 // INPUT: InputMessage from user
@@ -26,11 +26,9 @@ use log::*;
 use nym_gateway_client::AcknowledgementReceiver;
 use nym_sphinx::acknowledgements::AckKey;
 use nym_sphinx::addressing::clients::Recipient;
-use nym_sphinx::params::PacketSize;
 use nym_task::connections::{ConnectionCommandReceiver, LaneQueueLengths};
 use rand::{rngs::OsRng, CryptoRng, Rng};
 use std::sync::Arc;
-use std::time::Duration;
 
 use crate::client::replies::reply_controller;
 use crate::config;
@@ -45,61 +43,26 @@ pub struct Config {
     /// Key used to decrypt contents of received SURBAcks
     ack_key: Arc<AckKey>,
 
-    /// Given ack timeout in the form a * BASE_DELAY + b, it specifies the additive part `b`
-    ack_wait_addition: Duration,
-
-    /// Given ack timeout in the form a * BASE_DELAY + b, it specifies the multiplier `a`
-    ack_wait_multiplier: f64,
-
     /// Address of `this` client.
     self_recipient: Recipient,
 
-    /// Average delay between sending subsequent packets from this client.
-    average_message_sending_delay: Duration,
+    /// Specifies all traffic related configuration options.
+    traffic: config::Traffic,
 
-    /// Average delay a data packet is going to get delayed at a single mixnode.
-    average_packet_delay_duration: Duration,
+    /// Specifies all acknowledgements related configuration options.
+    acks: config::Acknowledgements,
 
-    /// Average delay an acknowledgement packet is going to get delayed at a single mixnode.
-    average_ack_delay_duration: Duration,
-
-    /// Controls whether the main packet stream constantly produces packets according to the predefined
-    /// poisson distribution.
-    disable_main_poisson_packet_distribution: bool,
-
-    /// Predefined packet size used for the encapsulated messages.
-    packet_size: PacketSize,
-
-    /// Defines the minimum number of reply surbs the client would request.
-    minimum_reply_surb_request_size: u32,
-
-    /// Defines the maximum number of reply surbs the client would request.
-    maximum_reply_surb_request_size: u32,
-
-    /// Defines the maximum number of reply surbs a remote party is allowed to request from this client at once.
-    maximum_allowed_reply_surb_request_size: u32,
-
-    /// Defines maximum amount of time the client is going to wait for reply surbs before explicitly asking
-    /// for more even though in theory they wouldn't need to.
-    maximum_reply_surb_rerequest_waiting_period: Duration,
-
-    /// Defines maximum amount of time the client is going to wait for reply surbs before
-    /// deciding it's never going to get them and would drop all pending messages
-    maximum_reply_surb_drop_waiting_period: Duration,
-
-    /// Defines maximum amount of time given reply surb is going to be valid for.
-    /// This is going to be superseded by key rotation once implemented.
-    maximum_reply_surb_age: Duration,
-
-    /// Defines maximum amount of time given reply key is going to be valid for.
-    /// This is going to be superseded by key rotation once implemented.
-    maximum_reply_key_age: Duration,
+    /// Specifies all reply SURBs related configuration options.
+    reply_surbs: config::ReplySurbs,
 }
 
 impl<'a> From<&'a Config> for acknowledgement_control::Config {
     fn from(cfg: &'a Config) -> Self {
-        acknowledgement_control::Config::new(cfg.ack_wait_addition, cfg.ack_wait_multiplier)
-            .with_custom_packet_size(cfg.packet_size)
+        acknowledgement_control::Config::new(
+            cfg.acks.ack_wait_addition,
+            cfg.acks.ack_wait_multiplier,
+        )
+        .with_custom_packet_size(cfg.traffic.primary_packet_size)
     }
 }
 
@@ -108,25 +71,25 @@ impl<'a> From<&'a Config> for real_traffic_stream::Config {
         real_traffic_stream::Config::new(
             Arc::clone(&cfg.ack_key),
             cfg.self_recipient,
-            cfg.average_ack_delay_duration,
-            cfg.average_packet_delay_duration,
-            cfg.average_message_sending_delay,
-            cfg.disable_main_poisson_packet_distribution,
+            cfg.acks.average_ack_delay,
+            cfg.traffic.average_packet_delay,
+            cfg.traffic.message_sending_average_delay,
+            cfg.traffic.disable_main_poisson_packet_distribution,
         )
-        .with_custom_cover_packet_size(cfg.packet_size)
+        .with_custom_cover_packet_size(cfg.traffic.primary_packet_size)
     }
 }
 
 impl<'a> From<&'a Config> for reply_controller::Config {
     fn from(cfg: &'a Config) -> Self {
         reply_controller::Config::new(
-            cfg.minimum_reply_surb_request_size,
-            cfg.maximum_reply_surb_request_size,
-            cfg.maximum_allowed_reply_surb_request_size,
-            cfg.maximum_reply_surb_rerequest_waiting_period,
-            cfg.maximum_reply_surb_drop_waiting_period,
-            cfg.maximum_reply_surb_age,
-            cfg.maximum_reply_key_age,
+            cfg.reply_surbs.minimum_reply_surb_request_size,
+            cfg.reply_surbs.maximum_reply_surb_request_size,
+            cfg.reply_surbs.maximum_allowed_reply_surb_request_size,
+            cfg.reply_surbs.maximum_reply_surb_rerequest_waiting_period,
+            cfg.reply_surbs.maximum_reply_surb_drop_waiting_period,
+            cfg.reply_surbs.maximum_reply_surb_age,
+            cfg.reply_surbs.maximum_reply_key_age,
         )
     }
 }
@@ -136,10 +99,10 @@ impl<'a> From<&'a Config> for message_handler::Config {
         message_handler::Config::new(
             Arc::clone(&cfg.ack_key),
             cfg.self_recipient,
-            cfg.average_packet_delay_duration,
-            cfg.average_ack_delay_duration,
+            cfg.traffic.average_packet_delay,
+            cfg.acks.average_ack_delay,
         )
-        .with_custom_packet_size(cfg.packet_size)
+        .with_custom_packet_size(cfg.traffic.primary_packet_size)
     }
 }
 
@@ -152,41 +115,10 @@ impl Config {
         Config {
             ack_key,
             self_recipient,
-            packet_size: Default::default(),
-            ack_wait_addition: base_client_debug_config.acknowledgements.ack_wait_addition,
-            ack_wait_multiplier: base_client_debug_config
-                .acknowledgements
-                .ack_wait_multiplier,
-            average_message_sending_delay: base_client_debug_config
-                .traffic
-                .message_sending_average_delay,
-            average_packet_delay_duration: base_client_debug_config.traffic.average_packet_delay,
-            average_ack_delay_duration: base_client_debug_config.acknowledgements.average_ack_delay,
-            disable_main_poisson_packet_distribution: base_client_debug_config
-                .traffic
-                .disable_main_poisson_packet_distribution,
-            minimum_reply_surb_request_size: base_client_debug_config
-                .reply_surbs
-                .minimum_reply_surb_request_size,
-            maximum_reply_surb_request_size: base_client_debug_config
-                .reply_surbs
-                .maximum_reply_surb_request_size,
-            maximum_allowed_reply_surb_request_size: base_client_debug_config
-                .reply_surbs
-                .maximum_allowed_reply_surb_request_size,
-            maximum_reply_surb_rerequest_waiting_period: base_client_debug_config
-                .reply_surbs
-                .maximum_reply_surb_rerequest_waiting_period,
-            maximum_reply_surb_drop_waiting_period: base_client_debug_config
-                .reply_surbs
-                .maximum_reply_surb_drop_waiting_period,
-            maximum_reply_surb_age: base_client_debug_config.reply_surbs.maximum_reply_surb_age,
-            maximum_reply_key_age: base_client_debug_config.reply_surbs.maximum_reply_key_age,
+            traffic: base_client_debug_config.traffic,
+            acks: base_client_debug_config.acknowledgements,
+            reply_surbs: base_client_debug_config.reply_surbs,
         }
-    }
-
-    pub fn set_custom_packet_size(&mut self, packet_size: PacketSize) {
-        self.packet_size = packet_size;
     }
 }
 

--- a/common/client-core/src/client/real_messages_control/mod.rs
+++ b/common/client-core/src/client/real_messages_control/mod.rs
@@ -102,7 +102,8 @@ impl<'a> From<&'a Config> for message_handler::Config {
             cfg.traffic.average_packet_delay,
             cfg.acks.average_ack_delay,
         )
-        .with_custom_packet_size(cfg.traffic.primary_packet_size)
+        .with_custom_primary_packet_size(cfg.traffic.primary_packet_size)
+        .with_custom_secondary_packet_size(cfg.traffic.secondary_packet_size)
     }
 }
 

--- a/common/client-core/src/client/real_messages_control/mod.rs
+++ b/common/client-core/src/client/real_messages_control/mod.rs
@@ -49,6 +49,9 @@ pub struct Config {
     /// Specifies all traffic related configuration options.
     traffic: config::Traffic,
 
+    /// Specifies all cover traffic related configuration options.
+    cover_traffic: config::CoverTraffic,
+
     /// Specifies all acknowledgements related configuration options.
     acks: config::Acknowledgements,
 
@@ -72,25 +75,15 @@ impl<'a> From<&'a Config> for real_traffic_stream::Config {
             Arc::clone(&cfg.ack_key),
             cfg.self_recipient,
             cfg.acks.average_ack_delay,
-            cfg.traffic.average_packet_delay,
-            cfg.traffic.message_sending_average_delay,
-            cfg.traffic.disable_main_poisson_packet_distribution,
+            cfg.traffic,
+            cfg.cover_traffic.cover_traffic_primary_size_ratio,
         )
-        .with_custom_cover_packet_size(cfg.traffic.primary_packet_size)
     }
 }
 
 impl<'a> From<&'a Config> for reply_controller::Config {
     fn from(cfg: &'a Config) -> Self {
-        reply_controller::Config::new(
-            cfg.reply_surbs.minimum_reply_surb_request_size,
-            cfg.reply_surbs.maximum_reply_surb_request_size,
-            cfg.reply_surbs.maximum_allowed_reply_surb_request_size,
-            cfg.reply_surbs.maximum_reply_surb_rerequest_waiting_period,
-            cfg.reply_surbs.maximum_reply_surb_drop_waiting_period,
-            cfg.reply_surbs.maximum_reply_surb_age,
-            cfg.reply_surbs.maximum_reply_key_age,
-        )
+        reply_controller::Config::new(cfg.reply_surbs)
     }
 }
 
@@ -117,6 +110,7 @@ impl Config {
             ack_key,
             self_recipient,
             traffic: base_client_debug_config.traffic,
+            cover_traffic: base_client_debug_config.cover_traffic,
             acks: base_client_debug_config.acknowledgements,
             reply_surbs: base_client_debug_config.reply_surbs,
         }

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -203,10 +203,11 @@ where
             return self.config.traffic.primary_packet_size
         };
 
-        if self
+        let use_primary = self
             .rng
-            .gen_bool(self.config.cover_traffic_primary_size_ratio)
-        {
+            .gen_bool(self.config.cover_traffic_primary_size_ratio);
+
+        if use_primary {
             self.config.traffic.primary_packet_size
         } else {
             secondary_packet_size

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -220,6 +220,7 @@ where
         let (next_message, fragment_id) = match next_message {
             StreamMessage::Cover => {
                 let cover_traffic_packet_size = self.loop_cover_message_size();
+                trace!("the next loop cover message will be put in a {cover_traffic_packet_size} packet");
 
                 // TODO for way down the line: in very rare cases (during topology update) we might have
                 // to wait a really tiny bit before actually obtaining the permit hence messing with our

--- a/common/client-core/src/client/transmission_buffer.rs
+++ b/common/client-core/src/client/transmission_buffer.rs
@@ -171,8 +171,6 @@ impl<T> TransmissionBuffer<T> {
         &mut self,
         n: usize,
     ) -> Option<Vec<(TransmissionLane, T)>> {
-        // let start = Instant::now();
-
         if self.buffer.is_empty() {
             return None;
         }
@@ -186,8 +184,6 @@ impl<T> TransmissionBuffer<T> {
             };
             items.push(next)
         }
-
-        // todo!("time time taken");
 
         Some(items)
     }

--- a/common/client-core/src/config/mod.rs
+++ b/common/client-core/src/config/mod.rs
@@ -363,10 +363,6 @@ impl<T> Config<T> {
         self.debug.traffic.disable_main_poisson_packet_distribution
     }
 
-    pub fn get_use_extended_packet_size(&self) -> Option<ExtendedPacketSize> {
-        self.debug.traffic.use_extended_packet_size
-    }
-
     pub fn get_minimum_reply_surb_storage_threshold(&self) -> usize {
         self.debug.reply_surbs.minimum_reply_surb_storage_threshold
     }
@@ -603,7 +599,7 @@ impl<T: NymConfig> Client<T> {
 pub struct Logging {}
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct Traffic {
     /// The parameter of Poisson distribution determining how long, on average,
     /// sent packet is going to be delayed at any given mix node.
@@ -631,10 +627,6 @@ pub struct Traffic {
     /// Note that its use decreases overall anonymity.
     /// Do not set it it unless you understand the consequences of that change.
     pub secondary_packet_size: Option<PacketSize>,
-
-    /// Controls whether the sent sphinx packet use a NON-DEFAULT bigger size.
-    #[deprecated]
-    pub use_extended_packet_size: Option<ExtendedPacketSize>,
 }
 
 impl Traffic {
@@ -658,7 +650,6 @@ impl Default for Traffic {
             disable_main_poisson_packet_distribution: false,
             primary_packet_size: PacketSize::RegularPacket,
             secondary_packet_size: None,
-            use_extended_packet_size: None,
         }
     }
 }
@@ -849,14 +840,6 @@ impl DebugConfig {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum ExtendedPacketSize {
-    Extended8,
-    Extended16,
-    Extended32,
-}
-
 // it could be derived, sure, but I'd rather have an explicit implementation in case we had to change
 // something manually at some point
 #[allow(clippy::derivable_impls)]
@@ -869,16 +852,6 @@ impl Default for DebugConfig {
             acknowledgements: Default::default(),
             topology: Default::default(),
             reply_surbs: Default::default(),
-        }
-    }
-}
-
-impl From<ExtendedPacketSize> for PacketSize {
-    fn from(size: ExtendedPacketSize) -> PacketSize {
-        match size {
-            ExtendedPacketSize::Extended8 => PacketSize::ExtendedPacket8,
-            ExtendedPacketSize::Extended16 => PacketSize::ExtendedPacket16,
-            ExtendedPacketSize::Extended32 => PacketSize::ExtendedPacket32,
         }
     }
 }

--- a/common/client-core/src/config/mod.rs
+++ b/common/client-core/src/config/mod.rs
@@ -32,7 +32,7 @@ const DEFAULT_TOPOLOGY_RESOLUTION_TIMEOUT: Duration = Duration::from_millis(5_00
 // bandwidth bridging protocol, we can come back to a smaller timeout value
 const DEFAULT_GATEWAY_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
-const DEFAULT_COVER_TRAFFIC_PRIMARY_SIZE_RATIO: f32 = 0.70;
+const DEFAULT_COVER_TRAFFIC_PRIMARY_SIZE_RATIO: f64 = 0.70;
 
 // reply-surbs related:
 
@@ -664,7 +664,7 @@ pub struct CoverTraffic {
 
     /// Specifies the ratio of `primary_packet_size` to `secondary_packet_size` used in cover traffic.
     /// Only applicable if `secondary_packet_size` is enabled.
-    pub cover_traffic_primary_size_ratio: f32,
+    pub cover_traffic_primary_size_ratio: f64,
 
     /// Controls whether the dedicated loop cover traffic stream should be enabled.
     /// (and sending packets, on average, every [Self::loop_cover_traffic_average_delay])

--- a/common/client-core/src/config/old_config_v1_1_13.rs
+++ b/common/client-core/src/config/old_config_v1_1_13.rs
@@ -105,10 +105,12 @@ impl From<OldDebugConfigV1_1_13> for DebugConfig {
                 disable_main_poisson_packet_distribution: value
                     .disable_main_poisson_packet_distribution,
                 use_extended_packet_size: value.use_extended_packet_size,
+                ..Traffic::default()
             },
             cover_traffic: CoverTraffic {
                 loop_cover_traffic_average_delay: value.loop_cover_traffic_average_delay,
                 disable_loop_cover_traffic_stream: value.disable_loop_cover_traffic_stream,
+                ..CoverTraffic::default()
             },
             gateway_connection: GatewayConnection {
                 gateway_response_timeout: value.gateway_response_timeout,

--- a/common/client-core/src/config/old_config_v1_1_13.rs
+++ b/common/client-core/src/config/old_config_v1_1_13.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::{
-    Acknowledgements, Client, Config, CoverTraffic, DebugConfig, ExtendedPacketSize,
-    GatewayConnection, Logging, ReplySurbs, Topology, Traffic, DEFAULT_ACK_WAIT_ADDITION,
-    DEFAULT_ACK_WAIT_MULTIPLIER, DEFAULT_AVERAGE_PACKET_DELAY, DEFAULT_GATEWAY_RESPONSE_TIMEOUT,
+    Acknowledgements, Client, Config, CoverTraffic, DebugConfig, GatewayConnection, Logging,
+    ReplySurbs, Topology, Traffic, DEFAULT_ACK_WAIT_ADDITION, DEFAULT_ACK_WAIT_MULTIPLIER,
+    DEFAULT_AVERAGE_PACKET_DELAY, DEFAULT_GATEWAY_RESPONSE_TIMEOUT,
     DEFAULT_LOOP_COVER_STREAM_AVERAGE_DELAY, DEFAULT_MAXIMUM_ALLOWED_SURB_REQUEST_SIZE,
     DEFAULT_MAXIMUM_REPLY_KEY_AGE, DEFAULT_MAXIMUM_REPLY_SURB_AGE,
     DEFAULT_MAXIMUM_REPLY_SURB_DROP_WAITING_PERIOD, DEFAULT_MAXIMUM_REPLY_SURB_REQUEST_SIZE,
@@ -14,9 +14,28 @@ use crate::config::{
     DEFAULT_TOPOLOGY_REFRESH_RATE, DEFAULT_TOPOLOGY_RESOLUTION_TIMEOUT,
 };
 use nym_config::NymConfig;
+use nym_sphinx::params::PacketSize;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use std::time::Duration;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ExtendedPacketSize {
+    Extended8,
+    Extended16,
+    Extended32,
+}
+
+impl From<ExtendedPacketSize> for PacketSize {
+    fn from(size: ExtendedPacketSize) -> PacketSize {
+        match size {
+            ExtendedPacketSize::Extended8 => PacketSize::ExtendedPacket8,
+            ExtendedPacketSize::Extended16 => PacketSize::ExtendedPacket16,
+            ExtendedPacketSize::Extended32 => PacketSize::ExtendedPacket32,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -104,8 +123,8 @@ impl From<OldDebugConfigV1_1_13> for DebugConfig {
                 message_sending_average_delay: value.message_sending_average_delay,
                 disable_main_poisson_packet_distribution: value
                     .disable_main_poisson_packet_distribution,
-                use_extended_packet_size: value.use_extended_packet_size,
-                ..Traffic::default()
+                primary_packet_size: PacketSize::RegularPacket,
+                secondary_packet_size: value.use_extended_packet_size.map(Into::into),
             },
             cover_traffic: CoverTraffic {
                 loop_cover_traffic_average_delay: value.loop_cover_traffic_average_delay,

--- a/common/nymsphinx/Cargo.toml
+++ b/common/nymsphinx/Cargo.toml
@@ -32,6 +32,7 @@ nym-outfox = { path = "../../nym-outfox" }
 
 [dev-dependencies]
 nym-mixnet-contract-common = { path = "../cosmwasm-smart-contracts/mixnet-contract" }
+nym-crypto = { path = "../crypto", version = "0.2.0", features = ["asymmetric"] }
 
 # do not include this when compiling into wasm as it somehow when combined together with reqwest, it will require
 # net2 via tokio-util -> tokio -> mio -> net2

--- a/common/nymsphinx/anonymous-replies/Cargo.toml
+++ b/common/nymsphinx/anonymous-replies/Cargo.toml
@@ -21,3 +21,6 @@ nym-topology = { path = "../../topology" }
 
 [target."cfg(target_arch = \"wasm32\")".dependencies.wasm-bindgen]
 version = "0.2.83"
+
+[dev-dependencies]
+rand_chacha = "0.2"

--- a/common/nymsphinx/anonymous-replies/src/encryption_key.rs
+++ b/common/nymsphinx/anonymous-replies/src/encryption_key.rs
@@ -63,6 +63,10 @@ impl SurbEncryptionKey {
         self.0.as_ref()
     }
 
+    pub fn size(&self) -> usize {
+        self.0.len()
+    }
+
     pub fn inner(&self) -> &CipherKey<ReplySurbEncryptionAlgorithm> {
         &self.0
     }

--- a/common/nymsphinx/anonymous-replies/src/reply_surb.rs
+++ b/common/nymsphinx/anonymous-replies/src/reply_surb.rs
@@ -34,8 +34,8 @@ pub enum ReplySurbError {
 
 #[derive(Debug)]
 pub struct ReplySurb {
-    surb: SURB,
-    encryption_key: SurbEncryptionKey,
+    pub(crate) surb: SURB,
+    pub(crate) encryption_key: SurbEncryptionKey,
 }
 
 // Serialize + Deserialize is not really used anymore (it was for a CBOR experiment)

--- a/common/nymsphinx/anonymous-replies/src/reply_surb.rs
+++ b/common/nymsphinx/anonymous-replies/src/reply_surb.rs
@@ -172,10 +172,8 @@ impl ReplySurb {
     pub fn apply_surb<M: AsRef<[u8]>>(
         self,
         message: M,
-        packet_size: Option<PacketSize>,
+        packet_size: PacketSize,
     ) -> Result<(SphinxPacket, NymNodeRoutingAddress), ReplySurbError> {
-        let packet_size = packet_size.unwrap_or_default();
-
         let message_bytes = message.as_ref();
         if message_bytes.len() != packet_size.plaintext_size() {
             return Err(ReplySurbError::UnpaddedMessageError);

--- a/common/nymsphinx/chunking/src/fragment.rs
+++ b/common/nymsphinx/chunking/src/fragment.rs
@@ -191,6 +191,14 @@ impl Fragment {
         })
     }
 
+    /// based on the size of the embedded data, determines which predefined `PacketSize`
+    /// was used for construction of this `Fragment`
+    pub fn serialized_size(&self) -> usize {
+        // TODO: optimisation: determine the size of the header without actually serializing it...
+        let header_size = self.header.to_bytes().len();
+        header_size + self.payload_size()
+    }
+
     /// Convert this `Fragment` into vector of bytes which can be put into a sphinx packet.
     pub fn into_bytes(self) -> Vec<u8> {
         self.header
@@ -434,8 +442,7 @@ impl FragmentHeader {
         let frag_id = self.id | (1 << 31);
         let frag_id_bytes = frag_id.to_be_bytes();
         let bytes_prefix_iter = frag_id_bytes
-            .iter()
-            .cloned()
+            .into_iter()
             .chain(std::iter::once(self.total_fragments))
             .chain(std::iter::once(self.current_fragment));
 

--- a/common/nymsphinx/chunking/src/lib.rs
+++ b/common/nymsphinx/chunking/src/lib.rs
@@ -5,6 +5,8 @@ use crate::fragment::{linked_fragment_payload_max_len, unlinked_fragment_payload
 pub use set::split_into_sets;
 use thiserror::Error;
 
+pub const MIN_PADDING_OVERHEAD: usize = 1;
+
 // Future consideration: currently in a lot of places, the payloads have randomised content
 // which is not a perfect testing strategy as it might not detect some edge cases I never would
 // have assumed could be possible. A better approach would be to research some Fuzz testing

--- a/common/nymsphinx/params/Cargo.toml
+++ b/common/nymsphinx/params/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 
 [dependencies]
 thiserror = "1.0.37"
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 
 nym-crypto = { path = "../../crypto", features = ["hashing", "symmetric"] }
 nym-sphinx-types = { path = "../types" }

--- a/common/nymsphinx/params/Cargo.toml
+++ b/common/nymsphinx/params/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 
 [dependencies]
 thiserror = "1.0.37"
+serde = { workspace = true }
 
 nym-crypto = { path = "../../crypto", features = ["hashing", "symmetric"] }
 nym-sphinx-types = { path = "../types" }

--- a/common/nymsphinx/params/src/packet_sizes.rs
+++ b/common/nymsphinx/params/src/packet_sizes.rs
@@ -7,21 +7,25 @@ use nym_sphinx_types::PAYLOAD_OVERHEAD_SIZE;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::convert::TryFrom;
+use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 use thiserror::Error;
 
+// each sphinx packet contains mandatory header and payload padding + markers
+const PACKET_OVERHEAD: usize = HEADER_SIZE + PAYLOAD_OVERHEAD_SIZE;
+
 // it's up to the smart people to figure those values out : )
-const REGULAR_PACKET_SIZE: usize = HEADER_SIZE + PAYLOAD_OVERHEAD_SIZE + 2 * 1024;
+const REGULAR_PACKET_SIZE: usize = 2 * 1024 + PACKET_OVERHEAD;
 // TODO: even though we have 16B IV, is having just 5B (FRAG_ID_LEN) of the ID possibly insecure?
 
 // TODO: I'm not entirely sure if we can easily extract `<AckEncryptionAlgorithm as NewStreamCipher>::NonceSize`
 // into a const usize before relevant stuff is stabilised in rust...
 const ACK_IV_SIZE: usize = 16;
 
-const ACK_PACKET_SIZE: usize = HEADER_SIZE + PAYLOAD_OVERHEAD_SIZE + ACK_IV_SIZE + FRAG_ID_LEN;
-const EXTENDED_PACKET_SIZE_8: usize = HEADER_SIZE + PAYLOAD_OVERHEAD_SIZE + 8 * 1024;
-const EXTENDED_PACKET_SIZE_16: usize = HEADER_SIZE + PAYLOAD_OVERHEAD_SIZE + 16 * 1024;
-const EXTENDED_PACKET_SIZE_32: usize = HEADER_SIZE + PAYLOAD_OVERHEAD_SIZE + 32 * 1024;
+const ACK_PACKET_SIZE: usize = ACK_IV_SIZE + FRAG_ID_LEN + PACKET_OVERHEAD;
+const EXTENDED_PACKET_SIZE_8: usize = 8 * 1024 + PACKET_OVERHEAD;
+const EXTENDED_PACKET_SIZE_16: usize = 16 * 1024 + PACKET_OVERHEAD;
+const EXTENDED_PACKET_SIZE_32: usize = 32 * 1024 + PACKET_OVERHEAD;
 
 #[derive(Debug, Error)]
 pub enum InvalidPacketSize {
@@ -36,7 +40,7 @@ pub enum InvalidPacketSize {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum PacketSize {
     // for example instant messaging use case
     #[default]
@@ -91,6 +95,28 @@ impl FromStr for PacketSize {
     }
 }
 
+impl Display for PacketSize {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PacketSize::RegularPacket => write!(f, "regular"),
+            PacketSize::AckPacket => write!(f, "ack"),
+            PacketSize::ExtendedPacket32 => write!(f, "extended32"),
+            PacketSize::ExtendedPacket8 => write!(f, "extended8"),
+            PacketSize::ExtendedPacket16 => write!(f, "extended16"),
+        }
+    }
+}
+
+impl Debug for PacketSize {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let name = self.to_string();
+        let size = self.size();
+        let plaintext = self.plaintext_size();
+
+        write!(f, "{name} ({size} bytes / {plaintext} plaintext)")
+    }
+}
+
 impl TryFrom<u8> for PacketSize {
     type Error = InvalidPacketSize;
 
@@ -107,7 +133,7 @@ impl TryFrom<u8> for PacketSize {
 }
 
 impl PacketSize {
-    pub fn size(self) -> usize {
+    pub const fn size(self) -> usize {
         match self {
             PacketSize::RegularPacket => REGULAR_PACKET_SIZE,
             PacketSize::AckPacket => ACK_PACKET_SIZE,
@@ -117,11 +143,11 @@ impl PacketSize {
         }
     }
 
-    pub fn plaintext_size(self) -> usize {
+    pub const fn plaintext_size(self) -> usize {
         self.size() - HEADER_SIZE - PAYLOAD_OVERHEAD_SIZE
     }
 
-    pub fn payload_size(self) -> usize {
+    pub const fn payload_size(self) -> usize {
         self.size() - HEADER_SIZE
     }
 
@@ -156,6 +182,11 @@ impl PacketSize {
         } else {
             None
         }
+    }
+
+    pub fn get_type_from_plaintext(plaintext_size: usize) -> Result<Self, InvalidPacketSize> {
+        let packet_size = plaintext_size + PACKET_OVERHEAD;
+        Self::get_type(packet_size)
     }
 }
 

--- a/common/nymsphinx/params/src/packet_sizes.rs
+++ b/common/nymsphinx/params/src/packet_sizes.rs
@@ -1,9 +1,10 @@
-// Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
+// Copyright 2021-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::FRAG_ID_LEN;
 use nym_sphinx_types::header::HEADER_SIZE;
 use nym_sphinx_types::PAYLOAD_OVERHEAD_SIZE;
+use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::str::FromStr;
 use thiserror::Error;
@@ -34,22 +35,27 @@ pub enum InvalidPacketSize {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum PacketSize {
     // for example instant messaging use case
     #[default]
+    #[serde(rename = "regular")]
     RegularPacket = 1,
 
     // for sending SURB-ACKs
+    #[serde(rename = "ack")]
     AckPacket = 2,
 
     // for example for streaming fast and furious in uncompressed 10bit 4K HDR quality
+    #[serde(rename = "extended32")]
     ExtendedPacket32 = 3,
 
     // for example for streaming fast and furious in heavily compressed lossy RealPlayer quality
+    #[serde(rename = "extended8")]
     ExtendedPacket8 = 4,
 
     // for example for streaming fast and furious in compressed XviD quality
+    #[serde(rename = "extended16")]
     ExtendedPacket16 = 5,
 }
 

--- a/common/nymsphinx/params/src/packet_sizes.rs
+++ b/common/nymsphinx/params/src/packet_sizes.rs
@@ -5,6 +5,7 @@ use crate::FRAG_ID_LEN;
 use nym_sphinx_types::header::HEADER_SIZE;
 use nym_sphinx_types::PAYLOAD_OVERHEAD_SIZE;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::convert::TryFrom;
 use std::str::FromStr;
 use thiserror::Error;
@@ -57,6 +58,20 @@ pub enum PacketSize {
     // for example for streaming fast and furious in compressed XviD quality
     #[serde(rename = "extended16")]
     ExtendedPacket16 = 5,
+}
+
+impl PartialOrd for PacketSize {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // order them by actual packet size
+        self.size().partial_cmp(&other.size())
+    }
+}
+
+impl Ord for PacketSize {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // order them by actual packet size
+        self.size().cmp(&other.size())
+    }
 }
 
 impl FromStr for PacketSize {

--- a/common/nymsphinx/src/message.rs
+++ b/common/nymsphinx/src/message.rs
@@ -16,6 +16,8 @@ use rand::Rng;
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
 
+pub(crate) const ACK_OVERHEAD: usize = MAX_NODE_ADDRESS_UNPADDED_LEN + PacketSize::AckPacket.size();
+
 #[derive(Debug, Error)]
 pub enum NymMessageError {
     #[error("{received} is not a valid type tag for a NymMessage")]
@@ -172,24 +174,9 @@ impl NymMessage {
         message_type_size + inner_size
     }
 
-    /// Determines the number of required packets of the provided size for the split message.
-    pub fn required_packets(&self, packet_size: PacketSize, num_mix_hops: u8) -> usize {
-        // let size = self.into_bytes()
-        let plaintext_per_packet = self.available_plaintext_per_packet(packet_size);
-        let serialized_len = self.serialized_size(num_mix_hops);
-
-        // same logic as in `pad_to_full_packet_lengths` for the additional '1' being added.
-        let (num_fragments, _) =
-            chunking::number_of_required_fragments(serialized_len + 1, plaintext_per_packet);
-
-        num_fragments
-    }
-
-    /// Length of plaintext (from the sphinx point of view) data that is available per sphinx
+    /// Length of plaintext (from the **sphinx** point of view) data that is available per sphinx
     /// packet.
-    pub fn available_plaintext_per_packet(&self, packet_size: PacketSize) -> usize {
-        let ack_overhead = MAX_NODE_ADDRESS_UNPADDED_LEN + PacketSize::AckPacket.size();
-
+    pub fn available_sphinx_plaintext_per_packet(&self, packet_size: PacketSize) -> usize {
         let variant_overhead = match self {
             // each plain or repliable packet attaches an ephemeral public key so that the recipient
             // could perform diffie-hellman with its own keys followed by a kdf to re-derive
@@ -200,7 +187,31 @@ impl NymMessage {
             NymMessage::Reply(_) => ReplySurbKeyDigestAlgorithm::output_size(),
         };
 
-        packet_size.plaintext_size() - ack_overhead - variant_overhead
+        // each packet will contain an ack + variant specific data (as described above)
+        packet_size.plaintext_size() - ACK_OVERHEAD - variant_overhead
+    }
+
+    /// Length of the actual (from the **message** point of view) data that is available in each packet.
+    pub fn true_available_plaintext_per_packet(&self, packet_size: PacketSize) -> usize {
+        let sphinx_plaintext = self.available_sphinx_plaintext_per_packet(packet_size);
+        sphinx_plaintext - chunking::MIN_PADDING_OVERHEAD
+    }
+
+    /// Determines the number of required packets of the provided size for the split message.
+    pub fn required_packets(&self, packet_size: PacketSize, num_mix_hops: u8) -> usize {
+        let plaintext_per_packet = self.true_available_plaintext_per_packet(packet_size);
+        let serialized_len = self.serialized_size(num_mix_hops);
+
+        let (num_fragments, _) =
+            chunking::number_of_required_fragments(serialized_len, plaintext_per_packet);
+
+        // by chunking I mean that currently the fragments hold variable amount of plaintext in them (I wish I had time to rewrite it...)
+        log::trace!(
+            "this message will use {serialized_len} bytes of PLAINTEXT (This does not account for Ack or chunking overhead). \
+            With {packet_size:?} PacketSize ({plaintext_per_packet} of usable plaintext available) it will require {num_fragments} packet(s).",
+        );
+
+        num_fragments
     }
 
     /// Pads the message so that after it gets chunked, it will occupy exactly N sphinx packets.
@@ -210,10 +221,14 @@ impl NymMessage {
 
         let bytes = self.into_bytes();
 
-        // 1 is added as there will always have to be at least a single byte of padding (1) added
+        // 1 (chunking::MIN_PADDING_OVERHEAD) is added as there will always have to be at least a single byte of padding (1) added
         // to be able to later distinguish the actual padding from the underlying message
+        // TODO: this whole `MIN_PADDING_OVERHEAD` feels very awkward. it should somehow be included in
+        // `available_plaintext_per_packet`
+        let total_required_bytes = bytes.len() + chunking::MIN_PADDING_OVERHEAD;
+
         let (packets_used, space_left) =
-            chunking::number_of_required_fragments(bytes.len() + 1, plaintext_per_packet);
+            chunking::number_of_required_fragments(total_required_bytes, plaintext_per_packet);
 
         let wasted_space = space_left as f32 / (bytes.len() + 1 + space_left) as f32;
         log::trace!("Padding {self_display}: {} of raw plaintext bytes are required. They're going to be put into {packets_used} sphinx packets with {space_left} bytes of leftover space. {wasted_space}% of packet capacity is going to be wasted.", bytes.len() + 1);

--- a/common/nymsphinx/src/preparer/mod.rs
+++ b/common/nymsphinx/src/preparer/mod.rs
@@ -258,8 +258,12 @@ where
         )
     }
 
-    pub fn pad_and_split_message(&mut self, message: NymMessage) -> Vec<Fragment> {
-        let plaintext_per_packet = message.available_plaintext_per_packet(self.primary_packet_size);
+    pub fn pad_and_split_message(
+        &mut self,
+        message: NymMessage,
+        packet_size: PacketSize,
+    ) -> Vec<Fragment> {
+        let plaintext_per_packet = message.available_plaintext_per_packet(packet_size);
 
         message
             .pad_to_full_packet_lengths(plaintext_per_packet)

--- a/common/nymsphinx/src/preparer/mod.rs
+++ b/common/nymsphinx/src/preparer/mod.rs
@@ -1,8 +1,10 @@
 // Copyright 2021-2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::message::NymMessage;
+use crate::message::{NymMessage, ACK_OVERHEAD};
 use crate::NymsphinxPayloadBuilder;
+use nym_crypto::asymmetric::encryption;
+use nym_crypto::Digest;
 use nym_sphinx_acknowledgements::surb_ack::SurbAck;
 use nym_sphinx_acknowledgements::AckKey;
 use nym_sphinx_addressing::clients::Recipient;
@@ -11,7 +13,7 @@ use nym_sphinx_anonymous_replies::reply_surb::ReplySurb;
 use nym_sphinx_chunking::fragment::{Fragment, FragmentIdentifier};
 use nym_sphinx_forwarding::packet::MixPacket;
 use nym_sphinx_params::packet_sizes::PacketSize;
-use nym_sphinx_params::DEFAULT_NUM_MIX_HOPS;
+use nym_sphinx_params::{ReplySurbKeyDigestAlgorithm, DEFAULT_NUM_MIX_HOPS};
 use nym_sphinx_types::builder::SphinxPacketBuilder;
 use nym_sphinx_types::{delays, Delay};
 use nym_topology::{NymTopology, NymTopologyError};
@@ -45,12 +47,6 @@ pub struct MessagePreparer<R> {
     /// Instance of a cryptographically secure random number generator.
     rng: R,
 
-    /// Size of the target [`SphinxPacket`] into which the underlying is going to get split.
-    primary_packet_size: PacketSize,
-
-    /// Alternative size of the target [`SphinxPacket`] into which the underlying is going to get split.
-    secondary_packet_size: Option<PacketSize>,
-
     /// Address of this client which also represent an address to which all acknowledgements
     /// and surb-based are going to be sent.
     sender_address: Recipient,
@@ -82,26 +78,12 @@ where
             average_packet_delay,
             average_ack_delay,
             num_mix_hops: DEFAULT_NUM_MIX_HOPS,
-            primary_packet_size: PacketSize::RegularPacket,
-            secondary_packet_size: None,
         }
     }
 
     /// Allows setting non-default number of expected mix hops in the network.
     pub fn with_mix_hops(mut self, hops: u8) -> Self {
         self.num_mix_hops = hops;
-        self
-    }
-
-    /// Allows setting non-default size of the sphinx packets sent out.
-    pub fn with_custom_primary_packet_size(mut self, packet_size: PacketSize) -> Self {
-        self.primary_packet_size = packet_size;
-        self
-    }
-
-    /// Allows setting non-default size of the sphinx packets sent out.
-    pub fn with_custom_secondary_packet_size(mut self, packet_size: Option<PacketSize>) -> Self {
-        self.secondary_packet_size = packet_size;
         self
     }
 
@@ -146,6 +128,16 @@ where
         ack_key: &AckKey,
         reply_surb: ReplySurb,
     ) -> Result<PreparedFragment, NymTopologyError> {
+        // each reply attaches the digest of the encryption key so that the recipient could
+        // lookup correct key for decryption,
+        let reply_overhead = ReplySurbKeyDigestAlgorithm::output_size();
+        let expected_plaintext = fragment.serialized_size() + ACK_OVERHEAD + reply_overhead;
+
+        // the reason we're unwrapping (or rather 'expecting') here rather than handling the error
+        // more gracefully is that this error should never be reached as it implies incorrect chunking
+        let packet_size = PacketSize::get_type_from_plaintext(expected_plaintext)
+            .expect("the message has been incorrectly fragmented");
+
         // this is not going to be accurate by any means. but that's the best estimation we can do
         let expected_forward_delay = Delay::new_from_millis(
             (self.average_packet_delay.as_millis() * self.num_mix_hops as u128) as u64,
@@ -162,9 +154,8 @@ where
 
         // the unwrap here is fine as the failures can only originate from attempting to use invalid payload lengths
         // and we just very carefully constructed a (presumably) valid one
-        let (sphinx_packet, first_hop_address) = reply_surb
-            .apply_surb(packet_payload, Some(self.primary_packet_size))
-            .unwrap();
+        let (sphinx_packet, first_hop_address) =
+            reply_surb.apply_surb(packet_payload, packet_size).unwrap();
 
         Ok(PreparedFragment {
             // the round-trip delay is the sum of delays of all hops on the forward route as
@@ -200,6 +191,17 @@ where
         ack_key: &AckKey,
         packet_recipient: &Recipient,
     ) -> Result<PreparedFragment, NymTopologyError> {
+        // each plain or repliable packet (i.e. not a reply) attaches an ephemeral public key so that the recipient
+        // could perform diffie-hellman with its own keys followed by a kdf to re-derive
+        // the packet encryption key
+        let non_reply_overhead = encryption::PUBLIC_KEY_SIZE;
+        let expected_plaintext = fragment.serialized_size() + ACK_OVERHEAD + non_reply_overhead;
+
+        // the reason we're unwrapping (or rather 'expecting') here rather than handling the error
+        // more gracefully is that this error should never be reached as it implies incorrect chunking
+        let packet_size = PacketSize::get_type_from_plaintext(expected_plaintext)
+            .expect("the message has been incorrectly fragmented");
+
         let fragment_identifier = fragment.fragment_identifier();
 
         // create an ack
@@ -223,7 +225,7 @@ where
         // create the actual sphinx packet here. With valid route and correct payload size,
         // there's absolutely no reason for this call to fail.
         let sphinx_packet = SphinxPacketBuilder::new()
-            .with_payload_size(self.primary_packet_size.payload_size())
+            .with_payload_size(packet_size.payload_size())
             .build_packet(packet_payload, &route, &destination, &delays)
             .unwrap();
 
@@ -263,7 +265,7 @@ where
         message: NymMessage,
         packet_size: PacketSize,
     ) -> Vec<Fragment> {
-        let plaintext_per_packet = message.available_plaintext_per_packet(packet_size);
+        let plaintext_per_packet = message.available_sphinx_plaintext_per_packet(packet_size);
 
         message
             .pad_to_full_packet_lengths(plaintext_per_packet)

--- a/common/socks5-client-core/src/config/mod.rs
+++ b/common/socks5-client-core/src/config/mod.rs
@@ -77,6 +77,11 @@ impl Config {
         }
     }
 
+    pub fn validate(&self) -> bool {
+        // no other sections have explicit requirements (yet)
+        self.base.validate()
+    }
+
     // getters
     pub fn get_base(&self) -> &BaseConfig<Self> {
         &self.base

--- a/sdk/rust/nym-sdk/examples/simple.rs
+++ b/sdk/rust/nym-sdk/examples/simple.rs
@@ -18,4 +18,6 @@ async fn main() {
     client
         .on_messages(|msg| println!("Received: {}", String::from_utf8_lossy(&msg.message)))
         .await;
+
+    client.disconnect().await;
 }

--- a/sdk/rust/nym-sdk/examples/simple.rs
+++ b/sdk/rust/nym-sdk/examples/simple.rs
@@ -18,6 +18,4 @@ async fn main() {
     client
         .on_messages(|msg| println!("Received: {}", String::from_utf8_lossy(&msg.message)))
         .await;
-
-    client.disconnect().await;
 }

--- a/service-providers/network-requester/src/cli/run.rs
+++ b/service-providers/network-requester/src/cli/run.rs
@@ -126,6 +126,10 @@ pub(crate) async fn execute(args: &Run) -> Result<(), NetworkRequesterError> {
         }
     };
 
+    if !config.validate() {
+        return Err(NetworkRequesterError::ConfigValidationFailure);
+    }
+
     let override_config_fields = OverrideConfig::from(args.clone());
     config = override_config(config, override_config_fields);
 

--- a/service-providers/network-requester/src/config/mod.rs
+++ b/service-providers/network-requester/src/config/mod.rs
@@ -119,6 +119,11 @@ impl Config {
         cfg
     }
 
+    pub fn validate(&self) -> bool {
+        // no other sections have explicit requirements (yet)
+        self.base.validate()
+    }
+
     // getters
     pub fn get_config_file_save_location(&self) -> PathBuf {
         self.config_directory().join(Self::config_file_name())

--- a/service-providers/network-requester/src/error.rs
+++ b/service-providers/network-requester/src/error.rs
@@ -21,6 +21,10 @@ pub enum NetworkRequesterError {
     #[error("failed to load configuration file: {0}")]
     FailedToLoadConfig(String),
 
+    // TODO: add more details here
+    #[error("Failed to validate the loaded config")]
+    ConfigValidationFailure,
+
     #[error("failed local version check, client and config mismatch")]
     FailedLocalVersionCheck,
 


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/3189

This PR allows clients to optionally specify a `secondary_packet_size` for its messages. Right now deciding which packet size should be used is rather naive. We check how many packets would be required with `primary` packet size vs `secondary` packet size. We then choose the smaller option.

This should be of interest to @simonwicky .

This PR depends on https://github.com/nymtech/nym/pull/3199 so it can't be merged until that one is dealt with first.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
