### PR TITLE
Stop using rewarding reports as a source of truth for whether mixnodes got rewards

### DIFF
--- a/nym-api/src/epoch_operations/error.rs
+++ b/nym-api/src/epoch_operations/error.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::node_status_api::models::NymApiStorageError;
-use nym_mixnet_contract_common::EpochState;
+use nym_mixnet_contract_common::{EpochState, MixId};
 use thiserror::Error;
 use validator_client::nyxd::error::NyxdError;
 use validator_client::nyxd::AccountId;
@@ -21,6 +21,9 @@ pub enum RewardingError {
         current_state: EpochState,
         operation: String,
     },
+
+    #[error("it seems the current epoch is in mid-rewarding state (last rewarded is {last_rewarded}). With our current nym-api this shouldn't have been possible. Manual intervention is required.")]
+    MidMixRewarding { last_rewarded: MixId },
 
     // #[error("There were no mixnodes to reward (network is dead)")]
     // NoMixnodesToReward,

--- a/nym-api/src/support/storage/manager.rs
+++ b/nym-api/src/support/storage/manager.rs
@@ -867,6 +867,7 @@ impl StorageManager {
     /// # Arguments
     ///
     /// * `report`: report to insert into the database
+    #[allow(unused)]
     pub(crate) async fn insert_rewarding_report(
         &self,
         report: RewardingReport,
@@ -885,6 +886,7 @@ impl StorageManager {
         Ok(())
     }
 
+    #[allow(unused)]
     pub(crate) async fn get_rewarding_report(
         &self,
         absolute_epoch_id: EpochId,

--- a/nym-api/src/support/storage/mod.rs
+++ b/nym-api/src/support/storage/mod.rs
@@ -9,8 +9,8 @@ use crate::node_status_api::models::{
 };
 use crate::node_status_api::{ONE_DAY, ONE_HOUR};
 use crate::storage::manager::StorageManager;
-use crate::storage::models::{NodeStatus, RewardingReport, TestingRoute};
-use nym_mixnet_contract_common::{EpochId, MixId};
+use crate::storage::models::{NodeStatus, TestingRoute};
+use nym_mixnet_contract_common::MixId;
 use rocket::fairing::AdHoc;
 use sqlx::ConnectOptions;
 use std::path::PathBuf;
@@ -713,26 +713,6 @@ impl NymApiStorage {
         self.manager.purge_old_mixnode_statuses(until).await?;
         self.manager
             .purge_old_gateway_statuses(until)
-            .await
-            .map_err(|err| err.into())
-    }
-
-    pub(crate) async fn insert_rewarding_report(
-        &self,
-        report: RewardingReport,
-    ) -> Result<(), NymApiStorageError> {
-        self.manager
-            .insert_rewarding_report(report)
-            .await
-            .map_err(|err| err.into())
-    }
-
-    pub(crate) async fn get_rewarding_report(
-        &self,
-        absolute_epoch_id: EpochId,
-    ) -> Result<Option<RewardingReport>, NymApiStorageError> {
-        self.manager
-            .get_rewarding_report(absolute_epoch_id)
             .await
             .map_err(|err| err.into())
     }

--- a/nym-api/src/support/storage/models.rs
+++ b/nym-api/src/support/storage/models.rs
@@ -41,6 +41,8 @@ pub(crate) struct TestingRoute {
     pub(crate) monitor_run_db_id: i64,
 }
 
+// for now let's leave it here to have a data model to use with existing database tables
+#[allow(unused)]
 pub(crate) struct RewardingReport {
     // references particular interval_rewarding
     pub(crate) absolute_epoch_id: u32,


### PR DESCRIPTION
use contract information instead

# Description

Closes: https://github.com/nymtech/nym/issues/3224

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
