### PR TITLE
Feature/performance active set selection

### DIFF
--- a/nym-api/src/epoch_operations/helpers.rs
+++ b/nym-api/src/epoch_operations/helpers.rs
@@ -2,6 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use cosmwasm_std::{Decimal, Fraction};
+use nym_mixnet_contract_common::reward_params::Performance;
+use nym_mixnet_contract_common::{ExecuteMsg, MixId};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MixnodeWithPerformance {
+    pub(crate) mix_id: MixId,
+
+    pub(crate) performance: Performance,
+}
+
+impl From<MixnodeWithPerformance> for ExecuteMsg {
+    fn from(mix_reward: MixnodeWithPerformance) -> Self {
+        ExecuteMsg::RewardMixnode {
+            mix_id: mix_reward.mix_id,
+            performance: mix_reward.performance,
+        }
+    }
+}
 
 pub(super) fn stake_to_f64(stake: Decimal) -> f64 {
     let max = f64::MAX.round() as u128;

--- a/nym-api/src/epoch_operations/helpers.rs
+++ b/nym-api/src/epoch_operations/helpers.rs
@@ -1,9 +1,10 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::epoch_operations::RewardedSetUpdater;
 use cosmwasm_std::{Decimal, Fraction};
 use nym_mixnet_contract_common::reward_params::Performance;
-use nym_mixnet_contract_common::{ExecuteMsg, MixId};
+use nym_mixnet_contract_common::{ExecuteMsg, Interval, MixId};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct MixnodeWithPerformance {
@@ -32,6 +33,40 @@ pub(super) fn stake_to_f64(stake: Decimal) -> f64 {
         (num / den) as f64
     } else {
         (num as f64) / (den as f64)
+    }
+}
+
+impl RewardedSetUpdater {
+    pub(crate) async fn load_performance(
+        &self,
+        interval: &Interval,
+        mix_id: MixId,
+    ) -> MixnodeWithPerformance {
+        let uptime = self
+            .storage
+            .get_average_mixnode_uptime_in_the_last_24hrs(
+                mix_id,
+                interval.current_epoch_end_unix_timestamp(),
+            )
+            .await
+            .unwrap_or_default();
+
+        MixnodeWithPerformance {
+            mix_id,
+            performance: uptime.into(),
+        }
+    }
+
+    pub(crate) async fn load_nodes_performance(
+        &self,
+        interval: &Interval,
+        nodes: &[MixId],
+    ) -> Vec<MixnodeWithPerformance> {
+        let mut with_performance = Vec::with_capacity(nodes.len());
+        for mix_id in nodes {
+            with_performance.push(self.load_performance(interval, *mix_id).await)
+        }
+        with_performance
     }
 }
 

--- a/nym-api/src/epoch_operations/mod.rs
+++ b/nym-api/src/epoch_operations/mod.rs
@@ -17,9 +17,9 @@ use crate::nym_contract_cache::cache::NymContractCache;
 use crate::support::nyxd::Client;
 use crate::support::storage::NymApiStorage;
 use error::RewardingError;
+pub(crate) use helpers::MixnodeWithPerformance;
 use nym_mixnet_contract_common::{CurrentIntervalResponse, Interval};
 use nym_task::{TaskClient, TaskManager};
-pub(crate) use rewarding::MixnodeWithPerformance;
 use std::collections::HashSet;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -133,7 +133,7 @@ impl RewardedSetUpdater {
         // note: those operations don't really have to be atomic, so it's fine to send them
         // as separate transactions
         self.reconcile_epoch_events().await?;
-        self.update_rewarded_set_and_advance_epoch(&all_mixnodes)
+        self.update_rewarded_set_and_advance_epoch(interval, &all_mixnodes)
             .await?;
 
         log::info!("Purging old node statuses from the storage...");

--- a/nym-api/src/epoch_operations/mod.rs
+++ b/nym-api/src/epoch_operations/mod.rs
@@ -19,7 +19,7 @@ use crate::support::storage::NymApiStorage;
 use error::RewardingError;
 use nym_mixnet_contract_common::{CurrentIntervalResponse, Interval};
 use nym_task::{TaskClient, TaskManager};
-pub(crate) use rewarding::MixnodeToReward;
+pub(crate) use rewarding::MixnodeWithPerformance;
 use std::collections::HashSet;
 use std::time::Duration;
 use tokio::time::sleep;

--- a/nym-api/src/epoch_operations/rewarding.rs
+++ b/nym-api/src/epoch_operations/rewarding.rs
@@ -4,8 +4,7 @@
 use crate::epoch_operations::error::RewardingError;
 use crate::epoch_operations::helpers::MixnodeWithPerformance;
 use crate::RewardedSetUpdater;
-use nym_mixnet_contract_common::reward_params::Performance;
-use nym_mixnet_contract_common::{EpochState, ExecuteMsg, Interval, MixId};
+use nym_mixnet_contract_common::{EpochState, Interval, MixId};
 
 impl RewardedSetUpdater {
     pub(super) async fn reward_current_rewarded_set(
@@ -85,22 +84,6 @@ impl RewardedSetUpdater {
             }
         };
 
-        let mut eligible_nodes = Vec::with_capacity(rewarded_set.len());
-        for mix_id in rewarded_set {
-            let uptime = self
-                .storage
-                .get_average_mixnode_uptime_in_the_last_24hrs(
-                    mix_id,
-                    interval.current_epoch_end_unix_timestamp(),
-                )
-                .await
-                .unwrap_or_default();
-            eligible_nodes.push(MixnodeWithPerformance {
-                mix_id,
-                performance: uptime.into(),
-            })
-        }
-
-        eligible_nodes
+        self.load_nodes_performance(&interval, &rewarded_set).await
     }
 }

--- a/nym-api/src/epoch_operations/rewarding.rs
+++ b/nym-api/src/epoch_operations/rewarding.rs
@@ -2,25 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::epoch_operations::error::RewardingError;
+use crate::epoch_operations::helpers::MixnodeWithPerformance;
 use crate::RewardedSetUpdater;
 use nym_mixnet_contract_common::reward_params::Performance;
 use nym_mixnet_contract_common::{EpochState, ExecuteMsg, Interval, MixId};
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct MixnodeToReward {
-    pub(crate) mix_id: MixId,
-
-    pub(crate) performance: Performance,
-}
-
-impl From<MixnodeToReward> for ExecuteMsg {
-    fn from(mix_reward: MixnodeToReward) -> Self {
-        ExecuteMsg::RewardMixnode {
-            mix_id: mix_reward.mix_id,
-            performance: mix_reward.performance,
-        }
-    }
-}
 
 impl RewardedSetUpdater {
     pub(super) async fn reward_current_rewarded_set(
@@ -83,7 +68,7 @@ impl RewardedSetUpdater {
         Ok(())
     }
 
-    async fn nodes_to_reward(&self, interval: Interval) -> Vec<MixnodeToReward> {
+    async fn nodes_to_reward(&self, interval: Interval) -> Vec<MixnodeWithPerformance> {
         // try to get current up to date view of the network bypassing the cache
         // in case the epochs were significantly shortened for the purposes of testing
         let rewarded_set: Vec<MixId> = match self.nyxd_client.get_rewarded_set_mixnodes().await {
@@ -110,7 +95,7 @@ impl RewardedSetUpdater {
                 )
                 .await
                 .unwrap_or_default();
-            eligible_nodes.push(MixnodeToReward {
+            eligible_nodes.push(MixnodeWithPerformance {
                 mix_id,
                 performance: uptime.into(),
             })

--- a/nym-api/src/support/nyxd/mod.rs
+++ b/nym-api/src/support/nyxd/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::coconut::error::CoconutError;
-use crate::epoch_operations::MixnodeToReward;
+use crate::epoch_operations::MixnodeWithPerformance;
 use crate::support::config::Config;
 use anyhow::Result;
 use async_trait::async_trait;
@@ -238,13 +238,13 @@ impl Client {
 
     pub(crate) async fn send_rewarding_messages(
         &self,
-        nodes: &[MixnodeToReward],
+        nodes: &[MixnodeWithPerformance],
     ) -> Result<(), ValidatorClientError> {
         // for some reason, compiler complains if this is explicitly inline in code ¯\_(ツ)_/¯
         #[inline]
         #[allow(unused_variables)]
         fn generate_reward_messages(
-            eligible_mixnodes: &[MixnodeToReward],
+            eligible_mixnodes: &[MixnodeWithPerformance],
         ) -> Vec<(ExecuteMsg, Vec<Coin>)> {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "no-reward")] {


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/3234

With this change node with 10k stake and 10% performance will have the same probability of being in the active set as a node with 1k stake but 100% performance. 

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
