### PR TITLE
removed stake and location fields from gateway::Node

### DIFF
--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -176,10 +176,7 @@ async fn choose_gateway_by_latency<R: Rng>(
                 continue;
             }
         };
-        debug!(
-            "{id} ({}): {:?}",
-            with_latency.gateway.location, with_latency.latency
-        );
+        debug!("{id}: {:?}", with_latency.latency);
         gateways_with_latency.push(with_latency)
     }
 
@@ -188,8 +185,8 @@ async fn choose_gateway_by_latency<R: Rng>(
         .expect("invalid selection weight!");
 
     info!(
-        "chose gateway {} (located at {}) with average latency of {:?}",
-        chosen.gateway.identity_key, chosen.gateway.location, chosen.latency
+        "chose gateway {} with average latency of {:?}",
+        chosen.gateway.identity_key, chosen.latency
     );
 
     Ok(chosen.gateway.clone())

--- a/common/nymsphinx/src/receiver.rs
+++ b/common/nymsphinx/src/receiver.rs
@@ -337,8 +337,6 @@ mod message_receiver {
             mixes,
             vec![gateway::Node {
                 owner: "foomp4".to_string(),
-                stake: 123,
-                location: "unknown".to_string(),
                 host: "1.2.3.4".parse().unwrap(),
                 mix_host: "1.2.3.4:1789".parse().unwrap(),
                 clients_port: 9000,

--- a/common/topology/src/gateway.rs
+++ b/common/topology/src/gateway.rs
@@ -31,10 +31,6 @@ pub enum GatewayConversionError {
 #[derive(Debug, Clone)]
 pub struct Node {
     pub owner: String,
-    // somebody correct me if I'm wrong, but we should only ever have a single denom of currency
-    // on the network at a type, right?
-    pub stake: u128,
-    pub location: String,
     pub host: NetworkAddress,
     // we're keeping this as separate resolved field since we do not want to be resolving the potential
     // hostname every time we want to construct a path via this node
@@ -59,8 +55,8 @@ impl fmt::Display for Node {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Node(id: {}, owner: {}, stake: {}, location: {}, host: {})",
-            self.identity_key, self.owner, self.stake, self.location, self.host,
+            "Node(id: {}, owner: {}, host: {})",
+            self.identity_key, self.owner, self.host,
         )
     }
 }
@@ -105,8 +101,6 @@ impl<'a> TryFrom<&'a GatewayBond> for Node {
 
         Ok(Node {
             owner: bond.owner.as_str().to_owned(),
-            stake: bond.pledge_amount.amount.into(),
-            location: bond.gateway.location.clone(),
             host,
             mix_host,
             clients_port: bond.gateway.clients_port,


### PR DESCRIPTION
# Description

Just removed fields that served no purpose in routing or creating sphinx packets. Ideally I'd have also removed `owner` and `identity_key` (from both mixnode and gateway), but too many things incorrectly depend on them.
