### PR TITLE
gateway: cap the number of configs to keep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3259,12 +3259,14 @@ dependencies = [
  "clap 4.1.11",
  "clap_complete",
  "clap_complete_fig",
+ "filetime",
  "log",
  "pretty_env_logger",
  "semver 0.11.0",
  "serde",
  "serde_json",
  "vergen",
+ "walkdir",
 ]
 
 [[package]]

--- a/common/bin-common/Cargo.toml
+++ b/common/bin-common/Cargo.toml
@@ -12,11 +12,13 @@ atty = "0.2"
 clap = { version = "4.0", features = ["derive"] }
 clap_complete = "4.0"
 clap_complete_fig = "4.0"
+filetime = "0.2.20"
 log = { workspace = true }
 pretty_env_logger = "0.4.0"
 semver = "0.11"
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
+walkdir = "2.3.3"
 
 [build-dependencies]
 vergen = { version = "=7.4.3", default-features = false, features = ["build", "git", "rustc", "cargo"] }

--- a/common/bin-common/src/file_handling/mod.rs
+++ b/common/bin-common/src/file_handling/mod.rs
@@ -1,0 +1,54 @@
+use std::{
+    collections::HashMap,
+    io,
+    path::{Path, PathBuf},
+};
+
+use filetime::FileTime;
+use walkdir::WalkDir;
+
+/// Keeps the most recently accessed directories in the given directory.
+pub fn keep_recently_accessed_dirs<P: AsRef<Path>>(dir: P, num_to_keep: usize) -> io::Result<()> {
+    let mut dir_access_times: HashMap<PathBuf, FileTime> = HashMap::new();
+
+    for entry in std::fs::read_dir(dir)?.flatten() {
+        if entry.file_type().map(|e| e.is_dir()).unwrap_or(false) {
+            // For each sub directory, keep track of the most recently accessed time of any
+            // file inside that sub directory.
+            let sub_dir = entry.path();
+            let mut most_recent_access_time: Option<FileTime> = None;
+
+            for file_entry in WalkDir::new(&sub_dir)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().is_file())
+            {
+                let metadata = file_entry.metadata().unwrap();
+                let accessed_time = FileTime::from_last_access_time(&metadata);
+
+                if most_recent_access_time.map_or(true, |current| accessed_time > current) {
+                    most_recent_access_time = Some(accessed_time);
+                }
+            }
+
+            if let Some(access_time) = most_recent_access_time {
+                dir_access_times.insert(sub_dir, access_time);
+            }
+        }
+    }
+
+    let mut sorted_dir_access_times: Vec<(PathBuf, FileTime)> =
+        dir_access_times.into_iter().collect();
+    sorted_dir_access_times.sort_unstable_by_key(|(_, accessed_time)| *accessed_time);
+    sorted_dir_access_times.reverse();
+    let dirs_to_remove = sorted_dir_access_times.split_off(num_to_keep);
+
+    for (path, _) in dirs_to_remove {
+        println!("Removing: {:?}", path);
+        if let Err(err) = std::fs::remove_dir_all(path.clone()) {
+            println!("Failed to remove {:?} due to: {:?}", path, err);
+        }
+    }
+
+    Ok(())
+}

--- a/common/bin-common/src/lib.rs
+++ b/common/bin-common/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub mod build_information;
 pub mod completions;
+pub mod file_handling;
 pub mod logging;
 pub mod output_format;
 pub mod version_checker;
-pub mod file_handling;

--- a/common/bin-common/src/lib.rs
+++ b/common/bin-common/src/lib.rs
@@ -6,3 +6,4 @@ pub mod completions;
 pub mod logging;
 pub mod output_format;
 pub mod version_checker;
+pub mod file_handling;

--- a/gateway/src/config/mod.rs
+++ b/gateway/src/config/mod.rs
@@ -29,6 +29,8 @@ const DEFAULT_MAXIMUM_CONNECTION_BUFFER_SIZE: usize = 128;
 const DEFAULT_STORED_MESSAGE_FILENAME_LENGTH: u16 = 16;
 const DEFAULT_MESSAGE_RETRIEVAL_LIMIT: i64 = 100;
 
+pub const MAX_NUMBER_OF_CONFIGS_TO_KEEP: usize = 100_000;
+
 pub fn missing_string_value() -> String {
     MISSING_VALUE.to_string()
 }


### PR DESCRIPTION
# Description

Cap the number of gateway configs we keep around by deleting old ones at startup.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
