### PR TITLE
Rename SP contract service owner to announcer

### DIFF
--- a/common/cosmwasm-smart-contracts/service-provider-directory/src/events.rs
+++ b/common/cosmwasm-smart-contracts/service-provider-directory/src/events.rs
@@ -41,7 +41,7 @@ pub fn new_announce_event(service_id: ServiceId, service: Service) -> Event {
         .add_attribute(SERVICE_ID, service_id.to_string())
         .add_attribute(SERVICE_TYPE, service.service_type.to_string())
         .add_attribute(NYM_ADDRESS, service.nym_address.to_string())
-        .add_attribute(OWNER, service.owner.to_string())
+        .add_attribute(OWNER, service.announcer.to_string())
 }
 
 pub fn new_delete_id_event(service_id: ServiceId, service: Service) -> Event {

--- a/common/cosmwasm-smart-contracts/service-provider-directory/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/service-provider-directory/src/msg.rs
@@ -48,8 +48,8 @@ pub enum QueryMsg {
     ServiceId {
         service_id: ServiceId,
     },
-    Owner {
-        owner: Addr,
+    Announcer {
+        announcer: Addr,
     },
     NymAddress {
         nym_address: NymAddress,

--- a/common/cosmwasm-smart-contracts/service-provider-directory/src/types.rs
+++ b/common/cosmwasm-smart-contracts/service-provider-directory/src/types.rs
@@ -13,7 +13,7 @@ pub struct Service {
     /// The service type.
     pub service_type: ServiceType,
     /// Service owner.
-    pub owner: Addr,
+    pub announcer: Addr,
     /// Block height at which the service was added.
     pub block_height: u64,
     /// The deposit used to announce the service.

--- a/contracts/service-provider-directory/src/constants.rs
+++ b/contracts/service-provider-directory/src/constants.rs
@@ -1,5 +1,5 @@
 // We limit the these for simplicity and to avoid having to deal with paging.
-pub const MAX_NUMBER_OF_PROVIDERS_PER_OWNER: u32 = 100;
+pub const MAX_NUMBER_OF_PROVIDERS_PER_ANNOUNCER: u32 = 100;
 pub const MAX_NUMBER_OF_ALIASES_FOR_NYM_ADDRESS: u32 = 100;
 
 pub const SERVICE_DEFAULT_RETRIEVAL_LIMIT: u32 = 100;
@@ -11,5 +11,5 @@ pub const ADMIN_KEY: &str = "admin";
 pub const SERVICE_ID_COUNTER_KEY: &str = "sidc";
 
 pub const SERVICES_PK_NAMESPACE: &str = "sernames";
-pub const SERVICES_OWNER_IDX_NAMESPACE: &str = "serown";
+pub const SERVICES_ANNOUNCER_IDX_NAMESPACE: &str = "serown";
 pub const SERVICES_NYM_ADDRESS_IDX_NAMESPACE: &str = "sernyma";

--- a/contracts/service-provider-directory/src/contract.rs
+++ b/contracts/service-provider-directory/src/contract.rs
@@ -88,7 +88,7 @@ pub fn execute(
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary> {
     let response = match msg {
         QueryMsg::ServiceId { service_id } => to_binary(&query::query_id(deps, service_id)?),
-        QueryMsg::Owner { owner } => to_binary(&query::query_owner(deps, owner)?),
+        QueryMsg::Announcer { announcer } => to_binary(&query::query_announcer(deps, announcer)?),
         QueryMsg::NymAddress { nym_address } => {
             to_binary(&query::query_nym_address(deps, nym_address)?)
         }
@@ -153,13 +153,13 @@ mod tests {
 
         // Announce
         let msg: ExecuteMsg = service_fixture().into();
-        let owner = service_fixture().owner.to_string();
+        let announcer = service_fixture().announcer.to_string();
 
         assert_eq!(
             execute(
                 deps.as_mut(),
                 mock_env(),
-                mock_info(&owner, &[nyms(99)]),
+                mock_info(&announcer, &[nyms(99)]),
                 msg.clone()
             )
             .unwrap_err(),
@@ -173,7 +173,7 @@ mod tests {
             execute(
                 deps.as_mut(),
                 mock_env(),
-                mock_info(&owner, &[nyms(101)]),
+                mock_info(&announcer, &[nyms(101)]),
                 msg
             )
             .unwrap_err(),
@@ -231,7 +231,7 @@ mod tests {
         // Announce
         let msg: ExecuteMsg = service_fixture().into();
         let info_steve = mock_info("steve", &[nyms(100)]);
-        assert_eq!(info_steve.sender, service_fixture().owner);
+        assert_eq!(info_steve.sender, service_fixture().announcer);
         execute(deps.as_mut(), mock_env(), info_steve, msg).unwrap();
 
         // The expected announced service
@@ -254,20 +254,20 @@ mod tests {
 
         // Removing an non-existent service will fail
         let msg = ExecuteMsg::delete_id(expected_id + 1);
-        let info_owner = MessageInfo {
-            sender: service_fixture().owner,
+        let info_announcer = MessageInfo {
+            sender: service_fixture().announcer,
             funds: vec![],
         };
         assert_eq!(
-            execute(deps.as_mut(), mock_env(), info_owner.clone(), msg).unwrap_err(),
+            execute(deps.as_mut(), mock_env(), info_announcer.clone(), msg).unwrap_err(),
             ContractError::NotFound {
                 service_id: expected_id + 1
             }
         );
 
-        // Remove as correct owner succeeds
+        // Remove as correct announcer succeeds
         let msg = ExecuteMsg::delete_id(expected_id);
-        let res = execute(deps.as_mut(), mock_env(), info_owner, msg).unwrap();
+        let res = execute(deps.as_mut(), mock_env(), info_announcer, msg).unwrap();
         assert_eq!(
             get_attribute(&res, "delete_id", "service_id"),
             expected_id.to_string()

--- a/contracts/service-provider-directory/src/contract/query.rs
+++ b/contracts/service-provider-directory/src/contract/query.rs
@@ -18,8 +18,8 @@ pub fn query_id(deps: Deps, service_id: ServiceId) -> Result<ServiceInfo> {
     })
 }
 
-pub fn query_owner(deps: Deps, owner: Addr) -> Result<ServicesListResponse> {
-    let services = state::services::load_owner(deps.storage, owner)?;
+pub fn query_announcer(deps: Deps, announcer: Addr) -> Result<ServicesListResponse> {
+    let services = state::services::load_announcer(deps.storage, announcer)?;
     Ok(ServicesListResponse::new(services))
 }
 

--- a/contracts/service-provider-directory/src/error.rs
+++ b/contracts/service-provider-directory/src/error.rs
@@ -14,7 +14,7 @@ pub enum ContractError {
     #[error("service not found: {service_id}")]
     NotFound { service_id: ServiceId },
 
-    #[error("{sender} is not owner of service")]
+    #[error("{sender} is not announcer of service")]
     Unauthorized { sender: Addr },
 
     #[error("deposit required to announce service")]
@@ -32,8 +32,8 @@ pub enum ContractError {
         deposit_required: cosmwasm_std::Uint128,
     },
 
-    #[error("reached the max number of providers ({max_providers}) for owner {owner}")]
-    ReachedMaxProvidersForAdmin { max_providers: u32, owner: Addr },
+    #[error("reached the max number of providers ({max_providers}) for announcer {announcer}")]
+    ReachedMaxProvidersForAdmin { max_providers: u32, announcer: Addr },
 
     #[error("reached the max number of aliases ({max_aliases}) for nym address {0}", nym_address.to_string())]
     ReachedMaxAliasesForNymAddress {

--- a/contracts/service-provider-directory/src/integration_tests.rs
+++ b/contracts/service-provider-directory/src/integration_tests.rs
@@ -40,15 +40,15 @@ fn announce_and_query_service() {
     );
 
     // Announce a first service
-    let owner = Addr::unchecked("owner");
+    let announcer = Addr::unchecked("announcer");
     let nym_address = NymAddress::new("nymAddress");
     assert_eq!(setup.contract_balance(), nyms(0));
-    assert_eq!(setup.balance(&owner), nyms(250));
-    setup.announce_net_req(nym_address.clone(), owner.clone());
+    assert_eq!(setup.balance(&announcer), nyms(250));
+    setup.announce_net_req(nym_address.clone(), announcer.clone());
 
-    // Deposit is deposited to contract and deducted from owner's balance
+    // Deposit is deposited to contract and deducted from announcers's balance
     assert_eq!(setup.contract_balance(), nyms(100));
-    assert_eq!(setup.balance(&owner), nyms(150));
+    assert_eq!(setup.balance(&announcer), nyms(150));
 
     // We can query the full service list
     assert_eq!(
@@ -59,7 +59,7 @@ fn announce_and_query_service() {
                 service: Service {
                     nym_address: nym_address.clone(),
                     service_type: ServiceType::NetworkRequester,
-                    owner: owner.clone(),
+                    announcer: announcer.clone(),
                     block_height: 12345,
                     deposit: nyms(100),
                 },
@@ -77,7 +77,7 @@ fn announce_and_query_service() {
             service: Service {
                 nym_address: nym_address.clone(),
                 service_type: ServiceType::NetworkRequester,
-                owner: owner.clone(),
+                announcer: announcer.clone(),
                 block_height: 12345,
                 deposit: nyms(100),
             },
@@ -85,17 +85,17 @@ fn announce_and_query_service() {
     );
 
     // Announce a second service
-    let owner2 = Addr::unchecked("owner2");
+    let announcer2 = Addr::unchecked("announcer2");
     let nym_address2 = NymAddress::new("nymAddress2");
-    setup.announce_net_req(nym_address2.clone(), owner2.clone());
+    setup.announce_net_req(nym_address2.clone(), announcer2.clone());
 
     assert_eq!(setup.contract_balance(), nyms(200));
     assert_eq!(
         setup.query_all(),
         PagedServicesListResponse {
             services: vec![
-                service_info(1, nym_address, owner),
-                service_info(2, nym_address2, owner2)
+                service_info(1, nym_address, announcer),
+                service_info(2, nym_address2, announcer2)
             ],
             per_page: SERVICE_DEFAULT_RETRIEVAL_LIMIT as usize,
             start_next_after: Some(2),
@@ -106,28 +106,28 @@ fn announce_and_query_service() {
 #[test]
 fn delete_service() {
     let mut setup = TestSetup::new();
-    setup.announce_net_req(NymAddress::new("nymAddress"), Addr::unchecked("owner"));
+    setup.announce_net_req(NymAddress::new("nymAddress"), Addr::unchecked("announcer"));
     assert_eq!(setup.contract_balance(), nyms(100));
-    assert_eq!(setup.balance("owner"), nyms(150));
+    assert_eq!(setup.balance("announcer"), nyms(150));
     assert!(!setup.query_all().services.is_empty());
-    setup.delete(1, Addr::unchecked("owner"));
+    setup.delete(1, Addr::unchecked("announcer"));
 
-    // Deleting the service returns the deposit to the owner
+    // Deleting the service returns the deposit to the announcer
     assert_eq!(setup.contract_balance(), nyms(0));
-    assert_eq!(setup.balance("owner"), nyms(250));
+    assert_eq!(setup.balance("announcer"), nyms(250));
     assert!(setup.query_all().services.is_empty());
 }
 
 #[test]
-fn only_owner_can_delete_service() {
+fn only_announcer_can_delete_service() {
     let mut setup = TestSetup::new();
     assert_eq!(setup.contract_balance(), nyms(0));
-    setup.announce_net_req(NymAddress::new("nymAddress"), Addr::unchecked("owner"));
+    setup.announce_net_req(NymAddress::new("nymAddress"), Addr::unchecked("announcer"));
     assert_eq!(setup.contract_balance(), nyms(100));
     assert!(!setup.query_all().services.is_empty());
 
     let delete_resp: ContractError = setup
-        .try_delete(1, Addr::unchecked("not_owner"))
+        .try_delete(1, Addr::unchecked("not_announcer"))
         .unwrap_err()
         .downcast()
         .unwrap();
@@ -136,7 +136,7 @@ fn only_owner_can_delete_service() {
     assert_eq!(
         delete_resp,
         ContractError::Unauthorized {
-            sender: Addr::unchecked("not_owner")
+            sender: Addr::unchecked("not_announcer")
         }
     );
 }
@@ -144,12 +144,12 @@ fn only_owner_can_delete_service() {
 #[test]
 fn cant_delete_service_that_does_not_exist() {
     let mut setup = TestSetup::new();
-    setup.announce_net_req(NymAddress::new("nymAddress"), Addr::unchecked("owner"));
+    setup.announce_net_req(NymAddress::new("nymAddress"), Addr::unchecked("announcer"));
     assert_eq!(setup.contract_balance(), nyms(100));
     assert!(!setup.query_all().services.is_empty());
 
     let delete_resp: ContractError = setup
-        .try_delete(0, Addr::unchecked("owner"))
+        .try_delete(0, Addr::unchecked("announcer"))
         .unwrap_err()
         .downcast()
         .unwrap();
@@ -157,7 +157,7 @@ fn cant_delete_service_that_does_not_exist() {
     assert_eq!(delete_resp, ContractError::NotFound { service_id: 0 });
 
     let delete_resp: ContractError = setup
-        .try_delete(2, Addr::unchecked("owner"))
+        .try_delete(2, Addr::unchecked("announcer"))
         .unwrap_err()
         .downcast()
         .unwrap();
@@ -165,7 +165,7 @@ fn cant_delete_service_that_does_not_exist() {
     assert_eq!(delete_resp, ContractError::NotFound { service_id: 2 });
 
     assert!(!setup.query_all().services.is_empty());
-    setup.delete(1, Addr::unchecked("owner"));
+    setup.delete(1, Addr::unchecked("announcer"));
     assert_eq!(setup.contract_balance(), nyms(0));
     assert!(setup.query_all().services.is_empty());
 }
@@ -173,31 +173,31 @@ fn cant_delete_service_that_does_not_exist() {
 #[test]
 fn announce_multiple_services_and_deleting_by_name() {
     let mut setup = TestSetup::new();
-    let owner1 = Addr::unchecked("wealthy_owner_1");
-    let owner2 = Addr::unchecked("wealthy_owner_2");
+    let announcer1 = Addr::unchecked("wealthy_announcer_1");
+    let announcer2 = Addr::unchecked("wealthy_announcer_2");
     let nym_address1 = NymAddress::new("nymAddress1");
     let nym_address2 = NymAddress::new("nymAddress2");
 
-    // We announce the same address three times, but with different owners
+    // We announce the same address three times, but with different annoucers
     assert_eq!(setup.contract_balance(), nyms(0));
-    assert_eq!(setup.balance(&owner1), nyms(1000));
-    setup.announce_net_req(nym_address1.clone(), owner1.clone());
-    setup.announce_net_req(nym_address1.clone(), owner1.clone());
-    setup.announce_net_req(nym_address2.clone(), owner1.clone());
-    setup.announce_net_req(nym_address1.clone(), owner2.clone());
-    setup.announce_net_req(nym_address2.clone(), owner2.clone());
+    assert_eq!(setup.balance(&announcer1), nyms(1000));
+    setup.announce_net_req(nym_address1.clone(), announcer1.clone());
+    setup.announce_net_req(nym_address1.clone(), announcer1.clone());
+    setup.announce_net_req(nym_address2.clone(), announcer1.clone());
+    setup.announce_net_req(nym_address1.clone(), announcer2.clone());
+    setup.announce_net_req(nym_address2.clone(), announcer2.clone());
 
     assert_eq!(setup.contract_balance(), nyms(500));
-    assert_eq!(setup.balance(&owner1), nyms(700));
+    assert_eq!(setup.balance(&announcer1), nyms(700));
     assert_eq!(
         setup.query_all(),
         PagedServicesListResponse {
             services: vec![
-                service_info(1, nym_address1.clone(), owner1.clone()),
-                service_info(2, nym_address1.clone(), owner1.clone()),
-                service_info(3, nym_address2.clone(), owner1.clone()),
-                service_info(4, nym_address1.clone(), owner2.clone()),
-                service_info(5, nym_address2.clone(), owner2.clone()),
+                service_info(1, nym_address1.clone(), announcer1.clone()),
+                service_info(2, nym_address1.clone(), announcer1.clone()),
+                service_info(3, nym_address2.clone(), announcer1.clone()),
+                service_info(4, nym_address1.clone(), announcer2.clone()),
+                service_info(5, nym_address2.clone(), announcer2.clone()),
             ],
             per_page: SERVICE_DEFAULT_RETRIEVAL_LIMIT as usize,
             start_next_after: Some(5),
@@ -206,17 +206,17 @@ fn announce_multiple_services_and_deleting_by_name() {
 
     // Even though multiple of them point to the same nym address, we only delete the ones we actually
     // own.
-    setup.delete_nym_address(nym_address1.clone(), owner1.clone());
+    setup.delete_nym_address(nym_address1.clone(), announcer1.clone());
 
     assert_eq!(setup.contract_balance(), nyms(300));
-    assert_eq!(setup.balance(&owner1), nyms(900));
+    assert_eq!(setup.balance(&announcer1), nyms(900));
     assert_eq!(
         setup.query_all(),
         PagedServicesListResponse {
             services: vec![
-                service_info(3, nym_address2.clone(), owner1),
-                service_info(4, nym_address1, owner2.clone()),
-                service_info(5, nym_address2, owner2),
+                service_info(3, nym_address2.clone(), announcer1),
+                service_info(4, nym_address1, announcer2.clone()),
+                service_info(5, nym_address2, announcer2),
             ],
             per_page: SERVICE_DEFAULT_RETRIEVAL_LIMIT as usize,
             start_next_after: Some(5),
@@ -229,27 +229,27 @@ fn announce_multiple_services_and_deleting_by_name() {
 #[test]
 fn paging_works() {
     let mut setup = TestSetup::new();
-    let owner1 = Addr::unchecked("wealthy_owner_1");
-    let owner2 = Addr::unchecked("wealthy_owner_2");
+    let announcer1 = Addr::unchecked("wealthy_announcer_1");
+    let announcer2 = Addr::unchecked("wealthy_announcer_2");
     let nym_address1 = NymAddress::new("nymAddress1");
     let nym_address2 = NymAddress::new("nymAddress2");
 
-    // We announce the same address three times, but with different owners
-    setup.announce_net_req(nym_address1.clone(), owner1.clone());
-    setup.announce_net_req(nym_address1.clone(), owner1.clone());
-    setup.announce_net_req(nym_address2.clone(), owner1.clone());
-    setup.announce_net_req(nym_address1.clone(), owner2.clone());
-    setup.announce_net_req(nym_address2.clone(), owner2.clone());
+    // We announce the same address three times, but with different announcers
+    setup.announce_net_req(nym_address1.clone(), announcer1.clone());
+    setup.announce_net_req(nym_address1.clone(), announcer1.clone());
+    setup.announce_net_req(nym_address2.clone(), announcer1.clone());
+    setup.announce_net_req(nym_address1.clone(), announcer2.clone());
+    setup.announce_net_req(nym_address2.clone(), announcer2.clone());
 
     assert_eq!(
         setup.query_all_with_limit(Some(10), None),
         PagedServicesListResponse {
             services: vec![
-                service_info(1, nym_address1.clone(), owner1.clone()),
-                service_info(2, nym_address1.clone(), owner1.clone()),
-                service_info(3, nym_address2.clone(), owner1.clone()),
-                service_info(4, nym_address1.clone(), owner2.clone()),
-                service_info(5, nym_address2.clone(), owner2.clone()),
+                service_info(1, nym_address1.clone(), announcer1.clone()),
+                service_info(2, nym_address1.clone(), announcer1.clone()),
+                service_info(3, nym_address2.clone(), announcer1.clone()),
+                service_info(4, nym_address1.clone(), announcer2.clone()),
+                service_info(5, nym_address2.clone(), announcer2.clone()),
             ],
             per_page: 10,
             start_next_after: Some(5),
@@ -260,9 +260,9 @@ fn paging_works() {
         setup.query_all_with_limit(Some(3), None),
         PagedServicesListResponse {
             services: vec![
-                service_info(1, nym_address1.clone(), owner1.clone()),
-                service_info(2, nym_address1.clone(), owner1.clone()),
-                service_info(3, nym_address2.clone(), owner1.clone()),
+                service_info(1, nym_address1.clone(), announcer1.clone()),
+                service_info(2, nym_address1.clone(), announcer1.clone()),
+                service_info(3, nym_address2.clone(), announcer1.clone()),
             ],
             per_page: 3,
             start_next_after: Some(3),
@@ -272,8 +272,8 @@ fn paging_works() {
         setup.query_all_with_limit(Some(3), Some(3)),
         PagedServicesListResponse {
             services: vec![
-                service_info(4, nym_address1.clone(), owner2.clone()),
-                service_info(5, nym_address2.clone(), owner2.clone()),
+                service_info(4, nym_address1.clone(), announcer2.clone()),
+                service_info(5, nym_address2.clone(), announcer2.clone()),
             ],
             per_page: 3,
             start_next_after: Some(5),
@@ -284,8 +284,14 @@ fn paging_works() {
 #[test]
 fn service_id_increases_for_new_services() {
     let mut setup = TestSetup::new();
-    setup.announce_net_req(NymAddress::new("nymAddress1"), Addr::unchecked("owner1"));
-    setup.announce_net_req(NymAddress::new("nymAddress2"), Addr::unchecked("owner2"));
+    setup.announce_net_req(
+        NymAddress::new("nymAddress1"),
+        Addr::unchecked("announcer1"),
+    );
+    setup.announce_net_req(
+        NymAddress::new("nymAddress2"),
+        Addr::unchecked("announcer2"),
+    );
 
     assert_eq!(
         setup
@@ -301,29 +307,49 @@ fn service_id_increases_for_new_services() {
 #[test]
 fn service_id_is_not_resused_when_deleting_and_then_adding_a_new_service() {
     let mut setup = TestSetup::new();
-    setup.announce_net_req(NymAddress::new("nymAddress1"), Addr::unchecked("owner1"));
-    setup.announce_net_req(NymAddress::new("nymAddress2"), Addr::unchecked("owner2"));
-    setup.announce_net_req(NymAddress::new("nymAddress3"), Addr::unchecked("owner3"));
+    setup.announce_net_req(
+        NymAddress::new("nymAddress1"),
+        Addr::unchecked("announcer1"),
+    );
+    setup.announce_net_req(
+        NymAddress::new("nymAddress2"),
+        Addr::unchecked("announcer2"),
+    );
+    setup.announce_net_req(
+        NymAddress::new("nymAddress3"),
+        Addr::unchecked("announcer3"),
+    );
 
-    setup.delete(1, Addr::unchecked("owner1"));
-    setup.delete(3, Addr::unchecked("owner3"));
+    setup.delete(1, Addr::unchecked("announcer1"));
+    setup.delete(3, Addr::unchecked("announcer3"));
 
     assert_eq!(
         setup.query_all().services,
         vec![service_info(
             2,
             NymAddress::new("nymAddress2"),
-            Addr::unchecked("owner2")
+            Addr::unchecked("announcer2")
         )]
     );
 
-    setup.announce_net_req(NymAddress::new("nymAddress4"), Addr::unchecked("owner4"));
+    setup.announce_net_req(
+        NymAddress::new("nymAddress4"),
+        Addr::unchecked("announcer4"),
+    );
 
     assert_eq!(
         setup.query_all().services,
         vec![
-            service_info(2, NymAddress::new("nymAddress2"), Addr::unchecked("owner2")),
-            service_info(4, NymAddress::new("nymAddress4"), Addr::unchecked("owner4"))
+            service_info(
+                2,
+                NymAddress::new("nymAddress2"),
+                Addr::unchecked("announcer2")
+            ),
+            service_info(
+                4,
+                NymAddress::new("nymAddress4"),
+                Addr::unchecked("announcer4")
+            )
         ]
     );
 }

--- a/contracts/service-provider-directory/src/test_helpers/fixture.rs
+++ b/contracts/service-provider-directory/src/test_helpers/fixture.rs
@@ -9,7 +9,7 @@ pub fn service_fixture() -> Service {
     Service {
         nym_address: NymAddress::new("nym"),
         service_type: ServiceType::NetworkRequester,
-        owner: Addr::unchecked("steve"),
+        announcer: Addr::unchecked("steve"),
         block_height: 12345,
         deposit: nyms(100),
     }
@@ -19,19 +19,23 @@ pub fn service_fixture_with_address(nym_address: &str) -> Service {
     Service {
         nym_address: NymAddress::new(nym_address),
         service_type: ServiceType::NetworkRequester,
-        owner: Addr::unchecked("steve"),
+        announcer: Addr::unchecked("steve"),
         block_height: 12345,
         deposit: nyms(100),
     }
 }
 
-pub fn service_info(service_id: ServiceId, nym_address: NymAddress, owner: Addr) -> ServiceInfo {
+pub fn service_info(
+    service_id: ServiceId,
+    nym_address: NymAddress,
+    announcer: Addr,
+) -> ServiceInfo {
     ServiceInfo {
         service_id,
         service: Service {
             nym_address,
             service_type: ServiceType::NetworkRequester,
-            owner: owner,
+            announcer,
             block_height: 12345,
             deposit: nyms(100),
         },

--- a/contracts/service-provider-directory/src/test_helpers/helpers.rs
+++ b/contracts/service-provider-directory/src/test_helpers/helpers.rs
@@ -85,7 +85,7 @@ pub fn instantiate_test_contract() -> OwnedDeps<MemoryStorage, MockApi, MockQuer
 
 pub fn announce_service(deps: DepsMut<'_>, service: &Service) -> ServiceId {
     let msg: ExecuteMsg = service.clone().into();
-    let info = mock_info(service.owner.as_str(), &coins(100, "unym"));
+    let info = mock_info(service.announcer.as_str(), &coins(100, "unym"));
     let res = crate::execute(deps, mock_env(), info, msg).unwrap();
     let service_id: ServiceId = get_attribute(
         &res,
@@ -97,8 +97,8 @@ pub fn announce_service(deps: DepsMut<'_>, service: &Service) -> ServiceId {
     service_id
 }
 
-pub fn delete_service(deps: DepsMut<'_>, service_id: ServiceId, owner: &str) {
+pub fn delete_service(deps: DepsMut<'_>, service_id: ServiceId, announcer: &str) {
     let msg = ExecuteMsg::DeleteId { service_id };
-    let info = mock_info(owner, &[]);
+    let info = mock_info(announcer, &[]);
     crate::execute(deps, mock_env(), info, msg).unwrap();
 }

--- a/contracts/service-provider-directory/src/test_helpers/test_setup.rs
+++ b/contracts/service-provider-directory/src/test_helpers/test_setup.rs
@@ -14,9 +14,15 @@ use crate::test_helpers::helpers::get_app_attribute;
 
 const DENOM: &str = "unym";
 const ADDRESSES: &[&str] = &[
-    "user", "admin", "owner", "owner1", "owner2", "owner3", "owner4",
+    "user",
+    "admin",
+    "announcer",
+    "announcer1",
+    "announcer2",
+    "announcer3",
+    "announcer4",
 ];
-const WEALTHY_ADDRESSES: &[&str] = &["wealthy_owner_1", "wealthy_owner_2"];
+const WEALTHY_ADDRESSES: &[&str] = &["wealthy_announcer_1", "wealthy_announcer_2"];
 
 /// Helper for being able to systematic integration tests
 pub struct TestSetup {
@@ -100,11 +106,11 @@ impl TestSetup {
         self.query(&QueryMsg::All { limit, start_after })
     }
 
-    pub fn announce_net_req(&mut self, address: NymAddress, owner: Addr) -> AppResponse {
+    pub fn announce_net_req(&mut self, address: NymAddress, announcer: Addr) -> AppResponse {
         let resp = self
             .app
             .execute_contract(
-                owner,
+                announcer,
                 self.addr.clone(),
                 &ExecuteMsg::Announce {
                     nym_address: address,
@@ -123,17 +129,17 @@ impl TestSetup {
         resp
     }
 
-    pub fn try_delete(&mut self, service_id: ServiceId, owner: Addr) -> Result<AppResponse> {
+    pub fn try_delete(&mut self, service_id: ServiceId, announcer: Addr) -> Result<AppResponse> {
         self.app.execute_contract(
-            owner,
+            announcer,
             self.addr.clone(),
             &ExecuteMsg::DeleteId { service_id },
             &[],
         )
     }
 
-    pub fn delete(&mut self, service_id: ServiceId, owner: Addr) -> AppResponse {
-        let delete_resp = self.try_delete(service_id, owner).unwrap();
+    pub fn delete(&mut self, service_id: ServiceId, announcer: Addr) -> AppResponse {
+        let delete_resp = self.try_delete(service_id, announcer).unwrap();
         assert_eq!(
             get_app_attribute(&delete_resp, "wasm-delete_id", "action"),
             "delete_id"
@@ -141,10 +147,10 @@ impl TestSetup {
         delete_resp
     }
 
-    pub fn delete_nym_address(&mut self, nym_address: NymAddress, owner: Addr) -> AppResponse {
+    pub fn delete_nym_address(&mut self, nym_address: NymAddress, announcer: Addr) -> AppResponse {
         self.app
             .execute_contract(
-                owner,
+                announcer,
                 self.addr.clone(),
                 &ExecuteMsg::DeleteNymAddress { nym_address },
                 &[],


### PR DESCRIPTION
# Description

In the service provider directory contract the identity announcing a service is currently referred to as the owner, as that identity is the only one that can reclaim the deposit paid to announce an entry. Rename this to `announcer` to clarify that the announcer is not necessarily the owner of the service registered.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
