### PR TITLE
A branch with all clippy warnings dealt with in contracts

### DIFF
--- a/contracts/coconut-bandwidth/src/storage.rs
+++ b/contracts/coconut-bandwidth/src/storage.rs
@@ -86,9 +86,9 @@ mod tests {
         assert!(res.is_none());
 
         let mut spend_credential = SpendCredential::new(
-            funds.clone(),
+            funds,
             blind_serial_number.to_string(),
-            gateway_cosmos_address.clone(),
+            gateway_cosmos_address,
         );
         spend_credential.mark_as_spent();
 

--- a/contracts/coconut-bandwidth/src/support/tests/helpers.rs
+++ b/contracts/coconut-bandwidth/src/support/tests/helpers.rs
@@ -20,6 +20,6 @@ pub fn init_contract() -> OwnedDeps<MemoryStorage, MockApi, MockQuerier<Empty>> 
     };
     let env = mock_env();
     let info = mock_info("creator", &[]);
-    instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
+    instantiate(deps.as_mut(), env, info, msg).unwrap();
     deps
 }

--- a/contracts/coconut-bandwidth/src/transactions.rs
+++ b/contracts/coconut-bandwidth/src/transactions.rs
@@ -173,7 +173,7 @@ mod tests {
         );
         let info = mock_info("requester", &[coin]);
 
-        let tx = deposit_funds(deps.as_mut(), env.clone(), info, data).unwrap();
+        let tx = deposit_funds(deps.as_mut(), env, info, data).unwrap();
 
         let events: Vec<_> = tx
             .events
@@ -246,13 +246,8 @@ mod tests {
 
         deps.querier
             .update_balance(env.contract.address.clone(), vec![funds.clone()]);
-        let err = release_funds(
-            deps.as_mut(),
-            env.clone(),
-            mock_info(invalid_admin, &[]),
-            funds.clone(),
-        )
-        .unwrap_err();
+        let err =
+            release_funds(deps.as_mut(), env, mock_info(invalid_admin, &[]), funds).unwrap_err();
         assert_eq!(err, ContractError::Admin(AdminError::NotAdmin {}));
     }
 
@@ -294,7 +289,7 @@ mod tests {
         {
             assert_eq!(contract_addr, MULTISIG_CONTRACT);
             assert!(funds.is_empty());
-            let multisig_msg: MultisigExecuteMsg = from_binary(&msg).unwrap();
+            let multisig_msg: MultisigExecuteMsg = from_binary(msg).unwrap();
             if let MultisigExecuteMsg::Propose {
                 title: _,
                 description,
@@ -312,7 +307,7 @@ mod tests {
                 {
                     assert_eq!(*contract_addr, env.contract.address.into_string());
                     assert!(funds.is_empty());
-                    let release_funds_req: ExecuteMsg = from_binary(&msg).unwrap();
+                    let release_funds_req: ExecuteMsg = from_binary(msg).unwrap();
                     if let ExecuteMsg::ReleaseFunds { funds } = release_funds_req {
                         assert_eq!(funds, *data.funds());
                     } else {

--- a/contracts/coconut-dkg/src/contract.rs
+++ b/contracts/coconut-dkg/src/contract.rs
@@ -216,7 +216,7 @@ mod tests {
         };
         let info = mock_info("creator", &[]);
 
-        let res = instantiate(deps.as_mut(), env.clone(), info, msg);
+        let res = instantiate(deps.as_mut(), env, info, msg);
         assert!(res.is_ok())
     }
 
@@ -245,7 +245,7 @@ mod tests {
                         announce_address: "127.0.0.1:8000".to_string(),
                         resharing: false,
                     },
-                    &vec![],
+                    &[],
                 )
                 .unwrap();
             assert_eq!(parse_node_index(res), (idx + 1) as u64);
@@ -259,7 +259,7 @@ mod tests {
                         announce_address: "127.0.0.1:8000".to_string(),
                         resharing: false,
                     },
-                    &vec![],
+                    &[],
                 )
                 .unwrap_err();
             assert_eq!(ContractError::AlreadyADealer, err.downcast().unwrap());
@@ -269,13 +269,13 @@ mod tests {
         let err = app
             .execute_contract(
                 unauthorized_member,
-                coconut_dkg_contract_addr.clone(),
+                coconut_dkg_contract_addr,
                 &RegisterDealer {
                     bte_key_with_proof: "bte_key_with_proof".to_string(),
                     announce_address: "127.0.0.1:8000".to_string(),
                     resharing: false,
                 },
-                &vec![],
+                &[],
             )
             .unwrap_err();
         assert_eq!(ContractError::Unauthorized, err.downcast().unwrap());

--- a/contracts/coconut-dkg/src/dealers/transactions.rs
+++ b/contracts/coconut-dkg/src/dealers/transactions.rs
@@ -153,9 +153,9 @@ pub(crate) mod tests {
 
         let ret = try_add_dealer(
             deps.as_mut(),
-            info.clone(),
-            bte_key_with_proof.clone(),
-            announce_address.clone(),
+            info,
+            bte_key_with_proof,
+            announce_address,
             false,
         )
         .unwrap_err();

--- a/contracts/coconut-dkg/src/dealings/queries.rs
+++ b/contracts/coconut-dkg/src/dealings/queries.rs
@@ -56,11 +56,11 @@ pub(crate) mod tests {
         for n in 0..size {
             let dealing_share = dealing_bytes_fixture();
             let sender = Addr::unchecked(format!("owner{}", n));
-            for idx in 0..TOTAL_DEALINGS {
+            (0..TOTAL_DEALINGS).for_each(|idx| {
                 DEALINGS_BYTES[idx]
                     .save(deps.storage, &sender, &dealing_share)
                     .unwrap();
-            }
+            });
         }
     }
 

--- a/contracts/coconut-dkg/src/dealings/transactions.rs
+++ b/contracts/coconut-dkg/src/dealings/transactions.rs
@@ -131,8 +131,7 @@ pub(crate) mod tests {
             assert!(ret.is_ok());
             assert!(dealings.has(deps.as_mut().storage, &owner));
         }
-        let ret = try_commit_dealings(deps.as_mut(), info.clone(), dealing_bytes.clone(), true)
-            .unwrap_err();
+        let ret = try_commit_dealings(deps.as_mut(), info, dealing_bytes, true).unwrap_err();
         assert_eq!(
             ret,
             ContractError::AlreadyCommitted {

--- a/contracts/coconut-dkg/src/epoch_state/transactions.rs
+++ b/contracts/coconut-dkg/src/epoch_state/transactions.rs
@@ -236,10 +236,10 @@ pub(crate) mod tests {
                     let limit = *limits.next().unwrap();
                     {
                         let mut group_members = GROUP_MEMBERS.lock().unwrap();
-                        for i in 0..n as usize {
+                        for dealer in dealers.iter() {
                             group_members.push((
                                 Member {
-                                    addr: dealers[i].address.to_string(),
+                                    addr: dealer.address.to_string(),
                                     weight: 10,
                                 },
                                 1,
@@ -339,7 +339,7 @@ pub(crate) mod tests {
                 )
                 .unwrap()
             );
-            for i in 0..3 as u64 {
+            for i in 0..3_u64 {
                 let details = dealer_details_fixture(i + 1);
                 current_dealers()
                     .save(deps.as_mut().storage, &details.address, &details)

--- a/contracts/coconut-dkg/src/support/tests/helpers.rs
+++ b/contracts/coconut-dkg/src/support/tests/helpers.rs
@@ -90,6 +90,6 @@ pub fn init_contract() -> OwnedDeps<MemoryStorage, MockApi, MockQuerier<Empty>> 
     };
     let env = mock_env();
     let info = mock_info(ADMIN_ADDRESS, &[]);
-    instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
+    instantiate(deps.as_mut(), env, info, msg).unwrap();
     deps
 }

--- a/contracts/coconut-dkg/src/verification_key_shares/transactions.rs
+++ b/contracts/coconut-dkg/src/verification_key_shares/transactions.rs
@@ -129,14 +129,8 @@ mod tests {
             .save(deps.as_mut().storage, &dealer, &dealer_details)
             .unwrap();
 
-        try_commit_verification_key_share(
-            deps.as_mut(),
-            env.clone(),
-            info.clone(),
-            share.clone(),
-            false,
-        )
-        .unwrap();
+        try_commit_verification_key_share(deps.as_mut(), env, info.clone(), share.clone(), false)
+            .unwrap();
         let vk_share = vk_shares().load(&deps.storage, (&info.sender, 0)).unwrap();
         assert_eq!(
             vk_share,
@@ -215,14 +209,8 @@ mod tests {
         )
         .unwrap();
 
-        let ret = try_commit_verification_key_share(
-            deps.as_mut(),
-            env.clone(),
-            info.clone(),
-            share.clone(),
-            false,
-        )
-        .unwrap_err();
+        let ret =
+            try_commit_verification_key_share(deps.as_mut(), env, info, share, false).unwrap_err();
         assert_eq!(
             ret,
             ContractError::AlreadyCommitted {
@@ -318,14 +306,7 @@ mod tests {
         dealers_storage::current_dealers()
             .save(deps.as_mut().storage, &owner, &dealer_details)
             .unwrap();
-        try_commit_verification_key_share(
-            deps.as_mut(),
-            env.clone(),
-            info.clone(),
-            share.clone(),
-            false,
-        )
-        .unwrap();
+        try_commit_verification_key_share(deps.as_mut(), env.clone(), info, share, false).unwrap();
 
         env.block.time = env
             .block
@@ -338,7 +319,6 @@ mod tests {
             .plus_seconds(TimeConfiguration::default().verification_key_validation_time_secs);
         advance_epoch_state(deps.as_mut(), env).unwrap();
 
-        try_verify_verification_key_share(deps.as_mut(), multisig_info, owner.clone(), false)
-            .unwrap();
+        try_verify_verification_key_share(deps.as_mut(), multisig_info, owner, false).unwrap();
     }
 }

--- a/contracts/coconut-test/src/deposit_and_release.rs
+++ b/contracts/coconut-test/src/deposit_and_release.rs
@@ -89,13 +89,8 @@ fn deposit_and_release() {
     let msg = ExecuteMsg::ReleaseFunds {
         funds: deposit_funds[0].clone(),
     };
-    app.execute_contract(
-        Addr::unchecked(multisig_addr),
-        contract_addr.clone(),
-        &msg,
-        &[],
-    )
-    .unwrap();
+    app.execute_contract(Addr::unchecked(multisig_addr), contract_addr, &msg, &[])
+        .unwrap();
     let pool_bal = app.wrap().query_balance(pool_addr, TEST_MIX_DENOM).unwrap();
     assert_eq!(pool_bal, deposit_funds[0]);
 }

--- a/contracts/coconut-test/src/spend_credential_creates_proposal.rs
+++ b/contracts/coconut-test/src/spend_credential_creates_proposal.rs
@@ -101,7 +101,7 @@ fn spend_credential_creates_proposal() {
             Addr::unchecked(OWNER),
             coconut_bandwidth_contract_addr.clone(),
             &msg,
-            &vec![],
+            &[],
         )
         .unwrap();
     let proposal_id = res
@@ -124,7 +124,7 @@ fn spend_credential_creates_proposal() {
             Addr::unchecked(OWNER),
             coconut_bandwidth_contract_addr.clone(),
             &msg,
-            &vec![],
+            &[],
         )
         .unwrap_err();
     assert_eq!(
@@ -142,9 +142,9 @@ fn spend_credential_creates_proposal() {
     let res = app
         .execute_contract(
             Addr::unchecked(OWNER),
-            coconut_bandwidth_contract_addr.clone(),
+            coconut_bandwidth_contract_addr,
             &msg,
-            &vec![],
+            &[],
         )
         .unwrap();
     let proposal_id = res

--- a/contracts/coconut-test/src/submit_vk_creates_proposal.rs
+++ b/contracts/coconut-test/src/submit_vk_creates_proposal.rs
@@ -105,7 +105,7 @@ fn dkg_proposal() {
             announce_address: "127.0.0.1:8000".to_string(),
             resharing: false,
         },
-        &vec![],
+        &[],
     )
     .unwrap();
 
@@ -115,7 +115,7 @@ fn dkg_proposal() {
             Addr::unchecked(OWNER),
             coconut_dkg_contract_addr.clone(),
             &AdvanceEpochState {},
-            &vec![],
+            &[],
         )
         .unwrap();
     }
@@ -132,7 +132,7 @@ fn dkg_proposal() {
             Addr::unchecked(MEMBER1),
             coconut_dkg_contract_addr.clone(),
             &msg,
-            &vec![],
+            &[],
         )
         .unwrap();
 
@@ -174,7 +174,7 @@ fn dkg_proposal() {
             proposal_id,
             vote: cw3::Vote::Yes,
         },
-        &vec![],
+        &[],
     )
     .unwrap();
 
@@ -184,16 +184,16 @@ fn dkg_proposal() {
             Addr::unchecked(OWNER),
             coconut_dkg_contract_addr.clone(),
             &AdvanceEpochState {},
-            &vec![],
+            &[],
         )
         .unwrap();
     }
 
     app.execute_contract(
         Addr::unchecked(MEMBER1),
-        multisig_contract_addr.clone(),
+        multisig_contract_addr,
         &Execute { proposal_id },
-        &vec![],
+        &[],
     )
     .unwrap();
 

--- a/contracts/mixnet/clippy.toml
+++ b/contracts/mixnet/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/contracts/mixnet/src/families/transactions.rs
+++ b/contracts/mixnet/src/families/transactions.rs
@@ -489,7 +489,7 @@ mod test {
                 test.deps_mut(),
                 mock_info(illegal_proxy.as_ref(), &[]),
                 new_member.to_string(),
-                family_head.clone(),
+                family_head,
             )
             .unwrap_err();
 

--- a/contracts/mixnet/src/gateways/transactions.rs
+++ b/contracts/mixnet/src/gateways/transactions.rs
@@ -362,7 +362,7 @@ pub mod tests {
         let res = try_add_gateway(
             test.deps_mut(),
             env.clone(),
-            info.clone(),
+            info,
             gateway.clone(),
             signature.clone(),
         );

--- a/contracts/mixnet/src/mixnodes/queries.rs
+++ b/contracts/mixnet/src/mixnodes/queries.rs
@@ -459,10 +459,10 @@ pub(crate) mod tests {
         fn obeys_limits() {
             let mut deps = test_helpers::init_contract();
             let _env = mock_env();
-            let mut rng = test_helpers::test_rng();
+            let rng = test_helpers::test_rng();
             let limit = 2;
 
-            test_helpers::add_dummy_unbonded_mixnodes(&mut rng, deps.as_mut(), 1000);
+            test_helpers::add_dummy_unbonded_mixnodes(rng, deps.as_mut(), 1000);
             let page1 = query_unbonded_mixnodes_paged(deps.as_ref(), None, Some(limit)).unwrap();
             assert_eq!(limit, page1.nodes.len() as u32);
         }
@@ -471,8 +471,8 @@ pub(crate) mod tests {
         fn has_default_limit() {
             let mut deps = test_helpers::init_contract();
             let _env = mock_env();
-            let mut rng = test_helpers::test_rng();
-            test_helpers::add_dummy_unbonded_mixnodes(&mut rng, deps.as_mut(), 1000);
+            let rng = test_helpers::test_rng();
+            test_helpers::add_dummy_unbonded_mixnodes(rng, deps.as_mut(), 1000);
 
             // query without explicitly setting a limit
             let page1 = query_unbonded_mixnodes_paged(deps.as_ref(), None, None).unwrap();
@@ -487,8 +487,8 @@ pub(crate) mod tests {
         fn has_max_limit() {
             let mut deps = test_helpers::init_contract();
             let _env = mock_env();
-            let mut rng = test_helpers::test_rng();
-            test_helpers::add_dummy_unbonded_mixnodes(&mut rng, deps.as_mut(), 1000);
+            let rng = test_helpers::test_rng();
+            test_helpers::add_dummy_unbonded_mixnodes(rng, deps.as_mut(), 1000);
 
             // query with a crazily high limit in an attempt to use too many resources
             let crazy_limit = 1000;
@@ -589,16 +589,11 @@ pub(crate) mod tests {
         fn obeys_limits() {
             let mut deps = test_helpers::init_contract();
             let _env = mock_env();
-            let mut rng = test_helpers::test_rng();
+            let rng = test_helpers::test_rng();
             let limit = 2;
             let owner = "owner";
 
-            test_helpers::add_dummy_unbonded_mixnodes_with_owner(
-                &mut rng,
-                deps.as_mut(),
-                owner,
-                1000,
-            );
+            test_helpers::add_dummy_unbonded_mixnodes_with_owner(rng, deps.as_mut(), owner, 1000);
             let page1 = query_unbonded_mixnodes_by_owner_paged(
                 deps.as_ref(),
                 owner.into(),
@@ -613,15 +608,10 @@ pub(crate) mod tests {
         fn has_default_limit() {
             let mut deps = test_helpers::init_contract();
             let _env = mock_env();
-            let mut rng = test_helpers::test_rng();
+            let rng = test_helpers::test_rng();
             let owner = "owner";
 
-            test_helpers::add_dummy_unbonded_mixnodes_with_owner(
-                &mut rng,
-                deps.as_mut(),
-                owner,
-                1000,
-            );
+            test_helpers::add_dummy_unbonded_mixnodes_with_owner(rng, deps.as_mut(), owner, 1000);
 
             // query without explicitly setting a limit
             let page1 =
@@ -638,15 +628,10 @@ pub(crate) mod tests {
         fn has_max_limit() {
             let mut deps = test_helpers::init_contract();
             let _env = mock_env();
-            let mut rng = test_helpers::test_rng();
+            let rng = test_helpers::test_rng();
             let owner = "owner";
 
-            test_helpers::add_dummy_unbonded_mixnodes_with_owner(
-                &mut rng,
-                deps.as_mut(),
-                owner,
-                1000,
-            );
+            test_helpers::add_dummy_unbonded_mixnodes_with_owner(rng, deps.as_mut(), owner, 1000);
 
             // query with a crazily high limit in an attempt to use too many resources
             let crazy_limit = 1000;
@@ -836,12 +821,12 @@ pub(crate) mod tests {
         fn obeys_limits() {
             let mut deps = test_helpers::init_contract();
             let _env = mock_env();
-            let mut rng = test_helpers::test_rng();
+            let rng = test_helpers::test_rng();
             let limit = 2;
             let identity = "foomp123";
 
             test_helpers::add_dummy_unbonded_mixnodes_with_identity(
-                &mut rng,
+                rng,
                 deps.as_mut(),
                 identity,
                 1000,
@@ -860,10 +845,10 @@ pub(crate) mod tests {
         fn has_default_limit() {
             let mut deps = test_helpers::init_contract();
             let _env = mock_env();
-            let mut rng = test_helpers::test_rng();
+            let rng = test_helpers::test_rng();
             let identity = "foomp123";
             test_helpers::add_dummy_unbonded_mixnodes_with_identity(
-                &mut rng,
+                rng,
                 deps.as_mut(),
                 identity,
                 1000,
@@ -888,10 +873,10 @@ pub(crate) mod tests {
         fn has_max_limit() {
             let mut deps = test_helpers::init_contract();
             let _env = mock_env();
-            let mut rng = test_helpers::test_rng();
+            let rng = test_helpers::test_rng();
             let identity = "foomp123";
             test_helpers::add_dummy_unbonded_mixnodes_with_identity(
-                &mut rng,
+                rng,
                 deps.as_mut(),
                 identity,
                 1000,

--- a/contracts/mixnet/src/mixnodes/transactions.rs
+++ b/contracts/mixnet/src/mixnodes/transactions.rs
@@ -531,7 +531,7 @@ pub mod tests {
         let res = try_add_mixnode(
             test.deps_mut(),
             env.clone(),
-            info.clone(),
+            info,
             mixnode.clone(),
             cost_params.clone(),
             signature.clone(),

--- a/contracts/mixnet/src/rewards/helpers.rs
+++ b/contracts/mixnet/src/rewards/helpers.rs
@@ -253,8 +253,8 @@ mod tests {
     fn withdrawing_delegator_reward() {
         let mut test = TestSetup::new();
 
-        let delegation_amount = Uint128::new(2500_000_000);
-        let delegation_dec = 2500_000_000u32.into_base_decimal().unwrap();
+        let delegation_amount = Uint128::new(2_500_000_000);
+        let delegation_dec = 2_500_000_000_u32.into_base_decimal().unwrap();
         let mix_id = test.add_dummy_mixnode("mix-owner", None);
         let delegator = "delegator";
         test.add_immediate_delegation(delegator, delegation_amount, mix_id);

--- a/contracts/mixnet/src/rewards/transactions.rs
+++ b/contracts/mixnet/src/rewards/transactions.rs
@@ -486,8 +486,8 @@ pub mod tests {
 
                 try_reward_mixnode(
                     test.deps_mut(),
-                    env.clone(),
-                    sender.clone(),
+                    env,
+                    sender,
                     mix_id_never_existed,
                     performance,
                 )
@@ -2094,7 +2094,7 @@ pub mod tests {
                 .unwrap()
                 .active_set_size;
             let env = test.env();
-            let res = try_update_active_set_size(test.deps_mut(), env, owner.clone(), 42, true);
+            let res = try_update_active_set_size(test.deps_mut(), env, owner, 42, true);
             assert!(res.is_ok());
             let new = storage::REWARDING_PARAMS
                 .load(test.deps().storage)
@@ -2181,7 +2181,7 @@ pub mod tests {
                     test.deps_mut(),
                     env.clone(),
                     owner.clone(),
-                    update.clone(),
+                    update,
                     false,
                 );
                 assert!(matches!(
@@ -2193,7 +2193,7 @@ pub mod tests {
                     test.deps_mut(),
                     env.clone(),
                     owner,
-                    update.clone(),
+                    update,
                     true,
                 );
                 assert!(res_forced.is_ok())
@@ -2309,7 +2309,7 @@ pub mod tests {
             let old = storage::REWARDING_PARAMS.load(test.deps().storage).unwrap();
             let env = test.env();
             let res =
-                try_update_rewarding_params(test.deps_mut(), env, owner.clone(), update, true);
+                try_update_rewarding_params(test.deps_mut(), env, owner, update, true);
             assert!(res.is_ok());
             let new = storage::REWARDING_PARAMS.load(test.deps().storage).unwrap();
             assert_ne!(old, new);

--- a/contracts/mixnet/src/rewards/transactions.rs
+++ b/contracts/mixnet/src/rewards/transactions.rs
@@ -2189,13 +2189,8 @@ pub mod tests {
                     Err(MixnetContractError::EpochAdvancementInProgress { .. })
                 ));
 
-                let res_forced = try_update_rewarding_params(
-                    test.deps_mut(),
-                    env.clone(),
-                    owner,
-                    update,
-                    true,
-                );
+                let res_forced =
+                    try_update_rewarding_params(test.deps_mut(), env.clone(), owner, update, true);
                 assert!(res_forced.is_ok())
             }
         }
@@ -2308,8 +2303,7 @@ pub mod tests {
 
             let old = storage::REWARDING_PARAMS.load(test.deps().storage).unwrap();
             let env = test.env();
-            let res =
-                try_update_rewarding_params(test.deps_mut(), env, owner, update, true);
+            let res = try_update_rewarding_params(test.deps_mut(), env, owner, update, true);
             assert!(res.is_ok());
             let new = storage::REWARDING_PARAMS.load(test.deps().storage).unwrap();
             assert_ne!(old, new);

--- a/contracts/mixnet/src/support/tests/mod.rs
+++ b/contracts/mixnet/src/support/tests/mod.rs
@@ -190,7 +190,7 @@ pub mod test_helpers {
             let owner = head_mixnode.owner;
 
             let nonce =
-                signing_storage::get_signing_nonce(self.deps().storage, owner.clone()).unwrap();
+                signing_storage::get_signing_nonce(self.deps().storage, owner).unwrap();
 
             let proxy = if vesting {
                 Some(self.vesting_contract())
@@ -546,7 +546,7 @@ pub mod test_helpers {
                 sender,
                 None,
                 mixnode.clone(),
-                stake.clone(),
+                stake,
             );
             let owner_signature = ed25519_sign_message(msg, keypair.private_key());
 
@@ -575,7 +575,7 @@ pub mod test_helpers {
                 sender,
                 None,
                 gateway.clone(),
-                stake.clone(),
+                stake,
             );
             let owner_signature = ed25519_sign_message(msg, keypair.private_key());
 
@@ -1102,7 +1102,7 @@ pub mod test_helpers {
                 deps.branch(),
                 &env,
                 env.block.height,
-                Addr::unchecked(&format!("owner{}", i)),
+                Addr::unchecked(format!("owner{}", i)),
                 mix_id,
                 tests::fixtures::good_mixnode_pledge().pop().unwrap(),
                 None,

--- a/contracts/mixnet/src/support/tests/mod.rs
+++ b/contracts/mixnet/src/support/tests/mod.rs
@@ -189,8 +189,7 @@ pub mod test_helpers {
             let family_head = FamilyHead::new(&identity);
             let owner = head_mixnode.owner;
 
-            let nonce =
-                signing_storage::get_signing_nonce(self.deps().storage, owner).unwrap();
+            let nonce = signing_storage::get_signing_nonce(self.deps().storage, owner).unwrap();
 
             let proxy = if vesting {
                 Some(self.vesting_contract())
@@ -541,13 +540,8 @@ pub mod test_helpers {
                 sphinx_key: legit_sphinx_keys.public_key().to_base58_string(),
                 ..tests::fixtures::mix_node_fixture()
             };
-            let msg = mixnode_bonding_sign_payload(
-                self.deps(),
-                sender,
-                None,
-                mixnode.clone(),
-                stake,
-            );
+            let msg =
+                mixnode_bonding_sign_payload(self.deps(), sender, None, mixnode.clone(), stake);
             let owner_signature = ed25519_sign_message(msg, keypair.private_key());
 
             (mixnode, owner_signature, keypair)
@@ -570,13 +564,8 @@ pub mod test_helpers {
                 ..tests::fixtures::gateway_fixture()
             };
 
-            let msg = gateway_bonding_sign_payload(
-                self.deps(),
-                sender,
-                None,
-                gateway.clone(),
-                stake,
-            );
+            let msg =
+                gateway_bonding_sign_payload(self.deps(), sender, None, gateway.clone(), stake);
             let owner_signature = ed25519_sign_message(msg, keypair.private_key());
 
             (gateway, owner_signature)

--- a/contracts/multisig/cw3-flex-multisig/src/contract.rs
+++ b/contracts/multisig/cw3-flex-multisig/src/contract.rs
@@ -780,7 +780,7 @@ mod tests {
         let err = app
             .execute_contract(
                 Addr::unchecked(TEST_COCONUT_BANDWIDTH_CONTRACT_ADDRESS.to_string()),
-                flex_addr.clone(),
+                flex_addr,
                 &proposal_wrong_exp,
                 &[],
             )
@@ -856,12 +856,7 @@ mod tests {
 
         let proposer = TEST_COCONUT_BANDWIDTH_CONTRACT_ADDRESS.to_string();
         let res = app
-            .execute_contract(
-                Addr::unchecked(&proposer),
-                flex_addr.clone(),
-                &proposal,
-                &[],
-            )
+            .execute_contract(Addr::unchecked(&proposer), flex_addr, &proposal, &[])
             .unwrap();
         assert_eq!(
             res.custom_attrs(1),

--- a/contracts/service-provider-directory/src/integration_tests.rs
+++ b/contracts/service-provider-directory/src/integration_tests.rs
@@ -262,7 +262,7 @@ fn paging_works() {
             services: vec![
                 service_info(1, nym_address1.clone(), announcer1.clone()),
                 service_info(2, nym_address1.clone(), announcer1.clone()),
-                service_info(3, nym_address2.clone(), announcer1.clone()),
+                service_info(3, nym_address2.clone(), announcer1),
             ],
             per_page: 3,
             start_next_after: Some(3),
@@ -272,8 +272,8 @@ fn paging_works() {
         setup.query_all_with_limit(Some(3), Some(3)),
         PagedServicesListResponse {
             services: vec![
-                service_info(4, nym_address1.clone(), announcer2.clone()),
-                service_info(5, nym_address2.clone(), announcer2.clone()),
+                service_info(4, nym_address1, announcer2.clone()),
+                service_info(5, nym_address2, announcer2),
             ],
             per_page: 3,
             start_next_after: Some(5),

--- a/contracts/vesting/src/support/tests.rs
+++ b/contracts/vesting/src/support/tests.rs
@@ -325,12 +325,12 @@ pub mod helpers {
         };
         let env = mock_env();
         let info = mock_info("admin", &[]);
-        instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
+        instantiate(deps.as_mut(), env, info, msg).unwrap();
         deps
     }
 
     pub fn vesting_account_mid_fixture(storage: &mut dyn Storage, env: &Env) -> Account {
-        let start_time_ts = env.block.time.clone();
+        let start_time_ts = env.block.time;
         let start_time = env.block.time.seconds() - 7200;
         let periods = populate_vesting_periods(
             start_time,

--- a/contracts/vesting/src/vesting/mod.rs
+++ b/contracts/vesting/src/vesting/mod.rs
@@ -68,7 +68,7 @@ mod tests {
             cap: Some(PledgeCap::Absolute(Uint128::from(100_000_000_000u128))),
         };
         // Try creating an account when not admin
-        let response = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone());
+        let response = execute(deps.as_mut(), env.clone(), info, msg.clone());
         assert!(response.is_err());
 
         let info = mock_info("admin", &coins(1_000_000_000_000, TEST_COIN_DENOM));
@@ -142,7 +142,7 @@ mod tests {
         assert!(old_owner_account.is_none());
 
         // Not the owner
-        let response = execute(deps.as_mut(), env.clone(), info.clone(), msg);
+        let response = execute(deps.as_mut(), env.clone(), info, msg);
         assert!(response.is_err());
 
         // can't stake on behalf of the original owner anymore, but we can do it for the new one!
@@ -190,7 +190,7 @@ mod tests {
         assert!(response.is_ok());
 
         let info = mock_info("owner", &[]);
-        let response = execute(deps.as_mut(), env.clone(), info, msg.clone());
+        let response = execute(deps.as_mut(), env.clone(), info, msg);
         assert!(response.is_err());
     }
 
@@ -202,7 +202,7 @@ mod tests {
         let msg = ExecuteMsg::TransferOwnership {
             to_address: "new_owner".to_string(),
         };
-        let response = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone());
+        let response = execute(deps.as_mut(), env.clone(), info.clone(), msg);
         // Only owner can transfer
         assert!(response.is_err());
 
@@ -213,7 +213,7 @@ mod tests {
             },
         };
         env.block.time = Timestamp::from_nanos(env.block.time.nanos() + 100_000_000_000_000_000);
-        let response = execute(deps.as_mut(), env.clone(), info, msg.clone());
+        let response = execute(deps.as_mut(), env, info, msg);
         // Only owner can withdraw
         assert!(response.is_err());
     }
@@ -510,7 +510,7 @@ mod tests {
 
         assert_eq!(
             account.load_balance(&deps.storage).unwrap(),
-            Uint128::new(1000_000_000_000)
+            Uint128::new(1_000_000_000_000)
         );
 
         account
@@ -588,7 +588,7 @@ mod tests {
         };
         let info = mock_info("admin", &coins(1_000_000_000_000, TEST_COIN_DENOM));
 
-        let _response = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone());
+        let _response = execute(deps.as_mut(), env.clone(), info, msg);
         let account = load_account(Addr::unchecked("owner"), &deps.storage)
             .unwrap()
             .unwrap();
@@ -837,7 +837,7 @@ mod tests {
 
         // but the additional one is going to fail
         let res = vesting_account
-            .try_delegate_to_mixnode(mix_id, delegation.clone(), &env, &mut deps.storage)
+            .try_delegate_to_mixnode(mix_id, delegation, &env, &mut deps.storage)
             .unwrap_err();
 
         assert_eq!(

--- a/nym-api/src/node_status_api/helpers.rs
+++ b/nym-api/src/node_status_api/helpers.rs
@@ -27,10 +27,7 @@ async fn get_gateway_bond_annotated(
     let gateways = cache
         .gateways_annotated_filtered()
         .await
-        .ok_or(ErrorResponse::new(
-            "no data available",
-            Status::ServiceUnavailable,
-        ))?;
+        .ok_or_else(|| ErrorResponse::new("no data available", Status::ServiceUnavailable))?;
 
     gateways
         .into_iter()


### PR DESCRIPTION
# Description

We've got a lot of Clippy warnings in the monorepo (nothing major from a functionality or security point of view). Everything is clean on first glance, but if you open up e.g. a subproject like `contracts/mixnet` in vscode, Clippy lights up like a yellow Christmas tree. 

Part of this is because the `clippy.toml` from the root of the monorepo doesn't get evaluated - copying it into place gets rid of all the `.unwrap()`s in test code, so that's simple enough. 

This PR shows all the rest of Clippy fixes - some iterator-related things, lots of unnecessary `clone`s, and some unneeded mutability mostly. 

