### PR TITLE
Tidy the service provider directory contract

### DIFF
--- a/common/cosmwasm-smart-contracts/service-provider-directory/src/lib.rs
+++ b/common/cosmwasm-smart-contracts/service-provider-directory/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod events;
 pub mod msg;
+pub mod response;
 pub mod types;
 
 // Re-export all types at the top-level

--- a/common/cosmwasm-smart-contracts/service-provider-directory/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/service-provider-directory/src/msg.rs
@@ -1,5 +1,5 @@
-use crate::{NymAddress, Service, ServiceId, ServiceType};
-use cosmwasm_std::{Addr, Coin};
+use crate::{NymAddress, ServiceId, ServiceType};
+use cosmwasm_std::Coin;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -48,10 +48,10 @@ pub enum QueryMsg {
     ServiceId {
         service_id: ServiceId,
     },
-    Announcer {
-        announcer: Addr,
+    ByAnnouncer {
+        announcer: String,
     },
-    NymAddress {
+    ByNymAddress {
         nym_address: NymAddress,
     },
     All {
@@ -69,80 +69,6 @@ impl QueryMsg {
         QueryMsg::All {
             limit: None,
             start_after: None,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-#[serde(rename_all = "snake_case")]
-pub struct ServiceInfo {
-    pub service_id: ServiceId,
-    pub service: Service,
-}
-
-impl ServiceInfo {
-    pub fn new(service_id: ServiceId, service: Service) -> Self {
-        Self {
-            service_id,
-            service,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-#[serde(rename_all = "snake_case")]
-pub struct ServicesListResponse {
-    pub services: Vec<ServiceInfo>,
-}
-
-impl ServicesListResponse {
-    pub fn new(services: Vec<(ServiceId, Service)>) -> ServicesListResponse {
-        ServicesListResponse {
-            services: services
-                .into_iter()
-                .map(|(service_id, service)| ServiceInfo::new(service_id, service))
-                .collect(),
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-#[serde(rename_all = "snake_case")]
-pub struct PagedServicesListResponse {
-    pub services: Vec<ServiceInfo>,
-    pub per_page: usize,
-    pub start_next_after: Option<ServiceId>,
-}
-
-impl PagedServicesListResponse {
-    pub fn new(
-        services: Vec<(ServiceId, Service)>,
-        per_page: usize,
-        start_next_after: Option<ServiceId>,
-    ) -> PagedServicesListResponse {
-        let services = services
-            .into_iter()
-            .map(|(service_id, service)| ServiceInfo::new(service_id, service))
-            .collect();
-        PagedServicesListResponse {
-            services,
-            per_page,
-            start_next_after,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-#[serde(rename_all = "snake_case")]
-pub struct ConfigResponse {
-    pub deposit_required: Coin,
-}
-
-impl From<Service> for ExecuteMsg {
-    fn from(service: Service) -> Self {
-        ExecuteMsg::Announce {
-            nym_address: service.nym_address,
-            service_type: service.service_type,
         }
     }
 }

--- a/common/cosmwasm-smart-contracts/service-provider-directory/src/response.rs
+++ b/common/cosmwasm-smart-contracts/service-provider-directory/src/response.rs
@@ -1,0 +1,68 @@
+use crate::{msg::ExecuteMsg, Service, ServiceId, ServiceInfo};
+use cosmwasm_std::Coin;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct ServiceInfoResponse {
+    pub service_id: ServiceId,
+    pub service: Option<Service>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct ServicesListResponse {
+    pub services: Vec<ServiceInfo>,
+}
+
+impl ServicesListResponse {
+    pub fn new(services: Vec<(ServiceId, Service)>) -> ServicesListResponse {
+        ServicesListResponse {
+            services: services
+                .into_iter()
+                .map(|(service_id, service)| ServiceInfo::new(service_id, service))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct PagedServicesListResponse {
+    pub services: Vec<ServiceInfo>,
+    pub per_page: usize,
+    pub start_next_after: Option<ServiceId>,
+}
+
+impl PagedServicesListResponse {
+    pub fn new(
+        services: Vec<(ServiceId, Service)>,
+        per_page: usize,
+        start_next_after: Option<ServiceId>,
+    ) -> PagedServicesListResponse {
+        let services = services
+            .into_iter()
+            .map(|(service_id, service)| ServiceInfo::new(service_id, service))
+            .collect();
+        PagedServicesListResponse {
+            services,
+            per_page,
+            start_next_after,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct ConfigResponse {
+    pub deposit_required: Coin,
+}
+
+impl From<Service> for ExecuteMsg {
+    fn from(service: Service) -> Self {
+        ExecuteMsg::Announce {
+            nym_address: service.nym_address,
+            service_type: service.service_type,
+        }
+    }
+}

--- a/common/cosmwasm-smart-contracts/service-provider-directory/src/types.rs
+++ b/common/cosmwasm-smart-contracts/service-provider-directory/src/types.rs
@@ -65,3 +65,19 @@ impl std::fmt::Display for ServiceType {
         write!(f, "{service_type}")
     }
 }
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct ServiceInfo {
+    pub service_id: ServiceId,
+    pub service: Service,
+}
+
+impl ServiceInfo {
+    pub fn new(service_id: ServiceId, service: Service) -> Self {
+        Self {
+            service_id,
+            service,
+        }
+    }
+}

--- a/contracts/service-provider-directory/src/contract.rs
+++ b/contracts/service-provider-directory/src/contract.rs
@@ -88,8 +88,8 @@ pub fn execute(
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary> {
     let response = match msg {
         QueryMsg::ServiceId { service_id } => to_binary(&query::query_id(deps, service_id)?),
-        QueryMsg::Announcer { announcer } => to_binary(&query::query_announcer(deps, announcer)?),
-        QueryMsg::NymAddress { nym_address } => {
+        QueryMsg::ByAnnouncer { announcer } => to_binary(&query::query_announcer(deps, announcer)?),
+        QueryMsg::ByNymAddress { nym_address } => {
             to_binary(&query::query_nym_address(deps, nym_address)?)
         }
         QueryMsg::All { limit, start_after } => {
@@ -116,10 +116,7 @@ mod tests {
         testing::{mock_dependencies, mock_env, mock_info},
         Addr, Coin,
     };
-    use nym_service_provider_directory_common::{
-        msg::{ExecuteMsg, ServiceInfo},
-        ServiceId,
-    };
+    use nym_service_provider_directory_common::{msg::ExecuteMsg, ServiceId, ServiceInfo};
 
     const DENOM: &str = "unym";
 

--- a/contracts/service-provider-directory/src/contract/execute.rs
+++ b/contracts/service-provider-directory/src/contract/execute.rs
@@ -26,7 +26,7 @@ fn ensure_correct_deposit(will_deposit: Uint128, deposit_required: Uint128) -> R
 }
 
 fn ensure_max_services_per_announcer(deps: Deps, announcer: Addr) -> Result<()> {
-    let current_entries = query::query_announcer(deps, announcer.clone())?;
+    let current_entries = query::query_announcer(deps, announcer.to_string())?;
     if current_entries.services.len() < MAX_NUMBER_OF_PROVIDERS_PER_ANNOUNCER as usize {
         Ok(())
     } else {

--- a/contracts/service-provider-directory/src/contract/query.rs
+++ b/contracts/service-provider-directory/src/contract/query.rs
@@ -1,8 +1,8 @@
-use cosmwasm_std::{Addr, Deps};
+use cosmwasm_std::Deps;
 use nym_contracts_common::ContractBuildInformation;
 use nym_service_provider_directory_common::{
-    msg::{ConfigResponse, PagedServicesListResponse, ServiceInfo, ServicesListResponse},
-    NymAddress, ServiceId,
+    response::{ConfigResponse, PagedServicesListResponse, ServicesListResponse},
+    NymAddress, ServiceId, ServiceInfo,
 };
 
 use crate::{
@@ -18,7 +18,8 @@ pub fn query_id(deps: Deps, service_id: ServiceId) -> Result<ServiceInfo> {
     })
 }
 
-pub fn query_announcer(deps: Deps, announcer: Addr) -> Result<ServicesListResponse> {
+pub fn query_announcer(deps: Deps, announcer: String) -> Result<ServicesListResponse> {
+    let announcer = deps.api.addr_validate(&announcer)?;
     let services = state::services::load_announcer(deps.storage, announcer)?;
     Ok(ServicesListResponse::new(services))
 }

--- a/contracts/service-provider-directory/src/integration_tests.rs
+++ b/contracts/service-provider-directory/src/integration_tests.rs
@@ -2,8 +2,8 @@
 
 use cosmwasm_std::Addr;
 use nym_service_provider_directory_common::{
-    msg::{ConfigResponse, PagedServicesListResponse, ServiceInfo},
-    NymAddress, Service, ServiceType,
+    response::{ConfigResponse, PagedServicesListResponse},
+    NymAddress, Service, ServiceInfo, ServiceType,
 };
 
 use crate::{

--- a/contracts/service-provider-directory/src/state/config.rs
+++ b/contracts/service-provider-directory/src/state/config.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{Coin, Storage};
 use cw_storage_plus::Item;
-use nym_service_provider_directory_common::msg::ConfigResponse;
+use nym_service_provider_directory_common::response::ConfigResponse;
 use serde::{Deserialize, Serialize};
 
 use crate::{constants::CONFIG_KEY, error::Result};

--- a/contracts/service-provider-directory/src/state/service_id_counter.rs
+++ b/contracts/service-provider-directory/src/state/service_id_counter.rs
@@ -17,7 +17,7 @@ pub(crate) fn next_service_id_counter(store: &mut dyn Storage) -> Result<Service
 #[cfg(test)]
 mod tests {
 
-    use nym_service_provider_directory_common::msg::ServiceInfo;
+    use nym_service_provider_directory_common::ServiceInfo;
 
     use crate::test_helpers::{
         assert::assert_services,

--- a/contracts/service-provider-directory/src/test_helpers/assert.rs
+++ b/contracts/service-provider-directory/src/test_helpers/assert.rs
@@ -1,7 +1,8 @@
 use cosmwasm_std::{from_binary, testing::mock_env, Addr, Coin, Deps};
 use nym_service_provider_directory_common::{
-    msg::{ConfigResponse, PagedServicesListResponse, QueryMsg, ServiceInfo},
-    ServiceId,
+    msg::QueryMsg,
+    response::{ConfigResponse, PagedServicesListResponse},
+    ServiceId, ServiceInfo,
 };
 
 use crate::{constants::SERVICE_DEFAULT_RETRIEVAL_LIMIT, error::ContractError};

--- a/contracts/service-provider-directory/src/test_helpers/fixture.rs
+++ b/contracts/service-provider-directory/src/test_helpers/fixture.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::Addr;
 use nym_service_provider_directory_common::{
-    msg::ServiceInfo, NymAddress, Service, ServiceId, ServiceType,
+    NymAddress, Service, ServiceId, ServiceInfo, ServiceType,
 };
 
 use super::helpers::nyms;

--- a/contracts/service-provider-directory/src/test_helpers/test_setup.rs
+++ b/contracts/service-provider-directory/src/test_helpers/test_setup.rs
@@ -2,11 +2,9 @@ use anyhow::Result;
 use cosmwasm_std::{coins, Addr, Coin, Uint128};
 use cw_multi_test::{App, AppBuilder, AppResponse, ContractWrapper, Executor};
 use nym_service_provider_directory_common::{
-    msg::{
-        ConfigResponse, ExecuteMsg, InstantiateMsg, PagedServicesListResponse, QueryMsg,
-        ServiceInfo,
-    },
-    NymAddress, ServiceId, ServiceType,
+    msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
+    response::{ConfigResponse, PagedServicesListResponse},
+    NymAddress, ServiceId, ServiceInfo, ServiceType,
 };
 use serde::de::DeserializeOwned;
 


### PR DESCRIPTION
# Description

Tidy the service provider directory contract after implementing query
methods on the validator-client.

- split out response types and use consistently
- query msg use "By" prefix
- pass address as String and validator

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
