### PR TITLE
fix a minor issue in mkdir/touch paths

### DIFF
--- a/documentation/dev-portal/src/tutorials/simple-service-provider/user-client.md
+++ b/documentation/dev-portal/src/tutorials/simple-service-provider/user-client.md
@@ -233,8 +233,8 @@ function displayJsonSend(message) {
 Lets add the finishing touches to the UI by adding in the stylesheet which we specified at the top of `index.html`: 
 
 ```
-mkdir -p src/assets
-touch src/assets/styles.css
+mkdir -p assets
+touch assets/styles.css
 
 # grab the stylesheet from the remote repo and save it to the newly created css file
 curl https://raw.githubusercontent.com/nymtech/developer-tutorials/main/simple-service-provider-tutorial/user-client/assets/styles.css -o assets/styles.css


### PR DESCRIPTION
# Description

As mentioned in Element, the lines 


```
mkdir -p src/assets
touch src/assets/styles.css

# grab the stylesheet from the remote repo and save it to the newly created css file
curl https://raw.githubusercontent.com/nymtech/developer-tutorials/main/simple-service-provider-tutorial/user-client/assets/styles.css -o assets/styles.css
```

don't work smoothly

I decided to stay in line with the `curl` and the `src/index.html href` tree structure logic and instead change the `mkdir` and `touch` paths. It is a minor update, but which will make the life of people just copy-pasting the code-snippets easier.

```
<!doctype html>
<html>
    <head>
        <meta charset="UTF-8">
        <title>Mixnet Websocket Starter Client</title>
        <link rel="stylesheet" href="../assets/styles.css"/>
    </head>
```