### PR TITLE
Reduce logging of warnings associated with Poisson process throttling

### DIFF
--- a/clients/native/src/commands/init.rs
+++ b/clients/native/src/commands/init.rs
@@ -115,7 +115,7 @@ impl Display for InitResults {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}", self.client_core)?;
         writeln!(f, "Client listening port: {}", self.client_listening_port)?;
-        write!(f, "address of this client: {}", self.client_address)
+        write!(f, "Address of this client: {}", self.client_address)
     }
 }
 

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -116,8 +116,8 @@ impl InitResults {
 impl Display for InitResults {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}", self.client_core)?;
-        write!(f, "SOCKS5 listening port: {}", self.socks5_listening_port)?;
-        write!(f, "address of this client: {}", self.client_address)
+        writeln!(f, "SOCKS5 listening port: {}", self.socks5_listening_port)?;
+        write!(f, "Address of this client: {}", self.client_address)
     }
 }
 
@@ -181,7 +181,6 @@ pub(crate) async fn execute(args: &Init) -> Result<(), Socks5ClientError> {
     let init_results = InitResults::new(&config, &address);
     println!("{}", args.output.format(&init_results));
 
-    eprintln!("\nThe address of this client is: {}\n", address);
     Ok(())
 }
 

--- a/common/client-core/src/client/cover_traffic_stream.rs
+++ b/common/client-core/src/client/cover_traffic_stream.rs
@@ -203,10 +203,6 @@ impl LoopCoverTrafficStream<OsRng> {
                     // This isn't a problem, if the channel is full means we're already sending the
                     // max amount of messages downstream can handle.
                     log::debug!("Failed to send cover message - channel full");
-                    // However it's still useful to alert the user that the gateway or the link to
-                    // the gateway can't keep up. Either due to insufficient bandwidth on the
-                    // client side, or that the gateway is overloaded.
-                    log::warn!("Failed to send sphinx packet - gateway or connection to gateway can't keep up");
                 }
                 TrySendError::Closed(_) => {
                     log::warn!("Failed to send cover message - channel closed");

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -500,11 +500,20 @@ where
 
     #[cfg(not(target_arch = "wasm32"))]
     fn log_status_infrequent(&self) {
-        if self.sending_delay_controller.current_multiplier() > 1 {
-            log::warn!(
-                "Unable to send packets at the default rate - rate reduced by setting the delay multiplier set to: {}",
+        let multiplier_change = self.sending_delay_controller.current_multiplier()
+            - self.sending_delay_controller.min_multiplier();
+        if multiplier_change > 0 {
+            let status_str = format!(
+                "Poisson delay currently scaled by: {}",
                 self.sending_delay_controller.current_multiplier()
             );
+            if multiplier_change > 0 {
+                log::debug!("{status_str}");
+            } else if multiplier_change > 1 {
+                log::info!("{status_str}");
+            } else if multiplier_change > 2 {
+                log::warn!("{status_str}");
+            }
         }
     }
 

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream/sending_delay_controller.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream/sending_delay_controller.rs
@@ -134,27 +134,27 @@ impl SendingDelayController {
         let multiple_elevated = self.current_multiplier - self.lower_bound;
         if multiple_elevated == 0 {
             self.multiplier_elevated_counter = 0;
-        } else if multiple_elevated > 0 {
+        } else {
             self.multiplier_elevated_counter += 1;
         }
 
         // If needed, log about the elevated multiplier.
         let now = get_time_now();
-        if self.multiplier_elevated_counter > 20 {
-            if now > self.time_when_logged_about_elevated_multiplier + Duration::from_secs(60) {
-                let status_str = format!(
-                    "Poisson delay currently scaled by: {}",
-                    self.current_multiplier()
-                );
-                if self.current_multiplier() > 0 {
-                    log::debug!("{}", status_str);
-                } else if self.current_multiplier() > 1 {
-                    log::info!("{}", status_str);
-                } else if self.current_multiplier() > 2 {
-                    log::warn!("{}", status_str);
-                }
-                self.time_when_logged_about_elevated_multiplier = now;
+        if self.multiplier_elevated_counter > 20
+            && now > self.time_when_logged_about_elevated_multiplier + Duration::from_secs(60)
+        {
+            let status_str = format!(
+                "Poisson delay currently scaled by: {}",
+                self.current_multiplier()
+            );
+            if self.current_multiplier() > 0 {
+                log::debug!("{}", status_str);
+            } else if self.current_multiplier() > 1 {
+                log::info!("{}", status_str);
+            } else if self.current_multiplier() > 2 {
+                log::warn!("{}", status_str);
             }
+            self.time_when_logged_about_elevated_multiplier = now;
         }
     }
 }

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream/sending_delay_controller.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream/sending_delay_controller.rs
@@ -79,7 +79,7 @@ impl SendingDelayController {
             self.current_multiplier =
                 (self.current_multiplier + 1).clamp(self.lower_bound, self.upper_bound);
             self.time_when_changed = get_time_now();
-            log::warn!(
+            log::debug!(
                 "Increasing sending delay multiplier to: {}",
                 self.current_multiplier
             );

--- a/service-providers/network-requester/src/cli/init.rs
+++ b/service-providers/network-requester/src/cli/init.rs
@@ -86,7 +86,8 @@ impl InitResults {
 
 impl Display for InitResults {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.client_core)
+        writeln!(f, "{}", self.client_core)?;
+        write!(f, "Address of this client: {}", self.client_address)
     }
 }
 

--- a/service-providers/network-requester/src/cli/init.rs
+++ b/service-providers/network-requester/src/cli/init.rs
@@ -87,7 +87,7 @@ impl InitResults {
 impl Display for InitResults {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}", self.client_core)?;
-        write!(f, "Address of this client: {}", self.client_address)
+        write!(f, "Address of this network-requester: {}", self.client_address)
     }
 }
 

--- a/service-providers/network-requester/src/cli/init.rs
+++ b/service-providers/network-requester/src/cli/init.rs
@@ -87,7 +87,11 @@ impl InitResults {
 impl Display for InitResults {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}", self.client_core)?;
-        write!(f, "Address of this network-requester: {}", self.client_address)
+        write!(
+            f,
+            "Address of this network-requester: {}",
+            self.client_address
+        )
     }
 }
 


### PR DESCRIPTION
# Description

Closes: #3299

- Downgrade some of the warnings related to the Poisson process adjust its rate.
- Refine the logic for when we log about elevated Poisson process  delay multiplier.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
