### PR TITLE
Wallet - fix bonding signature issue with vesting acc

### DIFF
--- a/nym-wallet/src/components/Bonding/forms/GatewaySignatureForm.tsx
+++ b/nym-wallet/src/components/Bonding/forms/GatewaySignatureForm.tsx
@@ -40,6 +40,7 @@ const GatewaySignatureForm = ({
         await generateGatewayMsgPayload({
           pledge: amount.amount,
           gateway: gatewayToTauri(gateway),
+          tokenPool: amount.tokenPool as 'balance' | 'locked',
         }),
       );
     } catch (e) {

--- a/nym-wallet/src/components/Bonding/forms/MixnodeSignatureForm.tsx
+++ b/nym-wallet/src/components/Bonding/forms/MixnodeSignatureForm.tsx
@@ -41,6 +41,7 @@ const MixnodeSignatureForm = ({
           pledge: amount.amount,
           mixnode: mixnodeToTauri(mixnode),
           costParams: costParamsToTauri(amount),
+          tokenPool: amount.tokenPool as 'balance' | 'locked',
         })) as string,
       );
     } catch (e) {

--- a/nym-wallet/src/context/mocks/bonding.tsx
+++ b/nym-wallet/src/context/mocks/bonding.tsx
@@ -206,6 +206,7 @@ export const MockBondingContextProvider = ({
       checkOwnership,
       generateMixnodeMsgPayload,
       generateGatewayMsgPayload,
+      isVestingAccount: false,
     }),
     [isLoading, error, bondedMixnode, bondedGateway, trigger, fee],
   );

--- a/nym-wallet/src/hooks/useCheckOwnership.ts
+++ b/nym-wallet/src/hooks/useCheckOwnership.ts
@@ -18,7 +18,7 @@ export const useCheckOwnership = () => {
   const [error, setError] = useState<string>();
 
   const checkOwnership = useCallback(async () => {
-    const status = {} as TNodeOwnership;
+    const status = initial as TNodeOwnership;
 
     try {
       const [ownsMixnode, ownsGateway] = await Promise.all([checkMixnodeOwnership(), checkGatewayOwnership()]);

--- a/nym-wallet/src/requests/actions.ts
+++ b/nym-wallet/src/requests/actions.ts
@@ -20,7 +20,7 @@ import { invokeWrapper } from './wrapper';
 export const bondGateway = async (args: TBondGatewayArgs) =>
   invokeWrapper<TransactionExecuteResult>('bond_gateway', args);
 
-export const generateGatewayMsgPayload = async (args: TBondGatewaySignatureArgs) =>
+export const generateGatewayMsgPayload = async (args: Omit<TBondGatewaySignatureArgs, 'tokenPool'>) =>
   invokeWrapper<string>('generate_gateway_bonding_msg_payload', args);
 
 export const unbondGateway = async (fee?: Fee) => invokeWrapper<TransactionExecuteResult>('unbond_gateway', { fee });
@@ -28,7 +28,7 @@ export const unbondGateway = async (fee?: Fee) => invokeWrapper<TransactionExecu
 export const bondMixNode = async (args: TBondMixNodeArgs) =>
   invokeWrapper<TransactionExecuteResult>('bond_mixnode', args);
 
-export const generateMixnodeMsgPayload = async (args: TBondMixnodeSignatureArgs) =>
+export const generateMixnodeMsgPayload = async (args: Omit<TBondMixnodeSignatureArgs, 'tokenPool'>) =>
   invokeWrapper<string>('generate_mixnode_bonding_msg_payload', args);
 
 export const unbondMixNode = async (fee?: Fee) => invokeWrapper<TransactionExecuteResult>('unbond_mixnode', { fee });

--- a/nym-wallet/src/requests/vesting.ts
+++ b/nym-wallet/src/requests/vesting.ts
@@ -48,7 +48,7 @@ export const vestingBondGateway = async ({
   msgSignature: string;
 }) => invokeWrapper<TransactionExecuteResult>('vesting_bond_gateway', { gateway, msgSignature, pledge });
 
-export const vestingGenerateGatewayMsgPayload = async (args: TBondGatewaySignatureArgs) =>
+export const vestingGenerateGatewayMsgPayload = async (args: Omit<TBondGatewaySignatureArgs, 'tokenPool'>) =>
   invokeWrapper<string>('vesting_generate_gateway_bonding_msg_payload', args);
 
 export const vestingUnbondGateway = async (fee?: Fee) =>
@@ -66,7 +66,7 @@ export const vestingBondMixNode = async ({
   msgSignature: string;
 }) => invokeWrapper<TransactionExecuteResult>('vesting_bond_mixnode', { mixnode, costParams, msgSignature, pledge });
 
-export const vestingGenerateMixnodeMsgPayload = async (args: TBondMixnodeSignatureArgs) =>
+export const vestingGenerateMixnodeMsgPayload = async (args: Omit<TBondMixnodeSignatureArgs, 'tokenPool'>) =>
   invokeWrapper<string>('vesting_generate_mixnode_bonding_msg_payload', args);
 
 export const vestingUnbondMixnode = async (fee?: Fee) =>

--- a/nym-wallet/src/types/global.ts
+++ b/nym-wallet/src/types/global.ts
@@ -45,11 +45,13 @@ export type TBondMixnodeSignatureArgs = {
   mixnode: MixNode;
   costParams: MixNodeCostParams;
   pledge: DecCoin;
+  tokenPool: 'balance' | 'locked';
 };
 
 export type TBondGatewaySignatureArgs = {
   gateway: Gateway;
   pledge: DecCoin;
+  tokenPool: 'balance' | 'locked';
 };
 
 export type TBondMoreArgs = {


### PR DESCRIPTION
# Description

This PR fixes the bonding signature flow when the user bond using its _vested_ tokens.
Also introduce a proper `isVestingAccount` check inside the bonding context.

Closes: #3315