### PR TITLE
Convert stake saturation string to number type

### DIFF
--- a/explorer/src/components/MixNodes/index.tsx
+++ b/explorer/src/components/MixNodes/index.tsx
@@ -49,7 +49,7 @@ export function mixNodeResponseItemToMixnodeRowType(item: MixNodeResponseItem): 
     layer: item?.layer || '',
     profit_percentage: `${profitPercentage}%`,
     avg_uptime: `${toPercentIntegerString(item.node_performance.last_24h)}%`,
-    stake_saturation: uncappedSaturation.toFixed(2),
+    stake_saturation: Number(uncappedSaturation.toFixed(2)),
     operating_cost: `${unymToNym(item.operating_cost?.amount, 6)} NYM`,
     node_performance: `${toPercentIntegerString(item.node_performance.most_recent)}%`,
     blacklisted: item.blacklisted,


### PR DESCRIPTION
# Description

Fixes sorting stake saturation on mixnodes table in explorer.

Closes: #3320 

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
