### PR TITLE
refactor(wallet-bonding): fetch node data concurrently

### DIFF
--- a/nym-wallet/src/context/bonding.tsx
+++ b/nym-wallet/src/context/bonding.tsx
@@ -186,18 +186,6 @@ export const BondingContextProvider: FCWithChildren = ({ children }): JSX.Elemen
     setBondedNode(undefined);
   };
 
-  // try {
-  //   const stakeSaturationResponse = await getMixnodeStakeSaturation(mixId);
-  //   additionalDetails.stakeSaturation = decimalToPercentage(stakeSaturationResponse.saturation);
-  //
-  //   const rawUncappedSaturation = decimalToFloatApproximation(stakeSaturationResponse.uncapped_saturation);
-  //   if (rawUncappedSaturation && rawUncappedSaturation > 1) {
-  //     additionalDetails.uncappedSaturation = Math.round(rawUncappedSaturation * 100);
-  //   }
-  // } catch (e) {
-  //   Console.log('getMixnodeStakeSaturation fails', e);
-  // }
-
   /**
    * Fetch mixnode **optional** data.
    * ⚠ The underlying queries are allowed to fail.
@@ -261,6 +249,10 @@ export const BondingContextProvider: FCWithChildren = ({ children }): JSX.Elemen
     const saturationRes = promises[2];
     if (saturationRes.status === 'fulfilled') {
       details.stakeSaturation = decimalToPercentage(saturationRes.value.saturation);
+      const rawUncappedSaturation = decimalToFloatApproximation(saturationRes.value.uncapped_saturation);
+      if (rawUncappedSaturation && rawUncappedSaturation > 1) {
+        details.uncappedSaturation = Math.round(rawUncappedSaturation * 100);
+      }
     }
 
     const rewardRes = promises[3];


### PR DESCRIPTION
# Description

Refactor the way requests are fired in the _Bonding_ page. Currently, optional backend queries (allowed to fails without blocking the whole page render) are fired sequentially. That means all requests are executed one by one, the next being executed only after the previous one has resolved/rejected (waiting for the server response). Slowing down the page and data loading.
The changes here implement concurrency mode (thx to [Promise.allSettled](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled)), meaning the requests are fired and resolve (or reject) concurrently in “parallel” without blocking between each others.

This improves overall load time of the _Bonding_ page ⚡

