### PR TITLE
socks5: abort sending data if the connection is closed

### DIFF
--- a/common/socks5/proxy-helpers/src/proxy_runner/inbound.rs
+++ b/common/socks5/proxy-helpers/src/proxy_runner/inbound.rs
@@ -53,7 +53,6 @@ async fn send_empty_keepalive<F, S>(
         .expect("BatchRealMessageReceiver has stopped receiving!");
 }
 
-//#[allow(clippy::too_many_arguments)]
 async fn deal_with_data<F, S>(
     read_data: Option<io::Result<Bytes>>,
     local_destination_address: &str,


### PR DESCRIPTION
# Description

Closes: #3366 

Make sure to stop sending as soon as the connection is closed. 

- abort if connection is closed while waiting for lane to clear
- prioritize closing connection before reading more data

Co-author: @simonwicky, who investiged this and came up with the solution
