### PR TITLE
Add name-service endpoint to nym-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,6 +3105,7 @@ dependencies = [
  "nym-inclusion-probability",
  "nym-mixnet-contract-common",
  "nym-multisig-contract-common",
+ "nym-name-service-common",
  "nym-node-tester-utils",
  "nym-pemstore",
  "nym-service-provider-directory-common",
@@ -3773,6 +3774,7 @@ name = "nym-name-service-common"
 version = "0.1.0"
 dependencies = [
  "cosmwasm-std",
+ "schemars",
  "serde",
 ]
 

--- a/common/cosmwasm-smart-contracts/name-service/Cargo.toml
+++ b/common/cosmwasm-smart-contracts/name-service/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 cosmwasm-std = { workspace = true }
+schemars = "0.8"
 serde = { workspace = true, default-features = false, features = ["derive"] }
-#nym-sphinx-addressing = { path = "../../nymsphinx/addressing" }

--- a/common/cosmwasm-smart-contracts/name-service/src/response.rs
+++ b/common/cosmwasm-smart-contracts/name-service/src/response.rs
@@ -1,5 +1,6 @@
 use crate::{msg::ExecuteMsg, NameEntry, NameId, RegisteredName};
 use cosmwasm_std::Coin;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Like [`NameEntry`] but since it's a response type the name is an option depending on if
@@ -11,7 +12,7 @@ pub struct NameEntryResponse {
     pub name: Option<RegisteredName>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct NamesListResponse {
     pub names: Vec<NameEntry>,
@@ -24,6 +25,14 @@ impl NamesListResponse {
                 .into_iter()
                 .map(|(name_id, name)| NameEntry::new(name_id, name))
                 .collect(),
+        }
+    }
+}
+
+impl From<&[NameEntry]> for NamesListResponse {
+    fn from(names: &[NameEntry]) -> Self {
+        NamesListResponse {
+            names: names.to_vec(),
         }
     }
 }

--- a/common/cosmwasm-smart-contracts/name-service/src/types.rs
+++ b/common/cosmwasm-smart-contracts/name-service/src/types.rs
@@ -1,12 +1,13 @@
 use std::fmt::{Display, Formatter};
 
 use cosmwasm_std::{Addr, Coin};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// The directory of services are indexed by [`ServiceId`].
 pub type NameId = u32;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, JsonSchema)]
 pub struct RegisteredName {
     /// The name pointing to the nym address
     pub name: NymName,
@@ -23,11 +24,11 @@ pub struct RegisteredName {
 /// String representation of a nym address, which is of the form
 /// client_id.client_enc@gateway_id.
 /// NOTE: entirely unvalidated.
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Address {
     NymAddress(String),
-    // Possibly extension:
+    // Possible extension:
     //Gateway(String)
 }
 
@@ -58,7 +59,7 @@ impl Display for Address {
 }
 
 /// Name stored and pointing a to a nym-address
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct NymName(String);
 
@@ -98,7 +99,7 @@ impl Display for NymName {
 }
 
 /// [`RegisterdName`] together with the assigned [`NameId`].
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct NameEntry {
     pub name_id: NameId,

--- a/nym-api/Cargo.toml
+++ b/nym-api/Cargo.toml
@@ -83,6 +83,7 @@ nym-vesting-contract-common = { path = "../common/cosmwasm-smart-contracts/vesti
 nym-contracts-common = { path = "../common/cosmwasm-smart-contracts/contracts-common" }
 nym-multisig-contract-common = { path = "../common/cosmwasm-smart-contracts/multisig-contract" }
 nym-service-provider-directory-common = { path = "../common/cosmwasm-smart-contracts/service-provider-directory" }
+nym-name-service-common = { path = "../common/cosmwasm-smart-contracts/name-service" }
 nym-coconut = { path = "../common/nymcoconut" }
 nym-sphinx = { path = "../common/nymsphinx" }
 nym-pemstore = { path = "../common/pemstore" }

--- a/nym-api/src/nym_contract_cache/cache/data.rs
+++ b/nym-api/src/nym_contract_cache/cache/data.rs
@@ -6,6 +6,7 @@ use nym_mixnet_contract_common::{
     families::FamilyHead, GatewayBond, IdentityKey, Interval, MixId, MixNodeDetails,
     RewardingParams,
 };
+use nym_name_service_common::NameEntry;
 use nym_service_provider_directory_common::ServiceInfo;
 use std::collections::HashSet;
 
@@ -25,6 +26,7 @@ pub(crate) struct ValidatorCacheData {
     pub(crate) mix_to_family: Cache<Vec<(IdentityKey, FamilyHead)>>,
 
     pub(crate) service_providers: Cache<Vec<ServiceInfo>>,
+    pub(crate) names: Cache<Vec<NameEntry>>,
 }
 
 impl ValidatorCacheData {
@@ -40,6 +42,7 @@ impl ValidatorCacheData {
             current_reward_params: Cache::default(),
             mix_to_family: Cache::default(),
             service_providers: Cache::default(),
+            names: Cache::default(),
         }
     }
 }

--- a/nym-api/src/nym_contract_cache/cache/refresher.rs
+++ b/nym-api/src/nym_contract_cache/cache/refresher.rs
@@ -4,7 +4,7 @@ use crate::support::caching::CacheNotification;
 use anyhow::Result;
 use nym_mixnet_contract_common::{MixId, MixNodeDetails, RewardedSetNodeStatus};
 use nym_task::TaskClient;
-use nym_validator_client::nyxd::traits::SpDirectoryQueryClient;
+use nym_validator_client::nyxd::traits::{NameServiceQueryClient, SpDirectoryQueryClient};
 use std::{collections::HashMap, sync::atomic::Ordering, time::Duration};
 use tokio::sync::watch;
 use tokio::time;
@@ -51,8 +51,9 @@ impl NymContractCacheRefresher {
         let (rewarded_set, active_set) =
             Self::collect_rewarded_and_active_set_details(&mixnodes, &rewarded_set_map);
 
-        // The service providers are optional
+        // The service providers and names are optional
         let services = self.nyxd_client.get_all_services().await.ok();
+        let names = self.nyxd_client.get_all_names().await.ok();
 
         info!(
             "Updating validator cache. There are {} mixnodes and {} gateways",
@@ -70,6 +71,7 @@ impl NymContractCacheRefresher {
                 current_interval,
                 mix_to_family,
                 services,
+                names,
             )
             .await;
 

--- a/nym-api/src/nym_contract_cache/mod.rs
+++ b/nym-api/src/nym_contract_cache/mod.rs
@@ -28,7 +28,8 @@ pub(crate) fn nym_contract_cache_routes(settings: &OpenApiSettings) -> (Vec<Rout
         routes::get_blacklisted_gateways,
         routes::get_interval_reward_params,
         routes::get_current_epoch,
-        routes::get_services
+        routes::get_services,
+        routes::get_names
     ]
 }
 

--- a/nym-api/src/nym_contract_cache/routes.rs
+++ b/nym-api/src/nym_contract_cache/routes.rs
@@ -13,6 +13,7 @@ use nym_mixnet_contract_common::{
     mixnode::MixNodeDetails, reward_params::RewardingParams, GatewayBond, Interval, MixId,
 };
 
+use nym_name_service_common::response::NamesListResponse;
 use nym_service_provider_directory_common::response::ServicesListResponse;
 use rocket::{serde::json::Json, State};
 use rocket_okapi::openapi;
@@ -132,4 +133,11 @@ pub async fn get_current_epoch(cache: &State<NymContractCache>) -> Json<Option<I
 pub async fn get_services(cache: &State<NymContractCache>) -> Json<ServicesListResponse> {
     let services = cache.services().await.value;
     Json(services.as_slice().into())
+}
+
+#[openapi(tag = "contract-cache")]
+#[get("/names")]
+pub async fn get_names(cache: &State<NymContractCache>) -> Json<NamesListResponse> {
+    let names = cache.names().await.value;
+    Json(names.as_slice().into())
 }

--- a/nym-api/src/support/nyxd/mod.rs
+++ b/nym-api/src/support/nyxd/mod.rs
@@ -25,6 +25,7 @@ use nym_mixnet_contract_common::{
     CurrentIntervalResponse, EpochStatus, ExecuteMsg, GatewayBond, IdentityKey, LayerAssignment,
     MixId, RewardedSetNodeStatus,
 };
+use nym_name_service_common::msg::QueryMsg as NameServiceQueryMsg;
 use nym_service_provider_directory_common::msg::QueryMsg as SpQueryMsg;
 use nym_validator_client::nyxd::error::NyxdError;
 use nym_validator_client::nyxd::traits::{
@@ -34,7 +35,7 @@ use nym_validator_client::nyxd::{
     cosmwasm_client::types::ExecuteResult,
     traits::{
         CoconutBandwidthQueryClient, DkgQueryClient, DkgSigningClient, GroupQueryClient,
-        MultisigQueryClient, MultisigSigningClient,
+        MultisigQueryClient, MultisigSigningClient, NameServiceQueryClient,
     },
     Fee,
 };
@@ -515,6 +516,24 @@ impl SpDirectoryQueryClient for Client {
             .await
             .nyxd
             .query_service_provider_contract(query)
+            .await
+    }
+}
+
+#[async_trait]
+impl NameServiceQueryClient for Client {
+    async fn query_name_service_contract<T>(
+        &self,
+        query: NameServiceQueryMsg,
+    ) -> std::result::Result<T, NyxdError>
+    where
+        for<'a> T: Deserialize<'a>,
+    {
+        self.0
+            .read()
+            .await
+            .nyxd
+            .query_name_service_contract(query)
             .await
     }
 }

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -2981,6 +2981,7 @@ name = "nym-name-service-common"
 version = "0.1.0"
 dependencies = [
  "cosmwasm-std",
+ "schemars",
  "serde",
 ]
 


### PR DESCRIPTION
# Description

Closes: #3403 

Add name-service endpoint to nym-api. This includes cache the contract as part of the general contract cache.
