### PR TITLE
nym-cli: support name-service contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,6 +3265,7 @@ dependencies = [
  "nym-crypto",
  "nym-mixnet-contract-common",
  "nym-multisig-contract-common",
+ "nym-name-service-common",
  "nym-network-defaults",
  "nym-service-provider-directory-common",
  "nym-validator-client",

--- a/common/client-libs/validator-client/src/nym_api/mod.rs
+++ b/common/client-libs/validator-client/src/nym_api/mod.rs
@@ -15,6 +15,7 @@ use nym_api_requests::models::{
 };
 use nym_mixnet_contract_common::mixnode::MixNodeDetails;
 use nym_mixnet_contract_common::{GatewayBond, IdentityKeyRef, MixId};
+use nym_name_service_common::NameEntry;
 use nym_service_provider_directory_common::ServiceInfo;
 use reqwest::{Response, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -486,6 +487,11 @@ impl Client {
 
     pub async fn get_service_providers(&self) -> Result<Vec<ServiceInfo>, NymAPIError> {
         self.query_nym_api(&[routes::API_VERSION, routes::SERVICE_PROVIDERS], NO_PARAMS)
+            .await
+    }
+
+    pub async fn get_registered_names(&self) -> Result<Vec<NameEntry>, NymAPIError> {
+        self.query_nym_api(&[routes::API_VERSION, routes::REGISTERED_NAMES], NO_PARAMS)
             .await
     }
 }

--- a/common/client-libs/validator-client/src/nym_api/mod.rs
+++ b/common/client-libs/validator-client/src/nym_api/mod.rs
@@ -15,7 +15,9 @@ use nym_api_requests::models::{
 };
 use nym_mixnet_contract_common::mixnode::MixNodeDetails;
 use nym_mixnet_contract_common::{GatewayBond, IdentityKeyRef, MixId};
+use nym_name_service_common::response::NamesListResponse;
 use nym_name_service_common::NameEntry;
+use nym_service_provider_directory_common::response::ServicesListResponse;
 use nym_service_provider_directory_common::ServiceInfo;
 use reqwest::{Response, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -62,6 +64,7 @@ impl Client {
         V: AsRef<str>,
     {
         let url = create_api_url(&self.url, path, params);
+        dbg!(&url);
         Ok(self.reqwest_client.get(url).send().await?)
     }
 
@@ -75,7 +78,9 @@ impl Client {
         K: AsRef<str>,
         V: AsRef<str>,
     {
+        dbg!(&path);
         let res = self.send_get_request(path, params).await?;
+        dbg!(&res);
         if res.status().is_success() {
             Ok(res.json().await?)
         } else if res.status() == StatusCode::NOT_FOUND {
@@ -485,12 +490,15 @@ impl Client {
         .await
     }
 
-    pub async fn get_service_providers(&self) -> Result<Vec<ServiceInfo>, NymAPIError> {
+    pub async fn get_service_providers(&self) -> Result<ServicesListResponse, NymAPIError> {
+        log::trace!("Getting service providers");
         self.query_nym_api(&[routes::API_VERSION, routes::SERVICE_PROVIDERS], NO_PARAMS)
             .await
     }
 
-    pub async fn get_registered_names(&self) -> Result<Vec<NameEntry>, NymAPIError> {
+    //pub async fn get_registered_names(&self) -> Result<Vec<NameEntry>, NymAPIError> {
+    pub async fn get_registered_names(&self) -> Result<NamesListResponse, NymAPIError> {
+        log::trace!("Getting registered names");
         self.query_nym_api(&[routes::API_VERSION, routes::REGISTERED_NAMES], NO_PARAMS)
             .await
     }

--- a/common/client-libs/validator-client/src/nym_api/mod.rs
+++ b/common/client-libs/validator-client/src/nym_api/mod.rs
@@ -16,9 +16,7 @@ use nym_api_requests::models::{
 use nym_mixnet_contract_common::mixnode::MixNodeDetails;
 use nym_mixnet_contract_common::{GatewayBond, IdentityKeyRef, MixId};
 use nym_name_service_common::response::NamesListResponse;
-use nym_name_service_common::NameEntry;
 use nym_service_provider_directory_common::response::ServicesListResponse;
-use nym_service_provider_directory_common::ServiceInfo;
 use reqwest::{Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -64,7 +62,6 @@ impl Client {
         V: AsRef<str>,
     {
         let url = create_api_url(&self.url, path, params);
-        dbg!(&url);
         Ok(self.reqwest_client.get(url).send().await?)
     }
 
@@ -78,9 +75,7 @@ impl Client {
         K: AsRef<str>,
         V: AsRef<str>,
     {
-        dbg!(&path);
         let res = self.send_get_request(path, params).await?;
-        dbg!(&res);
         if res.status().is_success() {
             Ok(res.json().await?)
         } else if res.status() == StatusCode::NOT_FOUND {

--- a/common/client-libs/validator-client/src/nym_api/routes.rs
+++ b/common/client-libs/validator-client/src/nym_api/routes.rs
@@ -34,3 +34,4 @@ pub const STAKE_SATURATION: &str = "stake-saturation";
 pub const INCLUSION_CHANCE: &str = "inclusion-probability";
 
 pub const SERVICE_PROVIDERS: &str = "service-providers";
+pub const REGISTERED_NAMES: &str = "names";

--- a/common/client-libs/validator-client/src/nym_api/routes.rs
+++ b/common/client-libs/validator-client/src/nym_api/routes.rs
@@ -33,5 +33,5 @@ pub const AVG_UPTIME: &str = "avg_uptime";
 pub const STAKE_SATURATION: &str = "stake-saturation";
 pub const INCLUSION_CHANCE: &str = "inclusion-probability";
 
-pub const SERVICE_PROVIDERS: &str = "service-providers";
+pub const SERVICE_PROVIDERS: &str = "services";
 pub const REGISTERED_NAMES: &str = "names";

--- a/common/client-libs/validator-client/src/nyxd/mod.rs
+++ b/common/client-libs/validator-client/src/nyxd/mod.rs
@@ -16,7 +16,7 @@ use cosmrs::rpc::query::Query;
 use cosmrs::rpc::Error as TendermintRpcError;
 use cosmrs::rpc::HttpClientUrl;
 use cosmrs::tx::Msg;
-use log::debug;
+use log::{debug, trace};
 use nym_network_defaults::{ChainDetails, NymNetworkDetails};
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
@@ -79,8 +79,8 @@ impl Config {
         expected_prefix: &str,
     ) -> Result<Option<AccountId>, NyxdError> {
         if let Some(address) = raw {
-            debug!("Raw address:{:?}", raw);
-            debug!("Expected prefix:{:?}", expected_prefix);
+            trace!("Raw address:{:?}", raw);
+            trace!("Expected prefix:{:?}", expected_prefix);
             let parsed: AccountId = address
                 .parse()
                 .map_err(|_| NyxdError::MalformedAccountAddress(address.clone()))?;

--- a/common/commands/Cargo.toml
+++ b/common/commands/Cargo.toml
@@ -39,3 +39,4 @@ nym-coconut-bandwidth-contract-common = { path = "../cosmwasm-smart-contracts/co
 nym-coconut-dkg-common = { path = "../cosmwasm-smart-contracts/coconut-dkg" }
 nym-multisig-contract-common = { path = "../cosmwasm-smart-contracts/multisig-contract" }
 nym-service-provider-directory-common = { path = "../cosmwasm-smart-contracts/service-provider-directory" }
+nym-name-service-common = { path = "../cosmwasm-smart-contracts/name-service" }

--- a/common/commands/src/validator/mixnet/operators/mod.rs
+++ b/common/commands/src/validator/mixnet/operators/mod.rs
@@ -6,6 +6,7 @@ use clap::{Args, Subcommand};
 pub mod gateway;
 pub mod mixnode;
 pub mod service;
+pub mod name;
 
 #[derive(Debug, Args)]
 #[clap(args_conflicts_with_subcommands = true, subcommand_required = true)]
@@ -22,4 +23,6 @@ pub enum MixnetOperatorsCommands {
     Gateway(gateway::MixnetOperatorsGateway),
     /// Manage your service
     ServiceProvider(service::MixnetOperatorsService),
+    /// Manage your registered name
+    Name(name::MixnetOperatorsName),
 }

--- a/common/commands/src/validator/mixnet/operators/mod.rs
+++ b/common/commands/src/validator/mixnet/operators/mod.rs
@@ -5,8 +5,8 @@ use clap::{Args, Subcommand};
 
 pub mod gateway;
 pub mod mixnode;
-pub mod service;
 pub mod name;
+pub mod service;
 
 #[derive(Debug, Args)]
 #[clap(args_conflicts_with_subcommands = true, subcommand_required = true)]

--- a/common/commands/src/validator/mixnet/operators/name/delete.rs
+++ b/common/commands/src/validator/mixnet/operators/name/delete.rs
@@ -1,0 +1,23 @@
+use clap::Parser;
+use log::info;
+use nym_name_service_common::NameId;
+use nym_validator_client::nyxd::traits::NameServiceSigningClient;
+
+use crate::context::SigningClient;
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    #[clap(long)]
+    pub id: NameId,
+}
+
+pub async fn delete(args: Args, client: SigningClient) {
+    info!("Deleting registered name alias with id {}", args.id);
+
+    let res = client
+        .delete_name_by_id(args.id, None)
+        .await
+        .expect("Failed to delete name");
+
+    info!("Deleted: {res:?}");
+}

--- a/common/commands/src/validator/mixnet/operators/name/delete.rs
+++ b/common/commands/src/validator/mixnet/operators/name/delete.rs
@@ -1,7 +1,8 @@
 use clap::Parser;
-use log::info;
+use log::{error, info};
 use nym_name_service_common::NameId;
-use nym_validator_client::nyxd::traits::NameServiceSigningClient;
+use nym_validator_client::nyxd::{error::NyxdError, traits::NameServiceSigningClient};
+use tap::TapFallible;
 
 use crate::context::SigningClient;
 
@@ -11,13 +12,14 @@ pub struct Args {
     pub id: NameId,
 }
 
-pub async fn delete(args: Args, client: SigningClient) {
+pub async fn delete(args: Args, client: SigningClient) -> Result<(), NyxdError> {
     info!("Deleting registered name alias with id {}", args.id);
 
     let res = client
         .delete_name_by_id(args.id, None)
         .await
-        .expect("Failed to delete name");
+        .tap_err(|err| error!("Failed to delete name: {err:#?}"))?;
 
     info!("Deleted: {res:?}");
+    Ok(())
 }

--- a/common/commands/src/validator/mixnet/operators/name/mod.rs
+++ b/common/commands/src/validator/mixnet/operators/name/mod.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand};
 
-pub mod register;
 pub mod delete;
+pub mod register;
 
 #[derive(Debug, Args)]
 #[clap(args_conflicts_with_subcommands = true, subcommand_required = true)]

--- a/common/commands/src/validator/mixnet/operators/name/mod.rs
+++ b/common/commands/src/validator/mixnet/operators/name/mod.rs
@@ -1,0 +1,19 @@
+use clap::{Args, Subcommand};
+
+pub mod register;
+pub mod delete;
+
+#[derive(Debug, Args)]
+#[clap(args_conflicts_with_subcommands = true, subcommand_required = true)]
+pub struct MixnetOperatorsName {
+    #[clap(subcommand)]
+    pub command: MixnetOperatorsNameCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum MixnetOperatorsNameCommands {
+    /// Register a name alias for a nym address
+    Register(register::Args),
+    /// Delete name alias for a nym address
+    Delete(delete::Args),
+}

--- a/common/commands/src/validator/mixnet/operators/name/register.rs
+++ b/common/commands/src/validator/mixnet/operators/name/register.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use log::info;
-use nym_name_service_common::{Coin, NymName, Address};
+use nym_name_service_common::{Address, Coin, NymName};
 use nym_validator_client::nyxd::traits::NameServiceSigningClient;
 
 use crate::context::SigningClient;

--- a/common/commands/src/validator/mixnet/operators/name/register.rs
+++ b/common/commands/src/validator/mixnet/operators/name/register.rs
@@ -1,0 +1,38 @@
+use clap::Parser;
+use log::info;
+use nym_name_service_common::{Coin, NymName, Address};
+use nym_validator_client::nyxd::traits::NameServiceSigningClient;
+
+use crate::context::SigningClient;
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Name alias
+    #[clap(long)]
+    pub name: String,
+
+    /// Nym address that the alias is pointing to
+    #[clap(long)]
+    pub nym_address: String,
+
+    /// Deposit to be made to the service provider directory, in curent DENOMINATION (e.g. 'unym')
+    #[clap(long)]
+    pub deposit: u128,
+}
+
+pub async fn register(args: Args, client: SigningClient) {
+    info!("Registering name alias for nym address");
+
+    let name = NymName::new(&args.name).expect("invalid name");
+    let address = Address::new(&args.nym_address);
+
+    let denom = client.current_chain_details().mix_denom.base.as_str();
+    let deposit = Coin::new(args.deposit, denom);
+
+    let res = client
+        .register_name(name, address, deposit.into(), None)
+        .await
+        .expect("Failed to announce service provider");
+
+    info!("Announced service provider: {res:?}");
+}

--- a/common/commands/src/validator/mixnet/query/mod.rs
+++ b/common/commands/src/validator/mixnet/query/mod.rs
@@ -5,6 +5,7 @@ use clap::{Args, Subcommand};
 
 pub mod query_all_gateways;
 pub mod query_all_mixnodes;
+pub mod query_all_names;
 pub mod query_all_service_providers;
 
 #[derive(Debug, Args)]
@@ -22,4 +23,6 @@ pub enum MixnetQueryCommands {
     Gateways(query_all_gateways::Args),
     /// Query announced service-providers
     ServiceProviders(query_all_service_providers::Args),
+    /// Query registed names
+    Names(query_all_names::Args),
 }

--- a/common/commands/src/validator/mixnet/query/query_all_names.rs
+++ b/common/commands/src/validator/mixnet/query/query_all_names.rs
@@ -1,0 +1,50 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use comfy_table::Table;
+use nym_validator_client::nym_api::error::NymAPIError;
+
+use crate::context::QueryClientWithNyxd;
+use crate::utils::show_error;
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    #[clap(value_parser)]
+    #[clap(help = "Optionally, the registered name to display")]
+    pub name: Option<String>,
+}
+
+pub async fn query(args: Args, client: &QueryClientWithNyxd) {
+    match client.nym_api.get_registered_names().await {
+        Ok(res) => {
+            if let Some(name) = args.name {
+                let name = res.iter().find(|name_entry| {
+                    name_entry.name.name.to_string().eq_ignore_ascii_case(&name)
+                });
+                println!(
+                    "{}",
+                    ::serde_json::to_string_pretty(&name).expect("json formatting error")
+                );
+            } else {
+                let mut table = Table::new();
+
+                table.set_header(vec!["Name Id", "Owner", "Name"]);
+                for name_entry in res {
+                    table.add_row(vec![
+                        name_entry.name_id.to_string(),
+                        name_entry.name.owner.to_string(),
+                        name_entry.name.name.to_string(),
+                    ]);
+                }
+
+                println!("The registered names in the directory are:");
+                println!("{table}");
+            }
+        }
+        Err(NymAPIError::NotFound) => {
+            println!("nym-api reports no name endpoint available");
+        }
+        Err(e) => show_error(e),
+    }
+}

--- a/common/commands/src/validator/mixnet/query/query_all_names.rs
+++ b/common/commands/src/validator/mixnet/query/query_all_names.rs
@@ -31,11 +31,12 @@ pub async fn query(args: Args, client: &QueryClientWithNyxd) {
             } else {
                 let mut table = Table::new();
 
-                table.set_header(vec!["Name Id", "Owner", "Name"]);
+                table.set_header(vec!["Name Id", "Owner", "Nym Address", "Name"]);
                 for name_entry in res.names {
                     table.add_row(vec![
                         name_entry.name_id.to_string(),
                         name_entry.name.owner.to_string(),
+                        name_entry.name.address.to_string(),
                         name_entry.name.name.to_string(),
                     ]);
                 }
@@ -47,9 +48,6 @@ pub async fn query(args: Args, client: &QueryClientWithNyxd) {
         Err(NymAPIError::NotFound) => {
             println!("nym-api reports no name endpoint available");
         }
-        Err(e) => {
-            //log::trace!("Failed to query registered names - {:?}", e);
-            show_error(e)
-        },
+        Err(e) => show_error(e),
     }
 }

--- a/common/commands/src/validator/mixnet/query/query_all_names.rs
+++ b/common/commands/src/validator/mixnet/query/query_all_names.rs
@@ -17,6 +17,7 @@ pub struct Args {
 
 pub async fn query(args: Args, client: &QueryClientWithNyxd) {
     log::trace!("Querying all registered names");
+
     match client.nym_api.get_registered_names().await {
         Ok(res) => {
             if let Some(name) = args.name {

--- a/common/commands/src/validator/mixnet/query/query_all_names.rs
+++ b/common/commands/src/validator/mixnet/query/query_all_names.rs
@@ -16,10 +16,11 @@ pub struct Args {
 }
 
 pub async fn query(args: Args, client: &QueryClientWithNyxd) {
+    log::trace!("Querying all registered names");
     match client.nym_api.get_registered_names().await {
         Ok(res) => {
             if let Some(name) = args.name {
-                let name = res.iter().find(|name_entry| {
+                let name = res.names.iter().find(|name_entry| {
                     name_entry.name.name.to_string().eq_ignore_ascii_case(&name)
                 });
                 println!(
@@ -30,7 +31,7 @@ pub async fn query(args: Args, client: &QueryClientWithNyxd) {
                 let mut table = Table::new();
 
                 table.set_header(vec!["Name Id", "Owner", "Name"]);
-                for name_entry in res {
+                for name_entry in res.names {
                     table.add_row(vec![
                         name_entry.name_id.to_string(),
                         name_entry.name.owner.to_string(),
@@ -45,6 +46,9 @@ pub async fn query(args: Args, client: &QueryClientWithNyxd) {
         Err(NymAPIError::NotFound) => {
             println!("nym-api reports no name endpoint available");
         }
-        Err(e) => show_error(e),
+        Err(e) => {
+            //log::trace!("Failed to query registered names - {:?}", e);
+            show_error(e)
+        },
     }
 }

--- a/common/commands/src/validator/mixnet/query/query_all_service_providers.rs
+++ b/common/commands/src/validator/mixnet/query/query_all_service_providers.rs
@@ -19,7 +19,7 @@ pub async fn query(args: Args, client: &QueryClientWithNyxd) {
     match client.nym_api.get_service_providers().await {
         Ok(res) => {
             if let Some(nym_address) = args.nym_address {
-                let service = res.iter().find(|service| {
+                let service = res.services.iter().find(|service| {
                     service
                         .service
                         .nym_address
@@ -34,7 +34,7 @@ pub async fn query(args: Args, client: &QueryClientWithNyxd) {
                 let mut table = Table::new();
 
                 table.set_header(vec!["Service Id", "Announcer", "Nym Address"]);
-                for service in res {
+                for service in res.services {
                     table.add_row(vec![
                         service.service_id.to_string(),
                         service.service.announcer.to_string(),

--- a/common/commands/src/validator/mixnet/query/query_all_service_providers.rs
+++ b/common/commands/src/validator/mixnet/query/query_all_service_providers.rs
@@ -33,7 +33,7 @@ pub async fn query(args: Args, client: &QueryClientWithNyxd) {
             } else {
                 let mut table = Table::new();
 
-                table.set_header(vec!["Service Id", "Announcer", "Nym Address"]);
+                table.set_header(vec!["Service Id", "Announcer", "Type", "Nym Address"]);
                 for service in res.services {
                     table.add_row(vec![
                         service.service_id.to_string(),

--- a/common/cosmwasm-smart-contracts/name-service/src/lib.rs
+++ b/common/cosmwasm-smart-contracts/name-service/src/lib.rs
@@ -5,3 +5,5 @@ pub mod types;
 
 // Re-export all types at the top-level
 pub use types::*;
+
+pub use cosmwasm_std::{Addr, Coin, Decimal, Fraction};

--- a/nym-api/src/nym_contract_cache/cache/data.rs
+++ b/nym-api/src/nym_contract_cache/cache/data.rs
@@ -26,7 +26,7 @@ pub(crate) struct ValidatorCacheData {
     pub(crate) mix_to_family: Cache<Vec<(IdentityKey, FamilyHead)>>,
 
     pub(crate) service_providers: Cache<Vec<ServiceInfo>>,
-    pub(crate) names: Cache<Vec<NameEntry>>,
+    pub(crate) registered_names: Cache<Vec<NameEntry>>,
 }
 
 impl ValidatorCacheData {
@@ -42,7 +42,7 @@ impl ValidatorCacheData {
             current_reward_params: Cache::default(),
             mix_to_family: Cache::default(),
             service_providers: Cache::default(),
-            names: Cache::default(),
+            registered_names: Cache::default(),
         }
     }
 }

--- a/nym-api/src/nym_contract_cache/cache/mod.rs
+++ b/nym-api/src/nym_contract_cache/cache/mod.rs
@@ -66,7 +66,7 @@ impl NymContractCache {
                 cache.mix_to_family.update(mix_to_family);
                 // Just return empty lists when these are not available
                 cache.service_providers.update(services.unwrap_or_default());
-                cache.names.update(names.unwrap_or_default());
+                cache.registered_names.update(names.unwrap_or_default());
             }
             Err(err) => {
                 error!("{err}");
@@ -305,7 +305,7 @@ impl NymContractCache {
 
     pub(crate) async fn names(&self) -> Cache<Vec<NameEntry>> {
         match time::timeout(Duration::from_millis(100), self.inner.read()).await {
-            Ok(cache) => cache.names.clone(),
+            Ok(cache) => cache.registered_names.clone(),
             Err(err) => {
                 error!("{err}");
                 Cache::new(Vec::new())

--- a/nym-api/src/nym_contract_cache/mod.rs
+++ b/nym-api/src/nym_contract_cache/mod.rs
@@ -29,7 +29,7 @@ pub(crate) fn nym_contract_cache_routes(settings: &OpenApiSettings) -> (Vec<Rout
         routes::get_interval_reward_params,
         routes::get_current_epoch,
         routes::get_services,
-        routes::get_names
+        routes::get_registered_names
     ]
 }
 

--- a/nym-api/src/nym_contract_cache/routes.rs
+++ b/nym-api/src/nym_contract_cache/routes.rs
@@ -137,7 +137,7 @@ pub async fn get_services(cache: &State<NymContractCache>) -> Json<ServicesListR
 
 #[openapi(tag = "contract-cache")]
 #[get("/names")]
-pub async fn get_names(cache: &State<NymContractCache>) -> Json<NamesListResponse> {
+pub async fn get_registered_names(cache: &State<NymContractCache>) -> Json<NamesListResponse> {
     let names = cache.names().await.value;
     Json(names.as_slice().into())
 }

--- a/tools/nym-cli/src/validator/mixnet/operators/mod.rs
+++ b/tools/nym-cli/src/validator/mixnet/operators/mod.rs
@@ -6,6 +6,7 @@ use nym_network_defaults::NymNetworkDetails;
 
 pub(crate) mod gateways;
 pub(crate) mod mixnodes;
+pub(crate) mod name;
 pub(crate) mod services;
 
 pub(crate) async fn execute(
@@ -21,6 +22,7 @@ pub(crate) async fn execute(
             mixnode,
         ) => mixnodes::execute(global_args, mixnode, network_details).await?,
         nym_cli_commands::validator::mixnet::operators::MixnetOperatorsCommands::ServiceProvider(service) => services::execute(global_args, service, network_details).await?,
+        nym_cli_commands::validator::mixnet::operators::MixnetOperatorsCommands::Name(name) => name::execute(global_args, name, network_details).await?,
     }
     Ok(())
 }

--- a/tools/nym-cli/src/validator/mixnet/operators/mod.rs
+++ b/tools/nym-cli/src/validator/mixnet/operators/mod.rs
@@ -17,12 +17,11 @@ pub(crate) async fn execute(
     match operators.command {
         nym_cli_commands::validator::mixnet::operators::MixnetOperatorsCommands::Gateway(
             gateway,
-        ) => gateways::execute(global_args, gateway, network_details).await?,
+        ) => gateways::execute(global_args, gateway, network_details).await,
         nym_cli_commands::validator::mixnet::operators::MixnetOperatorsCommands::Mixnode(
             mixnode,
-        ) => mixnodes::execute(global_args, mixnode, network_details).await?,
-        nym_cli_commands::validator::mixnet::operators::MixnetOperatorsCommands::ServiceProvider(service) => services::execute(global_args, service, network_details).await?,
-        nym_cli_commands::validator::mixnet::operators::MixnetOperatorsCommands::Name(name) => name::execute(global_args, name, network_details).await?,
+        ) => mixnodes::execute(global_args, mixnode, network_details).await,
+        nym_cli_commands::validator::mixnet::operators::MixnetOperatorsCommands::ServiceProvider(service) => services::execute(global_args, service, network_details).await,
+        nym_cli_commands::validator::mixnet::operators::MixnetOperatorsCommands::Name(name) => name::execute(global_args, name, network_details).await,
     }
-    Ok(())
 }

--- a/tools/nym-cli/src/validator/mixnet/operators/name/mod.rs
+++ b/tools/nym-cli/src/validator/mixnet/operators/name/mod.rs
@@ -1,0 +1,14 @@
+use nym_cli_commands::context::{create_signing_client, ClientArgs};
+use nym_network_defaults::NymNetworkDetails;
+
+pub(crate) async fn execute(
+    global_args: ClientArgs,
+    name: nym_cli_commands::validator::mixnet::operators::name::MixnetOperatorsName,
+    network_details: &NymNetworkDetails,
+) -> anyhow::Result<()> {
+    match name.command {
+        nym_cli_commands::validator::mixnet::operators::name::MixnetOperatorsNameCommands::Register(register) => nym_cli_commands::validator::mixnet::operators::name::register::register(register, create_signing_client(global_args, network_details)?).await,
+        nym_cli_commands::validator::mixnet::operators::name::MixnetOperatorsNameCommands::Delete(delete) => nym_cli_commands::validator::mixnet::operators::name::delete::delete(delete, create_signing_client(global_args, network_details)?).await,
+    }
+    Ok(())
+}

--- a/tools/nym-cli/src/validator/mixnet/operators/name/mod.rs
+++ b/tools/nym-cli/src/validator/mixnet/operators/name/mod.rs
@@ -6,9 +6,23 @@ pub(crate) async fn execute(
     name: nym_cli_commands::validator::mixnet::operators::name::MixnetOperatorsName,
     network_details: &NymNetworkDetails,
 ) -> anyhow::Result<()> {
-    match name.command {
-        nym_cli_commands::validator::mixnet::operators::name::MixnetOperatorsNameCommands::Register(register) => nym_cli_commands::validator::mixnet::operators::name::register::register(register, create_signing_client(global_args, network_details)?).await,
-        nym_cli_commands::validator::mixnet::operators::name::MixnetOperatorsNameCommands::Delete(delete) => nym_cli_commands::validator::mixnet::operators::name::delete::delete(delete, create_signing_client(global_args, network_details)?).await,
-    }
-    Ok(())
+    let res = match name.command {
+        nym_cli_commands::validator::mixnet::operators::name::MixnetOperatorsNameCommands::Register(register) => {
+            let res = nym_cli_commands::validator::mixnet::operators::name::register::register(register, create_signing_client(global_args, network_details)?).await;
+            match res {
+                Ok(_) => println!("Successfully registered the name"),
+                Err(_) => println!("Failed to register name")
+            };
+            res
+        },
+        nym_cli_commands::validator::mixnet::operators::name::MixnetOperatorsNameCommands::Delete(delete) => {
+            let res = nym_cli_commands::validator::mixnet::operators::name::delete::delete(delete, create_signing_client(global_args, network_details)?).await;
+            match res {
+                Ok(_) => println!("Successfully deleted the name"),
+                Err(_) => println!("Failed to delete name")
+            };
+            res
+        },
+    };
+    Ok(res?)
 }

--- a/tools/nym-cli/src/validator/mixnet/query/mod.rs
+++ b/tools/nym-cli/src/validator/mixnet/query/mod.rs
@@ -30,6 +30,13 @@ pub(crate) async fn execute(
             )
             .await
         }
+        nym_cli_commands::validator::mixnet::query::MixnetQueryCommands::Names(args) => {
+            nym_cli_commands::validator::mixnet::query::query_all_names::query(
+                args,
+                &create_query_client_with_nym_api(network_details)?,
+            )
+            .await
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
# Description

Closes: #3355

Add support to nym-cli for querying, registering, and deleting entries in the name service contract.
