### PR TITLE
mixnode documentation update

### DIFF
--- a/documentation/docs/src/nodes/mix-node-setup.md
+++ b/documentation/docs/src/nodes/mix-node-setup.md
@@ -235,7 +235,6 @@ sudo ufw allow 1789,1790,8000,22/tcp
 # check the status of the firewall
 sudo ufw status
 # restart firewall
-sudo sytstemctl restart ufw
 ```
 
 For more information about your mix node's port configuration, check the [mix node port reference table](./mix-node-setup.md#mixnode-port-reference) below.

--- a/documentation/docs/src/nodes/mix-node-setup.md
+++ b/documentation/docs/src/nodes/mix-node-setup.md
@@ -228,7 +228,7 @@ sudo ufw enable
 sudo ufw status
 ```
 
-Finally open your mix node's p2p port, as well as ports for ssh, http, and https connections, and ports `8000` and `1790` for verloc and measurement pings:
+Finally open your mix node's p2p port, as well as ports for ssh and ports `8000` and `1790` for verloc and measurement pings:
 
 ```
 sudo ufw allow 1789,1790,8000,22/tcp

--- a/documentation/docs/src/nodes/mix-node-setup.md
+++ b/documentation/docs/src/nodes/mix-node-setup.md
@@ -234,7 +234,6 @@ Finally open your mix node's p2p port, as well as ports for ssh and ports `8000`
 sudo ufw allow 1789,1790,8000,22/tcp
 # check the status of the firewall
 sudo ufw status
-# restart firewall
 ```
 
 For more information about your mix node's port configuration, check the [mix node port reference table](./mix-node-setup.md#mixnode-port-reference) below.

--- a/documentation/docs/src/nodes/mix-node-setup.md
+++ b/documentation/docs/src/nodes/mix-node-setup.md
@@ -231,9 +231,11 @@ sudo ufw status
 Finally open your mix node's p2p port, as well as ports for ssh, http, and https connections, and ports `8000` and `1790` for verloc and measurement pings:
 
 ```
-sudo ufw allow 1789,1790,8000,22,80,443/tcp
+sudo ufw allow 1789,1790,8000,22/tcp
 # check the status of the firewall
 sudo ufw status
+# restart firewall
+sudo sytstemctl restart ufw
 ```
 
 For more information about your mix node's port configuration, check the [mix node port reference table](./mix-node-setup.md#mixnode-port-reference) below.


### PR DESCRIPTION
# Description

Closes: #XXXX

Removed http and https ports from ufw rules in mixnode documentation

