### PR TITLE
Tweak fern logging format to be more similar to pretty_env_logger

### DIFF
--- a/nym-connect/desktop/src-tauri/src/logging.rs
+++ b/nym-connect/desktop/src-tauri/src/logging.rs
@@ -37,10 +37,10 @@ pub fn setup_logging(app_handle: tauri::AppHandle) -> Result<(), log::SetLoggerE
     let stdout_config = fern::Dispatch::new()
         .format(move |out, message, record| {
             out.finish(format_args!(
-                "{}[{}][{}] {}",
+                "{} {:5} {}  > {}",
                 formatted_time(),
-                record.target(),
                 colors.color(record.level()),
+                record.target(),
                 message,
             ))
         })

--- a/nym-connect/mobile/src-tauri/src/logging.rs
+++ b/nym-connect/mobile/src-tauri/src/logging.rs
@@ -37,10 +37,10 @@ pub fn setup_logging(app_handle: tauri::AppHandle) -> Result<(), log::SetLoggerE
     let stdout_config = fern::Dispatch::new()
         .format(move |out, message, record| {
             out.finish(format_args!(
-                "{}[{}][{}] {}",
+                "{} {:5} {}  > {}",
                 formatted_time(),
-                record.target(),
                 colors.color(record.level()),
+                record.target(),
                 message,
             ))
         })

--- a/nym-wallet/src-tauri/src/log.rs
+++ b/nym-wallet/src-tauri/src/log.rs
@@ -38,10 +38,10 @@ pub fn setup_logging(app_handle: tauri::AppHandle) -> Result<(), log::SetLoggerE
     let stdout_config = fern::Dispatch::new()
         .format(move |out, message, record| {
             out.finish(format_args!(
-                "{}[{}][{}] {}",
+                "{} {:5} {}  > {}",
                 formatted_time(),
-                record.target(),
                 colors.color(record.level()),
+                record.target(),
                 message,
             ))
         })


### PR DESCRIPTION
# Description

Tweak the fern logging format to be more similar to the format used by `pretty_env_logger` used elsewhere.
