### PR TITLE
[BUG] network requester documentation update

### DIFF
--- a/documentation/docs/src/nodes/network-requester-setup.md
+++ b/documentation/docs/src/nodes/network-requester-setup.md
@@ -190,7 +190,7 @@ sudo ufw status
 Finally open your requester's p2p port, as well as ports for ssh and incoming traffic connections:
 
 ```
-sudo ufw allow 1789,22,9000/tcp
+sudo ufw allow 22,9000/tcp
 # check the status of the firewall
 sudo ufw status
 ```


### PR DESCRIPTION
# Description

Networks requester only have a connection with the gateway, not with mixed nodes (Mixnet) (`1789` port)

# Checklist:

- [X] Removed 1789 port from ufw rules in network requester documentation

![tempsnip](https://github.com/nymtech/nym/assets/89636253/b41c1a55-c4be-40c4-b273-c86d6faa3db1)

![imagen](https://github.com/nymtech/nym/assets/89636253/29a05ca5-f359-45d1-b9b2-97cbf5a18330)

src: https://nymtech.net/docs/nodes/network-requester-setup.html#ports