### PR TITLE
Statically link openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4631,6 +4631,7 @@ dependencies = [
  "nym-service-provider-directory-common",
  "nym-vesting-contract",
  "nym-vesting-contract-common",
+ "openssl",
  "prost 0.10.4",
  "reqwest",
  "serde",

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -29,6 +29,7 @@ log = { workspace = true }
 url = { version = "2.2", features = ["serde"] }
 tokio = { version = "1.24.1", features = ["sync", "time"] }
 futures = "0.3"
+openssl = { version = "0.10", features = ["vendored"] }
 
 nym-coconut-interface = { path = "../../coconut-interface" }
 nym-network-defaults = { path = "../../network-defaults" }

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -78,13 +78,14 @@ required-features = ["nyxd-client"]
 nyxd-client = [
     "async-trait",
     "cosmrs",
+    "cosmwasm-std",
     "cw3",
     "cw4",
-    "prost",
     "flate2",
-    "sha2",
     "itertools",
-    "cosmwasm-std",
+    "openssl",
+    "prost",
+    "sha2",
     "signing"
 ]
 signing = [

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -29,7 +29,7 @@ log = { workspace = true }
 url = { version = "2.2", features = ["serde"] }
 tokio = { version = "1.24.1", features = ["sync", "time"] }
 futures = "0.3"
-openssl = { version = "0.10", features = ["vendored"] }
+openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 nym-coconut-interface = { path = "../../coconut-interface" }
 nym-network-defaults = { path = "../../network-defaults" }


### PR DESCRIPTION
# Description

Statically link openssl across the main workspace.

```
❯ ldd target/x86_64-unknown-linux-gnu/debug/nym-socks5-client
	linux-vdso.so.1 (0x00007ffc9bfe4000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f4f1a36e000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f4f1a28f000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4f17e1f000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f4f1a3ad000)
```

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`

Fixes: #3510 
Fixes: https://github.com/nymtech/nym/issues/1780