### PR TITLE
Allow query network-requestor for open_proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,10 +4214,12 @@ name = "nym-socks5-requests"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "log",
  "nym-service-providers-common",
  "nym-sphinx-addressing",
  "serde",
  "serde_json",
+ "tap",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bip32"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4203,6 +4212,7 @@ dependencies = [
 name = "nym-socks5-requests"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "nym-service-providers-common",
  "nym-sphinx-addressing",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3931,6 +3931,7 @@ dependencies = [
 name = "nym-network-requester"
 version = "1.1.20"
 dependencies = [
+ "anyhow",
  "async-file-watcher",
  "async-trait",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4098,6 +4098,7 @@ dependencies = [
  "log",
  "nym-bin-common",
  "nym-sdk",
+ "nym-socks5-requests",
  "nym-sphinx-anonymous-replies",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4679,6 +4679,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4681,21 +4681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/common/socks5-client-core/src/socks/mixnet_responses.rs
+++ b/common/socks5-client-core/src/socks/mixnet_responses.rs
@@ -85,6 +85,13 @@ impl MixnetResponseListener {
                     .unwrap();
                 Ok(())
             }
+            Socks5ResponseContent::OpenProxy(response) => {
+                //self.controller_sender
+                //    .unbounded_send(response.into())
+                //    .unwrap();
+                log::info!("Open proxy response: {:?}", response);
+                Ok(())
+            }
         }
     }
 

--- a/common/socks5-client-core/src/socks/mixnet_responses.rs
+++ b/common/socks5-client-core/src/socks/mixnet_responses.rs
@@ -85,15 +85,12 @@ impl MixnetResponseListener {
                     .unwrap();
                 Ok(())
             }
-            Socks5ResponseContent::OpenProxy(response) => {
-                //self.controller_sender
-                //    .unbounded_send(response.into())
-                //    .unwrap();
-                log::info!("Open proxy response: {:?}", response);
-                Ok(())
-            }
             Socks5ResponseContent::Query(response) => {
-                log::info!("Query response: {:?}", response);
+                error!("received a query response which we don't know how to handle yet!");
+                error!("got: {:?}", response);
+
+                // I guess we'd need another channel here to forward those to where they need to go
+
                 Ok(())
             }
         }

--- a/common/socks5-client-core/src/socks/mixnet_responses.rs
+++ b/common/socks5-client-core/src/socks/mixnet_responses.rs
@@ -92,6 +92,10 @@ impl MixnetResponseListener {
                 log::info!("Open proxy response: {:?}", response);
                 Ok(())
             }
+            Socks5ResponseContent::Query(response) => {
+                log::info!("Query response: {:?}", response);
+                Ok(())
+            }
         }
     }
 

--- a/common/socks5/requests/Cargo.toml
+++ b/common/socks5/requests/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = { workspace = true }
 
 nym-sphinx-addressing = { path = "../../../common/nymsphinx/addressing" }
 nym-service-providers-common = { path = "../../../service-providers/common" }
+bincode = "1.3.3"

--- a/common/socks5/requests/Cargo.toml
+++ b/common/socks5/requests/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = { workspace = true }
+bincode = "1.3.3"
+log = { workspace = true }
+nym-service-providers-common = { path = "../../../service-providers/common" }
+nym-sphinx-addressing = { path = "../../../common/nymsphinx/addressing" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-
-nym-sphinx-addressing = { path = "../../../common/nymsphinx/addressing" }
-nym-service-providers-common = { path = "../../../service-providers/common" }
-bincode = "1.3.3"
+tap = { workspace = true }
+thiserror = { workspace = true }

--- a/common/socks5/requests/src/lib.rs
+++ b/common/socks5/requests/src/lib.rs
@@ -32,6 +32,11 @@ pub enum Socks5RequestError {
 
     #[error(transparent)]
     ProviderInterfaceError(#[from] ServiceProviderMessagingError),
+
+    #[error("received unsupported request protocol version: {protocol_version:?}")]
+    UnsupportedProtocolVersion {
+        protocol_version: <Socks5Request as interface::ServiceProviderRequest>::ProtocolVersion,
+    },
 }
 
 #[cfg(test)]

--- a/common/socks5/requests/src/lib.rs
+++ b/common/socks5/requests/src/lib.rs
@@ -33,10 +33,17 @@ pub enum Socks5RequestError {
     #[error(transparent)]
     ProviderInterfaceError(#[from] ServiceProviderMessagingError),
 
-    #[error("received unsupported request protocol version: {protocol_version:?}")]
+    #[error("received unsupported request protocol version: {protocol_version}")]
     UnsupportedProtocolVersion {
         protocol_version: <Socks5Request as interface::ServiceProviderRequest>::ProtocolVersion,
     },
+}
+
+fn make_bincode_serializer() -> impl bincode::Options {
+    use bincode::Options;
+    bincode::DefaultOptions::new()
+        .with_big_endian()
+        .with_varint_encoding()
 }
 
 #[cfg(test)]

--- a/common/socks5/requests/src/request.rs
+++ b/common/socks5/requests/src/request.rs
@@ -244,7 +244,6 @@ impl Socks5RequestContent {
     /// an already-established connection we should send up (`new_send`), or
     /// a request to close an established connection (`new_close`).
     pub fn try_from_bytes(b: &[u8]) -> Result<Socks5RequestContent, RequestDeserializationError> {
-        println!("Socks5RequestContent::try_from_bytes");
         // each request needs to at least contain flag and ConnectionId
         if b.is_empty() {
             return Err(RequestDeserializationError::NoData);

--- a/common/socks5/requests/src/request.rs
+++ b/common/socks5/requests/src/request.rs
@@ -166,6 +166,13 @@ impl Socks5Request {
             content: Socks5RequestContent::new_send(conn_id, data, local_closed),
         }
     }
+
+    pub fn new_open_proxy(protocol_version: Socks5ProtocolVersion) -> Socks5Request {
+        Socks5Request {
+            protocol_version,
+            content: Socks5RequestContent::OpenProxy,
+        }
+    }
 }
 
 /// A request from a SOCKS5 client that a Nym Socks5 service provider should
@@ -179,6 +186,9 @@ pub enum Socks5RequestContent {
 
     /// Re-use an existing TCP connection, sending more request data up it.
     Send(SendRequest),
+
+    /// Query if the proxy is open.
+    OpenProxy,
 }
 
 impl Socks5RequestContent {
@@ -317,6 +327,8 @@ impl Socks5RequestContent {
                 .chain(std::iter::once(req.local_closed as u8))
                 .chain(req.data.into_iter())
                 .collect(),
+
+            Socks5RequestContent::OpenProxy => panic!("OpenProxy is not serializable"),
         }
     }
 }

--- a/common/socks5/requests/src/request.rs
+++ b/common/socks5/requests/src/request.rs
@@ -117,6 +117,13 @@ impl Serializable for Socks5Request {
         }
 
         let protocol_version = Socks5ProtocolVersion::from(b[0]);
+        if protocol_version > Self::max_supported_version() {
+            return Err(Socks5RequestError::UnsupportedProtocolVersion { protocol_version });
+        }
+
+        // TODO: handle the case then protocol version if less then the current one. Then we should
+        // make sure to only respond with the same version
+
         Ok(Socks5Request {
             protocol_version,
             content: Socks5RequestContent::try_from_bytes(&b[1..])?,

--- a/common/socks5/requests/src/request.rs
+++ b/common/socks5/requests/src/request.rs
@@ -250,11 +250,6 @@ impl Socks5RequestContent {
             return Err(RequestDeserializationError::NoData);
         }
 
-        //dbg!(&b.len());
-        //if b.len() < 9 {
-        //    return Err(RequestDeserializationError::ConnectionIdTooShort);
-        //}
-        //let conn_id = u64::from_be_bytes([b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8]]);
         match RequestFlag::try_from(b[0])? {
             RequestFlag::Connect => {
                 if b.len() < 9 {

--- a/common/socks5/requests/src/response.rs
+++ b/common/socks5/requests/src/response.rs
@@ -76,7 +76,6 @@ impl Serializable for Socks5Response {
     }
 
     fn try_from_bytes(b: &[u8]) -> Result<Self, Self::Error> {
-        println!("Socks5Response::try_from_bytes - received {:?}", b);
         if b.is_empty() {
             return Err(ResponseDeserializationError::NoData.into());
         }

--- a/common/socks5/requests/src/response.rs
+++ b/common/socks5/requests/src/response.rs
@@ -75,6 +75,7 @@ impl Serializable for Socks5Response {
     }
 
     fn try_from_bytes(b: &[u8]) -> Result<Self, Self::Error> {
+        println!("Socks5Response::try_from_bytes - received {:?}", b);
         if b.is_empty() {
             return Err(ResponseDeserializationError::NoData.into());
         }

--- a/nym-connect/desktop/Cargo.lock
+++ b/nym-connect/desktop/Cargo.lock
@@ -218,6 +218,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bip32"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3662,10 +3671,13 @@ dependencies = [
 name = "nym-socks5-requests"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "log",
  "nym-service-providers-common",
  "nym-sphinx-addressing",
  "serde",
  "serde_json",
+ "tap",
  "thiserror",
 ]
 

--- a/service-providers/common/Cargo.toml
+++ b/service-providers/common/Cargo.toml
@@ -22,6 +22,4 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 nym-sdk = { path = "../../sdk/rust/nym-sdk" }
 nym-socks5-requests = { path = "../../common/socks5/requests" }
-#nym-network-requester = { path = "../network-requester" }
-#nym-bin-common = { path = "../../bin-commokn" }
 

--- a/service-providers/common/Cargo.toml
+++ b/service-providers/common/Cargo.toml
@@ -21,5 +21,6 @@ anyhow = "1.0.68"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 nym-sdk = { path = "../../sdk/rust/nym-sdk" }
+nym-socks5-requests = { path = "../../common/socks5/requests" }
 
 

--- a/service-providers/common/Cargo.toml
+++ b/service-providers/common/Cargo.toml
@@ -22,5 +22,6 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 nym-sdk = { path = "../../sdk/rust/nym-sdk" }
 nym-socks5-requests = { path = "../../common/socks5/requests" }
-
+#nym-network-requester = { path = "../network-requester" }
+#nym-bin-common = { path = "../../bin-commokn" }
 

--- a/service-providers/common/examples/control_requests.rs
+++ b/service-providers/common/examples/control_requests.rs
@@ -96,7 +96,12 @@ async fn main() -> anyhow::Result<()> {
 
     let open_proxy_request = Request::new_provider_data(
         ProviderInterfaceVersion::new_current(),
-        Socks5Request::new_open_proxy(Socks5ProtocolVersion::new_current()),
+        //Socks5Request::new_open_proxy(Socks5ProtocolVersion::new_current()),
+        Socks5Request::new_query(
+            Socks5ProtocolVersion::new_current(),
+            //nym_socks5_requests::QueryRequest::OpenProxy,
+            nym_socks5_requests::QueryRequest::Description,
+        ),
     );
     println!("Sending 'Open Proxy' request...");
     client

--- a/service-providers/common/examples/control_requests.rs
+++ b/service-providers/common/examples/control_requests.rs
@@ -34,12 +34,14 @@ async fn main() -> anyhow::Result<()> {
     // but I needed an easy way of sending to and receiving from the mixnet
     // and that was the most straightforward way of achieving it
     let mut client = MixnetClient::connect_new().await.unwrap();
-    let provider: Recipient = "AN8eLxYWFitCkMn92zim3PrPszxJZDYyFFKP7qnnAAew.8UAxL3LwQBis6WpM3GGXaqKGaVdnLCpGJWumHT6KNdTH@77TSuVU8d1oXKbPzjec2xh4i3Wj5WwUyy9Lr36sm8gZm".parse().unwrap();
+    //let provider: Recipient = "AN8eLxYWFitCkMn92zim3PrPszxJZDYyFFKP7qnnAAew.8UAxL3LwQBis6WpM3GGXaqKGaVdnLCpGJWumHT6KNdTH@77TSuVU8d1oXKbPzjec2xh4i3Wj5WwUyy9Lr36sm8gZm".parse().unwrap();
+    let provider: Recipient = "85xZUGsMi8koFGXnoKQpn3wkcajSghu99uW3P4aQqP3E.D5PdTNtPZnek28BsctU1pYGFzMSTx9z7g9EL9ryjDB5Z@9xJM74FwwHhEKKJHihD21QSZnHM2QBRMoFx9Wst6qNBS".parse().unwrap();
 
     // generic service provider request, so we don't even need to care it's to the socks5 provider
     let request_health = ControlRequest::Health;
     let request_binary_info = ControlRequest::BinaryInfo;
     let request_versions = ControlRequest::SupportedRequestVersions;
+    let request_open_proxy = ControlRequest::OpenProxy;
 
     let full_request_health: Request =
         Request::new_control(ProviderInterfaceVersion::new_current(), request_health);
@@ -47,6 +49,8 @@ async fn main() -> anyhow::Result<()> {
         Request::new_control(ProviderInterfaceVersion::new_current(), request_binary_info);
     let full_request_versions: Request =
         Request::new_control(ProviderInterfaceVersion::new_current(), request_versions);
+    let full_request_versions: Request =
+        Request::new_control(ProviderInterfaceVersion::new_current(), request_open_proxy);
 
     // // TODO: currently we HAVE TO use surbs unfortunately
     println!("Sending 'Health' request...");

--- a/service-providers/common/examples/control_requests.rs
+++ b/service-providers/common/examples/control_requests.rs
@@ -7,6 +7,7 @@ use nym_sdk::mixnet::{IncludedSurbs, MixnetClient, Recipient, ReconstructedMessa
 use nym_service_providers_common::interface::{
     ControlRequest, ControlResponse, ProviderInterfaceVersion, Request, Response, ResponseContent,
 };
+use nym_socks5_requests::Socks5Request;
 
 fn parse_control_response(received: Vec<ReconstructedMessage>) -> ControlResponse {
     assert_eq!(received.len(), 1);
@@ -41,7 +42,7 @@ async fn main() -> anyhow::Result<()> {
     let request_health = ControlRequest::Health;
     let request_binary_info = ControlRequest::BinaryInfo;
     let request_versions = ControlRequest::SupportedRequestVersions;
-    let request_open_proxy = ControlRequest::OpenProxy;
+    //let request_open_proxy = ControlRequest::OpenProxy;
 
     let full_request_health: Request =
         Request::new_control(ProviderInterfaceVersion::new_current(), request_health);
@@ -49,8 +50,12 @@ async fn main() -> anyhow::Result<()> {
         Request::new_control(ProviderInterfaceVersion::new_current(), request_binary_info);
     let full_request_versions: Request =
         Request::new_control(ProviderInterfaceVersion::new_current(), request_versions);
-    let full_request_versions: Request =
-        Request::new_control(ProviderInterfaceVersion::new_current(), request_open_proxy);
+    //let full_request_versions: Request =
+    //Request::new_control(ProviderInterfaceVersion::new_current(), request_open_proxy);
+    let a: Request = Request::new_provider_data(
+        ProviderInterfaceVersion::new_current(),
+        Socks5Request::new_open_proxy(Socks5ProtocolVersion::Legacy),
+    );
 
     // // TODO: currently we HAVE TO use surbs unfortunately
     println!("Sending 'Health' request...");

--- a/service-providers/common/examples/control_requests.rs
+++ b/service-providers/common/examples/control_requests.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-// use nym_client::client::config::{BaseConfig, Config, GatewayEndpointConfig};
+// use nym_client::client::config::{BaseClientConfig, Config, GatewayEndpointConfig};
 // use nym_client::client::{DirectClient, KeyManager, Recipient, ReconstructedMessage, SocketClient};
 use nym_sdk::mixnet::{IncludedSurbs, MixnetClient, Recipient, ReconstructedMessage};
 use nym_service_providers_common::interface::{

--- a/service-providers/common/examples/control_requests.rs
+++ b/service-providers/common/examples/control_requests.rs
@@ -7,17 +7,14 @@ use nym_sdk::mixnet::{IncludedSurbs, MixnetClient, Recipient, ReconstructedMessa
 use nym_service_providers_common::interface::{
     ControlRequest, ControlResponse, ProviderInterfaceVersion, Request, Response, ResponseContent,
 };
-use nym_socks5_requests::{Socks5Request, Socks5Response};
 
 fn parse_control_response(received: Vec<ReconstructedMessage>) -> ControlResponse {
     assert_eq!(received.len(), 1);
-    let response: Response<Socks5Request> = Response::try_from_bytes(&received[0].message).unwrap();
+    let response: Response = Response::try_from_bytes(&received[0].message).unwrap();
     match response.content {
         ResponseContent::Control(control) => control,
-        ResponseContent::ProviderData(data) => {
-            println!("received provider data: {:?}", data);
-            dbg!(&data);
-            panic!();
+        ResponseContent::ProviderData(_) => {
+            panic!("received provider data even though we sent control request!")
         }
     }
 }
@@ -33,20 +30,16 @@ async fn wait_for_control_response(client: &mut MixnetClient) -> ControlResponse
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    nym_bin_common::logging::setup_logging();
-
     // technically we don't need to start the entire client with all the subroutines,
     // but I needed an easy way of sending to and receiving from the mixnet
     // and that was the most straightforward way of achieving it
     let mut client = MixnetClient::connect_new().await.unwrap();
-    //let provider: Recipient = "AN8eLxYWFitCkMn92zim3PrPszxJZDYyFFKP7qnnAAew.8UAxL3LwQBis6WpM3GGXaqKGaVdnLCpGJWumHT6KNdTH@77TSuVU8d1oXKbPzjec2xh4i3Wj5WwUyy9Lr36sm8gZm".parse().unwrap();
-    let provider: Recipient = "85xZUGsMi8koFGXnoKQpn3wkcajSghu99uW3P4aQqP3E.D5PdTNtPZnek28BsctU1pYGFzMSTx9z7g9EL9ryjDB5Z@9xJM74FwwHhEKKJHihD21QSZnHM2QBRMoFx9Wst6qNBS".parse().unwrap();
+    let provider: Recipient = "AN8eLxYWFitCkMn92zim3PrPszxJZDYyFFKP7qnnAAew.8UAxL3LwQBis6WpM3GGXaqKGaVdnLCpGJWumHT6KNdTH@77TSuVU8d1oXKbPzjec2xh4i3Wj5WwUyy9Lr36sm8gZm".parse().unwrap();
 
     // generic service provider request, so we don't even need to care it's to the socks5 provider
     let request_health = ControlRequest::Health;
     let request_binary_info = ControlRequest::BinaryInfo;
     let request_versions = ControlRequest::SupportedRequestVersions;
-    //let request_open_proxy = ControlRequest::OpenProxy;
 
     let full_request_health: Request =
         Request::new_control(ProviderInterfaceVersion::new_current(), request_health);
@@ -88,31 +81,6 @@ async fn main() -> anyhow::Result<()> {
         .await;
     let response = wait_for_control_response(&mut client).await;
     println!("response to 'SupportedRequestVersions' request: {response:#?}");
-
-    //let full_request_versions: Request =
-    //Request::new_control(ProviderInterfaceVersion::new_current(), request_open_proxy);
-
-    use nym_socks5_requests::Socks5ProtocolVersion;
-
-    let open_proxy_request = Request::new_provider_data(
-        ProviderInterfaceVersion::new_current(),
-        //Socks5Request::new_open_proxy(Socks5ProtocolVersion::new_current()),
-        Socks5Request::new_query(
-            Socks5ProtocolVersion::new_current(),
-            //nym_socks5_requests::QueryRequest::OpenProxy,
-            nym_socks5_requests::QueryRequest::Description,
-        ),
-    );
-    println!("Sending 'Open Proxy' request...");
-    client
-        .send_bytes(
-            provider,
-            open_proxy_request.into_bytes(),
-            //IncludedSurbs::none(),
-            IncludedSurbs::new(10), //crashes??
-        )
-        .await;
-    let response = wait_for_control_response(&mut client).await;
 
     Ok(())
 }

--- a/service-providers/common/src/interface/control.rs
+++ b/service-providers/common/src/interface/control.rs
@@ -10,6 +10,7 @@ pub enum ControlRequest {
     Health,
     BinaryInfo,
     SupportedRequestVersions,
+    OpenProxy,
 }
 
 #[repr(u8)]
@@ -22,6 +23,9 @@ enum ControlRequestTag {
 
     /// Value tag representing [`SupportedRequestVersions`] variant of the [`ControlRequest`]
     RequestVersions = 0x02,
+
+    /// Value tag representing [`OpenProxy`] variant of the [`ControlRequest`]
+    OpenProxy = 0x03,
 }
 
 impl TryFrom<u8> for ControlRequestTag {
@@ -32,6 +36,7 @@ impl TryFrom<u8> for ControlRequestTag {
             _ if value == (Self::Health as u8) => Ok(Self::Health),
             _ if value == (Self::BinaryInfo as u8) => Ok(Self::BinaryInfo),
             _ if value == (Self::RequestVersions as u8) => Ok(Self::RequestVersions),
+            _ if value == (Self::OpenProxy as u8) => Ok(Self::OpenProxy),
             received => Err(ServiceProviderMessagingError::InvalidControlRequestTag { received }),
         }
     }
@@ -55,6 +60,7 @@ impl Serializable for ControlRequest {
             ControlRequestTag::Health => Ok(ControlRequest::Health),
             ControlRequestTag::BinaryInfo => Ok(ControlRequest::BinaryInfo),
             ControlRequestTag::RequestVersions => Ok(ControlRequest::SupportedRequestVersions),
+            ControlRequestTag::OpenProxy => Ok(ControlRequest::OpenProxy),
         }
     }
 }
@@ -65,6 +71,7 @@ impl ControlRequest {
             ControlRequest::Health => ControlRequestTag::Health,
             ControlRequest::BinaryInfo => ControlRequestTag::BinaryInfo,
             ControlRequest::SupportedRequestVersions => ControlRequestTag::RequestVersions,
+            ControlRequest::OpenProxy => ControlRequestTag::OpenProxy,
         }
     }
 }
@@ -92,6 +99,7 @@ pub enum ControlResponse {
     BinaryInfo(Box<BinaryInformation>),
     SupportedRequestVersions(SupportedVersions),
     Error(ErrorResponse),
+    OpenProxy(bool),
 }
 
 #[repr(u8)]
@@ -104,6 +112,9 @@ enum ControlResponseTag {
 
     /// Value tag representing [`SupportedRequestVersions`] variant of the [`ControlResponse`]
     SupportedRequestVersions = 0x02,
+
+    /// Value tag representing [`OpenProxy`] variant of the [`ControlResponse`]
+    OpenProxy = 0x03,
 
     /// Value tag representing [`Error`] variant of the [`ControlResponse`]
     Error = 0xFF,
@@ -119,6 +130,7 @@ impl TryFrom<u8> for ControlResponseTag {
             _ if value == (Self::SupportedRequestVersions as u8) => {
                 Ok(Self::SupportedRequestVersions)
             }
+            _ if value == (Self::OpenProxy as u8) => Ok(Self::OpenProxy),
             _ if value == (Self::Error as u8) => Ok(Self::Error),
             received => Err(ServiceProviderMessagingError::InvalidControlResponseTag { received }),
         }
@@ -156,6 +168,12 @@ impl Serializable for ControlResponse {
                     Err(ServiceProviderMessagingError::MalformedErrorControlResponse { source })
                 }
             },
+            ControlResponseTag::OpenProxy => match serde_json::from_slice(&b[1..]) {
+                Ok(open_proxy) => Ok(ControlResponse::OpenProxy(open_proxy)),
+                Err(source) => {
+                    Err(ServiceProviderMessagingError::MalformedErrorControlResponse { source })
+                }
+            },
             ControlResponseTag::Error => match serde_json::from_slice(&b[1..]) {
                 Ok(error_response) => Ok(ControlResponse::Error(error_response)),
                 Err(source) => {
@@ -174,6 +192,7 @@ impl ControlResponse {
             ControlResponse::SupportedRequestVersions(_) => {
                 ControlResponseTag::SupportedRequestVersions
             }
+            ControlResponse::OpenProxy(_) => ControlResponseTag::OpenProxy,
             ControlResponse::Error(_) => ControlResponseTag::Error,
         }
     }
@@ -195,10 +214,11 @@ impl ControlResponse {
                 // (unless the serde's macro is bugged but at this point we're already out of luck)
                 serde_json::to_vec(&info).unwrap()
             }
-            ControlResponse::Error(error_response) => serde_json::to_vec(&error_response).unwrap(),
             ControlResponse::SupportedRequestVersions(supported_versions) => {
                 serde_json::to_vec(&supported_versions).unwrap()
             }
+            ControlResponse::OpenProxy(open) => serde_json::to_vec(&open).unwrap(),
+            ControlResponse::Error(error_response) => serde_json::to_vec(&error_response).unwrap(),
         }
     }
 }

--- a/service-providers/common/src/interface/response.rs
+++ b/service-providers/common/src/interface/response.rs
@@ -79,12 +79,6 @@ where
     }
 
     pub fn try_from_bytes(b: &[u8]) -> Result<Response<T>, <T as ServiceProviderRequest>::Error> {
-        println!(
-            "Response::try_from_bytes - Received response of length {}",
-            b.len()
-        );
-        log::error!("Response::try_from_bytes - Received response of length {}", b.len());
-        dbg!(&b);
         if b.is_empty() {
             log::error!("Response::try_from_bytes - received empty response!");
             return Err(ServiceProviderMessagingError::EmptyResponse.into());
@@ -92,10 +86,8 @@ where
 
         let interface_version = ProviderInterfaceVersion::from(b[0]);
         let content = if interface_version.is_legacy() {
-            log::info!("Response::try_from_bytes - received legacy response");
             ResponseContent::try_from_bytes(b, interface_version)
         } else {
-            log::info!("Response::try_from_bytes - received non-legacy response");
             ResponseContent::try_from_bytes(&b[1..], interface_version)
         }?;
 
@@ -149,7 +141,6 @@ where
             "ResponseContent::try_from_bytes - Received response of length {}",
             b.len()
         );
-        dbg!(&b);
 
         if interface_version.is_legacy() {
             // we received a request from an old client which can only possibly
@@ -166,17 +157,13 @@ where
             }
 
             let request_tag = ResponseTag::try_from(b[0])?;
-            dbg!(&request_tag);
             match request_tag {
                 ResponseTag::Control => Ok(ResponseContent::Control(
                     ControlResponse::try_from_bytes(&b[1..])?,
                 )),
-                ResponseTag::ProviderData => {
-                    println!("ReponseTag::ProviderData");
-                    Ok(ResponseContent::ProviderData(T::Response::try_from_bytes(
-                        &b[1..],
-                    )?))
-                }
+                ResponseTag::ProviderData => Ok(ResponseContent::ProviderData(
+                    T::Response::try_from_bytes(&b[1..])?,
+                )),
             }
         }
     }

--- a/service-providers/common/src/interface/response.rs
+++ b/service-providers/common/src/interface/response.rs
@@ -80,7 +80,6 @@ where
 
     pub fn try_from_bytes(b: &[u8]) -> Result<Response<T>, <T as ServiceProviderRequest>::Error> {
         if b.is_empty() {
-            log::error!("Response::try_from_bytes - received empty response!");
             return Err(ServiceProviderMessagingError::EmptyResponse.into());
         }
 
@@ -137,11 +136,6 @@ where
         b: &[u8],
         interface_version: ProviderInterfaceVersion,
     ) -> Result<ResponseContent<T>, <T as ServiceProviderRequest>::Error> {
-        log::info!(
-            "ResponseContent::try_from_bytes - Received response of length {}",
-            b.len()
-        );
-
         if interface_version.is_legacy() {
             // we received a request from an old client which can only possibly
             // use an old Socks5Message, which uses the entire buffer for deserialization

--- a/service-providers/common/src/lib.rs
+++ b/service-providers/common/src/lib.rs
@@ -85,6 +85,16 @@ where
                 ControlRequest::SupportedRequestVersions => {
                     let versions = self.handle_supported_request_versions_request().await?;
                     Some(ControlResponse::SupportedRequestVersions(versions))
+                }
+                // Version 4 requests:
+                ControlRequest::OpenProxy => {
+                    if interface_version == ProviderInterfaceVersion::Versioned(3) {
+                        log::info!("Received OpenProxy request for interface version 3. Ignoring.");
+                        None
+                    } else {
+                        let is_open = self.handle_open_proxy_control_request().await?;
+                        Some(ControlResponse::OpenProxy(is_open))
+                    }
                 } //
                   // TODO: if we ever add new request for interface version 4 (or higher),
                   // we need to include a check to make sure we return a `None` if passed `interface_version` was 3
@@ -112,6 +122,8 @@ where
             provider_version: T::max_supported_version().to_string(),
         })
     }
+
+    async fn handle_open_proxy_control_request(&self) -> Result<bool, Self::ServiceProviderError>;
 
     async fn handle_provider_data_request(
         &mut self,

--- a/service-providers/common/src/lib.rs
+++ b/service-providers/common/src/lib.rs
@@ -36,6 +36,7 @@ where
         sender: Option<AnonymousSenderTag>,
         request: Request<T>,
     ) -> Result<Option<Response<T>>, Self::ServiceProviderError> {
+        log::info!("handle_request - {:?}", request);
         match request.content {
             RequestContent::Control(control_request) => self
                 .handle_control_request(sender, control_request, request.interface_version)
@@ -54,6 +55,7 @@ where
                 )
                 .await
                 .map(|maybe_res| {
+                    println!("maybe_res: {:?}", maybe_res);
                     maybe_res.map(|provider_data_res| Response {
                         interface_version: request.interface_version,
                         content: ResponseContent::ProviderData(provider_data_res),

--- a/service-providers/common/src/lib.rs
+++ b/service-providers/common/src/lib.rs
@@ -36,7 +36,6 @@ where
         sender: Option<AnonymousSenderTag>,
         request: Request<T>,
     ) -> Result<Option<Response<T>>, Self::ServiceProviderError> {
-        log::info!("handle_request - {:?}", request);
         match request.content {
             RequestContent::Control(control_request) => self
                 .handle_control_request(sender, control_request, request.interface_version)
@@ -55,7 +54,6 @@ where
                 )
                 .await
                 .map(|maybe_res| {
-                    println!("maybe_res: {:?}", maybe_res);
                     maybe_res.map(|provider_data_res| Response {
                         interface_version: request.interface_version,
                         content: ResponseContent::ProviderData(provider_data_res),
@@ -114,8 +112,6 @@ where
             provider_version: T::max_supported_version().to_string(),
         })
     }
-
-    async fn handle_open_proxy_control_request(&self) -> Result<bool, Self::ServiceProviderError>;
 
     async fn handle_provider_data_request(
         &mut self,

--- a/service-providers/common/src/lib.rs
+++ b/service-providers/common/src/lib.rs
@@ -87,16 +87,6 @@ where
                 ControlRequest::SupportedRequestVersions => {
                     let versions = self.handle_supported_request_versions_request().await?;
                     Some(ControlResponse::SupportedRequestVersions(versions))
-                }
-                // Version 4 requests:
-                ControlRequest::OpenProxy => {
-                    if interface_version == ProviderInterfaceVersion::Versioned(3) {
-                        log::info!("Received OpenProxy request for interface version 3. Ignoring.");
-                        None
-                    } else {
-                        let is_open = self.handle_open_proxy_control_request().await?;
-                        Some(ControlResponse::OpenProxy(is_open))
-                    }
                 } //
                   // TODO: if we ever add new request for interface version 4 (or higher),
                   // we need to include a check to make sure we return a `None` if passed `interface_version` was 3

--- a/service-providers/network-requester/Cargo.toml
+++ b/service-providers/network-requester/Cargo.toml
@@ -54,3 +54,4 @@ nym-client-websocket-requests = { path = "../../clients/native/websocket-request
 
 [dev-dependencies]
 tempfile = "3.5.0"
+anyhow = "1.0.68"

--- a/service-providers/network-requester/examples/query.rs
+++ b/service-providers/network-requester/examples/query.rs
@@ -36,7 +36,10 @@ async fn main() -> anyhow::Result<()> {
 
     let open_proxy_request = Request::new_provider_data(
         ProviderInterfaceVersion::new_current(),
-        Socks5Request::new_open_proxy(Socks5ProtocolVersion::new_current()),
+        Socks5Request::new_query(
+            Socks5ProtocolVersion::new_current(),
+            QueryRequest::OpenProxy,
+        ),
     );
     let description_request = Request::new_provider_data(
         ProviderInterfaceVersion::new_current(),

--- a/service-providers/network-requester/examples/query.rs
+++ b/service-providers/network-requester/examples/query.rs
@@ -27,7 +27,7 @@ async fn wait_for_response(client: &mut MixnetClient) -> Socks5Response {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    nym_bin_common::logging::setup_logging();
+    //nym_bin_common::logging::setup_logging();
     let mut client = MixnetClient::connect_new().await.unwrap();
     //let provider: Recipient = "AN8eLxYWFitCkMn92zim3PrPszxJZDYyFFKP7qnnAAew.8UAxL3LwQBis6WpM3GGXaqKGaVdnLCpGJWumHT6KNdTH@77TSuVU8d1oXKbPzjec2xh4i3Wj5WwUyy9Lr36sm8gZm".parse().unwrap();
     let provider: Recipient = "85xZUGsMi8koFGXnoKQpn3wkcajSghu99uW3P4aQqP3E.D5PdTNtPZnek28BsctU1pYGFzMSTx9z7g9EL9ryjDB5Z@9xJM74FwwHhEKKJHihD21QSZnHM2QBRMoFx9Wst6qNBS".parse().unwrap();

--- a/service-providers/network-requester/examples/query.rs
+++ b/service-providers/network-requester/examples/query.rs
@@ -1,0 +1,71 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use nym_sdk::mixnet::{IncludedSurbs, MixnetClient, Recipient, ReconstructedMessage};
+use nym_service_providers_common::interface::{
+    ProviderInterfaceVersion, Request, Response, ResponseContent,
+};
+use nym_socks5_requests::{QueryRequest, Socks5Request, Socks5Response};
+
+fn parse_response(received: Vec<ReconstructedMessage>) -> Socks5Response {
+    assert_eq!(received.len(), 1);
+    let response: Response<Socks5Request> = Response::try_from_bytes(&received[0].message).unwrap();
+    match response.content {
+        ResponseContent::Control(control) => panic!("unexpected control response: {:?}", control),
+        ResponseContent::ProviderData(data) => data,
+    }
+}
+
+async fn wait_for_response(client: &mut MixnetClient) -> Socks5Response {
+    loop {
+        let next = client.wait_for_messages().await.unwrap();
+        if !next.is_empty() {
+            return parse_response(next);
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    nym_bin_common::logging::setup_logging();
+    let mut client = MixnetClient::connect_new().await.unwrap();
+    //let provider: Recipient = "AN8eLxYWFitCkMn92zim3PrPszxJZDYyFFKP7qnnAAew.8UAxL3LwQBis6WpM3GGXaqKGaVdnLCpGJWumHT6KNdTH@77TSuVU8d1oXKbPzjec2xh4i3Wj5WwUyy9Lr36sm8gZm".parse().unwrap();
+    let provider: Recipient = "85xZUGsMi8koFGXnoKQpn3wkcajSghu99uW3P4aQqP3E.D5PdTNtPZnek28BsctU1pYGFzMSTx9z7g9EL9ryjDB5Z@9xJM74FwwHhEKKJHihD21QSZnHM2QBRMoFx9Wst6qNBS".parse().unwrap();
+
+    use nym_socks5_requests::Socks5ProtocolVersion;
+
+    let open_proxy_request = Request::new_provider_data(
+        ProviderInterfaceVersion::new_current(),
+        Socks5Request::new_open_proxy(Socks5ProtocolVersion::new_current()),
+    );
+    let description_request = Request::new_provider_data(
+        ProviderInterfaceVersion::new_current(),
+        Socks5Request::new_query(
+            Socks5ProtocolVersion::new_current(),
+            QueryRequest::Description,
+        ),
+    );
+    println!("Sending 'OpenProxy' query...");
+    client
+        .send_bytes(
+            provider,
+            open_proxy_request.into_bytes(),
+            IncludedSurbs::new(10), //crashes??
+        )
+        .await;
+    let response = wait_for_response(&mut client).await;
+    println!("response to 'OpenProxy' query: {response:#?}");
+
+    println!("Sending 'Description' query...");
+    client
+        .send_bytes(
+            provider,
+            description_request.into_bytes(),
+            IncludedSurbs::none(),
+        )
+        .await;
+    let response = wait_for_response(&mut client).await;
+    println!("response to 'Description' query: {response:#?}");
+
+    Ok(())
+}

--- a/service-providers/network-requester/examples/query.rs
+++ b/service-providers/network-requester/examples/query.rs
@@ -29,8 +29,7 @@ async fn wait_for_response(client: &mut MixnetClient) -> Socks5Response {
 async fn main() -> anyhow::Result<()> {
     //nym_bin_common::logging::setup_logging();
     let mut client = MixnetClient::connect_new().await.unwrap();
-    //let provider: Recipient = "AN8eLxYWFitCkMn92zim3PrPszxJZDYyFFKP7qnnAAew.8UAxL3LwQBis6WpM3GGXaqKGaVdnLCpGJWumHT6KNdTH@77TSuVU8d1oXKbPzjec2xh4i3Wj5WwUyy9Lr36sm8gZm".parse().unwrap();
-    let provider: Recipient = "85xZUGsMi8koFGXnoKQpn3wkcajSghu99uW3P4aQqP3E.D5PdTNtPZnek28BsctU1pYGFzMSTx9z7g9EL9ryjDB5Z@9xJM74FwwHhEKKJHihD21QSZnHM2QBRMoFx9Wst6qNBS".parse().unwrap();
+    let provider: Recipient = "AN8eLxYWFitCkMn92zim3PrPszxJZDYyFFKP7qnnAAew.8UAxL3LwQBis6WpM3GGXaqKGaVdnLCpGJWumHT6KNdTH@77TSuVU8d1oXKbPzjec2xh4i3Wj5WwUyy9Lr36sm8gZm".parse().unwrap();
 
     use nym_socks5_requests::Socks5ProtocolVersion;
 

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -155,7 +155,6 @@ impl ServiceProvider<Socks5Request> for NRServiceProvider {
                 }
                 self.handle_proxy_send(req)
             }
-            Socks5RequestContent::OpenProxy => return self.handle_open_proxy(),
             Socks5RequestContent::Query(query) => return self.handle_query(query),
         }
 
@@ -482,24 +481,12 @@ impl NRServiceProvider {
         self.controller_sender.unbounded_send(req.into()).unwrap()
     }
 
-    fn handle_open_proxy(&self) -> Result<Option<Socks5Response>, NetworkRequesterError> {
-        log::info!("handle_open_proxy");
-        let protocol_version = Socks5ProtocolVersion::default();
-        Ok(Some(Socks5Response::new_open_proxy(
-            protocol_version,
-            self.open_proxy,
-        )))
-    }
-
     fn handle_query(
         &self,
         query: QueryRequest,
     ) -> Result<Option<Socks5Response>, NetworkRequesterError> {
         log::info!("handle_query");
         let protocol_version = Socks5ProtocolVersion::default();
-        //let response = self
-        //    .query(query)
-        //    .map(|data| Socks5Response::new_query_response(protocol_version, data))?;
         let response = match query {
             QueryRequest::OpenProxy => Socks5Response::new_query(
                 protocol_version,

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -80,9 +80,7 @@ impl ServiceProvider<Socks5Request> for NRServiceProvider {
         sender: Option<AnonymousSenderTag>,
         request: Request<Socks5Request>,
     ) -> Result<(), Self::ServiceProviderError> {
-        log::info!("on_request");
         if let Some(response) = self.handle_request(sender, request).await? {
-            dbg!(&response);
             // TODO: this (i.e. `reply::MixnetAddress`) should be incorporated into the actual interface
             if let Some(return_address) = reply::MixnetAddress::new(None, sender) {
                 let msg = MixnetMessage::new_provider_response(return_address, 0, response);
@@ -106,21 +104,16 @@ impl ServiceProvider<Socks5Request> for NRServiceProvider {
         })
     }
 
-    async fn handle_open_proxy_control_request(&self) -> Result<bool, Self::ServiceProviderError> {
-        Ok(self.open_proxy.clone())
-    }
-
     async fn handle_provider_data_request(
         &mut self,
         sender: Option<AnonymousSenderTag>,
         request: Socks5Request,
         interface_version: ProviderInterfaceVersion,
     ) -> Result<Option<Socks5Response>, Self::ServiceProviderError> {
-        log::info!("handle_provider_data_request");
         // TODO: streamline this a bit more
         let request_version = RequestVersion::new(interface_version, request.protocol_version);
 
-        log::info!(
+        log::debug!(
             "received request of version {:?} (interface) / {:?} (socks5)",
             interface_version,
             request.protocol_version

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -66,7 +66,6 @@ struct NRServiceProvider {
 
     controller_sender: ControllerSender,
     mix_input_sender: MixProxySender<MixnetMessage>,
-    //shared_lane_queue_lengths: LaneQueueLengths,
     stats_collector: Option<ServiceStatisticsCollector>,
     shutdown: TaskManager,
 }
@@ -104,6 +103,10 @@ impl ServiceProvider<Socks5Request> for NRServiceProvider {
         })
     }
 
+    async fn handle_open_proxy_control_request(&self) -> Result<bool, Self::ServiceProviderError> {
+        Ok(self.open_proxy.clone())
+    }
+
     async fn handle_provider_data_request(
         &mut self,
         sender: Option<AnonymousSenderTag>,
@@ -113,7 +116,7 @@ impl ServiceProvider<Socks5Request> for NRServiceProvider {
         // TODO: streamline this a bit more
         let request_version = RequestVersion::new(interface_version, request.protocol_version);
 
-        log::debug!(
+        log::info!(
             "received request of version {:?} (interface) / {:?} (socks5)",
             interface_version,
             request.protocol_version
@@ -251,7 +254,6 @@ impl NRServiceProviderBuilder {
             mixnet_client,
             controller_sender,
             mix_input_sender,
-            //shared_lane_queue_lengths: mixnet_client.shared_lane_queue_lengths(),
             stats_collector,
             shutdown,
         };

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -24,8 +24,9 @@ use nym_socks5_proxy_helpers::connection_controller::{
 };
 use nym_socks5_proxy_helpers::proxy_runner::{MixProxyReader, MixProxySender};
 use nym_socks5_requests::{
-    ConnectRequest, ConnectionId, NetworkData, SendRequest, Socks5ProtocolVersion,
-    Socks5ProviderRequest, Socks5Request, Socks5RequestContent, Socks5Response,
+    ConnectRequest, ConnectionId, NetworkData, QueryRequest, QueryResponse, SendRequest,
+    Socks5ProtocolVersion, Socks5ProviderRequest, Socks5Request, Socks5RequestContent,
+    Socks5Response,
 };
 use nym_sphinx::addressing::clients::Recipient;
 use nym_sphinx::anonymous_replies::requests::AnonymousSenderTag;
@@ -155,6 +156,7 @@ impl ServiceProvider<Socks5Request> for NRServiceProvider {
                 self.handle_proxy_send(req)
             }
             Socks5RequestContent::OpenProxy => return self.handle_open_proxy(),
+            Socks5RequestContent::Query(query) => return self.handle_query(query),
         }
 
         Ok(None)
@@ -483,7 +485,32 @@ impl NRServiceProvider {
     fn handle_open_proxy(&self) -> Result<Option<Socks5Response>, NetworkRequesterError> {
         log::info!("handle_open_proxy");
         let protocol_version = Socks5ProtocolVersion::default();
-        Ok(Some(Socks5Response::new_open_proxy(protocol_version, self.open_proxy)))
+        Ok(Some(Socks5Response::new_open_proxy(
+            protocol_version,
+            self.open_proxy,
+        )))
+    }
+
+    fn handle_query(
+        &self,
+        query: QueryRequest,
+    ) -> Result<Option<Socks5Response>, NetworkRequesterError> {
+        log::info!("handle_query");
+        let protocol_version = Socks5ProtocolVersion::default();
+        //let response = self
+        //    .query(query)
+        //    .map(|data| Socks5Response::new_query_response(protocol_version, data))?;
+        let response = match query {
+            QueryRequest::OpenProxy => Socks5Response::new_query(
+                protocol_version,
+                QueryResponse::OpenProxy(self.open_proxy),
+            ),
+            QueryRequest::Description => Socks5Response::new_query(
+                protocol_version,
+                QueryResponse::Description("Description (placeholder)".to_string()),
+            ),
+        };
+        Ok(Some(response))
     }
 }
 

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -151,6 +151,7 @@ impl ServiceProvider<Socks5Request> for NRServiceProvider {
                 }
                 self.handle_proxy_send(req)
             }
+            Socks5RequestContent::OpenProxy => return self.handle_open_proxy(),
         }
 
         Ok(None)
@@ -474,6 +475,11 @@ impl NRServiceProvider {
 
     fn handle_proxy_send(&mut self, req: SendRequest) {
         self.controller_sender.unbounded_send(req.into()).unwrap()
+    }
+
+    fn handle_open_proxy(&self) -> Result<Option<Socks5Response>, NetworkRequesterError> {
+        let protocol_version = Socks5ProtocolVersion::default();
+        Ok(Some(Socks5Response::new_open_proxy(protocol_version, self.open_proxy)))
     }
 }
 

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -79,7 +79,9 @@ impl ServiceProvider<Socks5Request> for NRServiceProvider {
         sender: Option<AnonymousSenderTag>,
         request: Request<Socks5Request>,
     ) -> Result<(), Self::ServiceProviderError> {
+        log::info!("on_request");
         if let Some(response) = self.handle_request(sender, request).await? {
+            dbg!(&response);
             // TODO: this (i.e. `reply::MixnetAddress`) should be incorporated into the actual interface
             if let Some(return_address) = reply::MixnetAddress::new(None, sender) {
                 let msg = MixnetMessage::new_provider_response(return_address, 0, response);
@@ -113,6 +115,7 @@ impl ServiceProvider<Socks5Request> for NRServiceProvider {
         request: Socks5Request,
         interface_version: ProviderInterfaceVersion,
     ) -> Result<Option<Socks5Response>, Self::ServiceProviderError> {
+        log::info!("handle_provider_data_request");
         // TODO: streamline this a bit more
         let request_version = RequestVersion::new(interface_version, request.protocol_version);
 
@@ -478,6 +481,7 @@ impl NRServiceProvider {
     }
 
     fn handle_open_proxy(&self) -> Result<Option<Socks5Response>, NetworkRequesterError> {
+        log::info!("handle_open_proxy");
         let protocol_version = Socks5ProtocolVersion::default();
         Ok(Some(Socks5Response::new_open_proxy(protocol_version, self.open_proxy)))
     }

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -478,7 +478,6 @@ impl NRServiceProvider {
         &self,
         query: QueryRequest,
     ) -> Result<Option<Socks5Response>, NetworkRequesterError> {
-        log::info!("handle_query");
         let protocol_version = Socks5ProtocolVersion::default();
         let response = match query {
             QueryRequest::OpenProxy => Socks5Response::new_query(


### PR DESCRIPTION
# Description

Closes: #3461

Add requests for being able to query a running network-requester across the
mixnet if it is an open proxy.
