### PR TITLE
[bugfix] NC: load old gateway configuration if we're not registering

### DIFF
--- a/nym-connect/desktop/src-tauri/src/config/mod.rs
+++ b/nym-connect/desktop/src-tauri/src/config/mod.rs
@@ -160,7 +160,11 @@ pub async fn init_socks5_config(provider_address: String, chosen_gateway_id: Str
         config.core.base.client.nym_api_urls = nym_config_common::parse_urls(&raw_validators);
     }
 
-    let gateway_setup = GatewaySetup::new_fresh(Some(chosen_gateway_id), None);
+    let gateway_setup = if register_gateway {
+        GatewaySetup::new_fresh(Some(chosen_gateway_id), None)
+    } else {
+        GatewaySetup::MustLoad
+    };
 
     // Setup gateway by either registering a new one, or reusing exiting keys
     let key_store = OnDiskKeys::new(config.storage_paths.common_paths.keys.clone());


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
