### PR TITLE
Don't fully turn off background task when cover traffic is disabled

### DIFF
--- a/common/client-core/src/config/mod.rs
+++ b/common/client-core/src/config/mod.rs
@@ -137,14 +137,46 @@ impl Config {
         self
     }
 
+    pub fn set_no_cover_traffic(&mut self) {
+        self.debug.cover_traffic.disable_loop_cover_traffic_stream = true;
+        self.debug.traffic.disable_main_poisson_packet_distribution = true;
+    }
+
+    pub fn with_disabled_cover_traffic_with_keepalive(mut self, disabled: bool) -> Self {
+        if disabled {
+            self.set_no_cover_traffic_with_keepalive()
+        }
+        self
+    }
+    pub fn set_no_cover_traffic_with_keepalive(&mut self) {
+        self.debug.traffic.disable_main_poisson_packet_distribution = true;
+        self.debug.cover_traffic.loop_cover_traffic_average_delay = Duration::from_secs(5);
+    }
+
     pub fn with_disabled_topology_refresh(mut self, disable_topology_refresh: bool) -> Self {
         self.debug.topology.disable_refreshing = disable_topology_refresh;
         self
     }
 
-    pub fn set_no_cover_traffic(&mut self) {
-        self.debug.cover_traffic.disable_loop_cover_traffic_stream = true;
-        self.debug.traffic.disable_main_poisson_packet_distribution = true;
+    pub fn with_no_per_hop_delays(mut self, no_per_hop_delays: bool) -> Self {
+        if no_per_hop_delays {
+            self.set_no_per_hop_delays()
+        }
+        self
+    }
+
+    pub fn set_no_per_hop_delays(&mut self) {
+        self.debug.traffic.average_packet_delay = Duration::ZERO;
+        self.debug.acknowledgements.average_ack_delay = Duration::ZERO;
+    }
+
+    pub fn with_secondary_packet_size(mut self, secondary_packet_size: Option<PacketSize>) -> Self {
+        self.set_secondary_packet_size(secondary_packet_size);
+        self
+    }
+
+    pub fn set_secondary_packet_size(&mut self, secondary_packet_size: Option<PacketSize>) {
+        self.debug.traffic.secondary_packet_size = secondary_packet_size;
     }
 
     pub fn set_custom_version(&mut self, version: &str) {

--- a/common/client-core/src/config/mod.rs
+++ b/common/client-core/src/config/mod.rs
@@ -143,11 +143,8 @@ impl Config {
     }
 
     pub fn set_no_cover_traffic(&mut self) {
+        self.debug.cover_traffic.disable_loop_cover_traffic_stream = true;
         self.debug.traffic.disable_main_poisson_packet_distribution = true;
-
-        // We don't fully disable the background loop cover traffic, instead limit it to something
-        // very infrequent as a way to make sure we keep the connection alive.
-        self.debug.cover_traffic.loop_cover_traffic_average_delay = Duration::from_secs(5);
     }
 
     pub fn set_custom_version(&mut self, version: &str) {

--- a/common/client-core/src/config/mod.rs
+++ b/common/client-core/src/config/mod.rs
@@ -143,8 +143,11 @@ impl Config {
     }
 
     pub fn set_no_cover_traffic(&mut self) {
-        self.debug.cover_traffic.disable_loop_cover_traffic_stream = true;
         self.debug.traffic.disable_main_poisson_packet_distribution = true;
+
+        // We don't fully disable the background loop cover traffic, instead limit it to something
+        // very infrequent as a way to make sure we keep the connection alive.
+        self.debug.cover_traffic.loop_cover_traffic_average_delay = Duration::from_secs(5);
     }
 
     pub fn set_custom_version(&mut self, version: &str) {

--- a/nym-connect/desktop/src-tauri/src/tasks.rs
+++ b/nym-connect/desktop/src-tauri/src/tasks.rs
@@ -7,7 +7,6 @@ use nym_socks5_client_core::Socks5ControlMessageSender;
 use nym_sphinx::params::PacketSize;
 use nym_task::manager::TaskStatus;
 use std::sync::Arc;
-use std::time::Duration;
 use tap::TapFallible;
 use tokio::sync::RwLock;
 

--- a/nym-connect/desktop/src-tauri/src/tasks.rs
+++ b/nym-connect/desktop/src-tauri/src/tasks.rs
@@ -48,19 +48,17 @@ pub async fn start_nym_socks5_client(
     // process that injects cover traffic into the traffic stream.
     if std::env::var("NYM_CONNECT_DISABLE_COVER").is_ok() {
         log::warn!("Disabling cover traffic");
-        config.core.base.debug.traffic.disable_main_poisson_packet_distribution = true;
-        config.core.base.debug.cover_traffic.loop_cover_traffic_average_delay = Duration::from_secs(5);
+        config.core.base.set_no_cover_traffic_with_keepalive();
     }
 
     if std::env::var("NYM_CONNECT_ENABLE_MIXED_SIZE_PACKETS").is_ok() {
         log::warn!("Enabling mixed size packets");
-        config.core.base.debug.traffic.secondary_packet_size = Some(PacketSize::ExtendedPacket16);
+        config.core.base.set_secondary_packet_size(Some(PacketSize::ExtendedPacket16));
     }
 
     if std::env::var("NYM_CONNECT_DISABLE_PER_HOP_DELAYS").is_ok() {
         log::warn!("Disabling per-hop delay");
-        config.core.base.debug.traffic.average_packet_delay = Duration::ZERO;
-        config.core.base.debug.acknowledgements.average_ack_delay = Duration::ZERO;
+        config.core.base.set_no_per_hop_delays();
     }
 
     log::trace!("Configuration used: {:#?}", config);

--- a/nym-connect/desktop/src-tauri/src/tasks.rs
+++ b/nym-connect/desktop/src-tauri/src/tasks.rs
@@ -48,7 +48,8 @@ pub async fn start_nym_socks5_client(
     // process that injects cover traffic into the traffic stream.
     if std::env::var("NYM_CONNECT_DISABLE_COVER").is_ok() {
         log::warn!("Disabling cover traffic");
-        config.core.base.set_no_cover_traffic();
+        config.core.base.debug.traffic.disable_main_poisson_packet_distribution = true;
+        config.core.base.debug.cover_traffic.loop_cover_traffic_average_delay = Duration::from_secs(5);
     }
 
     if std::env::var("NYM_CONNECT_ENABLE_MIXED_SIZE_PACKETS").is_ok() {

--- a/nym-connect/desktop/src-tauri/src/tasks.rs
+++ b/nym-connect/desktop/src-tauri/src/tasks.rs
@@ -53,7 +53,10 @@ pub async fn start_nym_socks5_client(
 
     if std::env::var("NYM_CONNECT_ENABLE_MIXED_SIZE_PACKETS").is_ok() {
         log::warn!("Enabling mixed size packets");
-        config.core.base.set_secondary_packet_size(Some(PacketSize::ExtendedPacket16));
+        config
+            .core
+            .base
+            .set_secondary_packet_size(Some(PacketSize::ExtendedPacket16));
     }
 
     if std::env::var("NYM_CONNECT_DISABLE_PER_HOP_DELAYS").is_ok() {

--- a/service-providers/network-requester/src/cli/init.rs
+++ b/service-providers/network-requester/src/cli/init.rs
@@ -65,6 +65,7 @@ impl From<Init> for OverrideConfig {
             nym_apis: init_config.nym_apis,
             fastmode: false,
             no_cover: false,
+            medium_toggle: false,
 
             nyxd_urls: init_config.nyxd_urls,
             enabled_credentials_mode: init_config.enabled_credentials_mode,

--- a/service-providers/network-requester/src/cli/mod.rs
+++ b/service-providers/network-requester/src/cli/mod.rs
@@ -78,7 +78,7 @@ pub(crate) struct OverrideConfig {
 
 pub(crate) fn override_config(config: Config, args: OverrideConfig) -> Config {
     let disable_cover_traffic_with_keepalive = args.medium_toggle;
-    let secondary_packet_size = args.medium_toggle.then(|| PacketSize::ExtendedPacket16);
+    let secondary_packet_size = args.medium_toggle.then_some(PacketSize::ExtendedPacket16);
     let no_per_hop_delays = args.medium_toggle;
 
     config

--- a/service-providers/network-requester/src/cli/mod.rs
+++ b/service-providers/network-requester/src/cli/mod.rs
@@ -19,6 +19,7 @@ use nym_client_core::client::base_client::storage::gateway_details::{
 use nym_client_core::client::key_manager::persistence::OnDiskKeys;
 use nym_client_core::config::GatewayEndpointConfig;
 use nym_client_core::error::ClientCoreError;
+use nym_sphinx::params::PacketSize;
 
 mod init;
 mod run;
@@ -70,16 +71,32 @@ pub(crate) struct OverrideConfig {
     nym_apis: Option<Vec<url::Url>>,
     fastmode: bool,
     no_cover: bool,
+    medium_toggle: bool,
     nyxd_urls: Option<Vec<url::Url>>,
     enabled_credentials_mode: Option<bool>,
 }
 
 pub(crate) fn override_config(config: Config, args: OverrideConfig) -> Config {
+    let disable_cover_traffic_with_keepalive = args.medium_toggle;
+    let secondary_packet_size = args.medium_toggle.then(|| PacketSize::ExtendedPacket16);
+    let no_per_hop_delays = args.medium_toggle;
+
     config
         .with_base(
             BaseClientConfig::with_high_default_traffic_volume,
             args.fastmode,
         )
+        .with_base(
+            // NOTE: This interacts with disabling cover traffic fully, so we want to this to be set before
+            BaseClientConfig::with_disabled_cover_traffic_with_keepalive,
+            disable_cover_traffic_with_keepalive,
+        )
+        .with_base(
+            BaseClientConfig::with_secondary_packet_size,
+            secondary_packet_size,
+        )
+        .with_base(BaseClientConfig::with_no_per_hop_delays, no_per_hop_delays)
+        // NOTE: see comment above about the order of the other disble cover traffic config
         .with_base(BaseClientConfig::with_disabled_cover_traffic, args.no_cover)
         .with_optional_base_custom_env(
             BaseClientConfig::with_custom_nym_apis,

--- a/service-providers/network-requester/src/cli/run.rs
+++ b/service-providers/network-requester/src/cli/run.rs
@@ -45,6 +45,11 @@ pub(crate) struct Run {
     /// Disable loop cover traffic and the Poisson rate limiter (for debugging only)
     #[clap(long, hide = true)]
     no_cover: bool,
+
+    /// Enable medium mixnet traffic, for experiments only.
+    /// This includes things like disabling cover traffic, no per hop delays, etc.
+    #[clap(long, hide = true)]
+    medium_toggle: bool,
 }
 
 impl From<Run> for OverrideConfig {
@@ -53,6 +58,7 @@ impl From<Run> for OverrideConfig {
             nym_apis: None,
             fastmode: run_config.fastmode,
             no_cover: run_config.no_cover,
+            medium_toggle: run_config.medium_toggle,
             nyxd_urls: None,
             enabled_credentials_mode: run_config.enabled_credentials_mode,
         }


### PR DESCRIPTION
# Description

To avoid closing the connection to the gateway, make sure the background loop
cover traffic is still enabled but set to something very infrequent even when
"disabled".

Also, add `--medium-toggle` to network-requester run command
