### PR TITLE
[UPDATE] Fix + update network-requester-setup doc

### DIFF
--- a/documentation/docs/src/nodes/network-requester-setup.md
+++ b/documentation/docs/src/nodes/network-requester-setup.md
@@ -201,8 +201,6 @@ sudo ufw allow 22/tcp
 sudo ufw status
 ```
 
-For more information about your requester's port configuration, check the [requester port reference table](./network-requester-setup.md#requester-port-reference) below.
-
 ## Using your network requester
 
 The next thing to do is use your requester, share its address with friends (or whoever you want to help privacy-enhance their app traffic). Is this safe to do? If it was an open proxy, this would be unsafe, because any Nym user could make network requests to any system on the internet.

--- a/documentation/docs/src/nodes/network-requester-setup.md
+++ b/documentation/docs/src/nodes/network-requester-setup.md
@@ -193,10 +193,10 @@ sudo ufw enable
 sudo ufw status
 ```
 
-Finally open your requester's p2p port, as well as ports for ssh and incoming traffic connections:
+Finally open your requester's ssh port to incoming administration connections:
 
 ```
-sudo ufw allow 22,9000/tcp
+sudo ufw allow 22/tcp
 # check the status of the firewall
 sudo ufw status
 ```
@@ -249,7 +249,3 @@ This command should return the following:
 ### Requester port reference
 
 All network-requester-specific port configuration can be found in `$HOME/.nym/service-providers/network-requester/<YOUR_ID>/config/config.toml`. If you do edit any port configs, remember to restart your client and requester processes.
-
-| Default port | Use                       |
-|--------------|---------------------------|
-| 9000         | Listen for Client traffic |


### PR DESCRIPTION
## Description

The NYM Network Requester, as a client component within the NYM network, operates by sending requests to other nodes for the purpose of routing and processing network traffic. In this context, **it is not required** for the Network Requester **to receive incoming requests** from other nodes within the network.

The primary role of the **Network Requester is to initiate outbound connections** to the NYM network (gateway in concrete)

By focusing on outbound connections and relying on the gateway node, the **Network Requester doesn't need incoming connections.**

## How

- [X] **Deleted port** of the command to add **port 9000** as a rule to allow incoming connection in the Firewall
- [X] Deleted all references related to the port in the doc

## Evidence

I'm running a network requester and I don't obtain any output when I type this command

![msg-1217675022-65876](https://github.com/twofaktor/nym/assets/89636253/159782b7-6310-409d-9092-8a8b9b9bab41)