### PR TITLE
Add medium toggle to socks5 client

### DIFF
--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -94,6 +94,7 @@ impl From<Init> for OverrideConfig {
             use_anonymous_replies: init_config.use_reply_surbs,
             fastmode: init_config.fastmode,
             no_cover: init_config.no_cover,
+            medium_toggle: false,
             nyxd_urls: init_config.nyxd_urls,
             enabled_credentials_mode: init_config.enabled_credentials_mode,
             outfox: false,

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -19,7 +19,7 @@ use nym_client_core::client::key_manager::persistence::OnDiskKeys;
 use nym_client_core::config::GatewayEndpointConfig;
 use nym_client_core::error::ClientCoreError;
 use nym_config::OptionalSet;
-use nym_sphinx::params::{PacketType, PacketSize};
+use nym_sphinx::params::{PacketSize, PacketType};
 use std::error::Error;
 
 pub mod init;

--- a/clients/socks5/src/commands/run.rs
+++ b/clients/socks5/src/commands/run.rs
@@ -60,6 +60,11 @@ pub(crate) struct Run {
     #[clap(long, hide = true)]
     no_cover: bool,
 
+    /// Enable medium mixnet traffic, for experiments only.
+    /// This includes things like disabling cover traffic, no per hop delays, etc.
+    #[clap(long, hide = true)]
+    medium_toggle: bool,
+
     /// Set this client to work in a enabled credentials mode that would attempt to use gateway
     /// with bandwidth credential requirement.
     #[clap(long, hide = true)]
@@ -77,6 +82,7 @@ impl From<Run> for OverrideConfig {
             use_anonymous_replies: run_config.use_anonymous_replies,
             fastmode: run_config.fastmode,
             no_cover: run_config.no_cover,
+            medium_toggle: run_config.medium_toggle,
             nyxd_urls: run_config.nyxd_urls,
             enabled_credentials_mode: run_config.enabled_credentials_mode,
             outfox: run_config.outfox,


### PR DESCRIPTION
# Description

Closes: #XXXX

Like `nym-network-requester`, add a `--medium-toggle` to `nym-socks5-client`.
