### PR TITLE
Reset gateway performance on disconnect

### DIFF
--- a/nym-connect/desktop/src/context/main.tsx
+++ b/nym-connect/desktop/src/context/main.tsx
@@ -150,6 +150,11 @@ export const ClientContextProvider: FCWithChildren = ({ children }) => {
     }
   }, []);
 
+  const afterDisconnection = useCallback(async () => {
+    setGatewayPerformance('Good');
+    setConnectedSince(undefined);
+  }, []);
+
   const startDisconnecting = useCallback(async () => {
     try {
       await invoke('start_disconnecting');
@@ -158,11 +163,6 @@ export const ClientContextProvider: FCWithChildren = ({ children }) => {
       console.log(e);
       Sentry.captureException(e);
     }
-  }, []);
-
-  const afterDisconnection = useCallback(async () => {
-    setGatewayPerformance('Good');
-    setConnectedSince(undefined);
   }, []);
 
   const shouldUseUserGateway = !!userDefinedGateway.gateway && userDefinedGateway.isActive;

--- a/nym-connect/desktop/src/context/main.tsx
+++ b/nym-connect/desktop/src/context/main.tsx
@@ -153,10 +153,16 @@ export const ClientContextProvider: FCWithChildren = ({ children }) => {
   const startDisconnecting = useCallback(async () => {
     try {
       await invoke('start_disconnecting');
+      afterDisconnection();
     } catch (e) {
       console.log(e);
       Sentry.captureException(e);
     }
+  }, []);
+
+  const afterDisconnection = useCallback(async () => {
+    setGatewayPerformance('Good');
+    setConnectedSince(undefined);
   }, []);
 
   const shouldUseUserGateway = !!userDefinedGateway.gateway && userDefinedGateway.isActive;

--- a/nym-connect/mobile/src/context/main.tsx
+++ b/nym-connect/mobile/src/context/main.tsx
@@ -116,9 +116,15 @@ export const ClientContextProvider: FCWithChildren = ({ children }) => {
     }
   }, []);
 
+  const afterDisconnection = useCallback(async () => {
+    setGatewayPerformance('Good');
+    setConnectedSince(undefined);
+  }, []);
+
   const startDisconnecting = useCallback(async () => {
     try {
       await invoke('start_disconnecting');
+      afterDisconnection();
     } catch (e) {
       console.log(e);
     }


### PR DESCRIPTION
# Description

Gateway performance state on the frontend should be reset on disconnect. This fixes an issue with gateway performance state not updating correctly on reconnection.

Closes: #3594 

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
