### PR TITLE
fix: typo in Rust SDK docs

### DIFF
--- a/documentation/docs/src/sdk/rust.md
+++ b/documentation/docs/src/sdk/rust.md
@@ -102,4 +102,4 @@ The following code shows how you can use the SDK to create and use a [credential
 {{#include ../../../../sdk/rust/nym-sdk/examples/bandwidth.rs}}
 ```
 
-You can read more about Coconut credentials (also referred to as `zk-Nym`) [here](../cococnut.md).
+You can read more about Coconut credentials (also referred to as `zk-Nym`) [here](../coconut.md).


### PR DESCRIPTION
# Description

Just a small typo fix in the Rust SDK documentation.

# Checklist:

Probably not even worth a changelog entry to `CHANGELOG.md`
