### PR TITLE
build(nc-desktop): sentry dsn as env vars

### DIFF
--- a/.github/workflows/nym-connect-publish-macos.yml
+++ b/.github/workflows/nym-connect-publish-macos.yml
@@ -78,6 +78,8 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          SENTRY_DSN_RUST: ${{ secrets.SENTRY_DSN_RUST }}
+          SENTRY_DSN_JS: ${{ secrets.SENTRY_DSN_JS }}
         run: yarn && yarn build
 
       - name: Upload Artifact

--- a/.github/workflows/nym-connect-publish-ubuntu.yml
+++ b/.github/workflows/nym-connect-publish-ubuntu.yml
@@ -61,6 +61,8 @@ jobs:
         env:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          SENTRY_DSN_RUST: ${{ secrets.SENTRY_DSN_RUST }}
+          SENTRY_DSN_JS: ${{ secrets.SENTRY_DSN_JS }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nym-connect-publish-windows10.yml
+++ b/.github/workflows/nym-connect-publish-windows10.yml
@@ -79,6 +79,8 @@ jobs:
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          SENTRY_DSN_RUST: ${{ secrets.SENTRY_DSN_RUST }}
+          SENTRY_DSN_JS: ${{ secrets.SENTRY_DSN_JS }}
         run: yarn build
 
       - name: Upload Artifact

--- a/nym-connect/desktop/Cargo.lock
+++ b/nym-connect/desktop/Cargo.lock
@@ -3532,6 +3532,7 @@ dependencies = [
  "anyhow",
  "bip39",
  "dirs 4.0.0",
+ "dotenv",
  "eyre",
  "fern",
  "fix-path-env",

--- a/nym-connect/desktop/Cargo.lock
+++ b/nym-connect/desktop/Cargo.lock
@@ -1414,9 +1414,9 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dotenvy"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
@@ -3532,7 +3532,7 @@ dependencies = [
  "anyhow",
  "bip39",
  "dirs 4.0.0",
- "dotenv",
+ "dotenvy",
  "eyre",
  "fern",
  "fix-path-env",

--- a/nym-connect/desktop/src-tauri/Cargo.toml
+++ b/nym-connect/desktop/src-tauri/Cargo.toml
@@ -46,7 +46,7 @@ yaml-rust = "0.4"
 toml = "0.7"
 sentry = { version = "0.31.5", features = [ "anyhow" ] }
 sentry-log = "0.31.5"
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 
 nym-client-core = { path = "../../../common/client-core" }
 nym-api-requests = { path = "../../../nym-api/nym-api-requests" }

--- a/nym-connect/desktop/src-tauri/Cargo.toml
+++ b/nym-connect/desktop/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ yaml-rust = "0.4"
 toml = "0.7"
 sentry = { version = "0.31.5", features = [ "anyhow" ] }
 sentry-log = "0.31.5"
+dotenv = "0.15.0"
 
 nym-client-core = { path = "../../../common/client-core" }
 nym-api-requests = { path = "../../../nym-api/nym-api-requests" }

--- a/nym-connect/desktop/src-tauri/src/build.rs
+++ b/nym-connect/desktop/src-tauri/src/build.rs
@@ -1,7 +1,8 @@
 use std::env;
 
-const SENTRY_DSN_RUST: &str = "SENTRY_DSN_RUST";
-const SENTRY_DSN_JS: &str = "SENTRY_DSN_JS";
+mod constants;
+
+use constants::{SENTRY_DSN_JS, SENTRY_DSN_RUST};
 
 fn main() {
     // set these env vars at compile time

--- a/nym-connect/desktop/src-tauri/src/build.rs
+++ b/nym-connect/desktop/src-tauri/src/build.rs
@@ -1,3 +1,15 @@
+use std::env;
+
+const SENTRY_DSN_RUST: &str = "SENTRY_DSN_RUST";
+const SENTRY_DSN_JS: &str = "SENTRY_DSN_JS";
+
 fn main() {
+    // set these env vars at compile time
+    if let Ok(dsn) = env::var(SENTRY_DSN_RUST) {
+        println!("cargo:rustc-env={}={}", SENTRY_DSN_RUST, dsn);
+    }
+    if let Ok(dsn) = env::var(SENTRY_DSN_JS) {
+        println!("cargo:rustc-env={}={}", SENTRY_DSN_JS, dsn);
+    }
     tauri_build::build();
 }

--- a/nym-connect/desktop/src-tauri/src/constants.rs
+++ b/nym-connect/desktop/src-tauri/src/constants.rs
@@ -1,0 +1,3 @@
+// env var keys
+pub const SENTRY_DSN_RUST: &str = "SENTRY_DSN_RUST";
+pub const SENTRY_DSN_JS: &str = "SENTRY_DSN_JS";

--- a/nym-connect/desktop/src-tauri/src/main.rs
+++ b/nym-connect/desktop/src-tauri/src/main.rs
@@ -3,7 +3,6 @@
     windows_subsystem = "windows"
 )]
 
-use dotenv::dotenv;
 use std::env;
 use std::sync::Arc;
 
@@ -29,7 +28,7 @@ mod tasks;
 mod window;
 
 fn main() {
-    dotenv().ok();
+    dotenvy::dotenv().ok();
     setup_env(None);
     println!("Starting up...");
 

--- a/nym-connect/desktop/src-tauri/src/main.rs
+++ b/nym-connect/desktop/src-tauri/src/main.rs
@@ -16,6 +16,7 @@ use crate::state::State;
 use crate::window::window_toggle;
 
 mod config;
+mod constants;
 mod error;
 mod events;
 mod logging;

--- a/nym-connect/desktop/src-tauri/src/monitoring.rs
+++ b/nym-connect/desktop/src-tauri/src/monitoring.rs
@@ -3,9 +3,7 @@ use std::env;
 use anyhow::{Context, Result};
 use sentry::ClientInitGuard;
 
-// env var keys
-const SENTRY_DSN_RUST: &str = "SENTRY_DSN_RUST";
-const SENTRY_DSN_JS: &str = "SENTRY_DSN_JS";
+use crate::constants::{SENTRY_DSN_JS, SENTRY_DSN_RUST};
 
 pub fn init() -> Result<ClientInitGuard> {
     // if these env vars were set at compile time, use their value

--- a/nym-connect/desktop/src-tauri/src/monitoring.rs
+++ b/nym-connect/desktop/src-tauri/src/monitoring.rs
@@ -1,0 +1,40 @@
+use std::env;
+
+use anyhow::{Context, Result};
+use sentry::ClientInitGuard;
+
+// env var keys
+const SENTRY_DSN_RUST: &str = "SENTRY_DSN_RUST";
+const SENTRY_DSN_JS: &str = "SENTRY_DSN_JS";
+
+pub fn init() -> Result<ClientInitGuard> {
+    // if these env vars were set at compile time, use their value
+    if let Some(v) = option_env!("SENTRY_DSN_RUST") {
+        env::set_var(SENTRY_DSN_RUST, v);
+    }
+    if let Some(v) = option_env!("SENTRY_DSN_JS") {
+        env::set_var(SENTRY_DSN_JS, v);
+    }
+
+    let dsn = env::var(SENTRY_DSN_RUST).context(format!("{} env var not set", SENTRY_DSN_RUST))?;
+    println!("using DSN {dsn}");
+    let guard = sentry::init((
+        dsn,
+        sentry::ClientOptions {
+            release: sentry::release_name!(),
+            sample_rate: 1.0, // TODO lower this in prod
+            traces_sample_rate: 1.0,
+            ..Default::default() // TODO add data scrubbing
+                                 // see https://docs.sentry.io/platforms/rust/data-management/sensitive-data/
+        },
+    ));
+
+    sentry::configure_scope(|scope| {
+        scope.set_user(Some(sentry::User {
+            id: Some("nym".into()),
+            ..Default::default()
+        }));
+    });
+
+    Ok(guard)
+}

--- a/nym-connect/desktop/src/sentry.ts
+++ b/nym-connect/desktop/src/sentry.ts
@@ -1,17 +1,25 @@
 import React from 'react';
 import { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-router-dom';
+import { invoke } from '@tauri-apps/api';
 import * as Sentry from '@sentry/react';
 import { CaptureConsole } from '@sentry/integrations';
 import { getVersion } from '@tauri-apps/api/app';
 
-const SENTRY_DSN = 'https://625e2658da4945a7a253f3ee04413a31@o967446.ingest.sentry.io/4505306292289536';
+const SENTRY_DSN = 'SENTRY_DSN_JS';
 
 async function initSentry() {
   console.log('⚠ performance monitoring and error reporting enabled');
   console.log('initializing sentry');
 
+  const dsn = await invoke<string | undefined>('get_env', { variable: SENTRY_DSN });
+
+  if (!dsn) {
+    console.warn(`unable to initialize sentry, ${SENTRY_DSN} env var not set`);
+    return;
+  }
+
   Sentry.init({
-    dsn: SENTRY_DSN,
+    dsn,
     integrations: [
       new Sentry.BrowserTracing({
         // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled


### PR DESCRIPTION
# Description

Closes: #3694

This PR remove hard-coded Sentry DSN (server URLs). Now they must be provided through env vars `SENTRY_DSN_RUST` and `SENTRY_DSN_JS`:

```dotenv
SENTRY_DSN_RUST=https://...
SENTRY_DSN_JS=https://...
```
Additionally, they can be set at build time (`yarn build`, CI releases etc) and they will be used automatically by the bundled binary.
Both vars have been added to repo secrets (https://github.com/nymtech/nym/settings/secrets/actions) and gh workflows have been updated accordingly.

For development (`yarn dev`) and for convenience, you can provide them in a `.env` file placed in `nym-conenct/desktop/`