### PR TITLE
Feature/simplify cli parsing

### DIFF
--- a/clients/native/src/commands/build_info.rs
+++ b/clients/native/src/commands/build_info.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Args;
+use nym_bin_common::bin_info_owned;
+use nym_bin_common::output_format::OutputFormat;
+
+#[derive(Args)]
+pub(crate) struct BuildInfo {
+    #[clap(short, long, default_value_t = OutputFormat::default())]
+    output: OutputFormat,
+}
+
+pub(crate) fn execute(args: &BuildInfo) {
+    println!("{}", args.output.format(&bin_info_owned!()))
+}

--- a/clients/native/src/commands/build_info.rs
+++ b/clients/native/src/commands/build_info.rs
@@ -11,6 +11,6 @@ pub(crate) struct BuildInfo {
     output: OutputFormat,
 }
 
-pub(crate) fn execute(args: &BuildInfo) {
+pub(crate) fn execute(args: BuildInfo) {
     println!("{}", args.output.format(&bin_info_owned!()))
 }

--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -80,13 +80,13 @@ pub(crate) struct OverrideConfig {
     enabled_credentials_mode: Option<bool>,
 }
 
-pub(crate) async fn execute(args: &Cli) -> Result<(), Box<dyn Error + Send + Sync>> {
+pub(crate) async fn execute(args: Cli) -> Result<(), Box<dyn Error + Send + Sync>> {
     let bin_name = "nym-native-client";
 
-    match &args.command {
-        Commands::Init(m) => init::execute(m).await?,
-        Commands::Run(m) => run::execute(m).await?,
-        Commands::BuildInfo(m) => build_info::execute(&m),
+    match args.command {
+        Commands::Init(m) => init::execute(&m).await?,
+        Commands::Run(m) => run::execute(&m).await?,
+        Commands::BuildInfo(m) => build_info::execute(m),
         Commands::Completions(s) => s.generate(&mut Cli::command(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut Cli::command(), bin_name),
     }

--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -42,6 +42,10 @@ pub(crate) struct Cli {
     #[clap(short, long)]
     pub(crate) config_env_file: Option<std::path::PathBuf>,
 
+    /// Flag used for disabling the printed banner in tty.
+    #[clap(long)]
+    pub(crate) no_banner: bool,
+
     #[clap(subcommand)]
     command: Commands,
 }

--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -10,7 +10,7 @@ use clap::CommandFactory;
 use clap::{Parser, Subcommand};
 use lazy_static::lazy_static;
 use log::{error, info};
-use nym_bin_common::build_information::BinaryBuildInformation;
+use nym_bin_common::bin_info;
 use nym_bin_common::completions::{fig_generate, ArgShell};
 use nym_client_core::client::base_client::storage::gateway_details::{
     OnDiskGatewayDetails, PersistedGatewayDetails,
@@ -22,12 +22,12 @@ use nym_config::OptionalSet;
 use std::error::Error;
 use std::net::IpAddr;
 
+pub(crate) mod build_info;
 pub(crate) mod init;
 pub(crate) mod run;
 
 lazy_static! {
-    pub static ref PRETTY_BUILD_INFORMATION: String =
-        BinaryBuildInformation::new(env!("CARGO_PKG_VERSION")).pretty_print();
+    pub static ref PRETTY_BUILD_INFORMATION: String = bin_info!().pretty_print();
 }
 
 // Helper for passing LONG_VERSION to clap
@@ -58,6 +58,9 @@ pub(crate) enum Commands {
     /// Run the Nym client with provided configuration client optionally overriding set parameters
     Run(run::Run),
 
+    /// Show build information of this binary
+    BuildInfo(build_info::BuildInfo),
+
     /// Generate shell completions
     Completions(ArgShell),
 
@@ -83,6 +86,7 @@ pub(crate) async fn execute(args: &Cli) -> Result<(), Box<dyn Error + Send + Syn
     match &args.command {
         Commands::Init(m) => init::execute(m).await?,
         Commands::Run(m) => run::execute(m).await?,
+        Commands::BuildInfo(m) => build_info::execute(&m),
         Commands::Completions(s) => s.generate(&mut Cli::command(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut Cli::command(), bin_name),
     }

--- a/clients/native/src/main.rs
+++ b/clients/native/src/main.rs
@@ -22,5 +22,5 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     }
     setup_logging();
 
-    commands::execute(&args).await
+    commands::execute(args).await
 }

--- a/clients/native/src/main.rs
+++ b/clients/native/src/main.rs
@@ -14,10 +14,13 @@ pub mod websocket;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
-    setup_logging();
-    maybe_print_banner(crate_name!(), crate_version!());
-
     let args = commands::Cli::parse();
     setup_env(args.config_env_file.as_ref());
+
+    if !args.no_banner {
+        maybe_print_banner(crate_name!(), crate_version!());
+    }
+    setup_logging();
+
     commands::execute(&args).await
 }

--- a/clients/socks5/src/commands/build_info.rs
+++ b/clients/socks5/src/commands/build_info.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Args;
+use nym_bin_common::bin_info_owned;
+use nym_bin_common::output_format::OutputFormat;
+
+#[derive(Args)]
+pub(crate) struct BuildInfo {
+    #[clap(short, long, default_value_t = OutputFormat::default())]
+    output: OutputFormat,
+}
+
+pub(crate) fn execute(args: &BuildInfo) {
+    println!("{}", args.output.format(&bin_info_owned!()))
+}

--- a/clients/socks5/src/commands/build_info.rs
+++ b/clients/socks5/src/commands/build_info.rs
@@ -11,6 +11,6 @@ pub(crate) struct BuildInfo {
     output: OutputFormat,
 }
 
-pub(crate) fn execute(args: &BuildInfo) {
+pub(crate) fn execute(args: BuildInfo) {
     println!("{}", args.output.format(&bin_info_owned!()))
 }

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -81,13 +81,13 @@ pub(crate) struct OverrideConfig {
     outfox: bool,
 }
 
-pub(crate) async fn execute(args: &Cli) -> Result<(), Box<dyn Error + Send + Sync>> {
+pub(crate) async fn execute(args: Cli) -> Result<(), Box<dyn Error + Send + Sync>> {
     let bin_name = "nym-socks5-client";
 
-    match &args.command {
-        Commands::Init(m) => init::execute(m).await?,
-        Commands::Run(m) => run::execute(m).await?,
-        Commands::BuildInfo(m) => build_info::execute(&m),
+    match args.command {
+        Commands::Init(m) => init::execute(&m).await?,
+        Commands::Run(m) => run::execute(&m).await?,
+        Commands::BuildInfo(m) => build_info::execute(m),
         Commands::Completions(s) => s.generate(&mut Cli::command(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut Cli::command(), bin_name),
     }

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -42,6 +42,10 @@ pub(crate) struct Cli {
     #[clap(short, long)]
     pub(crate) config_env_file: Option<std::path::PathBuf>,
 
+    /// Flag used for disabling the printed banner in tty.
+    #[clap(long)]
+    pub(crate) no_banner: bool,
+
     #[clap(subcommand)]
     command: Commands,
 }

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -10,7 +10,7 @@ use clap::CommandFactory;
 use clap::{Parser, Subcommand};
 use lazy_static::lazy_static;
 use log::{error, info};
-use nym_bin_common::build_information::BinaryBuildInformation;
+use nym_bin_common::bin_info;
 use nym_bin_common::completions::{fig_generate, ArgShell};
 use nym_client_core::client::base_client::storage::gateway_details::{
     OnDiskGatewayDetails, PersistedGatewayDetails,
@@ -22,12 +22,12 @@ use nym_config::OptionalSet;
 use nym_sphinx::params::{PacketSize, PacketType};
 use std::error::Error;
 
+pub(crate) mod build_info;
 pub mod init;
 pub(crate) mod run;
 
 lazy_static! {
-    pub static ref PRETTY_BUILD_INFORMATION: String =
-        BinaryBuildInformation::new(env!("CARGO_PKG_VERSION")).pretty_print();
+    pub static ref PRETTY_BUILD_INFORMATION: String = bin_info!().pretty_print();
 }
 
 // Helper for passing LONG_VERSION to clap
@@ -58,6 +58,9 @@ pub(crate) enum Commands {
     /// Run the Nym client with provided configuration client optionally overriding set parameters
     Run(run::Run),
 
+    /// Show build information of this binary
+    BuildInfo(build_info::BuildInfo),
+
     /// Generate shell completions
     Completions(ArgShell),
 
@@ -84,6 +87,7 @@ pub(crate) async fn execute(args: &Cli) -> Result<(), Box<dyn Error + Send + Syn
     match &args.command {
         Commands::Init(m) => init::execute(m).await?,
         Commands::Run(m) => run::execute(m).await?,
+        Commands::BuildInfo(m) => build_info::execute(&m),
         Commands::Completions(s) => s.generate(&mut Cli::command(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut Cli::command(), bin_name),
     }

--- a/clients/socks5/src/main.rs
+++ b/clients/socks5/src/main.rs
@@ -21,5 +21,5 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     }
     setup_logging();
 
-    commands::execute(&args).await
+    commands::execute(args).await
 }

--- a/clients/socks5/src/main.rs
+++ b/clients/socks5/src/main.rs
@@ -13,10 +13,13 @@ pub mod error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
-    setup_logging();
-    maybe_print_banner(crate_name!(), crate_version!());
-
     let args = commands::Cli::parse();
     setup_env(args.config_env_file.as_ref());
+
+    if !args.no_banner {
+        maybe_print_banner(crate_name!(), crate_version!());
+    }
+    setup_logging();
+
     commands::execute(&args).await
 }

--- a/common/bin-common/src/build_information/mod.rs
+++ b/common/bin-common/src/build_information/mod.rs
@@ -5,6 +5,7 @@
 // and be used by our smart contracts
 
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 
 #[derive(Debug)]
 pub struct BinaryBuildInformation {
@@ -70,34 +71,7 @@ impl BinaryBuildInformation {
     }
 
     pub fn pretty_print(&self) -> String {
-        format!(
-            r#"
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-{:<20}{}
-"#,
-            "Build Timestamp:",
-            self.build_timestamp,
-            "Build Version:",
-            self.build_version,
-            "Commit SHA:",
-            self.commit_sha,
-            "Commit Date:",
-            self.commit_timestamp,
-            "Commit Branch:",
-            self.commit_branch,
-            "rustc Version:",
-            self.rustc_version,
-            "rustc Channel:",
-            self.rustc_channel,
-            "cargo Profile:",
-            self.cargo_profile,
-        )
+        self.to_owned().to_string()
     }
 }
 
@@ -134,4 +108,53 @@ pub struct BinaryBuildInformationOwned {
     // VERGEN_CARGO_PROFILE
     /// Provides the cargo profile that was used for the build, for example `debug`.
     pub cargo_profile: String,
+}
+
+impl Display for BinaryBuildInformationOwned {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            r#"
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+{:<20}{}
+"#,
+            "Build Timestamp:",
+            self.build_timestamp,
+            "Build Version:",
+            self.build_version,
+            "Commit SHA:",
+            self.commit_sha,
+            "Commit Date:",
+            self.commit_timestamp,
+            "Commit Branch:",
+            self.commit_branch,
+            "rustc Version:",
+            self.rustc_version,
+            "rustc Channel:",
+            self.rustc_channel,
+            "cargo Profile:",
+            self.cargo_profile,
+        )
+    }
+}
+
+// since this macro will get expanded at the callsite, it will pull in correct binary version
+#[macro_export]
+macro_rules! bin_info {
+    () => {
+        $crate::build_information::BinaryBuildInformation::new(env!("CARGO_PKG_VERSION"))
+    };
+}
+
+#[macro_export]
+macro_rules! bin_info_owned {
+    () => {
+        $crate::build_information::BinaryBuildInformation::new(env!("CARGO_PKG_VERSION")).to_owned()
+    };
 }

--- a/common/bin-common/src/build_information/mod.rs
+++ b/common/bin-common/src/build_information/mod.rs
@@ -9,6 +9,9 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Debug)]
 pub struct BinaryBuildInformation {
+    /// Provides the name of the binary, i.e. the content of `CARGO_PKG_NAME` environmental variable.
+    pub binary_name: &'static str,
+
     // VERGEN_BUILD_TIMESTAMP
     /// Provides the build timestamp, for example `2021-02-23T20:14:46.558472672+00:00`.
     pub build_timestamp: &'static str,
@@ -44,8 +47,9 @@ pub struct BinaryBuildInformation {
 
 impl BinaryBuildInformation {
     // explicitly require the build_version to be passed as it's binary specific
-    pub const fn new(build_version: &'static str) -> Self {
+    pub const fn new(binary_name: &'static str, build_version: &'static str) -> Self {
         BinaryBuildInformation {
+            binary_name,
             build_timestamp: env!("VERGEN_BUILD_TIMESTAMP"),
             build_version,
             commit_sha: env!("VERGEN_GIT_SHA"),
@@ -59,6 +63,7 @@ impl BinaryBuildInformation {
 
     pub fn to_owned(&self) -> BinaryBuildInformationOwned {
         BinaryBuildInformationOwned {
+            binary_name: self.binary_name.to_owned(),
             build_timestamp: self.build_timestamp.to_owned(),
             build_version: self.build_version.to_owned(),
             commit_sha: self.commit_sha.to_owned(),
@@ -77,6 +82,9 @@ impl BinaryBuildInformation {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BinaryBuildInformationOwned {
+    /// Provides the name of the binary, i.e. the content of `CARGO_PKG_NAME` environmental variable.
+    pub binary_name: String,
+
     // VERGEN_BUILD_TIMESTAMP
     /// Provides the build timestamp, for example `2021-02-23T20:14:46.558472672+00:00`.
     pub build_timestamp: String,
@@ -123,7 +131,10 @@ impl Display for BinaryBuildInformationOwned {
 {:<20}{}
 {:<20}{}
 {:<20}{}
+{:<20}{}
 "#,
+            "Binary Name:",
+            self.binary_name,
             "Build Timestamp:",
             self.build_timestamp,
             "Build Version:",
@@ -148,13 +159,20 @@ impl Display for BinaryBuildInformationOwned {
 #[macro_export]
 macro_rules! bin_info {
     () => {
-        $crate::build_information::BinaryBuildInformation::new(env!("CARGO_PKG_VERSION"))
+        $crate::build_information::BinaryBuildInformation::new(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        )
     };
 }
 
 #[macro_export]
 macro_rules! bin_info_owned {
     () => {
-        $crate::build_information::BinaryBuildInformation::new(env!("CARGO_PKG_VERSION")).to_owned()
+        $crate::build_information::BinaryBuildInformation::new(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        )
+        .to_owned()
     };
 }

--- a/gateway/src/commands/build_info.rs
+++ b/gateway/src/commands/build_info.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Args;
+use nym_bin_common::bin_info_owned;
+use nym_bin_common::output_format::OutputFormat;
+
+#[derive(Args)]
+pub(crate) struct BuildInfo {
+    #[clap(short, long, default_value_t = OutputFormat::default())]
+    output: OutputFormat,
+}
+
+pub(crate) fn execute(args: &BuildInfo) {
+    println!("{}", args.output.format(&bin_info_owned!()))
+}

--- a/gateway/src/commands/build_info.rs
+++ b/gateway/src/commands/build_info.rs
@@ -11,6 +11,6 @@ pub(crate) struct BuildInfo {
     output: OutputFormat,
 }
 
-pub(crate) fn execute(args: &BuildInfo) {
+pub(crate) fn execute(args: BuildInfo) {
     println!("{}", args.output.format(&bin_info_owned!()))
 }

--- a/gateway/src/commands/mod.rs
+++ b/gateway/src/commands/mod.rs
@@ -18,6 +18,7 @@ use std::error::Error;
 use std::net::IpAddr;
 use std::path::PathBuf;
 
+pub(crate) mod build_info;
 pub(crate) mod init;
 pub(crate) mod node_details;
 pub(crate) mod run;
@@ -36,6 +37,9 @@ pub(crate) enum Commands {
 
     /// Sign text to prove ownership of this mixnode
     Sign(sign::Sign),
+
+    /// Show build information of this binary
+    BuildInfo(build_info::BuildInfo),
 
     /// Generate shell completions
     Completions(ArgShell),
@@ -67,6 +71,7 @@ pub(crate) async fn execute(args: Cli) -> Result<(), Box<dyn Error + Send + Sync
         Commands::NodeDetails(m) => node_details::execute(m).await?,
         Commands::Run(m) => run::execute(m).await?,
         Commands::Sign(m) => sign::execute(m)?,
+        Commands::BuildInfo(m) => build_info::execute(&m),
         Commands::Completions(s) => s.generate(&mut crate::Cli::command(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut crate::Cli::command(), bin_name),
     }

--- a/gateway/src/commands/mod.rs
+++ b/gateway/src/commands/mod.rs
@@ -71,7 +71,7 @@ pub(crate) async fn execute(args: Cli) -> Result<(), Box<dyn Error + Send + Sync
         Commands::NodeDetails(m) => node_details::execute(m).await?,
         Commands::Run(m) => run::execute(m).await?,
         Commands::Sign(m) => sign::execute(m)?,
-        Commands::BuildInfo(m) => build_info::execute(&m),
+        Commands::BuildInfo(m) => build_info::execute(m),
         Commands::Completions(s) => s.generate(&mut crate::Cli::command(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut crate::Cli::command(), bin_name),
     }

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -34,17 +34,23 @@ struct Cli {
     #[clap(short, long)]
     pub(crate) config_env_file: Option<std::path::PathBuf>,
 
+    /// Flag used for disabling the printed banner in tty.
+    #[clap(long)]
+    pub(crate) no_banner: bool,
+
     #[clap(subcommand)]
     command: commands::Commands,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
-    setup_logging();
-    maybe_print_banner(crate_name!(), crate_version!());
-
     let args = Cli::parse();
     setup_env(args.config_env_file.as_ref());
+
+    if !args.no_banner {
+        maybe_print_banner(crate_name!(), crate_version!());
+    }
+    setup_logging();
 
     commands::execute(args).await.map_err(|err| {
         if atty::is(atty::Stream::Stdout) {

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -5,7 +5,7 @@ use clap::{crate_name, crate_version, Parser};
 use colored::Colorize;
 use lazy_static::lazy_static;
 use log::error;
-use nym_bin_common::build_information::BinaryBuildInformation;
+use nym_bin_common::bin_info;
 use nym_bin_common::logging::{maybe_print_banner, setup_logging};
 use nym_bin_common::output_format::OutputFormat;
 use nym_network_defaults::setup_env;
@@ -18,8 +18,7 @@ mod node;
 pub(crate) mod support;
 
 lazy_static! {
-    pub static ref PRETTY_BUILD_INFORMATION: String =
-        BinaryBuildInformation::new(env!("CARGO_PKG_VERSION")).pretty_print();
+    pub static ref PRETTY_BUILD_INFORMATION: String = bin_info!().pretty_print();
 }
 
 // Helper for passing LONG_VERSION to clap

--- a/mixnode/src/commands/build_info.rs
+++ b/mixnode/src/commands/build_info.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Args;
+use nym_bin_common::bin_info_owned;
+use nym_bin_common::output_format::OutputFormat;
+
+#[derive(Args)]
+pub(crate) struct BuildInfo {
+    #[clap(short, long, default_value_t = OutputFormat::default())]
+    output: OutputFormat,
+}
+
+pub(crate) fn execute(args: &BuildInfo) {
+    println!("{}", args.output.format(&bin_info_owned!()))
+}

--- a/mixnode/src/commands/build_info.rs
+++ b/mixnode/src/commands/build_info.rs
@@ -11,6 +11,6 @@ pub(crate) struct BuildInfo {
     output: OutputFormat,
 }
 
-pub(crate) fn execute(args: &BuildInfo) {
+pub(crate) fn execute(args: BuildInfo) {
     println!("{}", args.output.format(&bin_info_owned!()))
 }

--- a/mixnode/src/commands/mod.rs
+++ b/mixnode/src/commands/mod.rs
@@ -68,7 +68,7 @@ pub(crate) async fn execute(args: Cli) -> anyhow::Result<()> {
         Commands::Run(m) => run::execute(&m).await?,
         Commands::Sign(m) => sign::execute(&m)?,
         Commands::NodeDetails(m) => node_details::execute(&m)?,
-        Commands::BuildInfo(m) => build_info::execute(&m),
+        Commands::BuildInfo(m) => build_info::execute(m),
         Commands::Completions(s) => s.generate(&mut crate::Cli::command(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut crate::Cli::command(), bin_name),
     }

--- a/mixnode/src/commands/mod.rs
+++ b/mixnode/src/commands/mod.rs
@@ -15,6 +15,7 @@ use nym_crypto::bech32_address_validation;
 use std::net::IpAddr;
 use std::process;
 
+mod build_info;
 mod describe;
 mod init;
 mod node_details;
@@ -37,6 +38,9 @@ pub(crate) enum Commands {
 
     /// Show details of this mixnode
     NodeDetails(node_details::NodeDetails),
+
+    /// Show build information of this binary
+    BuildInfo(build_info::BuildInfo),
 
     /// Generate shell completions
     Completions(ArgShell),
@@ -64,6 +68,7 @@ pub(crate) async fn execute(args: Cli) -> anyhow::Result<()> {
         Commands::Run(m) => run::execute(&m).await?,
         Commands::Sign(m) => sign::execute(&m)?,
         Commands::NodeDetails(m) => node_details::execute(&m)?,
+        Commands::BuildInfo(m) => build_info::execute(&m),
         Commands::Completions(s) => s.generate(&mut crate::Cli::command(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut crate::Cli::command(), bin_name),
     }

--- a/mixnode/src/main.rs
+++ b/mixnode/src/main.rs
@@ -37,6 +37,10 @@ struct Cli {
     #[clap(short, long)]
     pub(crate) config_env_file: Option<std::path::PathBuf>,
 
+    /// Flag used for disabling the printed banner in tty.
+    #[clap(long)]
+    pub(crate) no_banner: bool,
+
     #[clap(subcommand)]
     command: commands::Commands,
 }
@@ -49,6 +53,13 @@ fn test_function() {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let args = Cli::parse();
+    setup_env(args.config_env_file.as_ref());
+
+    if !args.no_banner {
+        maybe_print_banner(crate_name!(), crate_version!());
+    }
+
     cfg_if::cfg_if! {
         if #[cfg(feature = "cpucycles")] {
             setup_tracing!("mixnode");
@@ -59,10 +70,6 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    maybe_print_banner(crate_name!(), crate_version!());
-
-    let args = Cli::parse();
-    setup_env(args.config_env_file.as_ref());
     commands::execute(args).await?;
 
     cfg_if::cfg_if! {

--- a/mixnode/src/main.rs
+++ b/mixnode/src/main.rs
@@ -7,7 +7,8 @@ extern crate rocket;
 use ::nym_config::defaults::setup_env;
 use clap::{crate_name, crate_version, Parser};
 use lazy_static::lazy_static;
-use nym_bin_common::build_information::BinaryBuildInformation;
+use nym_bin_common::bin_info;
+
 #[allow(unused_imports)]
 use nym_bin_common::logging::{maybe_print_banner, setup_logging};
 #[cfg(feature = "cpucycles")]
@@ -16,13 +17,13 @@ use nym_bin_common::setup_tracing;
 use nym_mixnode_common::measure;
 #[cfg(feature = "cpucycles")]
 use tracing::instrument;
+
 mod commands;
 mod config;
 mod node;
 
 lazy_static! {
-    pub static ref PRETTY_BUILD_INFORMATION: String =
-        BinaryBuildInformation::new(env!("CARGO_PKG_VERSION")).pretty_print();
+    pub static ref PRETTY_BUILD_INFORMATION: String = bin_info!().pretty_print();
 }
 
 // Helper for passing LONG_VERSION to clap

--- a/nym-api/src/support/cli/mod.rs
+++ b/nym-api/src/support/cli/mod.rs
@@ -8,14 +8,13 @@ use ::nym_config::defaults::var_names::{MIXNET_CONTRACT_ADDRESS, VESTING_CONTRAC
 use anyhow::Result;
 use clap::Parser;
 use lazy_static::lazy_static;
-use nym_bin_common::build_information::BinaryBuildInformation;
+use nym_bin_common::bin_info;
 use nym_config::defaults::var_names::NYXD;
 use nym_config::OptionalSet;
 use nym_validator_client::nyxd;
 
 lazy_static! {
-    pub static ref PRETTY_BUILD_INFORMATION: String =
-        BinaryBuildInformation::new(env!("CARGO_PKG_VERSION")).pretty_print();
+    pub static ref PRETTY_BUILD_INFORMATION: String = bin_info!().pretty_print();
 }
 
 // Helper for passing LONG_VERSION to clap

--- a/service-providers/network-requester/src/cli/build_info.rs
+++ b/service-providers/network-requester/src/cli/build_info.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Args;
+use nym_bin_common::bin_info_owned;
+use nym_bin_common::output_format::OutputFormat;
+
+#[derive(Args)]
+pub(crate) struct BuildInfo {
+    #[clap(short, long, default_value_t = OutputFormat::default())]
+    output: OutputFormat,
+}
+
+pub(crate) fn execute(args: &BuildInfo) {
+    println!("{}", args.output.format(&bin_info_owned!()))
+}

--- a/service-providers/network-requester/src/cli/build_info.rs
+++ b/service-providers/network-requester/src/cli/build_info.rs
@@ -11,6 +11,6 @@ pub(crate) struct BuildInfo {
     output: OutputFormat,
 }
 
-pub(crate) fn execute(args: &BuildInfo) {
+pub(crate) fn execute(args: BuildInfo) {
     println!("{}", args.output.format(&bin_info_owned!()))
 }

--- a/service-providers/network-requester/src/cli/mod.rs
+++ b/service-providers/network-requester/src/cli/mod.rs
@@ -126,11 +126,11 @@ pub(crate) fn override_config(config: Config, args: OverrideConfig) -> Config {
 pub(crate) async fn execute(args: Cli) -> Result<(), NetworkRequesterError> {
     let bin_name = "nym-network-requester";
 
-    match &args.command {
-        Commands::Init(m) => init::execute(m).await?,
-        Commands::Run(m) => run::execute(m).await?,
-        Commands::Sign(m) => sign::execute(m).await?,
-        Commands::BuildInfo(m) => build_info::execute(&m),
+    match args.command {
+        Commands::Init(m) => init::execute(&m).await?,
+        Commands::Run(m) => run::execute(&m).await?,
+        Commands::Sign(m) => sign::execute(&m).await?,
+        Commands::BuildInfo(m) => build_info::execute(m),
         Commands::Completions(s) => s.generate(&mut Cli::command(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut Cli::command(), bin_name),
     }

--- a/service-providers/network-requester/src/cli/mod.rs
+++ b/service-providers/network-requester/src/cli/mod.rs
@@ -42,6 +42,10 @@ pub(crate) struct Cli {
     #[clap(short, long)]
     pub(crate) config_env_file: Option<std::path::PathBuf>,
 
+    /// Flag used for disabling the printed banner in tty.
+    #[clap(long)]
+    pub(crate) no_banner: bool,
+
     #[clap(subcommand)]
     command: Commands,
 }

--- a/service-providers/network-requester/src/cli/mod.rs
+++ b/service-providers/network-requester/src/cli/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use clap::{CommandFactory, Parser, Subcommand};
 use log::{error, info};
-use nym_bin_common::build_information::BinaryBuildInformation;
+use nym_bin_common::bin_info;
 use nym_bin_common::completions::{fig_generate, ArgShell};
 use nym_bin_common::version_checker;
 use nym_client_core::client::base_client::storage::gateway_details::{
@@ -21,13 +21,13 @@ use nym_client_core::config::GatewayEndpointConfig;
 use nym_client_core::error::ClientCoreError;
 use nym_sphinx::params::PacketSize;
 
+mod build_info;
 mod init;
 mod run;
 mod sign;
 
 lazy_static::lazy_static! {
-    pub static ref PRETTY_BUILD_INFORMATION: String =
-        BinaryBuildInformation::new(env!("CARGO_PKG_VERSION")).pretty_print();
+    pub static ref PRETTY_BUILD_INFORMATION: String = bin_info!().pretty_print();
 }
 
 // Helper for passing LONG_VERSION to clap
@@ -62,6 +62,9 @@ pub(crate) enum Commands {
 
     /// Sign to prove ownership of this network requester
     Sign(sign::Sign),
+
+    /// Show build information of this binary
+    BuildInfo(build_info::BuildInfo),
 
     /// Generate shell completions
     Completions(ArgShell),
@@ -127,6 +130,7 @@ pub(crate) async fn execute(args: Cli) -> Result<(), NetworkRequesterError> {
         Commands::Init(m) => init::execute(m).await?,
         Commands::Run(m) => run::execute(m).await?,
         Commands::Sign(m) => sign::execute(m).await?,
+        Commands::BuildInfo(m) => build_info::execute(&m),
         Commands::Completions(s) => s.generate(&mut Cli::command(), bin_name),
         Commands::GenerateFigSpec => fig_generate(&mut Cli::command(), bin_name),
     }

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -13,7 +13,7 @@ use crate::{reply, socks5};
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use log::warn;
-use nym_bin_common::build_information::BinaryBuildInformation;
+use nym_bin_common::bin_info_owned;
 use nym_client_core::config::disk_persistence::CommonClientPaths;
 use nym_network_defaults::NymNetworkDetails;
 use nym_service_providers_common::interface::{
@@ -101,7 +101,7 @@ impl ServiceProvider<Socks5Request> for NRServiceProvider {
     ) -> Result<BinaryInformation, Self::ServiceProviderError> {
         Ok(BinaryInformation {
             binary_name: env!("CARGO_PKG_NAME").to_string(),
-            build_information: BinaryBuildInformation::new(env!("CARGO_PKG_VERSION")).to_owned(),
+            build_information: bin_info_owned!(),
         })
     }
 

--- a/service-providers/network-requester/src/main.rs
+++ b/service-providers/network-requester/src/main.rs
@@ -18,11 +18,13 @@ mod statistics;
 
 #[tokio::main]
 async fn main() -> Result<(), NetworkRequesterError> {
-    setup_logging();
-    maybe_print_banner(crate_name!(), crate_version!());
-
     let args = cli::Cli::parse();
     setup_env(args.config_env_file.as_ref());
+
+    if !args.no_banner {
+        maybe_print_banner(crate_name!(), crate_version!());
+    }
+    setup_logging();
 
     cli::execute(args).await
 }


### PR DESCRIPTION
# Description

Closes: https://github.com/nymtech/nym/issues/3656

This PR introduces 2 things for our binaries (mixnode, gateway, socks5 client, native client, network requester):

- a `--no-banner` startup flag that will prevent our banner being printed even if run in tty environment
- a `build-info` command that prints, well, the build information like commit hash, rust version, binary version, etc. exactly what normal --version does now. However, you can also specify an --output=json flag that will format the whole thing as a json making it an order of magnitude easier to parse, for example:
```
❯ ./target/debug/nym-network-requester --no-banner build-info --output json
{"binary_name":"nym-network-requester","build_timestamp":"2023-07-24T15:38:37.00657Z","build_version":"1.1.23","commit_sha":"c70149400206dce24cf20babb1e64f22202672dd","commit_timestamp":"2023-07-24T14:45:45Z","commit_branch":"feature/simplify-cli-parsing","rustc_version":"1.71.0","rustc_channel":"stable","cargo_profile":"debug"}
```
