### PR TITLE
Print warning when coconut verif endpoint doesn't work

### DIFF
--- a/gateway/src/node/client_handling/websocket/connection_handler/coconut.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/coconut.rs
@@ -118,8 +118,15 @@ impl CoconutVerifier {
                     revoke_fee.clone(),
                 )
                 .await?;
-            if !ret?.verification_result {
-                debug!("Validator {} didn't accept the credential. It will probably vote No on the spending proposal", client.api_client.nym_api_client.current_url());
+            match ret {
+                Ok(res) => {
+                    if !res.verification_result {
+                        debug!("Validator {} didn't accept the credential. It will probably vote No on the spending proposal", client.api_client.nym_api_client.current_url());
+                    }
+                }
+                Err(e) => {
+                    warn!("Validator {} could not be reached. There might be a problem with the coconut endpoint - {:?}", client.api_client.nym_api_client.current_url(), e);
+                }
             }
         }
 


### PR DESCRIPTION
# Description

Print a warning instead of failing with an error when the coconut verification endpoint doesn't work, due to various reasons. This makes the verification flow also rely on the threshold on the system.

Closes: #3741 

