### PR TITLE
feat: retain connection between client `init` and `run`

### DIFF
--- a/clients/native/src/commands/init.rs
+++ b/clients/native/src/commands/init.rs
@@ -181,7 +181,8 @@ pub(crate) async fn execute(args: &Init) -> Result<(), ClientError> {
         Some(&config.base.client.nym_api_urls),
     )
     .await
-    .tap_err(|err| eprintln!("Failed to setup gateway\nError: {err}"))?;
+    .tap_err(|err| eprintln!("Failed to setup gateway\nError: {err}"))?
+    .details;
 
     let config_save_location = config.default_location();
     config.save_to_default_location().tap_err(|_| {

--- a/clients/native/src/commands/init.rs
+++ b/clients/native/src/commands/init.rs
@@ -174,7 +174,7 @@ pub(crate) async fn execute(args: &Init) -> Result<(), ClientError> {
     let details_store =
         OnDiskGatewayDetails::new(&config.storage_paths.common_paths.gateway_details);
     let init_details = nym_client_core::init::setup_gateway(
-        &gateway_setup,
+        gateway_setup,
         &key_store,
         &details_store,
         register_gateway,

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -186,7 +186,7 @@ pub(crate) async fn execute(args: &Init) -> Result<(), Socks5ClientError> {
     let details_store =
         OnDiskGatewayDetails::new(&config.storage_paths.common_paths.gateway_details);
     let init_details = nym_client_core::init::setup_gateway(
-        &gateway_setup,
+        gateway_setup,
         &key_store,
         &details_store,
         register_gateway,

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -193,7 +193,8 @@ pub(crate) async fn execute(args: &Init) -> Result<(), Socks5ClientError> {
         Some(&config.core.base.client.nym_api_urls),
     )
     .await
-    .tap_err(|err| eprintln!("Failed to setup gateway\nError: {err}"))?;
+    .tap_err(|err| eprintln!("Failed to setup gateway\nError: {err}"))?
+    .details;
 
     // TODO: ask the service provider we specified for its interface version and set it in the config
 

--- a/clients/webassembly/src/helpers.rs
+++ b/clients/webassembly/src/helpers.rs
@@ -8,7 +8,7 @@ use js_sys::Promise;
 use nym_client_core::client::replies::reply_storage::browser_backend;
 use nym_client_core::config;
 use nym_client_core::init::helpers::current_gateways;
-use nym_client_core::init::{setup_gateway_from, GatewaySetup, InitialisationDetails};
+use nym_client_core::init::{setup_gateway_from, GatewaySetup, InitialisationResult};
 use nym_sphinx::addressing::clients::Recipient;
 use nym_sphinx::anonymous_replies::requests::AnonymousSenderTag;
 use nym_topology::{gateway, NymTopology};
@@ -82,7 +82,7 @@ async fn setup_gateway(
     client_store: &ClientStorage,
     chosen_gateway: Option<IdentityKey>,
     gateways: &[gateway::Node],
-) -> Result<InitialisationDetails, WasmClientError> {
+) -> Result<InitialisationResult, WasmClientError> {
     let setup = if client_store.has_full_gateway_info().await? {
         GatewaySetup::MustLoad
     } else {
@@ -98,7 +98,7 @@ pub(crate) async fn setup_gateway_from_api(
     client_store: &ClientStorage,
     chosen_gateway: Option<IdentityKey>,
     nym_apis: &[Url],
-) -> Result<InitialisationDetails, WasmClientError> {
+) -> Result<InitialisationResult, WasmClientError> {
     let mut rng = thread_rng();
     let gateways = current_gateways(&mut rng, nym_apis).await?;
     setup_gateway(client_store, chosen_gateway, &gateways).await
@@ -108,7 +108,7 @@ pub(crate) async fn setup_from_topology(
     explicit_gateway: Option<IdentityKey>,
     topology: &NymTopology,
     client_store: &ClientStorage,
-) -> Result<InitialisationDetails, WasmClientError> {
+) -> Result<InitialisationResult, WasmClientError> {
     let gateways = topology.gateways();
     setup_gateway(client_store, explicit_gateway, gateways).await
 }

--- a/clients/webassembly/src/helpers.rs
+++ b/clients/webassembly/src/helpers.rs
@@ -89,7 +89,7 @@ async fn setup_gateway(
         GatewaySetup::new_fresh(chosen_gateway.clone(), None)
     };
 
-    setup_gateway_from(&setup, client_store, client_store, false, Some(gateways))
+    setup_gateway_from(setup, client_store, client_store, false, Some(gateways))
         .await
         .map_err(Into::into)
 }

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -51,7 +51,7 @@ use url::Url;
 use nym_bandwidth_controller::wasm_mockups::DkgQueryClient;
 
 use crate::client::base_client::storage::gateway_details::GatewayDetailsStore;
-use crate::init::{setup_gateway, GatewaySetup, InitialisationDetails};
+use crate::init::{setup_gateway, GatewaySetup, InitialisationResult};
 #[cfg(not(target_arch = "wasm32"))]
 use nym_validator_client::nyxd::traits::DkgQueryClient;
 
@@ -445,7 +445,7 @@ where
         Ok(mem_store)
     }
 
-    async fn initialise_keys_and_gateway(&self) -> Result<InitialisationDetails, ClientCoreError>
+    async fn initialise_keys_and_gateway(&self) -> Result<InitialisationResult, ClientCoreError>
     where
         <S::KeyStore as KeyStore>::StorageError: Sync + Send,
         <S::GatewayDetailsStore as GatewayDetailsStore>::StorageError: Sync + Send,
@@ -471,9 +471,9 @@ where
         info!("Starting nym client");
 
         // derive (or load) client keys and gateway configuration
-        let details = self.initialise_keys_and_gateway().await?;
-        let gateway_config = details.gateway_details;
-        let managed_keys = details.managed_keys;
+        let init_res = self.initialise_keys_and_gateway().await?;
+        let gateway_config = init_res.details.gateway_details;
+        let managed_keys = init_res.details.managed_keys;
 
         let (reply_storage_backend, credential_store) = self.client_store.into_runtime_stores();
 

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -455,17 +455,23 @@ where
         Ok(mem_store)
     }
 
-    async fn initialise_keys_and_gateway(&self) -> Result<InitialisationResult, ClientCoreError>
+    async fn initialise_keys_and_gateway(
+        setup_method: GatewaySetup,
+        key_store: &S::KeyStore,
+        details_store: &S::GatewayDetailsStore,
+        overwrite_data: bool,
+        validator_servers: Option<&[Url]>,
+    ) -> Result<InitialisationResult, ClientCoreError>
     where
         <S::KeyStore as KeyStore>::StorageError: Sync + Send,
         <S::GatewayDetailsStore as GatewayDetailsStore>::StorageError: Sync + Send,
     {
         setup_gateway(
-            &self.setup_method,
-            self.client_store.key_store(),
-            self.client_store.gateway_details_store(),
-            false,
-            Some(&self.config.client.nym_api_urls),
+            setup_method,
+            key_store,
+            details_store,
+            overwrite_data,
+            validator_servers,
         )
         .await
     }
@@ -481,7 +487,14 @@ where
         info!("Starting nym client");
 
         // derive (or load) client keys and gateway configuration
-        let init_res = self.initialise_keys_and_gateway().await?;
+        let init_res = Self::initialise_keys_and_gateway(
+            self.setup_method,
+            self.client_store.key_store(),
+            self.client_store.gateway_details_store(),
+            false,
+            Some(&self.config.client.nym_api_urls),
+        )
+        .await?;
 
         let (reply_storage_backend, credential_store) = self.client_store.into_runtime_stores();
 

--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -7,7 +7,6 @@ use futures::{SinkExt, StreamExt};
 use log::{debug, info, trace, warn};
 use nym_crypto::asymmetric::identity;
 use nym_gateway_client::GatewayClient;
-use nym_gateway_requests::registration::handshake::SharedKeys;
 use nym_topology::{filter::VersionFilterable, gateway};
 use rand::{seq::SliceRandom, Rng};
 use std::{sync::Arc, time::Duration};
@@ -15,8 +14,6 @@ use tap::TapFallible;
 use tungstenite::Message;
 use url::Url;
 
-#[cfg(not(target_arch = "wasm32"))]
-use nym_validator_client::nyxd::DirectSigningNyxdClient;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::net::TcpStream;
 #[cfg(not(target_arch = "wasm32"))]
@@ -30,8 +27,7 @@ type WsConn = WebSocketStream<MaybeTlsStream<TcpStream>>;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::time::sleep;
 
-#[cfg(target_arch = "wasm32")]
-use nym_bandwidth_controller::wasm_mockups::DirectSigningNyxdClient;
+use crate::init::RegistrationResult;
 #[cfg(target_arch = "wasm32")]
 use wasm_utils::websocket::JSWebsocket;
 #[cfg(target_arch = "wasm32")]
@@ -205,9 +201,9 @@ pub(super) fn uniformly_random_gateway<R: Rng>(
 pub(super) async fn register_with_gateway(
     gateway: &GatewayEndpointConfig,
     our_identity: Arc<identity::KeyPair>,
-) -> Result<Arc<SharedKeys>, ClientCoreError> {
+) -> Result<RegistrationResult, ClientCoreError> {
     let timeout = Duration::from_millis(1500);
-    let mut gateway_client: GatewayClient<DirectSigningNyxdClient, _> = GatewayClient::new_init(
+    let mut gateway_client = GatewayClient::new_init(
         gateway.gateway_listener.clone(),
         gateway.try_get_gateway_identity_key()?,
         our_identity.clone(),
@@ -221,5 +217,8 @@ pub(super) async fn register_with_gateway(
         .perform_initial_authentication()
         .await
         .tap_err(|_| log::warn!("Failed to register with the gateway!"))?;
-    Ok(shared_keys)
+    Ok(RegistrationResult {
+        shared_keys,
+        authenticated_ephemeral_client: Some(gateway_client),
+    })
 }

--- a/common/client-libs/gateway-client/src/client.rs
+++ b/common/client-libs/gateway-client/src/client.rs
@@ -809,6 +809,12 @@ impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
         bandwidth_controller: Option<BandwidthController<C, St>>,
         shutdown: TaskClient,
     ) -> GatewayClient<C, St> {
+        // invariants that can't be broken
+        // (unless somebody decided to expose some field that wasn't meant to be exposed)
+        assert!(self.authenticated);
+        assert!(self.connection.is_available());
+        assert!(self.shared_key.is_some());
+
         GatewayClient {
             authenticated: self.authenticated,
             disabled_credentials_mode: self.disabled_credentials_mode,

--- a/common/client-libs/gateway-client/src/client.rs
+++ b/common/client-libs/gateway-client/src/client.rs
@@ -471,6 +471,14 @@ impl<C, St> GatewayClient<C, St> {
     pub async fn perform_initial_authentication(
         &mut self,
     ) -> Result<Arc<SharedKeys>, GatewayClientError> {
+        if self.authenticated {
+            return if let Some(shared_key) = &self.shared_key {
+                Ok(Arc::clone(shared_key))
+            } else {
+                Err(GatewayClientError::AuthenticationFailure)
+            };
+        }
+
         if self.shared_key.is_some() {
             self.authenticate(None).await?;
         } else {
@@ -789,6 +797,33 @@ impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
             should_reconnect_on_failure: false,
             reconnection_attempts: DEFAULT_RECONNECTION_ATTEMPTS,
             reconnection_backoff: DEFAULT_RECONNECTION_BACKOFF,
+            shutdown,
+        }
+    }
+
+    pub fn upgrade<C, St>(
+        self,
+        mixnet_message_sender: MixnetMessageSender,
+        ack_sender: AcknowledgementSender,
+        response_timeout_duration: Duration,
+        bandwidth_controller: Option<BandwidthController<C, St>>,
+        shutdown: TaskClient,
+    ) -> GatewayClient<C, St> {
+        GatewayClient {
+            authenticated: self.authenticated,
+            disabled_credentials_mode: self.disabled_credentials_mode,
+            bandwidth_remaining: self.bandwidth_remaining,
+            gateway_address: self.gateway_address,
+            gateway_identity: self.gateway_identity,
+            local_identity: self.local_identity,
+            shared_key: self.shared_key,
+            connection: self.connection,
+            packet_router: PacketRouter::new(ack_sender, mixnet_message_sender, shutdown.clone()),
+            response_timeout_duration,
+            bandwidth_controller,
+            should_reconnect_on_failure: self.should_reconnect_on_failure,
+            reconnection_attempts: self.reconnection_attempts,
+            reconnection_backoff: self.reconnection_backoff,
             shutdown,
         }
     }

--- a/common/client-libs/gateway-client/src/client.rs
+++ b/common/client-libs/gateway-client/src/client.rs
@@ -45,7 +45,7 @@ use wasmtimer::tokio::sleep;
 const DEFAULT_RECONNECTION_ATTEMPTS: usize = 10;
 const DEFAULT_RECONNECTION_BACKOFF: Duration = Duration::from_secs(5);
 
-pub struct GatewayClient<C, St> {
+pub struct GatewayClient<C, St = EphemeralCredentialStorage> {
     authenticated: bool,
     disabled_credentials_mode: bool,
     bandwidth_remaining: i64,
@@ -755,7 +755,9 @@ impl<C, St> GatewayClient<C, St> {
     }
 }
 
-impl<C> GatewayClient<C, EphemeralCredentialStorage> {
+pub struct InitOnly;
+
+impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
     // for initialisation we do not need credential storage. Though it's still a bit weird we have to set the generic...
     pub fn new_init(
         gateway_address: String,
@@ -772,7 +774,7 @@ impl<C> GatewayClient<C, EphemeralCredentialStorage> {
         let shutdown = TaskClient::dummy();
         let packet_router = PacketRouter::new(ack_tx, mix_tx, shutdown.clone());
 
-        GatewayClient::<C, EphemeralCredentialStorage> {
+        GatewayClient::<InitOnly, EphemeralCredentialStorage> {
             authenticated: false,
             disabled_credentials_mode: true,
             bandwidth_remaining: 0,

--- a/nym-connect/desktop/src-tauri/src/config/mod.rs
+++ b/nym-connect/desktop/src-tauri/src/config/mod.rs
@@ -189,7 +189,8 @@ pub async fn init_socks5_config(provider_address: String, chosen_gateway_id: Str
         register_gateway,
         Some(&config.core.base.client.nym_api_urls),
     )
-    .await?;
+    .await?
+    .details;
 
     config.save_to_default_location().tap_err(|_| {
         log::error!("Failed to save the config file");

--- a/nym-connect/desktop/src-tauri/src/config/mod.rs
+++ b/nym-connect/desktop/src-tauri/src/config/mod.rs
@@ -183,7 +183,7 @@ pub async fn init_socks5_config(provider_address: String, chosen_gateway_id: Str
     let details_store =
         OnDiskGatewayDetails::new(&config.storage_paths.common_paths.gateway_details);
     let init_details = nym_client_core::init::setup_gateway(
-        &gateway_setup,
+        gateway_setup,
         &key_store,
         &details_store,
         register_gateway,

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -323,7 +323,7 @@ where
 
         // this will perform necessary key and details load and optional store
         let _init_result = nym_client_core::init::setup_gateway(
-            &gateway_setup,
+            gateway_setup,
             self.storage.key_store(),
             self.storage.gateway_details_store(),
             !self.config.key_mode.is_keep(),

--- a/service-providers/network-requester/src/cli/init.rs
+++ b/service-providers/network-requester/src/cli/init.rs
@@ -156,7 +156,8 @@ pub(crate) async fn execute(args: &Init) -> Result<(), NetworkRequesterError> {
         Some(&config.base.client.nym_api_urls),
     )
     .await
-    .tap_err(|err| eprintln!("Failed to setup gateway\nError: {err}"))?;
+    .tap_err(|err| eprintln!("Failed to setup gateway\nError: {err}"))?
+    .details;
 
     let config_save_location = config.default_location();
     config.save_to_default_location().tap_err(|_| {

--- a/service-providers/network-requester/src/cli/init.rs
+++ b/service-providers/network-requester/src/cli/init.rs
@@ -149,7 +149,7 @@ pub(crate) async fn execute(args: &Init) -> Result<(), NetworkRequesterError> {
     let details_store =
         OnDiskGatewayDetails::new(&config.storage_paths.common_paths.gateway_details);
     let init_details = nym_client_core::init::setup_gateway(
-        &gateway_setup,
+        gateway_setup,
         &key_store,
         &details_store,
         register_gateway,


### PR DESCRIPTION
# Description

If your client does something along the lines of "init and run", i.e. initialises gateway connection and starts sending traffic within the same command (like what our SDK or wasm clients are doing), this PR will make you retain the websocket you opened for the initialisation. 

I need this functionality to make my `nodejs` build of the wasm client (https://github.com/nymtech/nym/issues/3558) work correctly as for some reason it really dislikes multiple websockets being opened in quick succession. 
