### PR TITLE
Chore/enable versioning

### DIFF
--- a/common/socks5-client-core/src/config/mod.rs
+++ b/common/socks5-client-core/src/config/mod.rs
@@ -110,10 +110,10 @@ pub struct Socks5 {
     /// The version of the 'service provider' this client is going to use in its communication with the
     /// specified socks5 provider.
     // if in doubt, use the legacy version as initially nobody will be using the updated binaries
-    #[serde(default = "ProviderInterfaceVersion::new_legacy")]
+    #[serde(default)]
     pub provider_interface_version: ProviderInterfaceVersion,
 
-    #[serde(default = "Socks5ProtocolVersion::new_legacy")]
+    #[serde(default)]
     pub socks5_protocol_version: Socks5ProtocolVersion,
 
     /// Specifies whether this client is going to use an anonymous sender tag for communication with the service provider.
@@ -147,7 +147,7 @@ impl Socks5 {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct Socks5Debug {
     /// Number of reply SURBs attached to each `Request::Connect` message.
     pub connection_start_surbs: u32,

--- a/gateway/src/config/mod.rs
+++ b/gateway/src/config/mod.rs
@@ -292,8 +292,7 @@ impl Default for Debug {
             maximum_connection_buffer_size: DEFAULT_MAXIMUM_CONNECTION_BUFFER_SIZE,
             stored_messages_filename_length: DEFAULT_STORED_MESSAGE_FILENAME_LENGTH,
             message_retrieval_limit: DEFAULT_MESSAGE_RETRIEVAL_LIMIT,
-            // TODO: remember to change it in one of future releases!!
-            use_legacy_framed_packet_version: true,
+            use_legacy_framed_packet_version: false,
         }
     }
 }

--- a/mixnode/src/config/mod.rs
+++ b/mixnode/src/config/mod.rs
@@ -282,8 +282,7 @@ impl Default for Debug {
             packet_forwarding_maximum_backoff: DEFAULT_PACKET_FORWARDING_MAXIMUM_BACKOFF,
             initial_connection_timeout: DEFAULT_INITIAL_CONNECTION_TIMEOUT,
             maximum_connection_buffer_size: DEFAULT_MAXIMUM_CONNECTION_BUFFER_SIZE,
-            // TODO: remember to change it in one of future releases!!
-            use_legacy_framed_packet_version: true,
+            use_legacy_framed_packet_version: false,
         }
     }
 }


### PR DESCRIPTION
# Description

This PR finally enables versioning on mix packet framing and servive provider requests. 
We've had the code for this for long enough to not have to default to the `legacy` variants.