### PR TITLE
network-requester: disable poisson process by default

### DIFF
--- a/contracts/name-service/src/contract.rs
+++ b/contracts/name-service/src/contract.rs
@@ -286,7 +286,6 @@ mod tests {
         let owner = "steve";
         let (name, owner_signature) =
             new_name_details_with_sign(deps.as_mut(), &mut rng, "my-name", owner, deposit.clone());
-        dbg!(&name);
 
         // Register
         let msg = ExecuteMsg::Register {

--- a/contracts/name-service/src/integration_tests/register.rs
+++ b/contracts/name-service/src/integration_tests/register.rs
@@ -265,7 +265,6 @@ fn can_register_multiple_names_for_the_same_nym_address(mut setup: TestSetup) {
     let reg_name2 = reg_name2.sign(payload);
     setup.register(&reg_name2, &owner);
 
-    dbg!(&setup.query_all().names);
     assert_eq!(
         setup.query_all().names,
         vec![

--- a/service-providers/network-requester/src/allowed_hosts/hosts.rs
+++ b/service-providers/network-requester/src/allowed_hosts/hosts.rs
@@ -100,7 +100,7 @@ impl HostsStore {
             .unwrap();
 
         if let Err(e) = writeln!(file, "{text}") {
-            eprintln!("Couldn't write to file: {e}");
+            log::error!("Couldn't write to file: {e}");
         }
     }
 

--- a/service-providers/network-requester/src/cli/mod.rs
+++ b/service-providers/network-requester/src/cli/mod.rs
@@ -88,34 +88,26 @@ pub(crate) fn override_config(config: Config, args: OverrideConfig) -> Config {
     // Since a big chunk of these are hidden experimental flags there is hope we can remove them
     // soonish and clean this up.
 
-    let config = config.with_base(
-        BaseClientConfig::with_high_default_traffic_volume,
-        args.fastmode,
-    );
-
-    // There is a decent chance we might not need the medium toggle for network-requesters in the
-    // future, at which point we can remove this whole block.
-    let config = if args.medium_toggle {
-        let disable_cover_traffic_with_keepalive = args.medium_toggle;
-        let secondary_packet_size = args.medium_toggle.then_some(PacketSize::ExtendedPacket16);
-        let no_per_hop_delays = args.medium_toggle;
-
-        config
-            .with_base(
-                // NOTE: This interacts with disabling cover traffic fully, so we want to this to be set before
-                BaseClientConfig::with_disabled_cover_traffic_with_keepalive,
-                disable_cover_traffic_with_keepalive,
-            )
-            .with_base(
-                BaseClientConfig::with_secondary_packet_size,
-                secondary_packet_size,
-            )
-            .with_base(BaseClientConfig::with_no_per_hop_delays, no_per_hop_delays)
-    } else {
-        config
-    };
+    let disable_cover_traffic_with_keepalive =
+        config.network_requester.disable_poisson_rate || args.medium_toggle;
+    let secondary_packet_size = args.medium_toggle.then_some(PacketSize::ExtendedPacket16);
+    let no_per_hop_delays = args.medium_toggle;
 
     config
+        .with_base(
+            BaseClientConfig::with_high_default_traffic_volume,
+            args.fastmode,
+        )
+        .with_base(
+            // NOTE: This interacts with disabling cover traffic fully, so we want to this to be set before
+            BaseClientConfig::with_disabled_cover_traffic_with_keepalive,
+            disable_cover_traffic_with_keepalive,
+        )
+        .with_base(
+            BaseClientConfig::with_secondary_packet_size,
+            secondary_packet_size,
+        )
+        .with_base(BaseClientConfig::with_no_per_hop_delays, no_per_hop_delays)
         // NOTE: see comment above about the order of the other disble cover traffic config
         .with_base(BaseClientConfig::with_disabled_cover_traffic, args.no_cover)
         .with_optional_base_custom_env(

--- a/service-providers/network-requester/src/cli/run.rs
+++ b/service-providers/network-requester/src/cli/run.rs
@@ -83,6 +83,7 @@ pub(crate) async fn execute(args: &Run) -> Result<(), NetworkRequesterError> {
     }
 
     let mut config = try_load_current_config(&args.id)?;
+    dbg!(&config);
     config = override_config(config, OverrideConfig::from(args.clone()));
     log::debug!("Using config: {:#?}", config);
 
@@ -109,6 +110,5 @@ pub(crate) async fn execute(args: &Run) -> Result<(), NetworkRequesterError> {
         stats_provider_addr,
     )
     .await;
-    panic!();
     server.run_service_provider().await
 }

--- a/service-providers/network-requester/src/cli/run.rs
+++ b/service-providers/network-requester/src/cli/run.rs
@@ -83,7 +83,6 @@ pub(crate) async fn execute(args: &Run) -> Result<(), NetworkRequesterError> {
     }
 
     let mut config = try_load_current_config(&args.id)?;
-    dbg!(&config);
     config = override_config(config, OverrideConfig::from(args.clone()));
     log::debug!("Using config: {:#?}", config);
 

--- a/service-providers/network-requester/src/cli/run.rs
+++ b/service-providers/network-requester/src/cli/run.rs
@@ -84,6 +84,7 @@ pub(crate) async fn execute(args: &Run) -> Result<(), NetworkRequesterError> {
 
     let mut config = try_load_current_config(&args.id)?;
     config = override_config(config, OverrideConfig::from(args.clone()));
+    log::debug!("Using config: {:#?}", config);
 
     if !version_check(&config) {
         error!("failed the local version check");
@@ -108,5 +109,6 @@ pub(crate) async fn execute(args: &Run) -> Result<(), NetworkRequesterError> {
         stats_provider_addr,
     )
     .await;
+    panic!();
     server.run_service_provider().await
 }

--- a/service-providers/network-requester/src/config/mod.rs
+++ b/service-providers/network-requester/src/config/mod.rs
@@ -81,13 +81,8 @@ impl NymConfigTemplate for Config {
 
 impl Config {
     pub fn new<S: AsRef<str>>(id: S) -> Self {
-        let mut base = BaseClientConfig::new(id.as_ref(), env!("CARGO_PKG_VERSION"));
-        // By default we have no cover traffic, but we have a slow trickle of cover traffic
-        // packages acting as keepalive messages.
-        base.set_no_cover_traffic_with_keepalive();
-
         Config {
-            base,
+            base: BaseClientConfig::new(id.as_ref(), env!("CARGO_PKG_VERSION")),
             network_requester: Default::default(),
             storage_paths: NetworkRequesterPaths::new_default(default_data_directory(id.as_ref())),
             network_requester_debug: Default::default(),
@@ -164,9 +159,19 @@ impl Config {
     }
 }
 
-#[derive(Debug, Default, Clone, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
-pub struct NetworkRequester {}
+pub struct NetworkRequester {
+    pub disable_poisson_rate: bool,
+}
+
+impl Default for NetworkRequester {
+    fn default() -> Self {
+        NetworkRequester {
+            disable_poisson_rate: true,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]

--- a/service-providers/network-requester/src/config/mod.rs
+++ b/service-providers/network-requester/src/config/mod.rs
@@ -81,8 +81,13 @@ impl NymConfigTemplate for Config {
 
 impl Config {
     pub fn new<S: AsRef<str>>(id: S) -> Self {
+        let mut base = BaseClientConfig::new(id.as_ref(), env!("CARGO_PKG_VERSION"));
+        // By default we have no cover traffic, but we have a slow trickle of cover traffic
+        // packages acting as keepalive messages.
+        base.set_no_cover_traffic_with_keepalive();
+
         Config {
-            base: BaseClientConfig::new(id.as_ref(), env!("CARGO_PKG_VERSION")),
+            base,
             network_requester: Default::default(),
             storage_paths: NetworkRequesterPaths::new_default(default_data_directory(id.as_ref())),
             network_requester_debug: Default::default(),

--- a/service-providers/network-requester/src/config/old_config_v1_1_20_2.rs
+++ b/service-providers/network-requester/src/config/old_config_v1_1_20_2.rs
@@ -79,7 +79,7 @@ pub struct NetworkRequesterV1_1_20_2 {}
 
 impl From<NetworkRequesterV1_1_20_2> for NetworkRequester {
     fn from(_value: NetworkRequesterV1_1_20_2) -> Self {
-        NetworkRequester {}
+        NetworkRequester::default()
     }
 }
 

--- a/service-providers/network-requester/src/config/template.rs
+++ b/service-providers/network-requester/src/config/template.rs
@@ -37,7 +37,7 @@ nym_api_urls = [
     {{/each}}
 ]
 
-[storage_paths] 
+[storage_paths]
 
 # Path to file containing private identity key.
 keys.private_identity_key_file = '{{ storage_paths.keys.private_identity_key_file }}'
@@ -74,6 +74,14 @@ allowed_list_location = '{{ storage_paths.allowed_list_location }}'
 
 # Location of the file containing our unknown.list
 unknown_list_location = '{{ storage_paths.unknown_list_location }}'
+
+
+[network_requester]
+
+# Disable Poisson sending rate, and only send cover traffic occasionally as keepalive messages.
+# This is equivalent to setting debug.traffic.disable_main_poisson_packet_distribution = true,
+# and debug.cover_traffic.loop_cover_traffic_average_delay = 5s.
+disable_poisson_rate = '{{ network_requester.disable_poisson_rate }}'
 
 
 ##### logging configuration options #####

--- a/service-providers/network-requester/src/config/template.rs
+++ b/service-providers/network-requester/src/config/template.rs
@@ -81,7 +81,7 @@ unknown_list_location = '{{ storage_paths.unknown_list_location }}'
 # Disable Poisson sending rate, and only send cover traffic occasionally as keepalive messages.
 # This is equivalent to setting debug.traffic.disable_main_poisson_packet_distribution = true,
 # and debug.cover_traffic.loop_cover_traffic_average_delay = 5s.
-disable_poisson_rate = '{{ network_requester.disable_poisson_rate }}'
+disable_poisson_rate = {{ network_requester.disable_poisson_rate }}
 
 
 ##### logging configuration options #####


### PR DESCRIPTION
# Description

Closes: #3774

In the network-requester, by default disable the Poisson sending rate process.
We keep the cover traffic process running, but at a slow trickle to act as keepalive messages.
