### PR TITLE
network-requester: add description field in the config

### DIFF
--- a/service-providers/network-requester/src/cli/build_info.rs
+++ b/service-providers/network-requester/src/cli/build_info.rs
@@ -7,7 +7,7 @@ use nym_bin_common::output_format::OutputFormat;
 
 #[derive(Args)]
 pub(crate) struct BuildInfo {
-    #[clap(short, long, default_value_t = OutputFormat::default())]
+    #[arg(short, long, default_value_t = OutputFormat::default())]
     output: OutputFormat,
 }
 

--- a/service-providers/network-requester/src/cli/init.rs
+++ b/service-providers/network-requester/src/cli/init.rs
@@ -24,44 +24,48 @@ use tap::TapFallible;
 #[derive(Args, Clone)]
 pub(crate) struct Init {
     /// Id of the nym-mixnet-client we want to create config for.
-    #[clap(long)]
+    #[arg(long)]
     id: String,
 
+    #[arg(long)]
+    description: Option<String>,
+
     /// Id of the gateway we are going to connect to.
-    #[clap(long)]
+    #[arg(long)]
     gateway: Option<identity::PublicKey>,
 
     /// Specifies whether the new gateway should be determined based by latency as opposed to being chosen
     /// uniformly.
-    #[clap(long, conflicts_with = "gateway")]
+    #[arg(long, conflicts_with = "gateway")]
     latency_based_selection: bool,
 
     /// Force register gateway. WARNING: this will overwrite any existing keys for the given id,
     /// potentially causing loss of access.
-    #[clap(long)]
+    #[arg(long)]
     force_register_gateway: bool,
 
     /// Comma separated list of rest endpoints of the nyxd validators
-    #[clap(long, alias = "nymd_validators", value_delimiter = ',')]
+    #[arg(long, alias = "nymd_validators", value_delimiter = ',')]
     nyxd_urls: Option<Vec<url::Url>>,
 
     /// Comma separated list of rest endpoints of the API validators
-    #[clap(long, alias = "api_validators", value_delimiter = ',')]
+    #[arg(long, alias = "api_validators", value_delimiter = ',')]
     // the alias here is included for backwards compatibility (1.1.4 and before)
     nym_apis: Option<Vec<url::Url>>,
 
     /// Set this client to work in a enabled credentials mode that would attempt to use gateway
     /// with bandwidth credential requirement.
-    #[clap(long)]
+    #[arg(long)]
     enabled_credentials_mode: Option<bool>,
 
-    #[clap(short, long, default_value_t = OutputFormat::default())]
+    #[arg(short, long, default_value_t = OutputFormat::default())]
     output: OutputFormat,
 }
 
 impl From<Init> for OverrideConfig {
     fn from(init_config: Init) -> Self {
         OverrideConfig {
+            description: init_config.description,
             nym_apis: init_config.nym_apis,
             fastmode: false,
             no_cover: false,

--- a/service-providers/network-requester/src/cli/run.rs
+++ b/service-providers/network-requester/src/cli/run.rs
@@ -16,45 +16,46 @@ const ENABLE_STATISTICS: &str = "enable-statistics";
 #[derive(Args, Clone)]
 pub(crate) struct Run {
     /// Id of the nym-mixnet-client we want to run.
-    #[clap(long)]
+    #[arg(long)]
     id: String,
 
     /// Specifies whether this network requester should run in 'open-proxy' mode
-    #[clap(long)]
+    #[arg(long)]
     open_proxy: bool,
 
     /// Enable service anonymized statistics that get sent to a statistics aggregator server
-    #[clap(long)]
+    #[arg(long)]
     enable_statistics: bool,
 
     /// Mixnet client address where a statistics aggregator is running. The default value is a Nym
     /// aggregator client
-    #[clap(long)]
+    #[arg(long)]
     statistics_recipient: Option<String>,
 
     /// Set this client to work in a enabled credentials mode that would attempt to use gateway
     /// with bandwidth credential requirement.
-    #[clap(long)]
+    #[arg(long)]
     enabled_credentials_mode: Option<bool>,
 
     /// Mostly debug-related option to increase default traffic rate so that you would not need to
     /// modify config post init
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     fastmode: bool,
 
     /// Disable loop cover traffic and the Poisson rate limiter (for debugging only)
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     no_cover: bool,
 
     /// Enable medium mixnet traffic, for experiments only.
     /// This includes things like disabling cover traffic, no per hop delays, etc.
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     medium_toggle: bool,
 }
 
 impl From<Run> for OverrideConfig {
     fn from(run_config: Run) -> Self {
         OverrideConfig {
+            description: None,
             nym_apis: None,
             fastmode: run_config.fastmode,
             no_cover: run_config.no_cover,

--- a/service-providers/network-requester/src/cli/sign.rs
+++ b/service-providers/network-requester/src/cli/sign.rs
@@ -13,14 +13,14 @@ use nym_types::helpers::ConsoleSigningOutput;
 #[derive(Args, Clone)]
 pub(crate) struct Sign {
     /// The id of the mixnode you want to sign with
-    #[clap(long)]
+    #[arg(long)]
     id: String,
 
     /// Signs a transaction-specific payload, that is going to be sent to the smart contract, with your identity key
-    #[clap(long)]
+    #[arg(long)]
     contract_msg: String,
 
-    #[clap(short, long, default_value_t = OutputFormat::default())]
+    #[arg(short, long, default_value_t = OutputFormat::default())]
     output: OutputFormat,
 }
 

--- a/service-providers/network-requester/src/config/mod.rs
+++ b/service-providers/network-requester/src/config/mod.rs
@@ -112,6 +112,11 @@ impl Config {
         self.base.validate()
     }
 
+    pub fn with_description(mut self, description: String) -> Self {
+        self.network_requester.description = description;
+        self
+    }
+
     // poor man's 'builder' method
     pub fn with_base<F, T>(mut self, f: F, val: T) -> Self
     where
@@ -162,12 +167,14 @@ impl Config {
 #[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct NetworkRequester {
+    pub description: String,
     pub disable_poisson_rate: bool,
 }
 
 impl Default for NetworkRequester {
     fn default() -> Self {
         NetworkRequester {
+            description: String::new(),
             disable_poisson_rate: true,
         }
     }

--- a/service-providers/network-requester/src/config/template.rs
+++ b/service-providers/network-requester/src/config/template.rs
@@ -78,6 +78,9 @@ unknown_list_location = '{{ storage_paths.unknown_list_location }}'
 
 [network_requester]
 
+# User provided human readable description of this particular network requester.
+description = '{{ network_requester.description }}'
+
 # Disable Poisson sending rate, and only send cover traffic occasionally as keepalive messages.
 # This is equivalent to setting debug.traffic.disable_main_poisson_packet_distribution = true,
 # and debug.cover_traffic.loop_cover_traffic_average_delay = 5s.


### PR DESCRIPTION

# Description

The idea is that this is something that you can query across the mixnet in the future
