### PR TITLE
gateway: disconnect inactive duplicate clients

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = { workspace = true }
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "sqlite", "macros", "migrate", ] }
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 thiserror = "1"
-tokio = { version = "1.24.1", features = [ "rt-multi-thread", "net", "signal", "fs", "time" ] }
+tokio = { workspace = true, features = [ "rt-multi-thread", "net", "signal", "fs", "time" ] }
 tokio-stream = { version = "0.1.11", features = ["fs"] }
 tokio-tungstenite = "0.14"
 tokio-util = { version = "0.7.4", features = ["codec"] }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = { workspace = true }
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "sqlite", "macros", "migrate", ] }
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 thiserror = "1"
-tokio = { version = "1.24.1", features = [ "rt-multi-thread", "net", "signal", "fs", ] }
+tokio = { version = "1.24.1", features = [ "rt-multi-thread", "net", "signal", "fs", "time" ] }
 tokio-stream = { version = "0.1.11", features = ["fs"] }
 tokio-tungstenite = "0.14"
 tokio-util = { version = "0.7.4", features = ["codec"] }

--- a/gateway/src/node/client_handling/active_clients.rs
+++ b/gateway/src/node/client_handling/active_clients.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dashmap::DashMap;
-use futures::channel::{mpsc, oneshot};
 use nym_sphinx::DestinationAddressBytes;
 use std::sync::Arc;
 
@@ -63,7 +62,7 @@ impl ActiveClientsStore {
         &self,
         client: DestinationAddressBytes,
         handle: MixMessageSender,
-        is_active_sender: mpsc::UnboundedSender<oneshot::Sender<bool>>,
+        is_active_sender: IsActiveRequestSender,
     ) {
         self.0.insert(client, (handle, is_active_sender));
     }

--- a/gateway/src/node/client_handling/websocket/connection_handler/authenticated.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/authenticated.rs
@@ -427,7 +427,7 @@ where
     }
 
     /// Handles the ping timeout by responding back to the handler that requested the ping.
-    async fn handle_ping_timout(&mut self) {
+    async fn handle_ping_timeout(&mut self) {
         debug!("Ping timeout expired!");
         if let Some((_tag, reply_tx)) = self.is_active_ping_pending_reply.take() {
             if let Err(err) = reply_tx.send(IsActive::NotActive) {
@@ -497,7 +497,7 @@ where
                 // The ping timeout expired, meaning the client didn't respond to our ping request
                 _ = &mut ping_timeout, if !ping_timeout.is_terminated() => {
                    ping_timeout = None.into();
-                   self.handle_ping_timout().await;
+                   self.handle_ping_timeout().await;
                 },
                 socket_msg = self.inner.read_websocket_message() => {
                     let socket_msg = match socket_msg {

--- a/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
@@ -482,9 +482,9 @@ where
         let iv = IV::try_from_base58_string(iv)?;
 
         // Check for duplicate clients
-        if let Some((__, is_active_request_tx)) = self.active_clients_store.get(address) {
+        if let Some(client_tx) = self.active_clients_store.get(address) {
             log::warn!("Detected duplicate connection for client: {}", address);
-            self.handle_duplicate_client(address, is_active_request_tx)
+            self.handle_duplicate_client(address, client_tx.is_active_request_sender)
                 .await?;
         }
 

--- a/gateway/src/node/client_handling/websocket/connection_handler/mod.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/mod.rs
@@ -100,7 +100,7 @@ pub(crate) async fn handle_connection<R, S, St>(
         .await
     {
         None => {
-            trace!("received shutdown signal while performing initial authetnication");
+            trace!("received shutdown signal while performing initial authentication");
             return;
         }
         Some(None) => {

--- a/gateway/src/node/client_handling/websocket/message_receiver.rs
+++ b/gateway/src/node/client_handling/websocket/message_receiver.rs
@@ -10,4 +10,11 @@ pub(crate) type MixMessageReceiver = mpsc::UnboundedReceiver<Vec<Vec<u8>>>;
 // active. The result is then passed back to the requesting handler in the oneshot channel.
 pub(crate) type IsActiveRequestSender = mpsc::UnboundedSender<IsActiveResultSender>;
 pub(crate) type IsActiveRequestReceiver = mpsc::UnboundedReceiver<IsActiveResultSender>;
-pub(crate) type IsActiveResultSender = oneshot::Sender<bool>;
+
+#[derive(Debug)]
+pub(crate) enum IsActive {
+    Active,
+    NotActive,
+    BusyPinging,
+}
+pub(crate) type IsActiveResultSender = oneshot::Sender<IsActive>;

--- a/gateway/src/node/client_handling/websocket/message_receiver.rs
+++ b/gateway/src/node/client_handling/websocket/message_receiver.rs
@@ -1,7 +1,13 @@
 // Copyright 2020 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use futures::channel::mpsc;
+use futures::channel::{mpsc, oneshot};
 
 pub(crate) type MixMessageSender = mpsc::UnboundedSender<Vec<Vec<u8>>>;
 pub(crate) type MixMessageReceiver = mpsc::UnboundedReceiver<Vec<Vec<u8>>>;
+
+// Channels used for one handler to requester another handler to check that the client is still
+// active. The result is then passed back to the requesting handler in the oneshot channel.
+pub(crate) type IsActiveRequestSender = mpsc::UnboundedSender<IsActiveResultSender>;
+pub(crate) type IsActiveRequestReceiver = mpsc::UnboundedReceiver<IsActiveResultSender>;
+pub(crate) type IsActiveResultSender = oneshot::Sender<bool>;

--- a/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
+++ b/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
@@ -70,7 +70,7 @@ impl<St: Storage> ConnectionHandler<St> {
     }
 
     fn update_clients_store_cache_entry(&mut self, client_address: DestinationAddressBytes) {
-        if let Some(client_sender) = self.active_clients_store.get(client_address) {
+        if let Some((client_sender, _)) = self.active_clients_store.get(client_address) {
             self.clients_store_cache
                 .insert(client_address, client_sender);
         }

--- a/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
+++ b/gateway/src/node/mixnet_handling/receiver/connection_handler.rs
@@ -70,9 +70,9 @@ impl<St: Storage> ConnectionHandler<St> {
     }
 
     fn update_clients_store_cache_entry(&mut self, client_address: DestinationAddressBytes) {
-        if let Some((client_sender, _)) = self.active_clients_store.get(client_address) {
+        if let Some(client_senders) = self.active_clients_store.get(client_address) {
             self.clients_store_cache
-                .insert(client_address, client_sender);
+                .insert(client_address, client_senders.mix_message_sender);
         }
     }
 


### PR DESCRIPTION
# Description

Closes: #2845

In `nym-gateway` when a duplicate client connection is detected, query the existing connection if it's still active. If it's still active, deny the new connection (as before). If it's NOT active, drop the previous connection and allow the new client to connect.
