### PR TITLE
network-requester: add description to config

### DIFF
--- a/mixnode/src/config/persistence/paths.rs
+++ b/mixnode/src/config/persistence/paths.rs
@@ -24,6 +24,10 @@ impl MixNodePaths {
     pub fn new_default<P: AsRef<Path>>(id: P) -> Self {
         MixNodePaths {
             keys: KeysPaths::new_default(id.as_ref()),
+            // TODO: next time there is a breaking change in the mixnode config, change this to
+            // `default_base_directory`.
+            // I'd rather not change this willy-nilly since it means a `mixnode init` will break
+            // the existing configurated description.
             node_description: default_config_directory(id).join(DEFAULT_DESCRIPTION_FILENAME),
         }
     }

--- a/service-providers/network-requester/src/cli/build_info.rs
+++ b/service-providers/network-requester/src/cli/build_info.rs
@@ -7,7 +7,7 @@ use nym_bin_common::output_format::OutputFormat;
 
 #[derive(Args)]
 pub(crate) struct BuildInfo {
-    #[clap(short, long, default_value_t = OutputFormat::default())]
+    #[arg(short, long, default_value_t = OutputFormat::default())]
     output: OutputFormat,
 }
 

--- a/service-providers/network-requester/src/cli/init.rs
+++ b/service-providers/network-requester/src/cli/init.rs
@@ -24,38 +24,38 @@ use tap::TapFallible;
 #[derive(Args, Clone)]
 pub(crate) struct Init {
     /// Id of the nym-mixnet-client we want to create config for.
-    #[clap(long)]
+    #[arg(long)]
     id: String,
 
     /// Id of the gateway we are going to connect to.
-    #[clap(long)]
+    #[arg(long)]
     gateway: Option<identity::PublicKey>,
 
     /// Specifies whether the new gateway should be determined based by latency as opposed to being chosen
     /// uniformly.
-    #[clap(long, conflicts_with = "gateway")]
+    #[arg(long, conflicts_with = "gateway")]
     latency_based_selection: bool,
 
     /// Force register gateway. WARNING: this will overwrite any existing keys for the given id,
     /// potentially causing loss of access.
-    #[clap(long)]
+    #[arg(long)]
     force_register_gateway: bool,
 
     /// Comma separated list of rest endpoints of the nyxd validators
-    #[clap(long, alias = "nymd_validators", value_delimiter = ',')]
+    #[arg(long, alias = "nymd_validators", value_delimiter = ',')]
     nyxd_urls: Option<Vec<url::Url>>,
 
     /// Comma separated list of rest endpoints of the API validators
-    #[clap(long, alias = "api_validators", value_delimiter = ',')]
+    #[arg(long, alias = "api_validators", value_delimiter = ',')]
     // the alias here is included for backwards compatibility (1.1.4 and before)
     nym_apis: Option<Vec<url::Url>>,
 
     /// Set this client to work in a enabled credentials mode that would attempt to use gateway
     /// with bandwidth credential requirement.
-    #[clap(long)]
+    #[arg(long)]
     enabled_credentials_mode: Option<bool>,
 
-    #[clap(short, long, default_value_t = OutputFormat::default())]
+    #[arg(short, long, default_value_t = OutputFormat::default())]
     output: OutputFormat,
 }
 

--- a/service-providers/network-requester/src/cli/mod.rs
+++ b/service-providers/network-requester/src/cli/mod.rs
@@ -36,17 +36,17 @@ fn pretty_build_info_static() -> &'static str {
 }
 
 #[derive(Parser)]
-#[clap(author = "Nymtech", version, about, long_version = pretty_build_info_static())]
+#[command(author = "Nymtech", version, about, long_version = pretty_build_info_static())]
 pub(crate) struct Cli {
     /// Path pointing to an env file that configures the client.
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub(crate) config_env_file: Option<std::path::PathBuf>,
 
     /// Flag used for disabling the printed banner in tty.
-    #[clap(long)]
+    #[arg(long)]
     pub(crate) no_banner: bool,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Commands,
 }
 

--- a/service-providers/network-requester/src/cli/mod.rs
+++ b/service-providers/network-requester/src/cli/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     error::NetworkRequesterError,
 };
 use clap::{CommandFactory, Parser, Subcommand};
-use log::{error, info};
+use log::{error, info, trace};
 use nym_bin_common::bin_info;
 use nym_bin_common::completions::{fig_generate, ArgShell};
 use nym_bin_common::version_checker;
@@ -165,6 +165,7 @@ fn persist_gateway_details(
 }
 
 fn try_upgrade_v1_1_13_config(id: &str) -> Result<bool, NetworkRequesterError> {
+    trace!("Trying to load as v1.1.13 config");
     use nym_config::legacy_helpers::nym_config::MigrationNymConfig;
 
     // explicitly load it as v1.1.13 (which is incompatible with the next step, i.e. 1.1.19)
@@ -186,6 +187,7 @@ fn try_upgrade_v1_1_13_config(id: &str) -> Result<bool, NetworkRequesterError> {
 }
 
 fn try_upgrade_v1_1_20_config(id: &str) -> Result<bool, NetworkRequesterError> {
+    trace!("Trying to load as v1.1.20 config");
     use nym_config::legacy_helpers::nym_config::MigrationNymConfig;
 
     // explicitly load it as v1.1.20 (which is incompatible with the current one, i.e. +1.1.21)
@@ -207,6 +209,8 @@ fn try_upgrade_v1_1_20_config(id: &str) -> Result<bool, NetworkRequesterError> {
 }
 
 fn try_upgrade_v1_1_20_2_config(id: &str) -> Result<bool, NetworkRequesterError> {
+    trace!("Trying to load as v1.1.20_2 config");
+
     // explicitly load it as v1.1.20_2 (which is incompatible with the current one, i.e. +1.1.21)
     let Ok(old_config) = ConfigV1_1_20_2::read_from_default_path(id) else {
         // if we failed to load it, there might have been nothing to upgrade
@@ -224,6 +228,7 @@ fn try_upgrade_v1_1_20_2_config(id: &str) -> Result<bool, NetworkRequesterError>
 }
 
 fn try_upgrade_config(id: &str) -> Result<(), NetworkRequesterError> {
+    trace!("Attempting to upgrade config");
     if try_upgrade_v1_1_13_config(id)? {
         return Ok(());
     }

--- a/service-providers/network-requester/src/cli/run.rs
+++ b/service-providers/network-requester/src/cli/run.rs
@@ -16,39 +16,39 @@ const ENABLE_STATISTICS: &str = "enable-statistics";
 #[derive(Args, Clone)]
 pub(crate) struct Run {
     /// Id of the nym-mixnet-client we want to run.
-    #[clap(long)]
+    #[arg(long)]
     id: String,
 
     /// Specifies whether this network requester should run in 'open-proxy' mode
-    #[clap(long)]
+    #[arg(long)]
     open_proxy: bool,
 
     /// Enable service anonymized statistics that get sent to a statistics aggregator server
-    #[clap(long)]
+    #[arg(long)]
     enable_statistics: bool,
 
     /// Mixnet client address where a statistics aggregator is running. The default value is a Nym
     /// aggregator client
-    #[clap(long)]
+    #[arg(long)]
     statistics_recipient: Option<String>,
 
     /// Set this client to work in a enabled credentials mode that would attempt to use gateway
     /// with bandwidth credential requirement.
-    #[clap(long)]
+    #[arg(long)]
     enabled_credentials_mode: Option<bool>,
 
     /// Mostly debug-related option to increase default traffic rate so that you would not need to
     /// modify config post init
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     fastmode: bool,
 
     /// Disable loop cover traffic and the Poisson rate limiter (for debugging only)
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     no_cover: bool,
 
     /// Enable medium mixnet traffic, for experiments only.
     /// This includes things like disabling cover traffic, no per hop delays, etc.
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     medium_toggle: bool,
 }
 

--- a/service-providers/network-requester/src/cli/sign.rs
+++ b/service-providers/network-requester/src/cli/sign.rs
@@ -13,14 +13,14 @@ use nym_types::helpers::ConsoleSigningOutput;
 #[derive(Args, Clone)]
 pub(crate) struct Sign {
     /// The id of the mixnode you want to sign with
-    #[clap(long)]
+    #[arg(long)]
     id: String,
 
     /// Signs a transaction-specific payload, that is going to be sent to the smart contract, with your identity key
-    #[clap(long)]
+    #[arg(long)]
     contract_msg: String,
 
-    #[clap(short, long, default_value_t = OutputFormat::default())]
+    #[arg(short, long, default_value_t = OutputFormat::default())]
     output: OutputFormat,
 }
 

--- a/service-providers/network-requester/src/config/old_config_v1_1_20_2.rs
+++ b/service-providers/network-requester/src/config/old_config_v1_1_20_2.rs
@@ -13,6 +13,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use super::persistence::DEFAULT_DESCRIPTION_FILENAME;
+
 pub const DEFAULT_STANDARD_LIST_UPDATE_INTERVAL: Duration = Duration::from_secs(30 * 60);
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Serialize, Clone)]
@@ -57,12 +59,21 @@ impl ConfigV1_1_20_2 {
     // so its returned to be stored elsewhere.
     pub fn upgrade(self) -> (Config, GatewayEndpointConfig) {
         let gateway_details = self.base.client.gateway_endpoint.clone().into();
+        let nr_description = self
+            .storage_paths
+            .common_paths
+            .keys
+            .ack_key_file
+            .parent()
+            .expect("config paths upgrade failure")
+            .join(DEFAULT_DESCRIPTION_FILENAME);
         let config = Config {
             base: self.base.into(),
             storage_paths: NetworkRequesterPaths {
                 common_paths: self.storage_paths.common_paths.upgrade_default(),
                 allowed_list_location: self.storage_paths.allowed_list_location,
                 unknown_list_location: self.storage_paths.unknown_list_location,
+                nr_description,
             },
             network_requester_debug: self.network_requester_debug.into(),
             logging: self.logging,

--- a/service-providers/network-requester/src/config/old_config_v1_1_20_2.rs
+++ b/service-providers/network-requester/src/config/old_config_v1_1_20_2.rs
@@ -3,6 +3,7 @@
 
 use crate::config::persistence::NetworkRequesterPaths;
 use crate::config::{default_config_filepath, Config, Debug, NetworkRequester};
+use log::trace;
 use nym_bin_common::logging::LoggingSettings;
 use nym_client_core::config::disk_persistence::old_v1_1_20_2::CommonClientPathsV1_1_20_2;
 use nym_client_core::config::old_config_v1_1_20_2::ConfigV1_1_20_2 as BaseClientConfigV1_1_20_2;
@@ -58,6 +59,7 @@ impl ConfigV1_1_20_2 {
     // in this upgrade, gateway endpoint configuration was moved out of the config file,
     // so its returned to be stored elsewhere.
     pub fn upgrade(self) -> (Config, GatewayEndpointConfig) {
+        trace!("Upgrading from v1.1.20_2");
         let gateway_details = self.base.client.gateway_endpoint.clone().into();
         let nr_description = self
             .storage_paths

--- a/service-providers/network-requester/src/config/persistence.rs
+++ b/service-providers/network-requester/src/config/persistence.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 
 pub const DEFAULT_ALLOWED_LIST_FILENAME: &str = "allowed.list";
 pub const DEFAULT_UNKNOWN_LIST_FILENAME: &str = "unknown.list";
+pub const DEFAULT_DESCRIPTION_FILENAME: &str = "description.toml";
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Serialize, Clone)]
 pub struct NetworkRequesterPaths {
@@ -18,6 +19,11 @@ pub struct NetworkRequesterPaths {
 
     /// Location of the file containing our unknown.list
     pub unknown_list_location: PathBuf,
+
+    /// Location of the file containing our description
+    // For upgrade use default if missing. On next config upgrade iteration, remove the serde(default)
+    #[serde(default)]
+    pub nr_description: PathBuf,
 }
 
 impl NetworkRequesterPaths {
@@ -28,6 +34,7 @@ impl NetworkRequesterPaths {
             common_paths: CommonClientPaths::new_default(base_dir),
             allowed_list_location: base_dir.join(DEFAULT_ALLOWED_LIST_FILENAME),
             unknown_list_location: base_dir.join(DEFAULT_UNKNOWN_LIST_FILENAME),
+            nr_description: base_dir.join(DEFAULT_DESCRIPTION_FILENAME),
         }
     }
 }

--- a/service-providers/network-requester/src/config/template.rs
+++ b/service-providers/network-requester/src/config/template.rs
@@ -75,6 +75,9 @@ allowed_list_location = '{{ storage_paths.allowed_list_location }}'
 # Location of the file containing our unknown.list
 unknown_list_location = '{{ storage_paths.unknown_list_location }}'
 
+# Path to file containing description of this network-requester.
+nr_description = '{{ storage_paths.nr_description }}'
+
 
 [network_requester]
 


### PR DESCRIPTION
# Description

Add description to the network-requester, the same way we have them for mixnodes. The idea is that this will be queryable later on.

The config file will now have an entry:

```
[storage_paths]

...


# Path to file containing description of this network-requester.
nr_description = '/home/user/.nym/service-providers/network-requester/blkhjgsd3/data/description.toml'
```
