### PR TITLE
fix(wallet): gateway bond form wrong helper text

### DIFF
--- a/nym-wallet/src/components/Bonding/forms/gatewayValidationSchema.ts
+++ b/nym-wallet/src/components/Bonding/forms/gatewayValidationSchema.ts
@@ -28,7 +28,7 @@ export const gatewayValidationSchema = Yup.object().shape({
 
   location: Yup.string()
     .required('A location is required')
-    .test('valid-location', 'A valid version is required', (locationValueTest) =>
+    .test('valid-location', 'A valid location is required', (locationValueTest) =>
       locationValueTest ? validateLocation(locationValueTest) : false,
     ),
 


### PR DESCRIPTION
# Description

On location field the error message text displayed when wrong location values are entered is wrong.
