### PR TITLE
In geoaware routing, choose mixnodes close to exit gateway

### DIFF
--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -354,11 +354,13 @@ where
                 nym_api_urls,
                 env!("CARGO_PKG_VERSION").to_string(),
             )),
-            config::TopologyStructure::GeoAware(group) => Box::new(GeoAwareTopologyProvider::new(
-                nym_api_urls,
-                env!("CARGO_PKG_VERSION").to_string(),
-                group,
-            )),
+            config::TopologyStructure::GeoAware(group_by) => {
+                Box::new(GeoAwareTopologyProvider::new(
+                    nym_api_urls,
+                    env!("CARGO_PKG_VERSION").to_string(),
+                    group_by,
+                ))
+            }
         })
     }
 

--- a/common/client-core/src/client/topology_control/geo_aware_provider.rs
+++ b/common/client-core/src/client/topology_control/geo_aware_provider.rs
@@ -1,14 +1,14 @@
 use std::{collections::HashMap, fmt};
 
 use log::{debug, error, info};
-use nym_explorer_api_requests::PrettyDetailedMixNodeBond;
+use nym_explorer_api_requests::{PrettyDetailedMixNodeBond, PrettyDetailedGatewayBond};
 use nym_network_defaults::var_names::EXPLORER_API;
 use nym_topology::{
     nym_topology_from_detailed,
     provider_trait::{async_trait, TopologyProvider},
     NymTopology,
 };
-use nym_validator_client::client::MixId;
+use nym_validator_client::client::{MixId, IdentityKey};
 use rand::{prelude::SliceRandom, thread_rng};
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -43,6 +43,25 @@ async fn fetch_mixnodes_from_explorer_api() -> Option<Vec<PrettyDetailedMixNodeB
         .await
         .ok()?
         .json::<Vec<PrettyDetailedMixNodeBond>>()
+        .await
+        .ok()
+}
+
+// TODO: create a explorer-api-client
+async fn fetch_gateways_from_explorer_api() -> Option<Vec<PrettyDetailedGatewayBond>> {
+    let explorer_api_url = std::env::var(EXPLORER_API).ok()?;
+    let explorer_api_url = Url::parse(&explorer_api_url)
+        .ok()?
+        .join("v1/gateways")
+        .ok()?;
+
+    debug!("Fetching: {}", explorer_api_url);
+    reqwest_client()?
+        .get(explorer_api_url)
+        .send()
+        .await
+        .ok()?
+        .json::<Vec<PrettyDetailedGatewayBond>>()
         .await
         .ok()
 }
@@ -213,6 +232,22 @@ fn group_mixnodes_by_country_code(
         })
 }
 
+fn group_gateways_by_country_code(
+    gateways: Vec<PrettyDetailedGatewayBond>,
+) -> HashMap<CountryGroup, Vec<IdentityKey>> {
+    gateways
+        .into_iter()
+        .fold(HashMap::<CountryGroup, Vec<IdentityKey>>::new(), |mut acc, g| {
+            if let Some(ref location) = g.location {
+                let country_code = location.two_letter_iso_country_code.clone();
+                let group_code = CountryGroup::new(country_code.as_str());
+                let gateways = acc.entry(group_code).or_insert_with(Vec::new);
+                gateways.push(g.gateway.identity_key)
+            }
+            acc
+        })
+}
+
 fn log_mixnode_distribution(mixnodes: &HashMap<CountryGroup, Vec<MixId>>) {
     let mixnode_distribution = mixnodes
         .iter()
@@ -220,6 +255,15 @@ fn log_mixnode_distribution(mixnodes: &HashMap<CountryGroup, Vec<MixId>>) {
         .collect::<Vec<_>>()
         .join(", ");
     debug!("Mixnode distribution - {}", mixnode_distribution);
+}
+
+fn log_gateway_distribution(gateways: &HashMap<CountryGroup, Vec<IdentityKey>>) {
+    let gateway_distribution = gateways
+        .iter()
+        .map(|(k, v)| format!("{}: {}", k, v.len()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    debug!("Gateway distribution - {}", gateway_distribution);
 }
 
 fn check_layer_integrity(topology: NymTopology) -> Result<(), ()> {
@@ -294,6 +338,12 @@ impl GeoAwareTopologyProvider {
             return None;
         };
 
+        debug!("Fetching gateways from explorer-api...");
+        let Some(gateways_from_explorer_api) = fetch_gateways_from_explorer_api().await else {
+            error!("failed to get mixnodes from explorer-api");
+            return None;
+        };
+
         // Partition mixnodes_from_explorer_api according to the value of
         // two_letter_iso_country_code.
         // NOTE: we construct the full distribution here, but only use the one we're interested in.
@@ -302,14 +352,27 @@ impl GeoAwareTopologyProvider {
         let mixnode_distribution = group_mixnodes_by_country_code(mixnodes_from_explorer_api);
         log_mixnode_distribution(&mixnode_distribution);
 
+        let gateway_distribution = group_gateways_by_country_code(gateways_from_explorer_api);
+        log_gateway_distribution(&gateway_distribution);
+
         let Some(filtered_mixnode_ids) = mixnode_distribution.get(&self.filter_on) else {
             error!("no mixnodes found for: {}", self.filter_on);
+            return None;
+        };
+
+        let Some(filtered_gateway_ids) = gateway_distribution.get(&self.filter_on) else {
+            error!("no gateways found for: {}", self.filter_on);
             return None;
         };
 
         let mixnodes = mixnodes
             .into_iter()
             .filter(|m| filtered_mixnode_ids.contains(&m.mix_id()))
+            .collect::<Vec<_>>();
+
+        let gateways = gateways
+            .into_iter()
+            .filter(|g| filtered_gateway_ids.contains(g.identity()))
             .collect::<Vec<_>>();
 
         let topology = nym_topology_from_detailed(mixnodes, gateways)

--- a/common/client-core/src/config/mod.rs
+++ b/common/client-core/src/config/mod.rs
@@ -483,6 +483,7 @@ pub struct Topology {
     pub topology_structure: TopologyStructure,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Default, Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum TopologyStructure {
     #[default]
@@ -490,6 +491,7 @@ pub enum TopologyStructure {
     GeoAware(GroupBy),
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum GroupBy {
     CountryGroup(CountryGroup),

--- a/common/client-core/src/config/mod.rs
+++ b/common/client-core/src/config/mod.rs
@@ -3,7 +3,10 @@
 
 use nym_config::defaults::NymNetworkDetails;
 use nym_crypto::asymmetric::identity;
-use nym_sphinx::params::{PacketSize, PacketType};
+use nym_sphinx::{
+    addressing::clients::Recipient,
+    params::{PacketSize, PacketType},
+};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use url::Url;
@@ -484,7 +487,13 @@ pub struct Topology {
 pub enum TopologyStructure {
     #[default]
     NymApi,
-    GeoAware(CountryGroup),
+    GeoAware(GroupBy),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GroupBy {
+    CountryGroup(CountryGroup),
+    NymAddress(Recipient),
 }
 
 impl Default for Topology {

--- a/nym-connect/desktop/Cargo.lock
+++ b/nym-connect/desktop/Cargo.lock
@@ -3884,6 +3884,7 @@ version = "1.1.15"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
+ "cfg-if",
  "dashmap",
  "dirs 4.0.0",
  "futures",

--- a/nym-connect/desktop/src-tauri/src/tasks.rs
+++ b/nym-connect/desktop/src-tauri/src/tasks.rs
@@ -6,7 +6,7 @@ use nym_client_core::{
         },
         topology_control::geo_aware_provider::CountryGroup,
     },
-    config::{GatewayEndpointConfig, TopologyStructure},
+    config::{GatewayEndpointConfig, GroupdBy, TopologyStructure},
     error::ClientCoreStatusMessage,
 };
 use nym_socks5_client_core::{NymClient as Socks5NymClient, Socks5ControlMessageSender};
@@ -54,12 +54,17 @@ fn override_config_from_env(config: &mut Config, privacy_level: &PrivacyLevel) {
         config.core.base.set_no_per_hop_delays();
 
         // TODO: selectable in the UI
-        let default_country_group = CountryGroup::Europe;
-        log::warn!("Using geo-aware mixnode selection: {default_country_group}");
+        let address = config
+            .core
+            .socks5
+            .provider_mix_address
+            .parse()
+            .expect("failed to parse provider mix address");
+        log::warn!("Using geo-aware mixnode selection baseon the location of: {address}");
         config
             .core
             .base
-            .set_topology_structure(TopologyStructure::GeoAware(default_country_group));
+            .set_topology_structure(TopologyStructure::GeoAware(GroupBy::NymAddress(address)));
     }
 }
 

--- a/nym-connect/desktop/src-tauri/src/tasks.rs
+++ b/nym-connect/desktop/src-tauri/src/tasks.rs
@@ -1,12 +1,9 @@
 use futures::{channel::mpsc, StreamExt};
 use nym_client_core::{
-    client::{
-        base_client::storage::{
-            gateway_details::GatewayDetailsStore, MixnetClientStorage, OnDiskPersistent,
-        },
-        topology_control::geo_aware_provider::CountryGroup,
+    client::base_client::storage::{
+        gateway_details::GatewayDetailsStore, MixnetClientStorage, OnDiskPersistent,
     },
-    config::{GatewayEndpointConfig, GroupdBy, TopologyStructure},
+    config::{GatewayEndpointConfig, GroupBy, TopologyStructure},
     error::ClientCoreStatusMessage,
 };
 use nym_socks5_client_core::{NymClient as Socks5NymClient, Socks5ControlMessageSender};


### PR DESCRIPTION
# Description

Closes: #3775 

In geoaware mixnode routing, choose mixnodes close the gateway of the selected network-requester.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
