### PR TITLE
Revert clippy fix for arc_with_non_send_sync in wasm client

### DIFF
--- a/clients/webassembly/src/lib.rs
+++ b/clients/webassembly/src/lib.rs
@@ -1,6 +1,10 @@
 // Copyright 2021-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+// After reading https://github.com/rust-lang/rust-clippy/issues/11382
+// I suspect we *maybe* have hit a false positive, but I'm not sure.
+#![allow(clippy::arc_with_non_send_sync)]
+
 use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]

--- a/clients/webassembly/src/storage/mod.rs
+++ b/clients/webassembly/src/storage/mod.rs
@@ -1,8 +1,6 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use std::rc::Rc;
-
 use crate::client::config::Config;
 use crate::storage::error::ClientStorageError;
 use js_sys::Promise;
@@ -10,6 +8,7 @@ use nym_client_core::client::base_client::storage::gateway_details::PersistedGat
 use nym_crypto::asymmetric::{encryption, identity};
 use nym_gateway_client::SharedKeys;
 use nym_sphinx::acknowledgements::AckKey;
+use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 use wasm_utils::storage::{IdbVersionChangeEvent, WasmStorage};
@@ -44,7 +43,7 @@ mod v1 {
 pub struct ClientStorage {
     #[allow(dead_code)]
     pub(crate) name: String,
-    pub(crate) inner: Rc<WasmStorage>,
+    pub(crate) inner: Arc<WasmStorage>,
 }
 
 #[wasm_bindgen]
@@ -89,7 +88,7 @@ impl ClientStorage {
         .await?;
 
         Ok(ClientStorage {
-            inner: Rc::new(inner),
+            inner: Arc::new(inner),
             name,
         })
     }

--- a/clients/webassembly/src/tester/mod.rs
+++ b/clients/webassembly/src/tester/mod.rs
@@ -29,7 +29,6 @@ use nym_validator_client::client::IdentityKey;
 use nym_validator_client::QueryReqwestRpcNyxdClient;
 use rand::rngs::OsRng;
 use std::collections::HashSet;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex as SyncMutex};
 use std::time::Duration;
@@ -43,7 +42,7 @@ pub(crate) mod helpers;
 
 pub type NodeTestMessage = TestMessage<WasmTestMessageExt>;
 type LockedGatewayClient =
-    Rc<AsyncMutex<GatewayClient<QueryReqwestRpcNyxdClient, EphemeralStorage>>>;
+    Arc<AsyncMutex<GatewayClient<QueryReqwestRpcNyxdClient, EphemeralStorage>>>;
 
 pub(crate) const DEFAULT_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 pub(crate) const DEFAULT_TEST_PACKETS: u32 = 20;
@@ -211,7 +210,7 @@ impl NymNodeTesterBuilder {
             test_in_progress: Arc::new(AtomicBool::new(false)),
             current_test_nonce: Default::default(),
             tester: Arc::new(SyncMutex::new(tester)),
-            gateway_client: Rc::new(AsyncMutex::new(gateway_client)),
+            gateway_client: Arc::new(AsyncMutex::new(gateway_client)),
             processed_receiver: ReceivedReceiverWrapper::new(processed_receiver),
             _task_manager: task_manager,
         })
@@ -344,7 +343,7 @@ impl NymNodeTester {
         ));
 
         let processed_receiver_clone = self.processed_receiver.clone();
-        let gateway_client_clone = Rc::clone(&self.gateway_client);
+        let gateway_client_clone = Arc::clone(&self.gateway_client);
         let tester_marker = TestMarker::new(Arc::clone(&self.test_in_progress));
 
         // start doing async things (send packets and watch for anything coming back)


### PR DESCRIPTION
# Description

- Revert "Replace Arc with Rc on clippy's suggestion"
- Allow arc_with_non_send_sync in wasm client

