### PR TITLE
feat: add name to `TaskClient`

### DIFF
--- a/common/mixnode-common/src/verloc/mod.rs
+++ b/common/mixnode-common/src/verloc/mod.rs
@@ -197,12 +197,12 @@ impl VerlocMeasurer {
                 config.packet_timeout,
                 config.connection_timeout,
                 config.delay_between_packets,
-                shutdown_listener.clone(),
+                shutdown_listener.clone().named("VerlocPacketSender"),
             )),
             packet_listener: Arc::new(PacketListener::new(
                 config.listening_address,
                 Arc::clone(&identity),
-                shutdown_listener.clone(),
+                shutdown_listener.clone().named("VerlocPacketListener"),
             )),
             shutdown_listener,
             currently_used_api: 0,
@@ -241,7 +241,7 @@ impl VerlocMeasurer {
             return MeasurementOutcome::Done;
         }
 
-        let mut shutdown_listener = self.shutdown_listener.clone();
+        let mut shutdown_listener = self.shutdown_listener.clone().named("VerlocMeasurement");
         shutdown_listener.mark_as_success();
 
         for chunk in nodes_to_test.chunks(self.config.tested_nodes_batch_size) {

--- a/common/mixnode-common/src/verloc/sender.rs
+++ b/common/mixnode-common/src/verloc/sender.rs
@@ -83,7 +83,7 @@ impl PacketSender {
         self: Arc<Self>,
         tested_node: TestedNode,
     ) -> Result<Measurement, RttError> {
-        let mut shutdown_listener = self.shutdown_listener.clone();
+        let mut shutdown_listener = self.shutdown_listener.fork(tested_node.address.to_string());
         shutdown_listener.mark_as_success();
 
         let mut conn = match tokio::time::timeout(

--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -452,10 +452,11 @@ impl TaskClient {
 
 impl Drop for TaskClient {
     fn drop(&mut self) {
-        self.log(Level::Debug, "the shutdown is getting dropped");
-
         if !self.mode.should_signal_on_drop() {
+            self.log(Level::Debug, "the task client is getting dropped");
             return;
+        } else {
+            self.log(Level::Info, "the task client is getting dropped");
         }
 
         if !self.is_shutdown_poll() {

--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -282,6 +282,20 @@ impl TaskClient {
         }
     }
 
+    // TODO: not convinced about the name...
+    pub fn fork<S: Into<String>>(&self, child_suffix: S) -> Self {
+        let mut child = self.clone();
+        let suffix = child_suffix.into();
+        let child_name = if let Some(base) = &self.name {
+            format!("{base}-{suffix}")
+        } else {
+            format!("unknown-{suffix}")
+        };
+
+        child.name = Some(child_name);
+        child
+    }
+
     // just a convenience wrapper for including the shutdown name when logging
     // I really didn't want to create macros for that... because that seemed like an overkill.
     // but I guess it would have resolved needing to call `format!` for additional msg arguments

--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::{error::Error, time::Duration};
 
 use futures::{future::pending, FutureExt, SinkExt, StreamExt};
+use log::{log, Level};
 use tokio::{
     sync::{
         mpsc,
@@ -207,8 +208,11 @@ impl TaskManager {
 
 /// Listen for shutdown notifications, and can send error and status messages back to the
 /// `TaskManager`
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct TaskClient {
+    // optional name assigned to the shutdown handle
+    name: Option<String>,
+
     // If a shutdown notification has been registered
     shutdown: bool,
 
@@ -229,7 +233,35 @@ pub struct TaskClient {
     mode: ClientOperatingMode,
 }
 
+impl Clone for TaskClient {
+    fn clone(&self) -> Self {
+        // make sure to not accidentally overflow the stack if we keep cloning the handle
+        let name = if let Some(name) = &self.name {
+            if name != Self::OVERFLOW_NAME && name.len() < Self::MAX_NAME_LENGTH {
+                Some(format!("{name}-child"))
+            } else {
+                Some(Self::OVERFLOW_NAME.to_string())
+            }
+        } else {
+            None
+        };
+
+        TaskClient {
+            name,
+            shutdown: self.shutdown,
+            notify: self.notify.clone(),
+            return_error: self.return_error.clone(),
+            drop_error: self.drop_error.clone(),
+            status_msg: self.status_msg.clone(),
+            mode: self.mode.clone(),
+        }
+    }
+}
+
 impl TaskClient {
+    const MAX_NAME_LENGTH: usize = 128;
+    const OVERFLOW_NAME: &'static str = "reached maximum TaskClient children name depth";
+
     #[cfg(not(target_arch = "wasm32"))]
     const SHUTDOWN_TIMEOUT_WAITING_FOR_SIGNAL_ON_EXIT: Duration = Duration::from_secs(5);
 
@@ -240,6 +272,7 @@ impl TaskClient {
         status_msg: StatusSender,
     ) -> TaskClient {
         TaskClient {
+            name: None,
             shutdown: false,
             notify,
             return_error,
@@ -247,6 +280,27 @@ impl TaskClient {
             status_msg,
             mode: ClientOperatingMode::Listening,
         }
+    }
+
+    // just a convenience wrapper for including the shutdown name when logging
+    // I really didn't want to create macros for that... because that seemed like an overkill.
+    // but I guess it would have resolved needing to call `format!` for additional msg arguments
+    fn log<S: Into<String>>(&self, level: Level, msg: S) {
+        let msg = msg.into();
+
+        let target = &if let Some(name) = &self.name {
+            format!("TaskClient-{name}")
+        } else {
+            "unnamed-TaskClient".to_string()
+        };
+
+        log!(target: target, level, "{msg}")
+    }
+
+    #[must_use]
+    pub fn named<S: Into<String>>(mut self, name: S) -> Self {
+        self.name = Some(name.into());
+        self
     }
 
     pub async fn run_future<Fut, T>(&mut self, fut: Fut) -> Option<T>
@@ -267,6 +321,7 @@ impl TaskClient {
         let (task_drop_tx, _task_drop_rx) = mpsc::unbounded_channel();
         let (task_status_tx, _task_status_rx) = futures::channel::mpsc::channel(128);
         TaskClient {
+            name: None,
             shutdown: false,
             notify: notify_rx,
             return_error: task_halt_tx,
@@ -336,8 +391,9 @@ impl TaskClient {
                 has_changed
             }
             Err(err) => {
-                log::error!("Polling shutdown failed: {err}");
-                log::error!("Assuming this means we should shutdown...");
+                self.log(Level::Error, format!("Polling shutdown failed: {err}"));
+                self.log(Level::Error, "Assuming this means we should shutdown...");
+
                 true
             }
         }
@@ -354,9 +410,11 @@ impl TaskClient {
         if self.mode.is_dummy() {
             return;
         }
-        log::trace!("Notifying we stopped: {err}");
+
+        self.log(Level::Trace, format!("Notifying we stopped: {err}"));
+
         if self.return_error.send(err).is_err() {
-            log::error!("Failed to send back error message");
+            self.log(Level::Error, "failed to send back error message");
         }
     }
 
@@ -372,11 +430,15 @@ impl TaskClient {
 
 impl Drop for TaskClient {
     fn drop(&mut self) {
+        self.log(Level::Debug, "the shutdown is getting dropped");
+
         if !self.mode.should_signal_on_drop() {
             return;
         }
+
         if !self.is_shutdown_poll() {
-            log::trace!("Notifying stop on unexpected drop");
+            self.log(Level::Trace, "Notifying stop on unexpected drop");
+
             // If we can't send, well then there is not much to do
             self.drop_error
                 .send(Box::new(TaskError::UnexpectedHalt))

--- a/mixnode/src/node/mod.rs
+++ b/mixnode/src/node/mod.rs
@@ -274,16 +274,19 @@ impl MixNode {
 
         let shutdown = TaskManager::default();
 
-        let (node_stats_pointer, node_stats_update_sender) =
-            self.start_node_stats_controller(shutdown.subscribe());
-        let delay_forwarding_channel = self
-            .start_packet_delay_forwarder(node_stats_update_sender.clone(), shutdown.subscribe());
+        let (node_stats_pointer, node_stats_update_sender) = self
+            .start_node_stats_controller(shutdown.subscribe().named("node_statistics::Controller"));
+        let delay_forwarding_channel = self.start_packet_delay_forwarder(
+            node_stats_update_sender.clone(),
+            shutdown.subscribe().named("DelayForwarder"),
+        );
         self.start_socket_listener(
             node_stats_update_sender,
             delay_forwarding_channel,
-            shutdown.subscribe(),
+            shutdown.subscribe().named("Listener"),
         );
-        let atomic_verloc_results = self.start_verloc_measurements(shutdown.subscribe());
+        let atomic_verloc_results =
+            self.start_verloc_measurements(shutdown.subscribe().named("VerlocMeasurer"));
 
         // Rocket handles shutdown on it's own, but its shutdown handling should be incorporated
         // with that of the rest of the tasks.


### PR DESCRIPTION
# Description

Some QoL that came out from working on https://github.com/nymtech/nym/issues/3838. I figured I might as well create a separate PR for it. 

It should make it easier to debug those nasty dropped tasks. With named tasks such logs are now available (I have increased the logging level locally just for this example; it's not so verbose in the actual code):
```sh
 2023-09-05T14:52:02.031Z INFO  nym_task::signal                     > Received SIGINT
 2023-09-05T14:52:02.031Z INFO  nym_task::manager                    > Sending shutdown
 2023-09-05T14:52:02.031Z INFO  nym_task::manager                    > Waiting for tasks to finish... (Press ctrl-c to force)
 2023-09-05T14:52:02.032Z WARN  TaskClient-node_statistics::Controller-child > the shutdown is getting dropped
 2023-09-05T14:52:02.032Z WARN  TaskClient-node_statistics::Controller       > the shutdown is getting dropped
 2023-09-05T14:52:02.032Z WARN  TaskClient-VerlocPacketListener-child        > the shutdown is getting dropped
 2023-09-05T14:52:02.032Z WARN  TaskClient-VerlocPacketListener-child        > the shutdown is getting dropped
 2023-09-05T14:52:02.032Z WARN  TaskClient-node_statistics::Controller-child > the shutdown is getting dropped
 2023-09-05T14:52:02.033Z WARN  TaskClient-Listener                          > the shutdown is getting dropped
 2023-09-05T14:52:02.033Z WARN  TaskClient-DelayForwarder                    > the shutdown is getting dropped
 2023-09-05T14:52:02.181Z WARN  TaskClient-VerlocMeasurement                 > the shutdown is getting dropped
 2023-09-05T14:52:02.181Z WARN  TaskClient-VerlocPacketListener              > the shutdown is getting dropped
 2023-09-05T14:52:02.181Z WARN  TaskClient-VerlocMeasurer                    > the shutdown is getting dropped
 2023-09-05T14:52:02.186Z WARN  TaskClient-VerlocPacketSender-95.179.226.75:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.187Z WARN  TaskClient-VerlocPacketSender-51.195.255.51:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.191Z WARN  TaskClient-VerlocPacketSender-77.91.101.170:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.199Z WARN  TaskClient-VerlocPacketSender-185.215.167.12:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.201Z WARN  TaskClient-VerlocPacketSender-82.216.163.131:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.204Z WARN  TaskClient-VerlocPacketSender-85.1.11.146:1790    > the shutdown is getting dropped
 2023-09-05T14:52:02.205Z WARN  TaskClient-VerlocPacketSender-116.203.115.86:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.206Z WARN  TaskClient-VerlocPacketSender-185.229.90.217:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.206Z WARN  TaskClient-VerlocPacketSender-94.130.105.180:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.207Z WARN  TaskClient-VerlocPacketSender-167.235.134.255:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.207Z WARN  TaskClient-VerlocPacketSender-173.249.36.4:1790    > the shutdown is getting dropped
 2023-09-05T14:52:02.207Z WARN  TaskClient-VerlocPacketSender-161.97.71.166:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.208Z WARN  TaskClient-VerlocPacketSender-162.55.174.117:1790  > the shutdown is getting dropped
 2023-09-05T14:52:02.208Z WARN  TaskClient-VerlocPacketSender-167.235.242.140:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.208Z WARN  TaskClient-VerlocPacketSender-23.88.114.204:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.209Z WARN  TaskClient-VerlocPacketSender-136.243.90.57:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.219Z WARN  TaskClient-VerlocPacketSender-65.21.6.230:1790     > the shutdown is getting dropped
 2023-09-05T14:52:02.219Z WARN  TaskClient-VerlocPacketSender-65.108.104.113:1790  > the shutdown is getting dropped
 2023-09-05T14:52:02.220Z WARN  TaskClient-VerlocPacketSender-135.181.250.81:1790  > the shutdown is getting dropped
 2023-09-05T14:52:02.220Z WARN  TaskClient-VerlocPacketSender-135.181.114.98:1790  > the shutdown is getting dropped
 2023-09-05T14:52:02.220Z WARN  TaskClient-VerlocPacketSender-65.21.105.117:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.221Z WARN  TaskClient-VerlocPacketSender-65.109.1.171:1790    > the shutdown is getting dropped
 2023-09-05T14:52:02.221Z WARN  TaskClient-VerlocPacketSender-65.21.247.54:1790    > the shutdown is getting dropped
 2023-09-05T14:52:02.221Z WARN  TaskClient-VerlocPacketSender-65.109.15.194:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.221Z WARN  TaskClient-VerlocPacketSender-65.108.248.53:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.221Z WARN  TaskClient-VerlocPacketSender-65.108.52.71:1790    > the shutdown is getting dropped
 2023-09-05T14:52:02.221Z WARN  TaskClient-VerlocPacketSender-65.108.63.143:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.221Z WARN  TaskClient-VerlocPacketSender-65.108.243.67:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.221Z WARN  TaskClient-VerlocPacketSender-135.181.139.72:1790  > the shutdown is getting dropped
 2023-09-05T14:52:02.223Z WARN  TaskClient-VerlocPacketSender-88.201.196.152:1790  > the shutdown is getting dropped
 2023-09-05T14:52:02.224Z WARN  TaskClient-VerlocPacketSender-193.43.146.207:1790  > the shutdown is getting dropped
 2023-09-05T14:52:02.225Z WARN  TaskClient-VerlocPacketSender-185.232.171.127:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.227Z WARN  TaskClient-VerlocPacketSender-185.8.62.115:1790    > the shutdown is getting dropped
 2023-09-05T14:52:02.241Z WARN  TaskClient-VerlocPacketSender-149.102.129.77:1790  > the shutdown is getting dropped
 2023-09-05T14:52:02.243Z WARN  TaskClient-VerlocPacketSender-83.212.80.96:1790    > the shutdown is getting dropped
 2023-09-05T14:52:02.260Z WARN  TaskClient-VerlocPacketSender-45.11.27.209:1790    > the shutdown is getting dropped
 2023-09-05T14:52:02.263Z WARN  TaskClient-VerlocPacketSender-5.161.114.34:1790    > the shutdown is getting dropped
 2023-09-05T14:52:02.264Z WARN  TaskClient-VerlocPacketSender-5.161.114.178:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.265Z WARN  TaskClient-VerlocPacketSender-172.81.182.18:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.266Z WARN  TaskClient-VerlocPacketSender-5.161.81.152:1790    > the shutdown is getting dropped
 2023-09-05T14:52:02.267Z WARN  TaskClient-VerlocPacketSender-5.161.105.116:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.292Z WARN  TaskClient-VerlocPacketSender-192.151.146.250:1790 > the shutdown is getting dropped
 2023-09-05T14:52:02.314Z WARN  TaskClient-VerlocPacketSender-216.238.77.232:1790  > the shutdown is getting dropped
 2023-09-05T14:52:02.326Z WARN  TaskClient-VerlocPacketSender-204.15.76.157:1790   > the shutdown is getting dropped
 2023-09-05T14:52:02.327Z WARN  TaskClient-VerlocPacketSender-149.28.214.159:1790  > the shutdown is getting dropped
 2023-09-05T14:52:02.340Z WARN  TaskClient-VerlocPacketSender-139.59.92.15:1790    > the shutdown is getting dropped
 2023-09-05T14:52:02.392Z WARN  TaskClient-VerlocPacketSender-38.54.4.21:1790      > the shutdown is getting dropped
 2023-09-05T14:52:02.412Z WARN  TaskClient-VerlocPacketSender-139.162.60.229:1790  > the shutdown is getting dropped
 2023-09-05T14:52:02.416Z WARN  TaskClient-VerlocPacketSender-118.238.220.142:1790 > the shutdown is getting dropped
```

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
