### PR TITLE
clients: handle config upgrade failure

### DIFF
--- a/clients/native/src/client/config/old_config_v1_1_20_2.rs
+++ b/clients/native/src/client/config/old_config_v1_1_20_2.rs
@@ -1,8 +1,13 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::client::config::persistence::ClientPaths;
-use crate::client::config::{default_config_filepath, Config, Socket, SocketType};
+use crate::{
+    client::config::{
+        default_config_filepath, persistence::ClientPaths, Config, Socket, SocketType,
+    },
+    error::ClientError,
+};
+
 use nym_bin_common::logging::LoggingSettings;
 use nym_client_core::config::disk_persistence::old_v1_1_20_2::CommonClientPathsV1_1_20_2;
 use nym_client_core::config::old_config_v1_1_20_2::ConfigV1_1_20_2 as BaseConfigV1_1_20_2;
@@ -43,18 +48,18 @@ impl ConfigV1_1_20_2 {
 
     // in this upgrade, gateway endpoint configuration was moved out of the config file,
     // so its returned to be stored elsewhere.
-    pub fn upgrade(self) -> (Config, GatewayEndpointConfig) {
+    pub fn upgrade(self) -> Result<(Config, GatewayEndpointConfig), ClientError> {
         let gateway_details = self.base.client.gateway_endpoint.clone().into();
         let config = Config {
             base: self.base.into(),
             socket: self.socket.into(),
             storage_paths: ClientPaths {
-                common_paths: self.storage_paths.common_paths.upgrade_default(),
+                common_paths: self.storage_paths.common_paths.upgrade_default()?,
             },
             logging: self.logging,
         };
 
-        (config, gateway_details)
+        Ok((config, gateway_details))
     }
 }
 

--- a/clients/native/src/commands/mod.rs
+++ b/clients/native/src/commands/mod.rs
@@ -157,7 +157,7 @@ fn try_upgrade_v1_1_13_config(id: &str) -> Result<bool, ClientError> {
 
     let updated_step1: ConfigV1_1_20 = old_config.into();
     let updated_step2: ConfigV1_1_20_2 = updated_step1.into();
-    let (updated, gateway_config) = updated_step2.upgrade();
+    let (updated, gateway_config) = updated_step2.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;
@@ -177,7 +177,7 @@ fn try_upgrade_v1_1_20_config(id: &str) -> Result<bool, ClientError> {
     info!("It is going to get updated to the current specification.");
 
     let updated_step1: ConfigV1_1_20_2 = old_config.into();
-    let (updated, gateway_config) = updated_step1.upgrade();
+    let (updated, gateway_config) = updated_step1.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;
@@ -194,7 +194,7 @@ fn try_upgrade_v1_1_20_2_config(id: &str) -> Result<bool, ClientError> {
     info!("It seems the client is using <= v1.1.20_2 config template.");
     info!("It is going to get updated to the current specification.");
 
-    let (updated, gateway_config) = old_config.upgrade();
+    let (updated, gateway_config) = old_config.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -199,7 +199,7 @@ fn try_upgrade_v1_1_13_config(id: &str) -> Result<bool, Socks5ClientError> {
 
     let updated_step1: ConfigV1_1_20 = old_config.into();
     let updated_step2: ConfigV1_1_20_2 = updated_step1.into();
-    let (updated, gateway_config) = updated_step2.upgrade();
+    let (updated, gateway_config) = updated_step2.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;
@@ -219,7 +219,7 @@ fn try_upgrade_v1_1_20_config(id: &str) -> Result<bool, Socks5ClientError> {
     info!("It is going to get updated to the current specification.");
 
     let updated_step1: ConfigV1_1_20_2 = old_config.into();
-    let (updated, gateway_config) = updated_step1.upgrade();
+    let (updated, gateway_config) = updated_step1.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;
@@ -236,7 +236,7 @@ fn try_upgrade_v1_1_20_2_config(id: &str) -> Result<bool, Socks5ClientError> {
     info!("It seems the client is using <= v1.1.20_2 config template.");
     info!("It is going to get updated to the current specification.");
 
-    let (updated, gateway_config) = old_config.upgrade();
+    let (updated, gateway_config) = old_config.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;

--- a/common/client-core/src/config/disk_persistence/old_v1_1_20_2.rs
+++ b/common/client-core/src/config/disk_persistence/old_v1_1_20_2.rs
@@ -3,6 +3,7 @@
 
 use crate::config::disk_persistence::keys_paths::ClientKeysPaths;
 use crate::config::disk_persistence::{CommonClientPaths, DEFAULT_GATEWAY_DETAILS_FILENAME};
+use crate::error::ClientCoreError;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -15,16 +16,17 @@ pub struct CommonClientPathsV1_1_20_2 {
 }
 
 impl CommonClientPathsV1_1_20_2 {
-    pub fn upgrade_default(self) -> CommonClientPaths {
-        let data_dir = self
-            .reply_surb_database
-            .parent()
-            .expect("client paths upgrade failure");
-        CommonClientPaths {
+    pub fn upgrade_default(self) -> Result<CommonClientPaths, ClientCoreError> {
+        let data_dir = self.reply_surb_database.parent().ok_or_else(|| {
+            ClientCoreError::UnableToUpgradeConfigFile {
+                new_version: "1.1.20-2".to_string(),
+            }
+        })?;
+        Ok(CommonClientPaths {
             keys: self.keys,
             gateway_details: data_dir.join(DEFAULT_GATEWAY_DETAILS_FILENAME),
             credentials_database: self.credentials_database,
             reply_surb_database: self.reply_surb_database,
-        }
+        })
     }
 }

--- a/common/client-core/src/error.rs
+++ b/common/client-core/src/error.rs
@@ -119,6 +119,9 @@ pub enum ClientCoreError {
 
     #[error("the provided gateway details (for gateway {gateway_id}) do not correspond to the shared keys")]
     MismatchedGatewayDetails { gateway_id: String },
+
+    #[error("unable to upgrade config file to `{new_version}`")]
+    UnableToUpgradeConfigFile { new_version: String },
 }
 
 /// Set of messages that the client can send to listeners via the task manager

--- a/nym-connect/desktop/Cargo.lock
+++ b/nym-connect/desktop/Cargo.lock
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "nym-connect"
-version = "1.1.19"
+version = "1.1.20"
 dependencies = [
  "anyhow",
  "bip39",

--- a/nym-connect/desktop/src-tauri/src/config/mod.rs
+++ b/nym-connect/desktop/src-tauri/src/config/mod.rs
@@ -8,6 +8,7 @@ use crate::error::{BackendError, Result};
 use nym_client_core::client::base_client::storage::gateway_details::OnDiskGatewayDetails;
 use nym_client_core::client::key_manager::persistence::OnDiskKeys;
 use nym_client_core::config::GatewayEndpointConfig;
+use nym_client_core::error::ClientCoreError;
 use nym_client_core::init::GatewaySetup;
 use nym_config::{
     must_get_home, read_config_from_toml_file, save_formatted_config_to_file, NymConfigTemplate,
@@ -138,14 +139,11 @@ fn init_paths(id: &str) -> io::Result<()> {
 }
 
 fn try_extract_version_for_upgrade_failure(err: BackendError) -> Option<String> {
-    if let BackendError::ClientCoreError { source } = err {
-        if let nym_client_core::error::ClientCoreError::UnableToUpgradeConfigFile { new_version } =
-            source
-        {
-            Some(new_version)
-        } else {
-            None
-        }
+    if let BackendError::ClientCoreError {
+        source: ClientCoreError::UnableToUpgradeConfigFile { new_version },
+    } = err
+    {
+        Some(new_version)
     } else {
         None
     }

--- a/nym-connect/desktop/src-tauri/src/config/old_config_v1_1_20_2.rs
+++ b/nym-connect/desktop/src-tauri/src/config/old_config_v1_1_20_2.rs
@@ -3,6 +3,7 @@
 
 use crate::config::persistence::NymConnectPaths;
 use crate::config::{default_config_filepath, Config};
+use crate::error::Result;
 use nym_bin_common::logging::LoggingSettings;
 use nym_client_core::config::disk_persistence::old_v1_1_20_2::CommonClientPathsV1_1_20_2;
 use nym_client_core::config::GatewayEndpointConfig;
@@ -39,16 +40,16 @@ impl ConfigV1_1_20_2 {
 
     // in this upgrade, gateway endpoint configuration was moved out of the config file,
     // so its returned to be stored elsewhere.
-    pub fn upgrade(self) -> (Config, GatewayEndpointConfig) {
+    pub fn upgrade(self) -> Result<(Config, GatewayEndpointConfig)> {
         let gateway_details = self.core.base.client.gateway_endpoint.clone().into();
         let config = Config {
             core: self.core.into(),
             storage_paths: NymConnectPaths {
-                common_paths: self.storage_paths.common_paths.upgrade_default(),
+                common_paths: self.storage_paths.common_paths.upgrade_default()?,
             },
             // logging: self.logging,
         };
 
-        (config, gateway_details)
+        Ok((config, gateway_details))
     }
 }

--- a/nym-connect/desktop/src-tauri/src/config/upgrade.rs
+++ b/nym-connect/desktop/src-tauri/src/config/upgrade.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     error::{BackendError, Result},
 };
-use log::info;
+use log::{debug, info};
 use nym_client_core::{
     client::{
         base_client::storage::gateway_details::{OnDiskGatewayDetails, PersistedGatewayDetails},
@@ -52,7 +52,7 @@ fn try_upgrade_v1_1_13_config(id: &str) -> Result<bool> {
 
     let updated_step1: ConfigV1_1_20 = old_config.into();
     let updated_step2: ConfigV1_1_20_2 = updated_step1.into();
-    let (updated, gateway_config) = updated_step2.upgrade();
+    let (updated, gateway_config) = updated_step2.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;
@@ -72,7 +72,7 @@ fn try_upgrade_v1_1_20_config(id: &str) -> Result<bool> {
     info!("It is going to get updated to the current specification.");
 
     let updated_step1: ConfigV1_1_20_2 = old_config.into();
-    let (updated, gateway_config) = updated_step1.upgrade();
+    let (updated, gateway_config) = updated_step1.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;
@@ -89,7 +89,7 @@ fn try_upgrade_v1_1_20_2_config(id: &str) -> Result<bool> {
     info!("It seems the client is using <= v1.1.20_2 config template.");
     info!("It is going to get updated to the current specification.");
 
-    let (updated, gateway_config) = old_config.upgrade();
+    let (updated, gateway_config) = old_config.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;
@@ -97,6 +97,7 @@ fn try_upgrade_v1_1_20_2_config(id: &str) -> Result<bool> {
 }
 
 pub fn try_upgrade_config(id: &str) -> Result<()> {
+    debug!("Attempting to upgrade config file for \"{id}\"");
     if try_upgrade_v1_1_13_config(id)? {
         return Ok(());
     }

--- a/nym-connect/desktop/src-tauri/src/error.rs
+++ b/nym-connect/desktop/src-tauri/src/error.rs
@@ -81,6 +81,13 @@ pub enum BackendError {
     CouldNotGetConfigFilename,
     #[error("could not load existing gateway configuration")]
     CouldNotLoadExistingGatewayConfiguration(std::io::Error),
+    #[error("could not upgrade `{file}` to latest version")]
+    CouldNotUpgradeExistingConfigurationFile { file: std::path::PathBuf },
+    #[error("could not upgrade `{file}` to latest version (failed at {failed_at_version})")]
+    CouldNotUpgradeExistingConfigurationFileAtVersion {
+        file: std::path::PathBuf,
+        failed_at_version: String,
+    },
 
     #[error("no gateways found in directory")]
     NoGatewaysFoundInDirectory,

--- a/service-providers/network-requester/src/cli/mod.rs
+++ b/service-providers/network-requester/src/cli/mod.rs
@@ -179,7 +179,7 @@ fn try_upgrade_v1_1_13_config(id: &str) -> Result<bool, NetworkRequesterError> {
 
     let updated_step1: ConfigV1_1_20 = old_config.into();
     let updated_step2: ConfigV1_1_20_2 = updated_step1.into();
-    let (updated, gateway_config) = updated_step2.upgrade();
+    let (updated, gateway_config) = updated_step2.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;
@@ -201,7 +201,7 @@ fn try_upgrade_v1_1_20_config(id: &str) -> Result<bool, NetworkRequesterError> {
     info!("It is going to get updated to the current specification.");
 
     let updated_step1: ConfigV1_1_20_2 = old_config.into();
-    let (updated, gateway_config) = updated_step1.upgrade();
+    let (updated, gateway_config) = updated_step1.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;
@@ -220,7 +220,7 @@ fn try_upgrade_v1_1_20_2_config(id: &str) -> Result<bool, NetworkRequesterError>
     info!("It seems the client is using <= v1.1.20_2 config template.");
     info!("It is going to get updated to the current specification.");
 
-    let (updated, gateway_config) = old_config.upgrade();
+    let (updated, gateway_config) = old_config.upgrade()?;
     persist_gateway_details(&updated, gateway_config)?;
 
     updated.save_to_default_location()?;


### PR DESCRIPTION
# Description

Closes: #3847 

Sometimes nym-connect fails to connect due to the existing configuration file is too old to upgrade. Instead of panicking, handle the error and display what went wrong.

![image](https://github.com/nymtech/nym/assets/1894054/858a91b7-e197-4d9d-8ba4-19f77f854b91)
