### PR TITLE
DOCS: Create community legal forum wiki in /operators

### DIFF
--- a/documentation/operators/src/SUMMARY.md
+++ b/documentation/operators/src/SUMMARY.md
@@ -19,7 +19,7 @@
 - [Maintenance](./nodes/maintenance.md)
 - [Troubleshooting](./nodes/troubleshooting.md)
 - [FAQ](./faq.md)
-- [Legal Advice](legal/legal-forum.md)
+- [Legal Forum](./legal/legal-forum.md)
 
 --- 
 # Misc.

--- a/documentation/operators/src/SUMMARY.md
+++ b/documentation/operators/src/SUMMARY.md
@@ -19,6 +19,7 @@
 - [Maintenance](./nodes/maintenance.md)
 - [Troubleshooting](./nodes/troubleshooting.md)
 - [FAQ](./faq.md)
+- [Legal Advice](legal/legal-forum.md)
 
 --- 
 # Misc.

--- a/documentation/operators/src/legal/legal-forum.md
+++ b/documentation/operators/src/legal/legal-forum.md
@@ -1,0 +1,3 @@
+# Legal Forum
+
+**Legal advice and experiences collated by the Nym node operator community around the world**


### PR DESCRIPTION
# Description
As gateways change their character, operators need a place to share different jurisdictional conditions in order to prevent unnecessary troubles. The solution is a [`Legal Forum`](https://github.com/nymtech/nym/blob/f4dd0e69036a3c670c4cf51055e5eb9722652256/documentation/operators/src/legal/legal-forum.md), a page in [Nym Operators Guide](https://nymtech.net/operators) where the active operators and community members can inform each other. 

# Checklist:

- [x] Make a new branch, new page and PR
- [x] need something like "this is community advice and not the advice of Nym Technologies SA"
- [ ] Write a contributors copyright assignment
- [ ] Compose points from different regions
- [ ] Share with the operators