### PR TITLE
replaced '--disable-sign-ext' with '--signext-lowering' when running wasm-opt

### DIFF
--- a/.github/workflows/ci-contracts-upload-binaries.yml
+++ b/.github/workflows/ci-contracts-upload-binaries.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install wasm-opt
         uses: ./.github/actions/install-wasm-opt
         with:
-          version: '112'
+          version: '114'
 
       - name: Build release contracts
         run: make contracts

--- a/.github/workflows/ci-contracts-upload-binaries.yml
+++ b/.github/workflows/ci-contracts-upload-binaries.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.69.0
+          toolchain: stable
           target: wasm32-unknown-unknown
           override: true
 

--- a/.github/workflows/publish-nym-contracts.yml
+++ b/.github/workflows/publish-nym-contracts.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.69.0
+          toolchain: stable
           target: wasm32-unknown-unknown
           override: true
           components: rustfmt, clippy
 
       - name: Install wasm-opt
-        run: cargo install --version 0.112.0 wasm-opt
+        run: cargo install --version 0.114.0 wasm-opt
 
       - name: Build release contracts
         run: make contracts

--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,6 @@ $(eval $(call add_cargo_workspace,contracts,contracts,--lib --target wasm32-unkn
 $(eval $(call add_cargo_workspace,wallet,nym-wallet))
 $(eval $(call add_cargo_workspace,connect,nym-connect/desktop))
 
-# OVERRIDE: wasm-opt fails if the binary has been built with the latest rustc.
-# Pin to the last working version.
-contracts_BUILD_RELEASE_TOOLCHAIN := +1.69.0
-
 # -----------------------------------------------------------------------------
 # SDK
 # -----------------------------------------------------------------------------
@@ -144,7 +140,7 @@ contracts: build-release-contracts wasm-opt-contracts
 
 wasm-opt-contracts:
 	for contract in $(CONTRACTS_WASM); do \
-	  wasm-opt --disable-sign-ext -Os $(CONTRACTS_OUT_DIR)/$$contract -o $(CONTRACTS_OUT_DIR)/$$contract; \
+	  wasm-opt --signext-lowering -Os $(CONTRACTS_OUT_DIR)/$$contract -o $(CONTRACTS_OUT_DIR)/$$contract; \
 	done
 
 # Consider adding 's' to make plural consistent (beware: used in github workflow)

--- a/contracts/mixnet/Makefile
+++ b/contracts/mixnet/Makefile
@@ -1,5 +1,5 @@
 opt: wasm
-	wasm-opt --disable-sign-ext -Os ../target/wasm32-unknown-unknown/release/mixnet_contract.wasm -o ../target/wasm32-unknown-unknown/release/mixnet_contract.wasm
+	wasm-opt --signext-lowering -Os ../target/wasm32-unknown-unknown/release/mixnet_contract.wasm -o ../target/wasm32-unknown-unknown/release/mixnet_contract.wasm
 
 wasm:
 	RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown


### PR DESCRIPTION
# Description

This should allow us to build all the contracts with the most recent version of rust once more. 
Suggestion came from: https://github.com/CosmWasm/cosmwasm/issues/1727#issuecomment-1646513138

for QA:

make sure we're still able to upload, init and migrate contracts on our current verison of nyxd. because as we found out in the past, compilation is only one part of the story
