### PR TITLE
Fix all the cargo warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,3 +175,25 @@ wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = "0.4.37"
 wasmtimer = "0.2.0"
 web-sys = "0.3.63"
+
+# Profile settings for individual crates
+
+[profile.release.package.nym-socks5-listener]
+strip = true
+codegen-units = 1
+
+[profile.release.package.nym-client-wasm]
+# lto = true
+opt-level = 'z'
+
+[profile.release.package.nym-node-tester-wasm]
+# lto = true
+opt-level = 'z'
+
+[profile.release.package.nym-wasm-sdk]
+# lto = true
+opt-level = 'z'
+
+[profile.release.package.mix-fetch-wasm]
+# lto = true
+opt-level = 'z'

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "coconut-bandwidth",
     "coconut-dkg",

--- a/contracts/mixnet/Cargo.toml
+++ b/contracts/mixnet/Cargo.toml
@@ -54,8 +54,3 @@ vergen = { version = "=7.4.3", default-features = false, features = ["build", "g
 default = []
 contract-testing = ["mixnet-contract-common/contract-testing"]
 schema-gen = ["mixnet-contract-common/schema", "cosmwasm-schema"]
-
-[profile.release]
-overflow-checks = true
-
-

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -48,8 +48,5 @@ cosmwasm-crypto = { workspace = true }
 [build-dependencies]
 vergen = { version = "=7.4.3", default-features = false, features = ["build", "git", "rustc"] }
 
-[profile.release]
-overflow-checks = true
-
 [features]
 schema-gen = ["vesting-contract-common/schema", "cosmwasm-schema"]

--- a/nym-api/nym-api-requests/Cargo.toml
+++ b/nym-api/nym-api-requests/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 bs58 = "0.4.0"
 cosmrs = { workspace = true }
-cosmwasm-std = { workspace = true, default-features = false }
+cosmwasm-std = { workspace = true }
 getset = "0.1.1"
 schemars = { version = "0.8", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/sdk/lib/socks5-listener/Cargo.toml
+++ b/sdk/lib/socks5-listener/Cargo.toml
@@ -12,10 +12,6 @@ required-features = ["headers"]
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]
 
-[profile.release]
-strip = true
-codegen-units = 1
-
 [dependencies]
 anyhow = { workspace = true }
 futures = { workspace = true }

--- a/wasm/client/Cargo.toml
+++ b/wasm/client/Cargo.toml
@@ -40,7 +40,3 @@ node-tester = ["nym-node-tester-wasm", "nym-node-tester-utils"]
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false
-
-[profile.release]
-lto = true
-opt-level = 'z'

--- a/wasm/full-nym-wasm/Cargo.toml
+++ b/wasm/full-nym-wasm/Cargo.toml
@@ -27,6 +27,3 @@ mix-fetch = ["mix-fetch-wasm"]
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false
 
-[profile.release]
-lto = true
-opt-level = 'z'

--- a/wasm/mix-fetch/Cargo.toml
+++ b/wasm/mix-fetch/Cargo.toml
@@ -35,7 +35,3 @@ wasm-utils = { path = "../../common/wasm/utils" }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false
-
-[profile.release]
-lto = true
-opt-level = 'z'

--- a/wasm/mix-fetch/Cargo.toml
+++ b/wasm/mix-fetch/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 futures = { workspace = true }
 js-sys = { workspace = true }
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }
-reqwest = { workspace = true, default-features = false }
+reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde-wasm-bindgen = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/wasm/node-tester/Cargo.toml
+++ b/wasm/node-tester/Cargo.toml
@@ -33,7 +33,3 @@ wasm-utils = { path = "../../common/wasm/utils" }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false
-
-[profile.release]
-lto = true
-opt-level = 'z'


### PR DESCRIPTION
# Description

Fix a number of semi-longstanding warnings that Cargo has been complaining about

- You can't specify profile in the manifest of a crate when it's part of a workspace. Move the profile directives that cargo complains about to the top-level workspace Cargo.toml
- `resolver = "2"` for contracts
- Remove `default-features = false` for workspace dependencies that are ignored anyway