### PR TITLE
integrations added to developers/faq section

### DIFF
--- a/documentation/dev-portal/src/faq/integrations-faq.md
+++ b/documentation/dev-portal/src/faq/integrations-faq.md
@@ -1,4 +1,4 @@
-# Integration FAQ
+# Integrations FAQ
 
 On this page, you'll find links and frequently asked questions on how to get started on integrating your project with Nym's Mixnet and its blockchain, Nyx. 
 


### PR DESCRIPTION
# Description

The dev-portal [Integrations FAQ page](https://nymtech.net/developers/faq/integrations-faq.html) came out empty due to a wrong merge commit cherry pick (as it was added to the last version too late). This PR returns the [existing page](https://github.com/nymtech/nym/compare/patch/dev-portal/integrations-faq-fix?expand=1#diff-a139e9e3fdf246701f4be68ad5fca5fe8fd8bbd272cd8f9a9465f2421c464279) to the book.