### PR TITLE
Error instead of crash on UDP and BIND not supported

### DIFF
--- a/common/socks5-client-core/src/socks/client.rs
+++ b/common/socks5-client-core/src/socks/client.rs
@@ -507,8 +507,8 @@ impl SocksClient {
                 );
             }
 
-            SocksCommand::Bind => unimplemented!(), // not handled
-            SocksCommand::UdpAssociate => unimplemented!(), // not handled
+            SocksCommand::Bind => return Err(SocksProxyError::BindNotSupported), // not handled
+            SocksCommand::UdpAssociate => return Err(SocksProxyError::UdpNotSupported),
         };
 
         Ok(())

--- a/common/socks5-client-core/src/socks/types.rs
+++ b/common/socks5-client-core/src/socks/types.rs
@@ -83,6 +83,12 @@ pub enum SocksProxyError {
         #[from]
         source: Socks5RequestError,
     },
+
+    #[error("SOCKS5 UDP not (yet) supported")]
+    UdpNotSupported,
+
+    #[error("SOCKS5 BIND not (yet) supported")]
+    BindNotSupported,
 }
 
 /// DST.addr variant types


### PR DESCRIPTION
# Description

Closes: #3898

Instead of the socks5 client crashing, log an error that UDP and BIND not (yet) supported.
