### PR TITLE
Use TUN device for forwarding wireguard traffic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,6 +2957,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "etherparse"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "827292ea592108849932ad8e30218f8b1f21c0dfd0696698a18b5d0aed62d990"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5863,6 +5872,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7517,12 +7537,15 @@ dependencies = [
  "base64 0.21.4",
  "boringtun",
  "bytes",
+ "dashmap",
+ "etherparse",
  "futures",
  "log",
  "nym-task",
  "tap",
  "thiserror",
  "tokio",
+ "tokio-tun",
 ]
 
 [[package]]
@@ -10805,6 +10828,18 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-tun"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a67d1405a577ba1f4cd61f46608f1db2cadbb6a9549c3fc2eed7f1195393c9"
+dependencies = [
+ "libc",
+ "nix 0.27.1",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/common/wireguard/Cargo.toml
+++ b/common/wireguard/Cargo.toml
@@ -19,9 +19,15 @@ base64 = "0.21.3"
 #boringtun = "0.6.0"
 boringtun = { git = "https://github.com/cloudflare/boringtun", rev = "e1d6360d6ab4529fc942a078e4c54df107abe2ba" }
 bytes = "1.5.0"
+dashmap = "5.5.3"
+etherparse = "0.13.0"
 futures = "0.3.28"
 log.workspace = true
 nym-task = { path = "../task" }
+# pnet = "0.34.0"
+# smoltcp = "0.10.0"
 tap.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "net"]}
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
+tokio-tun = "0.9.0"
+# tun-tap = "0.1.4"

--- a/common/wireguard/Cargo.toml
+++ b/common/wireguard/Cargo.toml
@@ -24,10 +24,7 @@ etherparse = "0.13.0"
 futures = "0.3.28"
 log.workspace = true
 nym-task = { path = "../task" }
-# pnet = "0.34.0"
-# smoltcp = "0.10.0"
 tap.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
 tokio-tun = "0.9.0"
-# tun-tap = "0.1.4"

--- a/common/wireguard/src/event.rs
+++ b/common/wireguard/src/event.rs
@@ -2,6 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use bytes::Bytes;
 
+#[allow(unused)]
 #[derive(Debug, Clone)]
 pub enum Event {
     /// IP packet received from the WireGuard tunnel that should be passed through to the corresponding virtual device/internet.

--- a/common/wireguard/src/event.rs
+++ b/common/wireguard/src/event.rs
@@ -4,8 +4,6 @@ use bytes::Bytes;
 
 #[derive(Debug, Clone)]
 pub enum Event {
-    // Dumb event with no data.
-    // Dumb,
     /// IP packet received from the WireGuard tunnel that should be passed through to the corresponding virtual device/internet.
     /// Original implementation also has protocol here since it understands it, but we'll have to infer it downstream
     WgPacket(Bytes),
@@ -16,9 +14,6 @@ pub enum Event {
 impl Display for Event {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            //Event::Dumb => {
-            //    write!(f, "Dumb{{}}")
-            //}
             Event::WgPacket(data) => {
                 let size = data.len();
                 write!(f, "WgPacket{{ size={size} }}")

--- a/common/wireguard/src/event.rs
+++ b/common/wireguard/src/event.rs
@@ -2,11 +2,10 @@ use std::fmt::{Display, Formatter};
 
 use bytes::Bytes;
 
-#[allow(unused)]
 #[derive(Debug, Clone)]
 pub enum Event {
-    /// Dumb event with no data.
-    Dumb,
+    // Dumb event with no data.
+    // Dumb,
     /// IP packet received from the WireGuard tunnel that should be passed through to the corresponding virtual device/internet.
     /// Original implementation also has protocol here since it understands it, but we'll have to infer it downstream
     WgPacket(Bytes),
@@ -17,9 +16,9 @@ pub enum Event {
 impl Display for Event {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Event::Dumb => {
-                write!(f, "Dumb{{}}")
-            }
+            //Event::Dumb => {
+            //    write!(f, "Dumb{{}}")
+            //}
             Event::WgPacket(data) => {
                 let size = data.len();
                 write!(f, "WgPacket{{ size={size} }}")

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -27,7 +27,7 @@ mod error;
 mod event;
 mod tun;
 
-//const WG_ADDRESS = "0.0.0.0:51820";
+// const WG_ADDRESS: &str = "0.0.0.0:51820";
 const WG_ADDRESS: &str = "0.0.0.0:51822";
 
 // The private key of the listener

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -150,6 +150,7 @@ fn start_tun_device(active_peers: Arc<ActivePeers>) -> UnboundedSender<Vec<u8>> 
                             // NOTE: I think we should probably use the allowed IP here instead to
                             // route the packet to the correct peer
                             // Consier using ip_network_table crate
+                            dbg!(&active_peers);
                             active_peers.get(&SocketAddr::new(
                                 std::net::IpAddr::V4(destination_addr),
                                 WG_PORT,

--- a/common/wireguard/src/tun.rs
+++ b/common/wireguard/src/tun.rs
@@ -148,7 +148,7 @@ impl WireGuardTunnel {
                 .unwrap_or(true)
         };
         if to_update {
-            log::debug!("wg tunnel set_source_addr: {source_addr}");
+            log::info!("wg tunnel set_source_addr: {source_addr}");
             *self.source_addr.write().unwrap() = Some(source_addr);
         }
     }

--- a/common/wireguard/src/tun.rs
+++ b/common/wireguard/src/tun.rs
@@ -140,11 +140,14 @@ impl WireGuardTunnel {
     }
 
     fn set_source_addr(&self, source_addr: std::net::Ipv4Addr) {
-        let stored_source_addr = self.source_addr.read().unwrap();
-        let to_update = stored_source_addr
-            .map(|sa| sa != source_addr)
-            .unwrap_or(true);
+        let to_update = {
+            let stored_source_addr = self.source_addr.read().unwrap();
+            stored_source_addr
+                .map(|sa| sa != source_addr)
+                .unwrap_or(true)
+        };
         if to_update {
+            log::debug!("Setting source_addr: {source_addr}");
             *self.source_addr.write().unwrap() = Some(source_addr);
         }
     }

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -370,7 +370,7 @@ impl<St> Gateway<St> {
         // Once this is a bit more mature, make this a commandline flag instead of a compile time
         // flag
         #[cfg(feature = "wireguard")]
-        if let Err(err) = nym_wireguard::start_wg_listener(shutdown.subscribe()).await {
+        if let Err(err) = nym_wireguard::start_wireguard(shutdown.subscribe()).await {
             // that's a nasty workaround, but anyhow errors are generally nicer, especially on exit
             bail!("{err}")
         }


### PR DESCRIPTION
# Description

Closes: #3903 

Add TUN device as a mechanism of relaying traffic coming out of the wireguard tunnel
