### PR TITLE
Enable loop cover traffic by default in NR

### DIFF
--- a/common/client-core/src/config/mod.rs
+++ b/common/client-core/src/config/mod.rs
@@ -137,6 +137,17 @@ impl Config {
         self.debug.traffic.message_sending_average_delay = Duration::from_millis(4);
     }
 
+    pub fn with_disabled_poisson_process(mut self, disabled: bool) -> Self {
+        if disabled {
+            self.set_no_poisson_process()
+        }
+        self
+    }
+
+    pub fn set_no_poisson_process(&mut self) {
+        self.debug.traffic.disable_main_poisson_packet_distribution = true;
+    }
+
     pub fn with_disabled_cover_traffic(mut self, disabled: bool) -> Self {
         if disabled {
             self.set_no_cover_traffic()

--- a/service-providers/network-requester/src/cli/mod.rs
+++ b/service-providers/network-requester/src/cli/mod.rs
@@ -93,8 +93,11 @@ pub(crate) fn override_config(config: Config, args: OverrideConfig) -> Config {
     // Since a big chunk of these are hidden experimental flags there is hope we can remove them
     // soonish and clean this up.
 
-    let disable_cover_traffic_with_keepalive =
-        config.network_requester.disable_poisson_rate || args.medium_toggle;
+    // This is the default
+    let disable_poisson_rate = config.network_requester.disable_poisson_rate;
+
+    // This is with the medium toggle
+    let disable_cover_traffic_with_keepalive = args.medium_toggle;
     let secondary_packet_size = args.medium_toggle.then_some(PacketSize::ExtendedPacket16);
     let no_per_hop_delays = args.medium_toggle;
 
@@ -102,6 +105,11 @@ pub(crate) fn override_config(config: Config, args: OverrideConfig) -> Config {
         .with_base(
             BaseClientConfig::with_high_default_traffic_volume,
             args.fastmode,
+        )
+        .with_base(
+            // NOTE: This interacts with disabling cover traffic fully, so we want to this to be set before
+            BaseClientConfig::with_disabled_poisson_process,
+            disable_poisson_rate,
         )
         .with_base(
             // NOTE: This interacts with disabling cover traffic fully, so we want to this to be set before

--- a/service-providers/network-requester/src/config/mod.rs
+++ b/service-providers/network-requester/src/config/mod.rs
@@ -190,9 +190,8 @@ pub struct NetworkRequester {
     /// in case of enabled statistics, specifies mixnet client address where a statistics aggregator is running
     pub statistics_recipient: Option<String>,
 
-    /// Disable Poisson sending rate, and only send cover traffic occasionally as keepalive messages.
+    /// Disable Poisson sending rate.
     /// This is equivalent to setting debug.traffic.disable_main_poisson_packet_distribution = true,
-    /// and debug.cover_traffic.loop_cover_traffic_average_delay = 5s.
     pub disable_poisson_rate: bool,
 }
 

--- a/service-providers/network-requester/src/config/template.rs
+++ b/service-providers/network-requester/src/config/template.rs
@@ -91,9 +91,8 @@ enabled_statistics = {{ network_requester.enabled_statistics }}
 # in case of enabled statistics, specifies mixnet client address where a statistics aggregator is running
 statistics_recipient = '{{ network_requester.statistics_recipient }}'
 
-# Disable Poisson sending rate, and only send cover traffic occasionally as keepalive messages.
+# Disable Poisson sending rate
 # This is equivalent to setting debug.traffic.disable_main_poisson_packet_distribution = true,
-# and debug.cover_traffic.loop_cover_traffic_average_delay = 5s.
 disable_poisson_rate = {{ network_requester.disable_poisson_rate }}
 
 ##### logging configuration options #####


### PR DESCRIPTION
# Description

In #3783  the Poisson rate limiter and the loop cover traffic was disabled by default in network-requester. Re-enable the loop cover traffic while keeping the Poisson rate limiter off by default.
