### PR TITLE
Docs: make shell scripts exit on errors so that CI jobs fail on build errors

### DIFF
--- a/documentation/build_all_to_dist.sh
+++ b/documentation/build_all_to_dist.sh
@@ -1,4 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
 # this is a script called by the github CI and CD workflows to build all 3 docs projects
 # and move them to /dist/ in the root of the monorepo. They are rsynced to various servers
 # from there by subsequent workflow tasks.

--- a/documentation/bump_versions.sh
+++ b/documentation/bump_versions.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
 # takes one manadatory arg and one optional arg: wallet release and minimum rust versions
 # it then uses sed to bump them in the three book.toml files.
 #

--- a/documentation/post_process.sh
+++ b/documentation/post_process.sh
@@ -1,4 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
 # this is a script called by the github CI and CD workflows to post process CSS/image/href links for serving
 # several mdbooks from a subdirectory
 


### PR DESCRIPTION
It is always best to add the following to all CI build scripts, so that errors bubble up to the runner:

```
set -o errexit
set -o nounset
set -o pipefail
```