### PR TITLE
custom Debug impl for mix::Node and gateway::Node

### DIFF
--- a/common/topology/src/gateway.rs
+++ b/common/topology/src/gateway.rs
@@ -8,6 +8,7 @@ use nym_sphinx_addressing::nodes::{NodeIdentity, NymNodeRoutingAddress};
 use nym_sphinx_types::Node as SphinxNode;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
+use std::fmt::Formatter;
 use std::io;
 use std::net::SocketAddr;
 use thiserror::Error;
@@ -28,7 +29,7 @@ pub enum GatewayConversionError {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Node {
     pub owner: String,
     pub host: NetworkAddress,
@@ -39,6 +40,20 @@ pub struct Node {
     pub identity_key: identity::PublicKey,
     pub sphinx_key: encryption::PublicKey, // TODO: or nymsphinx::PublicKey? both are x25519
     pub version: NodeVersion,
+}
+
+impl std::fmt::Debug for Node {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("gateway::Node")
+            .field("host", &self.host)
+            .field("owner", &self.owner)
+            .field("mix_host", &self.mix_host)
+            .field("clients_port", &self.clients_port)
+            .field("identity_key", &self.identity_key.to_base58_string())
+            .field("sphinx_key", &self.sphinx_key.to_base58_string())
+            .field("version", &self.version)
+            .finish()
+    }
 }
 
 impl Node {

--- a/common/topology/src/mix.rs
+++ b/common/topology/src/mix.rs
@@ -8,6 +8,7 @@ use nym_mixnet_contract_common::{MixId, MixNodeBond};
 use nym_sphinx_addressing::nodes::NymNodeRoutingAddress;
 use nym_sphinx_types::Node as SphinxNode;
 use std::convert::{TryFrom, TryInto};
+use std::fmt::Formatter;
 use std::io;
 use std::net::SocketAddr;
 use thiserror::Error;
@@ -28,7 +29,7 @@ pub enum MixnodeConversionError {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Node {
     pub mix_id: MixId,
     pub owner: String,
@@ -40,6 +41,21 @@ pub struct Node {
     pub sphinx_key: encryption::PublicKey, // TODO: or nymsphinx::PublicKey? both are x25519
     pub layer: Layer,
     pub version: NodeVersion,
+}
+
+impl std::fmt::Debug for Node {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("mix::Node")
+            .field("mix_id", &self.mix_id)
+            .field("owner", &self.owner)
+            .field("host", &self.host)
+            .field("mix_host", &self.mix_host)
+            .field("identity_key", &self.identity_key.to_base58_string())
+            .field("sphinx_key", &self.sphinx_key.to_base58_string())
+            .field("layer", &self.layer)
+            .field("version", &self.version)
+            .finish()
+    }
 }
 
 impl Node {


### PR DESCRIPTION
# Description

Something that has been bothering me for quite a while. The auto derived `Debug` for `mix::Node` and `gateway::Node`. whenever you wanted to quickly print your node details to stdout you were slammed with detailed curve point information which in 99.99% cases is not what you want. Thus I've changed it to use stringified key details instead.

Long story short for `println!("{gateway:#?}")` instead of:
```
'Node {
    owner: "n1k5uwsuewkqhf3s6n5zx9ps2wkdgs9p9fhcdujn",
    host: IpAddr(
        85.159.212.96,
    ),
    mix_host: 85.159.212.96:1789,
    clients_port: 9000,
    identity_key: PublicKey(
        PublicKey(CompressedEdwardsY: [106, 216, 165, 242, 138, 74, 126, 89, 190, 83, 92, 199, 158, 188, 152, 77, 224, 215, 117, 101, 122, 136, 49, 133, 182, 48, 80, 217, 157, 164, 25, 60]), EdwardsPoint{
        	X: FieldElement51([401081558954162, 1119876266921654, 519567740851975, 1272911700607453, 1376462587655230]),
        	Y: FieldElement51([1770810497161322, 1082931082152751, 1644180073243378, 100341588966706, 1057293338514691]),
        	Z: FieldElement51([1, 0, 0, 0, 0]),
        	T: FieldElement51([2240565687814151, 1279965419925540, 1672344571450002, 716923175485544, 446094628035297])
        }),
    ),
    sphinx_key: PublicKey(
        PublicKey(
            MontgomeryPoint(
                [
                    9,
                    62,
                    19,
                    206,
                    161,
                    63,
                    48,
                    94,
                    151,
                    136,
                    110,
                    224,
                    202,
                    91,
                    178,
                    245,
                    142,
                    162,
                    206,
                    14,
                    185,
                    70,
                    163,
                    35,
                    176,
                    109,
                    17,
                    70,
                    218,
                    237,
                    214,
                    66,
                ],
            ),
        ),
    ),
    version: Explicit(
        Version {
            major: 1,
            minor: 1,
            patch: 25,
            pre: [],
            build: [],
        },
    ),
}'
```

you will now be seeing
```
'gateway::Node {
    host: IpAddr(
        85.159.212.96,
    ),
    owner: "n1k5uwsuewkqhf3s6n5zx9ps2wkdgs9p9fhcdujn",
    mix_host: 85.159.212.96:1789,
    clients_port: 9000,
    identity_key: "8C5pc2dQyqVj6tksNQpfQs8LCSMzKjh7qUgwbfz3qo15",
    sphinx_key: "d5a7FETkQ6jCWpawEgpzJCT7iVipY3cMaBuut7ji9jP",
    version: Explicit(
        Version {
            major: 1,
            minor: 1,
            patch: 25,
            pre: [],
            build: [],
        },
    ),
}'
```
