### PR TITLE
[wasm-client] keeping ownership over 'ReceivedBufferRequestSender' channel when spawning 'ResponsePusher'

### DIFF
--- a/.github/workflows/publish-sdk-npm.yml
+++ b/.github/workflows/publish-sdk-npm.yml
@@ -1,4 +1,4 @@
-name: publish-sdk-npm
+name: Publish Typescript SDK
 on:
   workflow_dispatch:
 
@@ -28,8 +28,10 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Build and publish
+      - name: Build WASM and Typescript SDK
+        run: yarn sdk:build
+
+      - name: Publish to NPM
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-        working-directory: ./sdk/typescript/packages/sdk
-        run: scripts/publish.sh
+        run: ./sdk/typescript/scripts/publish.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "extension-storage"
-version = "1.2.0-rc.9"
+version = "1.2.0-rc.10"
 dependencies = [
  "bip39",
  "console_error_panic_hook",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "mix-fetch-wasm"
-version = "1.2.0-rc.9"
+version = "1.2.0-rc.10"
 dependencies = [
  "futures",
  "js-sys",
@@ -6298,7 +6298,7 @@ dependencies = [
 
 [[package]]
 name = "nym-client-wasm"
-version = "1.2.0-rc.9"
+version = "1.2.0-rc.10"
 dependencies = [
  "anyhow",
  "futures",
@@ -6917,7 +6917,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node-tester-wasm"
-version = "1.2.0-rc.9"
+version = "1.2.0-rc.10"
 dependencies = [
  "futures",
  "js-sys",
@@ -7511,7 +7511,7 @@ dependencies = [
 
 [[package]]
 name = "nym-wasm-sdk"
-version = "1.2.0-rc.9"
+version = "1.2.0-rc.10"
 dependencies = [
  "mix-fetch-wasm",
  "nym-client-wasm",

--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -434,7 +434,7 @@ impl TaskClient {
         .await
         {
             self.log(Level::Error, "Task stopped without shutdown called");
-            panic!("{timeout}")
+            panic!("{:?}: {timeout}", self.name)
         }
     }
 

--- a/nym-browser-extension/storage/Cargo.toml
+++ b/nym-browser-extension/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extension-storage"
-version = "1.2.0-rc.9"
+version = "1.2.0-rc.10"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/nymtech/nym"

--- a/sdk/typescript/codegen/contract-clients/package.json
+++ b/sdk/typescript/codegen/contract-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nymproject/contract-clients",
-  "version": "1.2.0-rc.9",
+  "version": "1.2.0-rc.10",
   "description": "A client for all Nym smart contracts",
   "license": "Apache-2.0",
   "author": "Nym Technologies SA",

--- a/sdk/typescript/docs/package.json
+++ b/sdk/typescript/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nymproject/ts-sdk-docs",
-  "version": "1.2.0-rc.9",
+  "version": "1.2.0-rc.10",
   "description": "Nym Typescript SDK Docs",
   "license": "Apache-2.0",
   "author": "Nym Technologies SA",

--- a/sdk/typescript/packages/mix-fetch/package.json
+++ b/sdk/typescript/packages/mix-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nymproject/mix-fetch",
-  "version": "1.2.0-rc.9",
+  "version": "1.2.0-rc.10",
   "description": "This package is a drop-in replacement for `fetch` to send HTTP requests over the Nym Mixnet.",
   "license": "Apache-2.0",
   "author": "Nym Technologies SA",

--- a/sdk/typescript/packages/node-tester/package.json
+++ b/sdk/typescript/packages/node-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nymproject/node-tester",
-  "version": "1.2.0-rc.9",
+  "version": "1.2.0-rc.10",
   "description": "This package provides a tester that can send test packets to mixnode that is part of the Nym Mixnet.",
   "license": "Apache-2.0",
   "author": "Nym Technologies SA",

--- a/sdk/typescript/packages/nodejs-client/package.json
+++ b/sdk/typescript/packages/nodejs-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nymproject/nodejs-client",
-  "version": "1.2.0-rc.5",
+  "version": "1.2.0-rc.10",
   "license": "Apache-2.0",
   "author": "Nym Technologies SA",
   "files": [
@@ -27,7 +27,7 @@
     "tsc": "tsc --noEmit true"
   },
   "dependencies": {
-    "@nymproject/nym-client-wasm-node": ">=1.2.0-rc.7 || ^1",
+    "@nymproject/nym-client-wasm-node": ">=1.2.0-rc.10 || ^1",
     "comlink": "^4.3.1"
   },
   "devDependencies": {

--- a/sdk/typescript/packages/sdk-react/package.json
+++ b/sdk/typescript/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nymproject/sdk-react",
-  "version": "1.2.0-rc.9",
+  "version": "1.2.0-rc.10",
   "license": "Apache-2.0",
   "author": "Nym Technologies SA",
   "files": [

--- a/sdk/typescript/packages/sdk/package.json
+++ b/sdk/typescript/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nymproject/sdk",
-  "version": "1.2.0-rc.9",
+  "version": "1.2.0-rc.10",
   "license": "Apache-2.0",
   "author": "Nym Technologies SA",
   "files": [

--- a/sdk/typescript/packages/validator-client/package.json
+++ b/sdk/typescript/packages/validator-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nymproject/nym-validator-client",
-  "version": "1.2.0-rc.9",
+  "version": "1.2.0-rc.10",
   "description": "A TypeScript client for interacting with smart contracts in Nym validators",
   "license": "Apache-2.0",
   "author": "Nym Technologies SA (https://nymtech.net)",

--- a/sdk/typescript/scripts/build-prod-sdk.sh
+++ b/sdk/typescript/scripts/build-prod-sdk.sh
@@ -17,10 +17,4 @@ yarn build:wasm
 yarn build:sdk
 
 # build documentation
-cd sdk/typescript/docs
-npm i
-npm run docs:prod:build
-cd ../../..
-
-# build examples
-pwd
+yarn docs:prod:build

--- a/wasm/client/Cargo.toml
+++ b/wasm/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nym-client-wasm"
 authors = ["Dave Hrycyszyn <futurechimp@users.noreply.github.com>", "Jedrzej Stuczynski <andrew@nymtech.net>"]
-version = "1.2.0-rc.9"
+version = "1.2.0-rc.10"
 edition = "2021"
 keywords = ["nym", "sphinx", "wasm", "webassembly", "privacy", "client"]
 license = "Apache-2.0"

--- a/wasm/client/Makefile
+++ b/wasm/client/Makefile
@@ -5,6 +5,9 @@ build:
 	wasm-pack build --scope nymproject --target web --out-dir ../../dist/wasm/client
 	wasm-opt -Oz -o ../../dist/wasm/client/nym_client_wasm_bg.wasm ../../dist/wasm/client/nym_client_wasm_bg.wasm
 
+build-debug-dev:
+	wasm-pack build --scope nymproject --target no-modules
+
 build-rust-node:
 	wasm-pack build --scope nymproject --target nodejs --out-dir ../../dist/node/wasm/client
 	wasm-opt -Oz -o ../../dist/node/wasm/client/nym_client_wasm_bg.wasm ../../dist/node/wasm/client/nym_client_wasm_bg.wasm

--- a/wasm/client/internal-dev/package.json
+++ b/wasm/client/internal-dev/package.json
@@ -35,6 +35,6 @@
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
-    "@nymproject/nym-client-wasm": "file:../../../dist/wasm/client"
+    "@nymproject/nym-client-wasm": "file:../pkg"
   }
 }

--- a/wasm/client/internal-dev/webpack.config.js
+++ b/wasm/client/internal-dev/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
             patterns: [
                 'index.html',
                 {
-                    from: '../../../dist/wasm/client/*.(js|wasm)',
+                    from: '../pkg/*.(js|wasm)',
                     to: '[name][ext]',
                 },
             ],

--- a/wasm/client/internal-dev/yarn.lock
+++ b/wasm/client/internal-dev/yarn.lock
@@ -73,8 +73,8 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nymproject/nym-client-wasm@file:../../../dist/wasm/client":
-  version "1.2.0-rc.2"
+"@nymproject/nym-client-wasm@file:../pkg":
+  version "1.2.0-rc.9"
 
 "@types/body-parser@*":
   version "1.19.2"

--- a/wasm/full-nym-wasm/Cargo.toml
+++ b/wasm/full-nym-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nym-wasm-sdk"
 authors = ["Jedrzej Stuczynski <andrew@nymtech.net>"]
-version = "1.2.0-rc.9"
+version = "1.2.0-rc.10"
 edition = "2021"
 keywords = ["nym", "sphinx", "wasm", "webassembly", "privacy"]
 license = "Apache-2.0"

--- a/wasm/mix-fetch/Cargo.toml
+++ b/wasm/mix-fetch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mix-fetch-wasm"
 authors = ["Jedrzej Stuczynski <andrew@nymtech.net>"]
-version = "1.2.0-rc.9"
+version = "1.2.0-rc.10"
 edition = "2021"
 keywords = ["nym", "fetch", "wasm", "webassembly", "privacy"]
 license = "Apache-2.0"

--- a/wasm/node-tester/Cargo.toml
+++ b/wasm/node-tester/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nym-node-tester-wasm"
 authors = ["Jedrzej Stuczynski <andrew@nymtech.net>"]
-version = "1.2.0-rc.9"
+version = "1.2.0-rc.10"
 edition = "2021"
 keywords = ["nym", "sphinx", "webassembly", "privacy", "tester"]
 license = "Apache-2.0"


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
