### PR TITLE
Github Actions: Fix release process

### DIFF
--- a/.github/workflows/nightly-nym-wallet-build.yml
+++ b/.github/workflows/nightly-nym-wallet-build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [custom-linux, macos-latest, windows10]
+        os: [custom-ubuntu-20.04, macos-latest, windows10]
     runs-on: ${{ matrix.os }}
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/publish-nym-binaries.yml
+++ b/.github/workflows/publish-nym-binaries.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [custom-runner-linux]
+        platform: [custom-ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
 
     outputs:

--- a/.github/workflows/publish-nym-connect-ubuntu.yml
+++ b/.github/workflows/publish-nym-connect-ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [custom-runner-linux]
+        platform: [custom-ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
 
     outputs:

--- a/.github/workflows/publish-nym-contracts.yml
+++ b/.github/workflows/publish-nym-contracts.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     if: ${{ (startsWith(github.ref, 'refs/tags/nym-contracts-') && github.event_name == 'release') || github.event_name == 'workflow_dispatch' }}
-    runs-on: [self-hosted, custom-runner-linux]
+    runs-on: [self-hosted, custom-ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/publish-nym-wallet-ubuntu.yml
+++ b/.github/workflows/publish-nym-wallet-ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [custom-runner-linux]
+        platform: [custom-ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
 
     outputs:

--- a/.github/workflows/publish-nyms5-android-apk.yml
+++ b/.github/workflows/publish-nyms5-android-apk.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build APK
-    runs-on: custom-runner-linux
+    runs-on: custom-ubuntu-20.04
     env:
       ANDROID_HOME: ${{ github.workspace }}/android-sdk
       NDK_VERSION: 25.2.9519653

--- a/.github/workflows/publish-sdk-npm.yml
+++ b/.github/workflows/publish-sdk-npm.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   publish:
-    runs-on: [custom-runner-linux]
+    runs-on: [custom-ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Since we have a new github-runner on Debian stable, this will force builds and releases workflows to run on Ubuntu LTS 20.04 like before.