### PR TITLE
Fix rust-analyzer warnings

### DIFF
--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -86,4 +86,5 @@ required-features = ["http-client"]
 default = ["http-client"]
 http-client = ["cosmrs/rpc", "openssl"]
 generate-ts = []
+contract-testing = ["nym-mixnet-contract-common/contract-testing"]
 

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/mixnet_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/mixnet_signing_client.rs
@@ -683,13 +683,14 @@ pub trait MixnetSigningClient {
         .await
     }
 
-    #[cfg(feature = "nym_mixnet_contract_common/contract-testing")]
+    #[cfg(feature = "contract-testing")]
     async fn testing_resolve_all_pending_events(
+        &self,
         fee: Option<Fee>,
     ) -> Result<ExecuteResult, NyxdError> {
         self.execute_mixnet_contract(
             fee,
-            MixnetExecuteMsg::TestingResolveAllPendingEvents {},
+            MixnetExecuteMsg::TestingResolveAllPendingEvents { limit: None },
             vec![],
         )
         .await
@@ -928,8 +929,8 @@ mod tests {
                 .withdraw_delegator_reward_on_behalf(owner.parse().unwrap(), mix_id, None)
                 .ignore(),
 
-            #[cfg(feature = "nym_mixnet_contract_common/contract-testing")]
-            MixnetExecuteMsg::TestingResolveAllPendingEvents {} => {
+            #[cfg(feature = "contract-testing")]
+            MixnetExecuteMsg::TestingResolveAllPendingEvents { .. } => {
                 client.testing_resolve_all_pending_events(None).ignore()
             }
         };

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/mixnet_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/mixnet_signing_client.rs
@@ -932,6 +932,14 @@ mod tests {
             MixnetExecuteMsg::TestingResolveAllPendingEvents {} => {
                 client.testing_resolve_all_pending_events(None).ignore()
             }
+
+            // We add this entry purely to try to make rust-analyzer happy
+            #[cfg(not(feature = "nym_mixnet_contract_common/contract-testing"))]
+            _ => {
+                unimplemented!(
+                    "testing functionality is only available in contract-testing feature"
+                )
+            }
         };
     }
 }

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/mixnet_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/mixnet_signing_client.rs
@@ -932,14 +932,6 @@ mod tests {
             MixnetExecuteMsg::TestingResolveAllPendingEvents {} => {
                 client.testing_resolve_all_pending_events(None).ignore()
             }
-
-            // We add this entry purely to try to make rust-analyzer happy
-            #[cfg(not(feature = "nym_mixnet_contract_common/contract-testing"))]
-            _ => {
-                unimplemented!(
-                    "testing functionality is only available in contract-testing feature"
-                )
-            }
         };
     }
 }

--- a/sdk/rust/nym-sdk/examples/libp2p_ping/main.rs
+++ b/sdk/rust/nym-sdk/examples/libp2p_ping/main.rs
@@ -45,7 +45,6 @@ use libp2p::ping::Success;
 use libp2p::swarm::{keep_alive, NetworkBehaviour, SwarmEvent};
 use libp2p::{identity, ping, Multiaddr, PeerId};
 use log::{debug, info, LevelFilter};
-use nym_sdk::mixnet::MixnetClient;
 use std::error::Error;
 use std::time::Duration;
 
@@ -70,7 +69,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         use libp2p::swarm::SwarmBuilder;
         use rust_libp2p_nym::transport::NymTransport;
 
-        let client = MixnetClient::connect_new().await.unwrap();
+        let client = nym_sdk::mixnet::MixnetClient::connect_new().await.unwrap();
 
         let transport = NymTransport::new(client, local_key.clone()).await?;
         SwarmBuilder::with_tokio_executor(

--- a/sdk/rust/nym-sdk/examples/libp2p_shared/transport.rs
+++ b/sdk/rust/nym-sdk/examples/libp2p_shared/transport.rs
@@ -80,6 +80,7 @@ pub struct NymTransport {
 
 impl NymTransport {
     /// New transport.
+    #[allow(unused)]
     pub async fn new(client: MixnetClient, keypair: Keypair) -> Result<Self, Error> {
         Self::new_maybe_with_notify_inbound(client, keypair, None, None).await
     }


### PR DESCRIPTION
# Description

Fix some warnings that rust-analyzer emits due to enabling all features.
These are annoying when you try to list all warnings in the entire
workspace.
