### PR TITLE
use saturating sub in case outfox is not enabled

### DIFF
--- a/common/client-libs/gateway-client/src/traits.rs
+++ b/common/client-libs/gateway-client/src/traits.rs
@@ -42,7 +42,9 @@ pub trait GatewayPacketRouter {
                 }
 
                 n if n
-                    == PacketSize::OutfoxRegularPacket.plaintext_size() - outfox_ack_overhead =>
+                    == PacketSize::OutfoxRegularPacket
+                        .plaintext_size()
+                        .saturating_sub(outfox_ack_overhead) =>
                 {
                     trace!("received regular outfox packet");
                     received_messages.push(received_packet);


### PR DESCRIPTION
# Description

This fixes a weird edge case if your client received a packet of unexpected size and if `outfox` feature was disabled.
Essentially upon reaching the weird packet you hit this if branch: https://github.com/nymtech/nym/blob/114d92f93fc375d12bd7ea1b3ea862e53c0d020f/common/client-libs/gateway-client/src/traits.rs#L45 checking "does the size of received message match outfox?" - reasonable enough
however, if outfox is not enabled, the `size()` method will return 0: 
https://github.com/nymtech/nym/blob/369330f517459e8f0ca723b45e8ec186d4188075/common/nymsphinx/params/src/packet_sizes.rs#L181
meaning the gateway client will attempt to do subtract outfox overhead from the packet size of 0 and thus blowing up.
