### PR TITLE
wireguard: short circuit known addr

### DIFF
--- a/common/wireguard/src/event.rs
+++ b/common/wireguard/src/event.rs
@@ -5,10 +5,10 @@ use bytes::Bytes;
 #[allow(unused)]
 #[derive(Debug)]
 pub enum Event {
-    /// IP packet received from the WireGuard tunnel that should be passed through to the corresponding virtual device/internet.
-    /// Original implementation also has protocol here since it understands it, but we'll have to infer it downstream
+    /// IP packet received from the WireGuard tunnel that should be passed through to the
+    /// corresponding virtual device/internet.
     Wg(Bytes),
-    /// IP packet received from the UDP listener that was verified as part of the handshake
+    /// IP packet received from the WireGuard tunnel that was verified as part of the handshake.
     WgVerified(Bytes),
     /// IP packet to be sent through the WireGuard tunnel as crafted by the virtual device.
     Ip(Bytes),
@@ -19,15 +19,15 @@ impl Display for Event {
         match self {
             Event::Wg(data) => {
                 let size = data.len();
-                write!(f, "WgPacket{{ size={size} }}")
+                write!(f, "Wg{{ size={size} }}")
             }
             Event::WgVerified(data) => {
                 let size = data.len();
-                write!(f, "WgVerifiedPacket{{ size={size} }}")
+                write!(f, "WgVerified{{ size={size} }}")
             }
             Event::Ip(data) => {
                 let size = data.len();
-                write!(f, "IpPacket{{ size={size} }}")
+                write!(f, "Ip{{ size={size} }}")
             }
         }
     }

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -27,15 +27,13 @@ pub async fn start_wireguard(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     use std::sync::Arc;
 
-    // The set of active tunnels indexed by the peer's address
-    let active_peers = Arc::new(udp_listener::ActivePeers::new());
     let peers_by_ip = Arc::new(std::sync::Mutex::new(network_table::NetworkTable::new()));
 
     // Start the tun device that is used to relay traffic outbound
     let tun_task_tx = tun_device::start_tun_device(peers_by_ip.clone());
 
     // Start the UDP listener that clients connect to
-    udp_listener::start_udp_listener(tun_task_tx, active_peers, peers_by_ip, task_client).await?;
+    udp_listener::start_udp_listener(tun_task_tx, peers_by_ip, task_client).await?;
 
     Ok(())
 }

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -4,6 +4,7 @@ mod error;
 mod event;
 mod network_table;
 mod platform;
+mod registered_peers;
 mod setup;
 mod udp_listener;
 mod wg_tunnel;

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -1,4 +1,7 @@
 #![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+// #![warn(clippy::pedantic)]
+// #![warn(clippy::expect_used)]
+// #![warn(clippy::unwrap_used)]
 
 mod error;
 mod event;
@@ -22,6 +25,11 @@ impl TunTaskTx {
     }
 }
 
+/// Start wireguard UDP listener and TUN device
+///
+/// # Errors
+///
+/// This function will return an error if either the UDP listener of the TUN device fails to start.
 #[cfg(target_os = "linux")]
 pub async fn start_wireguard(
     task_client: nym_task::TaskClient,

--- a/common/wireguard/src/platform/linux/tun_device.rs
+++ b/common/wireguard/src/platform/linux/tun_device.rs
@@ -30,7 +30,7 @@ fn setup_tokio_tun_device(name: &str, address: Ipv4Addr, netmask: Ipv4Addr) -> t
 
 pub(crate) fn start_tun_device(peers_by_ip: Arc<std::sync::Mutex<PeersByIp>>) -> TunTaskTx {
     let tun = setup_tokio_tun_device(
-        format!("{}%d", TUN_BASE_NAME).as_str(),
+        format!("{TUN_BASE_NAME}%d").as_str(),
         TUN_DEVICE_ADDRESS.parse().unwrap(),
         TUN_DEVICE_NETMASK.parse().unwrap(),
     );

--- a/common/wireguard/src/registered_peers.rs
+++ b/common/wireguard/src/registered_peers.rs
@@ -49,8 +49,8 @@ impl RegisteredPeers {
 
     pub(crate) fn get_by_idx(
         &self,
-        peer_idx: &PeerIdx,
+        peer_idx: PeerIdx,
     ) -> Option<&Arc<tokio::sync::Mutex<RegisteredPeer>>> {
-        self.peers_by_idx.get(peer_idx)
+        self.peers_by_idx.get(&peer_idx)
     }
 }

--- a/common/wireguard/src/registered_peers.rs
+++ b/common/wireguard/src/registered_peers.rs
@@ -1,0 +1,56 @@
+use std::{collections::HashMap, sync::Arc};
+
+use boringtun::x25519;
+use ip_network::IpNetwork;
+
+pub(crate) type PeerIdx = u32;
+
+#[derive(Debug)]
+pub(crate) struct RegisteredPeer {
+    pub(crate) public_key: x25519::PublicKey,
+    pub(crate) index: PeerIdx,
+    pub(crate) allowed_ips: IpNetwork,
+    // endpoint: SocketAddr,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct RegisteredPeers {
+    peers: HashMap<x25519::PublicKey, Arc<tokio::sync::Mutex<RegisteredPeer>>>,
+    peers_by_idx: HashMap<PeerIdx, Arc<tokio::sync::Mutex<RegisteredPeer>>>,
+}
+
+impl RegisteredPeers {
+    pub(crate) async fn insert(
+        &mut self,
+        public_key: x25519::PublicKey,
+        peer: Arc<tokio::sync::Mutex<RegisteredPeer>>,
+    ) {
+        let peer_idx = { peer.lock().await.index };
+        self.peers.insert(public_key, Arc::clone(&peer));
+        self.peers_by_idx.insert(peer_idx, peer);
+    }
+
+    #[allow(unused)]
+    pub(crate) async fn remove(&mut self, public_key: &x25519::PublicKey) {
+        if let Some(peer) = self.peers.remove(public_key) {
+            let peer_idx = peer.lock().await.index;
+            if self.peers_by_idx.remove(&peer_idx).is_none() {
+                log::error!("Removed registered peer but no registered index was found");
+            }
+        }
+    }
+
+    pub(crate) fn get_by_key(
+        &self,
+        public_key: &x25519::PublicKey,
+    ) -> Option<&Arc<tokio::sync::Mutex<RegisteredPeer>>> {
+        self.peers.get(public_key)
+    }
+
+    pub(crate) fn get_by_idx(
+        &self,
+        peer_idx: &PeerIdx,
+    ) -> Option<&Arc<tokio::sync::Mutex<RegisteredPeer>>> {
+        self.peers_by_idx.get(peer_idx)
+    }
+}

--- a/common/wireguard/src/setup.rs
+++ b/common/wireguard/src/setup.rs
@@ -50,7 +50,7 @@ pub fn peer_static_public_key() -> x25519::PublicKey {
     let peer_static_public_bytes: [u8; 32] = decode_base64_key(PEER);
     let peer_static_public = x25519::PublicKey::try_from(peer_static_public_bytes).unwrap();
     info!(
-        "peer public key: {}",
+        "Adding wg peer public key: {}",
         general_purpose::STANDARD.encode(peer_static_public)
     );
     peer_static_public

--- a/common/wireguard/src/udp_listener.rs
+++ b/common/wireguard/src/udp_listener.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use boringtun::{
     noise::{self, handshake::parse_handshake_anon, rate_limiter::RateLimiter, TunnResult},
@@ -79,6 +79,10 @@ pub(crate) async fn start_udp_listener(
                     log::trace!("WireGuard UDP listener: received shutdown");
                     break;
                 }
+                // Reset the rate limiter every 1 sec
+                _ = tokio::time::sleep(Duration::from_secs(1)) => {
+                    rate_limiter.reset_count();
+                },
                 // Handle tunnel closing
                 Some(public_key) = active_peers_task_handles.next() => {
                     match public_key {

--- a/common/wireguard/src/udp_listener.rs
+++ b/common/wireguard/src/udp_listener.rs
@@ -75,12 +75,12 @@ pub(crate) async fn start_udp_listener(
 
         while !task_client.is_shutdown() {
             tokio::select! {
-                _ = task_client.recv() => {
+                () = task_client.recv() => {
                     log::trace!("WireGuard UDP listener: received shutdown");
                     break;
                 }
                 // Reset the rate limiter every 1 sec
-                _ = tokio::time::sleep(Duration::from_secs(1)) => {
+                () = tokio::time::sleep(Duration::from_secs(1)) => {
                     rate_limiter.reset_count();
                 },
                 // Handle tunnel closing
@@ -138,15 +138,15 @@ pub(crate) async fn start_udp_listener(
                             },
                             noise::Packet::HandshakeResponse(packet) => {
                                 let peer_idx = packet.receiver_idx >> 8;
-                                registered_peers.get_by_idx(&peer_idx)
+                                registered_peers.get_by_idx(peer_idx)
                             },
                             noise::Packet::PacketCookieReply(packet) => {
                                 let peer_idx = packet.receiver_idx >> 8;
-                                registered_peers.get_by_idx(&peer_idx)
+                                registered_peers.get_by_idx(peer_idx)
                             },
                             noise::Packet::PacketData(packet) => {
                                 let peer_idx = packet.receiver_idx >> 8;
-                                registered_peers.get_by_idx(&peer_idx)
+                                registered_peers.get_by_idx(peer_idx)
                             },
                         };
 

--- a/common/wireguard/src/udp_listener.rs
+++ b/common/wireguard/src/udp_listener.rs
@@ -110,6 +110,7 @@ pub(crate) async fn start_udp_listener(
                             .send(Event::Wg(buf[..len].to_vec().into()))
                             .tap_err(|e| log::error!("{e}"))
                             .ok();
+                        continue;
                     }
 
                     // Verify the incoming packet
@@ -171,7 +172,7 @@ pub(crate) async fn start_udp_listener(
                         log::info!("udp: received {len} bytes from {addr} from unknown peer, starting tunnel");
                         // NOTE: we are NOT passing in the existing rate_limiter. Re-visit this
                         // choice later.
-                        log::warn!("Creating new rate limiter, consider re-using");
+                        log::warn!("Creating new rate limiter, consider re-using?");
                         let (join_handle, peer_tx) = crate::wg_tunnel::start_wg_tunnel(
                             addr,
                             udp.clone(),

--- a/common/wireguard/src/wg_tunnel.rs
+++ b/common/wireguard/src/wg_tunnel.rs
@@ -15,7 +15,7 @@ use tokio::{
 };
 
 use crate::{
-    error::WgError, event::Event, network_table::NetworkTable, TunTaskTx, registered_peers::PeerIdx,
+    error::WgError, event::Event, network_table::NetworkTable, registered_peers::PeerIdx, TunTaskTx,
 };
 
 const HANDSHAKE_MAX_RATE: u64 = 10;

--- a/common/wireguard/src/wg_tunnel.rs
+++ b/common/wireguard/src/wg_tunnel.rs
@@ -145,7 +145,7 @@ impl WireGuardTunnel {
                         break;
                     },
                 },
-                _ = tokio::time::sleep(Duration::from_millis(250)) => {
+                () = tokio::time::sleep(Duration::from_millis(250)) => {
                     let _ = self.update_wg_timers()
                         .await
                         .map_err(|err| error!("WireGuard tunnel: update_wg_timers error: {err}"));
@@ -287,7 +287,7 @@ impl WireGuardTunnel {
                     return;
                 };
                 peer.format_handshake_initiation(&mut buf[..], false);
-                self.handle_routine_tun_result(result).await
+                self.handle_routine_tun_result(result).await;
             }
             TunnResult::Err(err) => {
                 error!("Failed to prepare routine packet for WireGuard endpoint: {err:?}");

--- a/common/wireguard/src/wg_tunnel.rs
+++ b/common/wireguard/src/wg_tunnel.rs
@@ -59,8 +59,8 @@ impl WireGuardTunnel {
         endpoint: SocketAddr,
         static_private: x25519::StaticSecret,
         peer_static_public: x25519::PublicKey,
-        peer_allowed_ips: ip_network::IpNetwork,
         index: PeerIdx,
+        peer_allowed_ips: ip_network::IpNetwork,
         // rate_limiter: Option<RateLimiter>,
         tunnel_tx: TunTaskTx,
     ) -> (Self, mpsc::UnboundedSender<Event>) {
@@ -305,8 +305,8 @@ pub(crate) fn start_wg_tunnel(
     udp: Arc<UdpSocket>,
     static_private: x25519::StaticSecret,
     peer_static_public: x25519::PublicKey,
-    peer_allowed_ips: ip_network::IpNetwork,
     peer_index: PeerIdx,
+    peer_allowed_ips: ip_network::IpNetwork,
     tunnel_tx: TunTaskTx,
 ) -> (
     tokio::task::JoinHandle<x25519::PublicKey>,
@@ -317,8 +317,8 @@ pub(crate) fn start_wg_tunnel(
         endpoint,
         static_private,
         peer_static_public,
-        peer_allowed_ips,
         peer_index,
+        peer_allowed_ips,
         tunnel_tx,
     );
     let join_handle = tokio::spawn(async move {

--- a/common/wireguard/src/wg_tunnel.rs
+++ b/common/wireguard/src/wg_tunnel.rs
@@ -15,7 +15,7 @@ use tokio::{
 };
 
 use crate::{
-    error::WgError, event::Event, network_table::NetworkTable, udp_listener::PeerIdx, TunTaskTx,
+    error::WgError, event::Event, network_table::NetworkTable, TunTaskTx, registered_peers::PeerIdx,
 };
 
 const HANDSHAKE_MAX_RATE: u64 = 10;


### PR DESCRIPTION
# Description

Closes: #3987
Closes: NC-61

Skip duplicate packet parsing when the addr encountered is a known one. If the addr is know we can forward the packet to the already existing tunnel for decapsulation without having to go through the anon parsing flow.

- Forward directly on known addr
- Extract out test dev creation
- Extract out RegisteredPeers
- Extract out registered_peers.rs
- Reset main rate limiter on a timer
- Some pedantic clippy
- minor tidy
