### PR TITLE
ensure refresh when changing accounts

### DIFF
--- a/nym-wallet/src/context/bonding.tsx
+++ b/nym-wallet/src/context/bonding.tsx
@@ -125,7 +125,6 @@ export type TBondingContext = {
   updateBondAmount: (data: TUpdateBondArgs, tokenPool: TokenPool) => Promise<TransactionExecuteResult | undefined>;
   redeemRewards: (fee?: FeeDetails) => Promise<TransactionExecuteResult | undefined>;
   updateMixnode: (pm: string, fee?: FeeDetails) => Promise<TransactionExecuteResult | undefined>;
-  checkOwnership: () => Promise<void>;
   generateMixnodeMsgPayload: (data: TBondMixnodeSignatureArgs) => Promise<string | undefined>;
   generateGatewayMsgPayload: (data: TBondGatewaySignatureArgs) => Promise<string | undefined>;
   isVestingAccount: boolean;
@@ -152,9 +151,6 @@ export const BondingContext = createContext<TBondingContext>({
   updateMixnode: async () => {
     throw new Error('Not implemented');
   },
-  checkOwnership(): Promise<void> {
-    throw new Error('Not implemented');
-  },
   generateMixnodeMsgPayload: async () => {
     throw new Error('Not implemented');
   },
@@ -171,7 +167,7 @@ export const BondingContextProvider: FCWithChildren = ({ children }): JSX.Elemen
   const [isVestingAccount, setIsVestingAccount] = useState(false);
 
   const { userBalance, clientDetails } = useContext(AppContext);
-  const { ownership, isLoading: isOwnershipLoading, checkOwnership } = useCheckOwnership();
+  const { ownership, isLoading: isOwnershipLoading } = useCheckOwnership();
 
   useEffect(() => {
     userBalance.fetchBalance();
@@ -341,8 +337,6 @@ export const BondingContextProvider: FCWithChildren = ({ children }): JSX.Elemen
   const refresh = useCallback(async () => {
     setIsLoading(true);
     setError(undefined);
-
-    await checkOwnership();
 
     if (ownership.hasOwnership && ownership.nodeType === EnumNodeType.mixnode && clientDetails) {
       try {
@@ -617,7 +611,6 @@ export const BondingContextProvider: FCWithChildren = ({ children }): JSX.Elemen
       refresh,
       redeemRewards,
       updateBondAmount,
-      checkOwnership,
       generateMixnodeMsgPayload,
       generateGatewayMsgPayload,
       isVestingAccount,

--- a/nym-wallet/src/hooks/useCheckOwnership.ts
+++ b/nym-wallet/src/hooks/useCheckOwnership.ts
@@ -4,7 +4,7 @@ import { AppContext } from '../context/main';
 import { checkGatewayOwnership, checkMixnodeOwnership, getVestingPledgeInfo } from '../requests';
 import { EnumNodeType, TNodeOwnership } from '../types';
 
-const initial = {
+const initial: TNodeOwnership = {
   hasOwnership: false,
   nodeType: undefined,
   vestingPledge: undefined,
@@ -18,8 +18,7 @@ export const useCheckOwnership = () => {
   const [error, setError] = useState<string>();
 
   const checkOwnership = useCallback(async () => {
-    const status = initial as TNodeOwnership;
-
+    const status = { ...initial };
     try {
       const [ownsMixnode, ownsGateway] = await Promise.all([checkMixnodeOwnership(), checkGatewayOwnership()]);
 

--- a/nym-wallet/src/pages/bonding/Bonding.tsx
+++ b/nym-wallet/src/pages/bonding/Bonding.tsx
@@ -34,17 +34,8 @@ const Bonding = () => {
 
   const navigate = useNavigate();
 
-  const {
-    bondedNode,
-    bondMixnode,
-    bondGateway,
-    redeemRewards,
-    isLoading,
-    checkOwnership,
-    updateBondAmount,
-    error,
-    refresh,
-  } = useBondingContext();
+  const { bondedNode, bondMixnode, bondGateway, redeemRewards, isLoading, updateBondAmount, error, refresh } =
+    useBondingContext();
 
   useEffect(() => {
     if (bondedNode && isMixnode(bondedNode) && bondedNode.uncappedStakeSaturation) {
@@ -54,7 +45,7 @@ const Bonding = () => {
 
   const handleCloseModal = async () => {
     setShowModal(undefined);
-    await checkOwnership();
+    refresh();
   };
 
   const handleError = (err: string) => {


### PR DESCRIPTION
# Description

Allow refresh of data after switching accounts on bonding page.

Closes: #3632 

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
