### PR TITLE
wireguard: create structs for udp handler and tun device

### DIFF
--- a/common/wireguard/src/active_peers.rs
+++ b/common/wireguard/src/active_peers.rs
@@ -1,0 +1,52 @@
+use std::net::SocketAddr;
+
+use boringtun::x25519;
+use dashmap::{
+    mapref::one::{Ref, RefMut},
+    DashMap,
+};
+use tokio::sync::mpsc::{self};
+
+use crate::event::Event;
+
+pub(crate) type PeersByKey = DashMap<x25519::PublicKey, mpsc::UnboundedSender<Event>>;
+pub(crate) type PeersByAddr = DashMap<SocketAddr, mpsc::UnboundedSender<Event>>;
+
+#[derive(Default)]
+pub(crate) struct ActivePeers {
+    active_peers: PeersByKey,
+    active_peers_by_addr: PeersByAddr,
+}
+
+impl ActivePeers {
+    pub(crate) fn remove(&self, public_key: &x25519::PublicKey) {
+        log::info!("Removing peer: {public_key:?}");
+        self.active_peers.remove(public_key);
+        log::warn!("TODO: remove from peers_by_ip?");
+        log::warn!("TODO: remove from peers_by_addr");
+    }
+
+    pub(crate) fn insert(
+        &self,
+        public_key: x25519::PublicKey,
+        addr: SocketAddr,
+        peer_tx: mpsc::UnboundedSender<Event>,
+    ) {
+        self.active_peers.insert(public_key, peer_tx.clone());
+        self.active_peers_by_addr.insert(addr, peer_tx);
+    }
+
+    pub(crate) fn get_by_key_mut(
+        &self,
+        public_key: &x25519::PublicKey,
+    ) -> Option<RefMut<'_, x25519::PublicKey, mpsc::UnboundedSender<Event>>> {
+        self.active_peers.get_mut(public_key)
+    }
+
+    pub(crate) fn get_by_addr(
+        &self,
+        addr: &SocketAddr,
+    ) -> Option<Ref<'_, SocketAddr, mpsc::UnboundedSender<Event>>> {
+        self.active_peers_by_addr.get(addr)
+    }
+}

--- a/common/wireguard/src/error.rs
+++ b/common/wireguard/src/error.rs
@@ -4,4 +4,6 @@ use thiserror::Error;
 pub enum WgError {
     #[error("unable to get tunnel")]
     UnableToGetTunnel,
+    #[error("handshake failed")]
+    HandshakeFailed,
 }

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -40,7 +40,9 @@ pub async fn start_wireguard(
     let peers_by_ip = Arc::new(std::sync::Mutex::new(network_table::NetworkTable::new()));
 
     // Start the tun device that is used to relay traffic outbound
-    let tun_task_tx = tun_device::start_tun_device(peers_by_ip.clone());
+    // let tun_task_tx = tun_device::start_tun_device(peers_by_ip.clone());
+    let (tun, tun_task_tx) = tun_device::TunDevice::new(peers_by_ip.clone());
+    tun.start();
 
     // Start the UDP listener that clients connect to
     // udp_listener::start_udp_listener(tun_task_tx, peers_by_ip, task_client).await?;

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -52,22 +52,6 @@ pub async fn start_wireguard(
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
-pub async fn new_wireguard2(
-) -> Result<udp_listener::WgUdpListener, Box<dyn std::error::Error + Send + Sync + 'static>> {
-    use std::sync::Arc;
-
-    let peers_by_ip = Arc::new(std::sync::Mutex::new(network_table::NetworkTable::new()));
-
-    // Start the tun device that is used to relay traffic outbound
-    let tun_task_tx = tun_device::start_tun_device(peers_by_ip.clone());
-
-    // Start the UDP listener that clients connect to
-    let udp_listener = udp_listener::WgUdpListener::new(tun_task_tx, peers_by_ip).await?;
-    Ok(udp_listener)
-    // Ok(udp_listener::start_udp_listener(tun_task_tx, peers_by_ip, task_client).await?)
-}
-
 #[cfg(not(target_os = "linux"))]
 pub async fn start_wireguard(
     _task_client: nym_task::TaskClient,

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -40,12 +40,10 @@ pub async fn start_wireguard(
     let peers_by_ip = Arc::new(std::sync::Mutex::new(network_table::NetworkTable::new()));
 
     // Start the tun device that is used to relay traffic outbound
-    // let tun_task_tx = tun_device::start_tun_device(peers_by_ip.clone());
     let (tun, tun_task_tx) = tun_device::TunDevice::new(peers_by_ip.clone());
     tun.start();
 
     // Start the UDP listener that clients connect to
-    // udp_listener::start_udp_listener(tun_task_tx, peers_by_ip, task_client).await?;
     let udp_listener = udp_listener::WgUdpListener::new(tun_task_tx, peers_by_ip).await?;
     udp_listener.start(task_client);
 

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -3,6 +3,7 @@
 // #![warn(clippy::expect_used)]
 // #![warn(clippy::unwrap_used)]
 
+mod active_peers;
 mod error;
 mod event;
 mod network_table;

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -26,27 +26,29 @@ impl TunTaskTx {
     }
 }
 
-// Start wireguard UDP listener and TUN device
-//
-// # Errors
-//
-// This function will return an error if either the UDP listener of the TUN device fails to start.
-//#[cfg(target_os = "linux")]
-//pub async fn start_wireguard(
-//    task_client: nym_task::TaskClient,
-//) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-//    use std::sync::Arc;
-//
-//    let peers_by_ip = Arc::new(std::sync::Mutex::new(network_table::NetworkTable::new()));
-//
-//    // Start the tun device that is used to relay traffic outbound
-//    let tun_task_tx = tun_device::start_tun_device(peers_by_ip.clone());
-//
-//    // Start the UDP listener that clients connect to
-//    udp_listener::start_udp_listener(tun_task_tx, peers_by_ip, task_client).await?;
-//
-//    Ok(())
-//}
+/// Start wireguard UDP listener and TUN device
+///
+/// # Errors
+///
+/// This function will return an error if either the UDP listener of the TUN device fails to start.
+#[cfg(target_os = "linux")]
+pub async fn start_wireguard(
+    task_client: nym_task::TaskClient,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    use std::sync::Arc;
+
+    let peers_by_ip = Arc::new(std::sync::Mutex::new(network_table::NetworkTable::new()));
+
+    // Start the tun device that is used to relay traffic outbound
+    let tun_task_tx = tun_device::start_tun_device(peers_by_ip.clone());
+
+    // Start the UDP listener that clients connect to
+    // udp_listener::start_udp_listener(tun_task_tx, peers_by_ip, task_client).await?;
+    let udp_listener = udp_listener::WgUdpListener::new(tun_task_tx, peers_by_ip).await?;
+    udp_listener.start(task_client);
+
+    Ok(())
+}
 
 #[cfg(target_os = "linux")]
 pub async fn new_wireguard2(

--- a/common/wireguard/src/network_table.rs
+++ b/common/wireguard/src/network_table.rs
@@ -4,7 +4,7 @@ use ip_network::IpNetwork;
 use ip_network_table::IpNetworkTable;
 
 #[derive(Default)]
-pub(crate) struct NetworkTable<T> {
+pub struct NetworkTable<T> {
     ips: IpNetworkTable<T>,
 }
 

--- a/common/wireguard/src/platform/linux/tun_device.rs
+++ b/common/wireguard/src/platform/linux/tun_device.rs
@@ -28,6 +28,97 @@ fn setup_tokio_tun_device(name: &str, address: Ipv4Addr, netmask: Ipv4Addr) -> t
         .expect("Failed to setup tun device, do you have permission?")
 }
 
+pub struct TunDevice {
+    // Incoming data that we should send
+    tun_task_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+
+    tun: tokio_tun::Tun,
+
+    peers_by_ip: Arc<std::sync::Mutex<PeersByIp>>,
+}
+
+impl TunDevice {
+    pub fn new(peers_by_ip: Arc<std::sync::Mutex<PeersByIp>>) -> (Self, TunTaskTx) {
+        let tun = setup_tokio_tun_device(
+            format!("{TUN_BASE_NAME}%d").as_str(),
+            TUN_DEVICE_ADDRESS.parse().unwrap(),
+            TUN_DEVICE_NETMASK.parse().unwrap(),
+        );
+        log::info!("Created TUN device: {}", tun.name());
+
+        // Channels to communicate with the other tasks
+        let (tun_task_tx, tun_task_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let tun_task_tx = TunTaskTx(tun_task_tx);
+
+        let tun_device = TunDevice {
+            tun_task_rx,
+            tun,
+            peers_by_ip,
+        };
+
+        (tun_device, tun_task_tx)
+    }
+
+    pub async fn run(mut self) {
+        let mut buf = [0u8; 1024];
+
+        loop {
+            tokio::select! {
+                // Reading from the TUN device
+                len = self.tun.read(&mut buf) => match len {
+                    Ok(len) => {
+                        let packet = &buf[..len];
+                        let dst_addr = boringtun::noise::Tunn::dst_address(packet).unwrap();
+
+                        let headers = SlicedPacket::from_ip(packet).unwrap();
+                        let src_addr = match headers.ip.unwrap() {
+                            InternetSlice::Ipv4(ip, _) => ip.source_addr().to_string(),
+                            InternetSlice::Ipv6(ip, _) => ip.source_addr().to_string(),
+                        };
+                        log::info!("iface: read Packet({src_addr} -> {dst_addr}, {len} bytes)");
+
+                        // Route packet to the correct peer.
+                        if let Some(peer_tx) = self.peers_by_ip.lock().unwrap().longest_match(dst_addr).map(|(_, tx)| tx) {
+                            log::info!("Forward packet to wg tunnel");
+                            peer_tx
+                                .send(Event::Ip(packet.to_vec().into()))
+                                .tap_err(|err| log::error!("{err}"))
+                                .unwrap();
+                        } else {
+                            log::info!("No peer found, packet dropped");
+                        }
+                    },
+                    Err(err) => {
+                        log::info!("iface: read error: {err}");
+                        break;
+                    }
+                },
+
+                // Writing to the TUN device
+                Some(data) = self.tun_task_rx.recv() => {
+                    let headers = SlicedPacket::from_ip(&data).unwrap();
+                    let (source_addr, destination_addr) = match headers.ip.unwrap() {
+                        InternetSlice::Ipv4(ip, _) => (ip.source_addr(), ip.destination_addr()),
+                        InternetSlice::Ipv6(_, _) => unimplemented!(),
+                    };
+
+                    log::info!(
+                        "iface: write Packet({source_addr} -> {destination_addr}, {} bytes)",
+                        data.len()
+                    );
+                    // log::info!("iface: writing {} bytes", data.len());
+                    self.tun.write_all(&data).await.unwrap();
+                }
+            }
+        }
+        log::info!("TUN device shutting down");
+    }
+
+    pub fn start(self) {
+        tokio::spawn(async move { self.run().await });
+    }
+}
+
 pub(crate) fn start_tun_device(peers_by_ip: Arc<std::sync::Mutex<PeersByIp>>) -> TunTaskTx {
     let tun = setup_tokio_tun_device(
         format!("{TUN_BASE_NAME}%d").as_str(),

--- a/common/wireguard/src/platform/linux/tun_device.rs
+++ b/common/wireguard/src/platform/linux/tun_device.rs
@@ -29,11 +29,14 @@ fn setup_tokio_tun_device(name: &str, address: Ipv4Addr, netmask: Ipv4Addr) -> t
 }
 
 pub struct TunDevice {
+    // The TUN device that we read/write to, to send/receive packets
+    tun: tokio_tun::Tun,
+
     // Incoming data that we should send
     tun_task_rx: mpsc::UnboundedReceiver<Vec<u8>>,
 
-    tun: tokio_tun::Tun,
-
+    // The routing table.
+    // An alternative would be to do NAT by just matching incoming with outgoing.
     peers_by_ip: Arc<std::sync::Mutex<PeersByIp>>,
 }
 
@@ -106,7 +109,6 @@ impl TunDevice {
                         "iface: write Packet({source_addr} -> {destination_addr}, {} bytes)",
                         data.len()
                     );
-                    // log::info!("iface: writing {} bytes", data.len());
                     self.tun.write_all(&data).await.unwrap();
                 }
             }
@@ -117,74 +119,4 @@ impl TunDevice {
     pub fn start(self) {
         tokio::spawn(async move { self.run().await });
     }
-}
-
-pub(crate) fn start_tun_device(peers_by_ip: Arc<std::sync::Mutex<PeersByIp>>) -> TunTaskTx {
-    let tun = setup_tokio_tun_device(
-        format!("{TUN_BASE_NAME}%d").as_str(),
-        TUN_DEVICE_ADDRESS.parse().unwrap(),
-        TUN_DEVICE_NETMASK.parse().unwrap(),
-    );
-    log::info!("Created TUN device: {}", tun.name());
-
-    let (mut tun_device_rx, mut tun_device_tx) = tokio::io::split(tun);
-
-    // Channels to communicate with the other tasks
-    let (tun_task_tx, mut tun_task_rx) = mpsc::unbounded_channel::<Vec<u8>>();
-    let tun_task_tx = TunTaskTx(tun_task_tx);
-
-    tokio::spawn(async move {
-        let mut buf = [0u8; 1024];
-        loop {
-            tokio::select! {
-                // Reading from the TUN device
-                len = tun_device_rx.read(&mut buf) => match len {
-                    Ok(len) => {
-                        let packet = &buf[..len];
-                        let dst_addr = boringtun::noise::Tunn::dst_address(packet).unwrap();
-
-                        let headers = SlicedPacket::from_ip(packet).unwrap();
-                        let src_addr = match headers.ip.unwrap() {
-                            InternetSlice::Ipv4(ip, _) => ip.source_addr().to_string(),
-                            InternetSlice::Ipv6(ip, _) => ip.source_addr().to_string(),
-                        };
-                        log::info!("iface: read Packet({src_addr} -> {dst_addr}, {len} bytes)");
-
-                        // Route packet to the correct peer.
-                        if let Some(peer_tx) = peers_by_ip.lock().unwrap().longest_match(dst_addr).map(|(_, tx)| tx) {
-                            log::info!("Forward packet to wg tunnel");
-                            peer_tx
-                                .send(Event::Ip(packet.to_vec().into()))
-                                .tap_err(|err| log::error!("{err}"))
-                                .unwrap();
-                        } else {
-                            log::info!("No peer found, packet dropped");
-                        }
-                    },
-                    Err(err) => {
-                        log::info!("iface: read error: {err}");
-                        break;
-                    }
-                },
-
-                // Writing to the TUN device
-                Some(data) = tun_task_rx.recv() => {
-                    let headers = SlicedPacket::from_ip(&data).unwrap();
-                    let (source_addr, destination_addr) = match headers.ip.unwrap() {
-                        InternetSlice::Ipv4(ip, _) => (ip.source_addr(), ip.destination_addr()),
-                        InternetSlice::Ipv6(_, _) => unimplemented!(),
-                    };
-
-                    log::info!(
-                        "iface: write Packet({source_addr} -> {destination_addr}, {} bytes)",
-                        data.len()
-                    );
-                    // log::info!("iface: writing {} bytes", data.len());
-                    tun_device_tx.write_all(&data).await.unwrap();
-                }
-            }
-        }
-        log::info!("TUN device shutting down");
-    });
-    tun_task_tx
 }

--- a/common/wireguard/src/udp_listener.rs
+++ b/common/wireguard/src/udp_listener.rs
@@ -189,6 +189,86 @@ pub(crate) async fn start_udp_listener(
     Ok(())
 }
 
+fn handle_packet() {
+    // If this addr has already been encountered, send directly to tunnel
+    // TODO: optimization opportunity to instead create a connected UDP socket
+    // inside the wg tunnel, where you can recv the data directly.
+    if let Some(peer_tx) = active_peers_by_addr.get(&addr) {
+        log::info!("udp: received {len} bytes from {addr} from known peer");
+        peer_tx
+            .send(Event::Wg(buf[..len].to_vec().into()))
+            .tap_err(|e| log::error!("{e}"))
+            .ok();
+    }
+
+    // Verify the incoming packet
+    let verified_packet = match rate_limiter.verify_packet(Some(addr.ip()), &buf[..len], &mut dst_buf) {
+        Ok(packet) => packet,
+        Err(TunnResult::WriteToNetwork(cookie)) => {
+            log::info!("Send back cookie to: {addr}");
+            udp.send_to(cookie, addr).await.tap_err(|e| log::error!("{e}")).ok();
+            continue;
+        }
+        Err(err) => {
+            log::warn!("{err:?}");
+            continue;
+        }
+    };
+
+    // Check if this is a registered peer, if not, just skip
+    let registered_peer = match parse_peer(
+        verified_packet,
+        &registered_peers,
+        &static_private,
+        &static_public
+    ) {
+        Ok(Some(peer)) => peer.lock().await,
+        Ok(None) => {
+            log::warn!("Peer not registered: {addr}");
+            continue;
+        }
+        Err(err) => {
+            log::error!("{err}");
+            continue;
+        },
+    };
+
+    // Look up if the peer is already connected
+    if let Some(peer_tx) = active_peers.get_mut(&registered_peer.public_key) {
+        // We found the peer as connected, even though the addr was not known
+        log::info!("udp: received {len} bytes from {addr} which is a known peer with unknown addr");
+        peer_tx.send(Event::WgVerified(buf[..len].to_vec().into()))
+            .tap_err(|err| log::error!("{err}"))
+            .ok();
+    } else {
+        // If it isn't, start a new tunnel
+        log::info!("udp: received {len} bytes from {addr} from unknown peer, starting tunnel");
+        // NOTE: we are NOT passing in the existing rate_limiter. Re-visit this
+        // choice later.
+        log::warn!("Creating new rate limiter, consider re-using");
+        let (join_handle, peer_tx) = crate::wg_tunnel::start_wg_tunnel(
+            addr,
+            udp.clone(),
+            static_private.clone(),
+            registered_peer.public_key,
+            registered_peer.index,
+            registered_peer.allowed_ips,
+            tun_task_tx.clone(),
+        );
+
+        peers_by_ip.lock().unwrap().insert(registered_peer.allowed_ips, peer_tx.clone());
+        active_peers_by_addr.insert(addr, peer_tx.clone());
+
+        peer_tx.send(Event::Wg(buf[..len].to_vec().into()))
+            .tap_err(|e| log::error!("{e}"))
+            .ok();
+
+        log::info!("Adding peer: {addr}");
+        active_peers.insert(registered_peer.public_key, peer_tx);
+        active_peers_task_handles.push(join_handle);
+    }
+}
+
 fn parse_peer<'a>(
     verified_packet: noise::Packet,
     registered_peers: &'a RegisteredPeers,

--- a/common/wireguard/src/udp_listener.rs
+++ b/common/wireguard/src/udp_listener.rs
@@ -82,7 +82,7 @@ impl WgUdpListener {
         })
     }
 
-    pub async fn run(&mut self, mut task_client: TaskClient) {
+    pub async fn run(self, mut task_client: TaskClient) {
         log::info!("run!");
         // The set of active tunnels
         let active_peers = ActivePeers::default();
@@ -201,7 +201,7 @@ impl WgUdpListener {
         log::info!("WireGuard listener: shutting down");
     }
 
-    pub fn start(mut self, task_client: TaskClient) {
+    pub fn start(self, task_client: TaskClient) {
         log::info!("start!");
         tokio::spawn(async move { self.run(task_client).await });
     }

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -387,7 +387,6 @@ impl<St> Gateway<St> {
         // Once this is a bit more mature, make this a commandline flag instead of a compile time
         // flag
         #[cfg(feature = "wireguard")]
-        // self.start_wireguard(shutdown.subscribe().named("wireguard")).await;
         if let Err(err) = self
             .start_wireguard(shutdown.subscribe().named("wireguard"))
             .await

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -158,8 +158,9 @@ impl<St> Gateway<St> {
 
     #[cfg(feature = "wireguard")]
     async fn start_wireguard(&self, shutdown: TaskClient) {
-        let wg_udp_listener = nym_wireguard::new_wireguard2().await.unwrap();
-        wg_udp_listener.start(shutdown);
+        // let wg_udp_listener = nym_wireguard::new_wireguard2().await.unwrap();
+        // wg_udp_listener.start(shutdown);
+        nym_wireguard::start_wireguard(shutdown).await.unwrap();
     }
 
     fn start_client_websocket_listener(


### PR DESCRIPTION
# Description

Part of: #3938 
NC-69

Create explicit structs for UDP handler and TUN device.
