### PR TITLE
ci: use custom-linux instead of custom-runner-linux

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: custom-runner-linux
+    runs-on: custom-linux
     steps:
       - uses: actions/checkout@v3
       - name: Install rsync

--- a/.github/workflows/ci-binary-checker.yml
+++ b/.github/workflows/ci-binary-checker.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [custom-runner-linux]
+        platform: [custom-linux]
          
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ci-contracts-schema.yml
+++ b/.github/workflows/ci-contracts-schema.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   check-schema:
     name: Generate and check schema
-    runs-on: custom-runner-linux
+    runs-on: custom-linux
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: custom-runner-linux
+    runs-on: custom-linux
     steps:
       - uses: actions/checkout@v3
       - name: Install rsync

--- a/.github/workflows/ci-nym-connect-desktop.yml
+++ b/.github/workflows/ci-nym-connect-desktop.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: custom-runner-linux
+    runs-on: custom-linux
     steps:
     - uses: actions/checkout@v2
     - name: Install rsync

--- a/.github/workflows/ci-nym-network-explorer.yml
+++ b/.github/workflows/ci-nym-network-explorer.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: custom-runner-linux
+    runs-on: custom-linux
     steps:
     - uses: actions/checkout@v2
     - name: Install rsync

--- a/.github/workflows/ci-nym-wallet-storybook.yml
+++ b/.github/workflows/ci-nym-wallet-storybook.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: custom-runner-linux
+    runs-on: custom-linux
     steps:
     - uses: actions/checkout@v2
     - name: Install rsync

--- a/.github/workflows/ci-sdk-docs-typescript.yml
+++ b/.github/workflows/ci-sdk-docs-typescript.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: custom-runner-linux
+    runs-on: custom-linux
     steps:
       - uses: actions/checkout@v2
       - name: Install rsync

--- a/.github/workflows/ci-sdk-wasm.yml
+++ b/.github/workflows/ci-sdk-wasm.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   wasm:
-    runs-on: [custom-runner-linux]
+    runs-on: [custom-linux]
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -70,7 +70,7 @@ jobs:
 
   notification:
     needs: build
-    runs-on: custom-runner-linux
+    runs-on: custom-linux
     steps:
       - name: Collect jobs status
         uses: technote-space/workflow-conclusion-action@v2

--- a/.github/workflows/nightly-nym-wallet-build.yml
+++ b/.github/workflows/nightly-nym-wallet-build.yml
@@ -68,7 +68,7 @@ jobs:
 
   notification:
     needs: build
-    runs-on: custom-runner-linux
+    runs-on: custom-linux
     steps:
       - name: Collect jobs status
         uses: technote-space/workflow-conclusion-action@v2

--- a/.github/workflows/nightly-security-audit.yml
+++ b/.github/workflows/nightly-security-audit.yml
@@ -26,7 +26,7 @@ jobs:
           path: .github/workflows/support-files/notifications/deny.message
   notification:
     needs: cargo-deny
-    runs-on: custom-runner-linux
+    runs-on: custom-linux
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/publish-nyms5-android-apk.yml
+++ b/.github/workflows/publish-nyms5-android-apk.yml
@@ -94,7 +94,7 @@ jobs:
   gh-release:
     name: Publish APK (GH release)
     needs: build
-    runs-on: custom-runner-linux
+    runs-on: custom-linux
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

Use custom-linux instead of custom-runner-linux in all the GitHub workflows
