### PR TITLE
wireguard: add packet relayer

### DIFF
--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -21,6 +21,8 @@ use std::sync::Arc;
 #[cfg(target_os = "linux")]
 use platform::linux::tun_device;
 
+
+
 /// Start wireguard UDP listener and TUN device
 ///
 /// # Errors

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -39,10 +39,12 @@ pub async fn start_wireguard(
     let peers_by_tag = Arc::new(std::sync::Mutex::new(wg_tunnel::PeersByTag::new()));
 
     // Start the tun device that is used to relay traffic outbound
-    let (tun, tun_task_tx, tun_task_response_rx) =
-        tun_device::TunDevice::new(peers_by_ip.clone(), peers_by_tag.clone());
+    let (tun, tun_task_tx, tun_task_response_rx) = tun_device::TunDevice::new(peers_by_ip.clone());
     tun.start();
 
+    // The packet relayer's responsibility is to route packets between the correct tunnel and the
+    // tun device. The tun device may or may not be on a separate host, which is why we can't do
+    // this routing in the tun device itself.
     let (packet_relayer, packet_tx) = packet_relayer::PacketRelayer::new(
         tun_task_tx.clone(),
         tun_task_response_rx,

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -7,6 +7,7 @@ mod active_peers;
 mod error;
 mod event;
 mod network_table;
+mod packet_relayer;
 mod platform;
 mod registered_peers;
 mod setup;
@@ -41,10 +42,9 @@ pub async fn start_wireguard(
     let (tun, tun_task_tx) = tun_device::TunDevice::new(peers_by_ip.clone(), peers_by_tag.clone());
     tun.start();
 
-    let (packet_relayer, packet_tx) = udp_listener::PacketRelayer::new(
-        tun_task_tx.clone(),
-        peers_by_tag.clone(),
-    );
+    let (packet_relayer, packet_tx) =
+        packet_relayer::PacketRelayer::new(tun_task_tx.clone(), peers_by_tag.clone());
+    packet_relayer.start();
 
     // Start the UDP listener that clients connect to
     let udp_listener = udp_listener::WgUdpListener::new(

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -42,6 +42,10 @@ pub async fn start_wireguard(
     let (tun, tun_task_tx, tun_task_response_rx) = tun_device::TunDevice::new(peers_by_ip.clone());
     tun.start();
 
+    // If we want to have the tun device on a separate host, it's the tun_task and
+    // tun_task_response channels that needs to be sent over the network to the host where the tun
+    // device is running.
+
     // The packet relayer's responsibility is to route packets between the correct tunnel and the
     // tun device. The tun device may or may not be on a separate host, which is why we can't do
     // this routing in the tun device itself.

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -39,11 +39,15 @@ pub async fn start_wireguard(
     let peers_by_tag = Arc::new(std::sync::Mutex::new(wg_tunnel::PeersByTag::new()));
 
     // Start the tun device that is used to relay traffic outbound
-    let (tun, tun_task_tx) = tun_device::TunDevice::new(peers_by_ip.clone(), peers_by_tag.clone());
+    let (tun, tun_task_tx, tun_task_response_rx) =
+        tun_device::TunDevice::new(peers_by_ip.clone(), peers_by_tag.clone());
     tun.start();
 
-    let (packet_relayer, packet_tx) =
-        packet_relayer::PacketRelayer::new(tun_task_tx.clone(), peers_by_tag.clone());
+    let (packet_relayer, packet_tx) = packet_relayer::PacketRelayer::new(
+        tun_task_tx.clone(),
+        tun_task_response_rx,
+        peers_by_tag.clone(),
+    );
     packet_relayer.start();
 
     // Start the UDP listener that clients connect to

--- a/common/wireguard/src/packet_relayer.rs
+++ b/common/wireguard/src/packet_relayer.rs
@@ -1,0 +1,55 @@
+use std::{collections::HashMap, sync::Arc};
+
+use tokio::sync::mpsc::{self};
+
+use crate::{event::Event, tun_task_channel::TunTaskTx};
+
+// The tunnels send packets to the packet relayer, which then relays it to the tun device. And
+// conversely, it's where the tun device send responses to, which are relayed back to the correct
+// tunnel.
+pub(crate) struct PacketRelayer {
+    // Receive packets from the various tunnels
+    packet_rx: mpsc::Receiver<(u64, Vec<u8>)>,
+
+    // After receive from tunnels, send to the tun device
+    tun_task_tx: TunTaskTx,
+
+    // Receive responses from the tun device
+    // tun_task_rx: TunTaskRx,
+
+    // After receiving from the tun device, relay back to the correct tunnel
+    peers_by_tag: Arc<std::sync::Mutex<HashMap<u64, mpsc::UnboundedSender<Event>>>>,
+}
+
+impl PacketRelayer {
+    pub(crate) fn new(
+        tun_task_tx: TunTaskTx,
+        // tun_task_rx: TunTaskRx,
+        peers_by_tag: Arc<std::sync::Mutex<HashMap<u64, mpsc::UnboundedSender<Event>>>>,
+    ) -> (Self, mpsc::Sender<(u64, Vec<u8>)>) {
+        let (packet_tx, packet_rx) = mpsc::channel(16);
+        (
+            Self {
+                packet_rx,
+                tun_task_tx,
+                // tun_task_rx,
+                peers_by_tag,
+            },
+            packet_tx,
+        )
+    }
+
+    pub(crate) async fn run(mut self) {
+        loop {
+            tokio::select! {
+                Some((tag, packet)) = self.packet_rx.recv() => {
+                    self.tun_task_tx.send((tag, packet)).unwrap();
+                }
+            }
+        }
+    }
+
+    pub(crate) fn start(self) {
+        tokio::spawn(async move { self.run().await });
+    }
+}

--- a/common/wireguard/src/packet_relayer.rs
+++ b/common/wireguard/src/packet_relayer.rs
@@ -2,7 +2,10 @@ use std::{collections::HashMap, sync::Arc};
 
 use tokio::sync::mpsc::{self};
 
-use crate::{event::Event, tun_task_channel::TunTaskTx};
+use crate::{
+    event::Event,
+    tun_task_channel::{TunTaskResponseRx, TunTaskTx},
+};
 
 // The tunnels send packets to the packet relayer, which then relays it to the tun device. And
 // conversely, it's where the tun device send responses to, which are relayed back to the correct
@@ -15,7 +18,7 @@ pub(crate) struct PacketRelayer {
     tun_task_tx: TunTaskTx,
 
     // Receive responses from the tun device
-    // tun_task_rx: TunTaskRx,
+    tun_task_response_rx: TunTaskResponseRx,
 
     // After receiving from the tun device, relay back to the correct tunnel
     peers_by_tag: Arc<std::sync::Mutex<HashMap<u64, mpsc::UnboundedSender<Event>>>>,
@@ -24,7 +27,7 @@ pub(crate) struct PacketRelayer {
 impl PacketRelayer {
     pub(crate) fn new(
         tun_task_tx: TunTaskTx,
-        // tun_task_rx: TunTaskRx,
+        tun_task_response_rx: TunTaskResponseRx,
         peers_by_tag: Arc<std::sync::Mutex<HashMap<u64, mpsc::UnboundedSender<Event>>>>,
     ) -> (Self, mpsc::Sender<(u64, Vec<u8>)>) {
         let (packet_tx, packet_rx) = mpsc::channel(16);
@@ -32,7 +35,7 @@ impl PacketRelayer {
             Self {
                 packet_rx,
                 tun_task_tx,
-                // tun_task_rx,
+                tun_task_response_rx,
                 peers_by_tag,
             },
             packet_tx,

--- a/common/wireguard/src/platform/linux/tun_device.rs
+++ b/common/wireguard/src/platform/linux/tun_device.rs
@@ -94,6 +94,8 @@ impl TunDevice {
         );
 
         // Route packet to the correct peer.
+
+        // This is how wireguard does it, by consulting the AllowedIPs table.
         if false {
             let Ok(peers) = self.peers_by_ip.lock() else {
                 log::error!("Failed to lock peers_by_ip, aborting tun device read");
@@ -109,6 +111,7 @@ impl TunDevice {
             }
         }
 
+        // But we do it by consulting the NAT table.
         {
             if let Some(tag) = self.nat_table.get(&dst_addr) {
                 log::info!("Forward packet to wg tunnel with tag: {tag}");

--- a/common/wireguard/src/platform/linux/tun_device.rs
+++ b/common/wireguard/src/platform/linux/tun_device.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use crate::{
     event::Event,
     setup::{TUN_BASE_NAME, TUN_DEVICE_ADDRESS, TUN_DEVICE_NETMASK},
-    tun_task_channel::{tun_task_channel, TunTaskPayload, TunTaskRx, TunTaskTx},
+    tun_task_channel::{tun_task_channel, TunTaskPayload, TunTaskResponseTx, TunTaskRx, TunTaskTx},
     udp_listener::PeersByIp,
     wg_tunnel::PeersByTag,
 };
@@ -36,6 +36,9 @@ pub struct TunDevice {
 
     // Incoming data that we should send
     tun_task_rx: TunTaskRx,
+
+    // And when we get replies, this is where we should send it
+    tun_task_response_tx: TunTaskResponseTx,
 
     // The routing table.
     // An alternative would be to do NAT by just matching incoming with outgoing.

--- a/common/wireguard/src/tun_task_channel.rs
+++ b/common/wireguard/src/tun_task_channel.rs
@@ -4,7 +4,6 @@ pub(crate) type TunTaskPayload = (u64, Vec<u8>);
 
 #[derive(Clone)]
 pub struct TunTaskTx(mpsc::UnboundedSender<TunTaskPayload>);
-
 pub(crate) struct TunTaskRx(mpsc::UnboundedReceiver<TunTaskPayload>);
 
 impl TunTaskTx {
@@ -29,7 +28,7 @@ pub(crate) fn tun_task_channel() -> (TunTaskTx, TunTaskRx) {
 
 // Send responses back from the tun device back to the PacketRelayer
 pub(crate) struct TunTaskResponseTx(mpsc::Sender<TunTaskPayload>);
-pub(crate) struct TunTaskResponseRx(mpsc::Receiver<TunTaskPayload>);
+pub struct TunTaskResponseRx(mpsc::Receiver<TunTaskPayload>);
 
 impl TunTaskResponseTx {
     pub(crate) async fn send(
@@ -44,4 +43,9 @@ impl TunTaskResponseRx {
     pub(crate) async fn recv(&mut self) -> Option<TunTaskPayload> {
         self.0.recv().await
     }
+}
+
+pub(crate) fn tun_task_response_channel() -> (TunTaskResponseTx, TunTaskResponseRx) {
+    let (tun_task_tx, tun_task_rx) = tokio::sync::mpsc::channel(16);
+    (TunTaskResponseTx(tun_task_tx), TunTaskResponseRx(tun_task_rx))
 }

--- a/common/wireguard/src/tun_task_channel.rs
+++ b/common/wireguard/src/tun_task_channel.rs
@@ -47,5 +47,8 @@ impl TunTaskResponseRx {
 
 pub(crate) fn tun_task_response_channel() -> (TunTaskResponseTx, TunTaskResponseRx) {
     let (tun_task_tx, tun_task_rx) = tokio::sync::mpsc::channel(16);
-    (TunTaskResponseTx(tun_task_tx), TunTaskResponseRx(tun_task_rx))
+    (
+        TunTaskResponseTx(tun_task_tx),
+        TunTaskResponseRx(tun_task_rx),
+    )
 }

--- a/common/wireguard/src/udp_listener.rs
+++ b/common/wireguard/src/udp_listener.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use boringtun::{
     noise::{self, handshake::parse_handshake_anon, rate_limiter::RateLimiter, TunnResult},

--- a/common/wireguard/src/udp_listener.rs
+++ b/common/wireguard/src/udp_listener.rs
@@ -45,42 +45,6 @@ async fn add_test_peer(registered_peers: &mut RegisteredPeers) {
     registered_peers.insert(test_peer).await;
 }
 
-// The tunnels send packets to the packet relayer, which then relays it to the tun device. And
-// conversely, it's where the tun device send responses to, which are relayed back to the correct
-// tunnel.
-pub(crate) struct PacketRelayer {
-    // Receive packets from the various tunnels
-    packet_rx: mpsc::Receiver<(u64, Vec<u8>)>,
-
-    // After receive from tunnels, send to the tun device
-    tun_task_tx: TunTaskTx,
-
-    // Receive responses from the tun device
-    // tun_task_rx: TunTaskRx,
-
-    // After receiving from the tun device, relay back to the correct tunnel
-    peers_by_tag: Arc<std::sync::Mutex<HashMap<u64, mpsc::UnboundedSender<Event>>>>,
-}
-
-impl PacketRelayer {
-    pub(crate) fn new(
-        tun_task_tx: TunTaskTx,
-        // tun_task_rx: TunTaskRx,
-        peers_by_tag: Arc<std::sync::Mutex<HashMap<u64, mpsc::UnboundedSender<Event>>>>,
-    ) -> (Self, mpsc::Sender<(u64, Vec<u8>)>) {
-        let (packet_tx, packet_rx) = mpsc::channel(16);
-        (
-            Self {
-                packet_rx,
-                tun_task_tx,
-                // tun_task_rx,
-                peers_by_tag,
-            },
-            packet_tx,
-        )
-    }
-}
-
 pub struct WgUdpListener {
     // Our private key
     static_private: x25519::StaticSecret,

--- a/common/wireguard/src/udp_listener.rs
+++ b/common/wireguard/src/udp_listener.rs
@@ -24,7 +24,6 @@ use crate::{
     network_table::NetworkTable,
     registered_peers::{RegisteredPeer, RegisteredPeers},
     setup::{self, WG_ADDRESS, WG_PORT},
-    tun_task_channel::{TunTaskRx, TunTaskTx},
     wg_tunnel::PeersByTag,
 };
 

--- a/common/wireguard/src/wg_tunnel.rs
+++ b/common/wireguard/src/wg_tunnel.rs
@@ -14,10 +14,7 @@ use tokio::{
     time::timeout,
 };
 
-use crate::{
-    error::WgError, event::Event, network_table::NetworkTable, registered_peers::PeerIdx,
-    tun_task_channel::TunTaskTx,
-};
+use crate::{error::WgError, event::Event, network_table::NetworkTable, registered_peers::PeerIdx};
 
 const HANDSHAKE_MAX_RATE: u64 = 10;
 
@@ -211,14 +208,20 @@ impl WireGuardTunnel {
             }
             TunnResult::WriteToTunnelV4(packet, addr) => {
                 if self.allowed_ips.longest_match(addr).is_some() {
-                    self.packet_tx.send((self.tag, packet.to_vec())).await.unwrap();
+                    self.packet_tx
+                        .send((self.tag, packet.to_vec()))
+                        .await
+                        .unwrap();
                 } else {
                     warn!("Packet from {addr} not in allowed_ips");
                 }
             }
             TunnResult::WriteToTunnelV6(packet, addr) => {
                 if self.allowed_ips.longest_match(addr).is_some() {
-                    self.packet_tx.send((self.tag, packet.to_vec())).await.unwrap();
+                    self.packet_tx
+                        .send((self.tag, packet.to_vec()))
+                        .await
+                        .unwrap();
                 } else {
                     warn!("Packet (v6) from {addr} not in allowed_ips");
                 }

--- a/common/wireguard/src/wg_tunnel.rs
+++ b/common/wireguard/src/wg_tunnel.rs
@@ -7,6 +7,7 @@ use boringtun::{
 };
 use bytes::Bytes;
 use log::{debug, error, info, warn};
+use rand::RngCore;
 use tap::TapFallible;
 use tokio::{
     net::UdpSocket,
@@ -90,7 +91,7 @@ impl WireGuardTunnel {
                 index,
                 rate_limiter,
             )
-            .unwrap(),
+            .expect("failed to create Tunn instance"),
         ));
 
         // Channels with incoming data that is received by the main event loop
@@ -102,10 +103,7 @@ impl WireGuardTunnel {
         let mut allowed_ips = NetworkTable::new();
         allowed_ips.insert(peer_allowed_ips, ());
 
-        // random u64
-        use rand::RngCore;
-        let mut rng = rand::rngs::OsRng;
-        let tag = rng.next_u64();
+        let tag = Self::new_tag();
 
         let tunnel = WireGuardTunnel {
             peer_rx,
@@ -120,6 +118,10 @@ impl WireGuardTunnel {
         };
 
         (tunnel, peer_tx, tag)
+    }
+
+    fn new_tag() -> u64 {
+        rand::thread_rng().next_u64()
     }
 
     fn close(&self) {

--- a/common/wireguard/src/wg_tunnel.rs
+++ b/common/wireguard/src/wg_tunnel.rs
@@ -121,6 +121,7 @@ impl WireGuardTunnel {
     }
 
     fn new_tag() -> u64 {
+        // TODO: check for collisions
         rand::thread_rng().next_u64()
     }
 


### PR DESCRIPTION
# Description

Closes: #3938
NC-48

Add PacketRelayer. The is the last step to enable splitting the UDP listener and the TUN device to exist on separate nodes.
