### PR TITLE
suppress error output

### DIFF
--- a/explorer-api/src/geo_ip/location.rs
+++ b/explorer-api/src/geo_ip/location.rs
@@ -107,18 +107,24 @@ impl GeoIp {
                         Ok(ip)
                     } else {
                         debug!("Fail to resolve IP address from {}:{}", &address, p);
-                        let mut failed_ips_guard = self.failed_addresses.failed_ips.lock().unwrap();
-                        if failed_ips_guard.insert(address.to_string()) {
-                            append_ip_to_file(address);
+                        if let Ok(mut failed_ips_guard) = self.failed_addresses.failed_ips.lock() {
+                            if failed_ips_guard.insert(address.to_string()) {
+                                append_ip_to_file(address);
+                            }
+                        } else {
+                            error!("Failed to acquire lock on failed_ips");
                         }
                         Err(GeoIpError::NoValidIP)
                     }
                 }
                 Err(_) => {
                     debug!("Fail to resolve IP address from {}:{}.", &address, p);
-                    let mut failed_ips_guard = self.failed_addresses.failed_ips.lock().unwrap();
-                    if failed_ips_guard.insert(address.to_string()) {
-                        append_ip_to_file(address);
+                    if let Ok(mut failed_ips_guard) = self.failed_addresses.failed_ips.lock() {
+                        if failed_ips_guard.insert(address.to_string()) {
+                            append_ip_to_file(address);
+                        }
+                    } else {
+                        error!("Failed to acquire lock on failed_ips");
                     }
                     Err(GeoIpError::NoValidIP)
                 }

--- a/explorer-api/src/geo_ip/location.rs
+++ b/explorer-api/src/geo_ip/location.rs
@@ -86,7 +86,7 @@ impl GeoIp {
                 })?
                 .next()
                 .ok_or_else(|| {
-                    error!("Fail to resolve IP address from {}:{}", &address, p);
+                    debug!("Fail to resolve IP address from {}:{}", &address, p);
                     GeoIpError::NoValidIP
                 })?;
             let ip = socket_addr.ip();

--- a/explorer-api/src/geo_ip/location.rs
+++ b/explorer-api/src/geo_ip/location.rs
@@ -50,7 +50,7 @@ pub(crate) struct Location {
 }
 
 pub(crate) struct FailedIpAddresses {
-    failed_ips: Arc<Mutex<HashSet<String>>>,
+    failed_ips: Mutex<HashSet<String>>,
 }
 
 impl FailedIpAddresses {
@@ -68,7 +68,7 @@ impl FailedIpAddresses {
         }
 
         FailedIpAddresses {
-            failed_ips: Arc::new(Mutex::new(failed_ips)),
+            failed_ips: Mutex::new(failed_ips),
         }
     }
 }

--- a/explorer-api/src/helpers.rs
+++ b/explorer-api/src/helpers.rs
@@ -5,6 +5,7 @@ use nym_mixnet_contract_common::{Decimal, Fraction};
 use std::env;
 use std::fs::OpenOptions;
 use std::io::Write;
+use std::path::PathBuf;
 
 pub(crate) fn best_effort_small_dec_to_f64(dec: Decimal) -> f64 {
     let num = dec.numerator().u128() as f64;
@@ -14,7 +15,9 @@ pub(crate) fn best_effort_small_dec_to_f64(dec: Decimal) -> f64 {
 
 pub fn failed_ips_filepath() -> String {
     let home_dir = env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    format!("{}/failed_ips.txt", home_dir)
+    let mut path = PathBuf::from(home_dir);
+    path.push("failed_ips.txt");
+    path.to_string_lossy().into_owned()
 }
 
 pub fn append_ip_to_file(address: &str) {

--- a/explorer-api/src/helpers.rs
+++ b/explorer-api/src/helpers.rs
@@ -18,11 +18,18 @@ pub fn failed_ips_filepath() -> String {
 }
 
 pub fn append_ip_to_file(address: &str) {
-    if let Ok(mut file) = OpenOptions::new()
+    match OpenOptions::new()
         .append(true)
         .create(true)
         .open(failed_ips_filepath())
     {
-        writeln!(file, "{}", address).expect("Failed to write to file");
+        Ok(mut file) => {
+            if let Err(e) = writeln!(file, "{}", address) {
+                error!("Failed to write to file: {}", e);
+            }
+        }
+        Err(e) => {
+            error!("Failed to open or create the file: {}", e);
+        }
     }
 }

--- a/explorer-api/src/helpers.rs
+++ b/explorer-api/src/helpers.rs
@@ -2,9 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use nym_mixnet_contract_common::{Decimal, Fraction};
+use std::env;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
 
 pub(crate) fn best_effort_small_dec_to_f64(dec: Decimal) -> f64 {
     let num = dec.numerator().u128() as f64;
     let den = dec.denominator().u128() as f64;
     num / den
+}
+
+pub fn failed_ips_filepath() -> String {
+    let home_dir = env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    format!("{}/failed_ips.txt", home_dir)
+}
+
+pub fn ip_exists_in_file(address: &str) -> bool {
+    if let Ok(content) = fs::read_to_string(failed_ips_filepath()) {
+        return content.contains(address);
+    }
+    false
+}
+
+pub fn append_ip_to_file(address: &str) {
+    if let Ok(mut file) = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(failed_ips_filepath())
+    {
+        writeln!(file, "{}", address).expect("Failed to write to file");
+    }
 }

--- a/explorer-api/src/helpers.rs
+++ b/explorer-api/src/helpers.rs
@@ -3,7 +3,6 @@
 
 use nym_mixnet_contract_common::{Decimal, Fraction};
 use std::env;
-use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
 
@@ -16,13 +15,6 @@ pub(crate) fn best_effort_small_dec_to_f64(dec: Decimal) -> f64 {
 pub fn failed_ips_filepath() -> String {
     let home_dir = env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
     format!("{}/failed_ips.txt", home_dir)
-}
-
-pub fn ip_exists_in_file(address: &str) -> bool {
-    if let Ok(content) = fs::read_to_string(failed_ips_filepath()) {
-        return content.contains(address);
-    }
-    false
 }
 
 pub fn append_ip_to_file(address: &str) {


### PR DESCRIPTION
- we can run the api and set the logging level differently on launch
- same offending characters are spamming the logs
- write to tmp file if the same offending characters appear

