### PR TITLE
[mixnode] replace rocket with axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6697,6 +6697,7 @@ name = "nym-mixnode"
 version = "1.1.31"
 dependencies = [
  "anyhow",
+ "axum",
  "bs58 0.4.0",
  "cfg-if",
  "clap 4.4.6",
@@ -6714,6 +6715,7 @@ dependencies = [
  "nym-crypto",
  "nym-mixnet-client",
  "nym-mixnode-common",
+ "nym-node",
  "nym-nonexhaustive-delayqueue",
  "nym-pemstore",
  "nym-sphinx",
@@ -6730,6 +6732,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "thiserror",
  "tokio",
  "tokio-util",
  "toml 0.5.11",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6728,7 +6728,6 @@ dependencies = [
  "opentelemetry",
  "pretty_env_logger",
  "rand 0.7.3",
- "rocket",
  "serde",
  "serde_json",
  "sysinfo",

--- a/common/mixnode-common/src/verloc/measurement.rs
+++ b/common/mixnode-common/src/verloc/measurement.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 
+#[derive(Clone)]
 pub struct AtomicVerlocResult {
     inner: Arc<RwLock<VerlocResult>>,
 }
@@ -32,13 +33,6 @@ impl AtomicVerlocResult {
                 run_finished: None,
                 results: Vec::new(),
             })),
-        }
-    }
-
-    // this could have also been achieved with a normal #[derive(Clone)] but I prefer to be explicit about it
-    pub(crate) fn clone_data_pointer(&self) -> Self {
-        AtomicVerlocResult {
-            inner: Arc::clone(&self.inner),
         }
     }
 

--- a/common/mixnode-common/src/verloc/mod.rs
+++ b/common/mixnode-common/src/verloc/mod.rs
@@ -226,7 +226,7 @@ impl VerlocMeasurer {
     }
 
     pub fn get_verloc_results_pointer(&self) -> AtomicVerlocResult {
-        self.results.clone_data_pointer()
+        self.results.clone()
     }
 
     fn start_listening(&self) -> JoinHandle<()> {

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -52,7 +52,7 @@ tokio = { workspace = true, features = [
 tokio-stream = { version = "0.1.11", features = ["fs"] }
 tokio-tungstenite = { version = "0.20.1" }
 tokio-util = { version = "0.7.4", features = ["codec"] }
-url = { version = "2.2", features = ["serde"] }
+url = { workspace = true, features = ["serde"] }
 zeroize = { workspace = true }
 
 # internal

--- a/mixnode/Cargo.toml
+++ b/mixnode/Cargo.toml
@@ -29,7 +29,6 @@ lazy_static = "1.4.0"
 log = { workspace = true }
 pretty_env_logger = "0.4.0"
 rand = "0.7.3"
-rocket = { version = "0.5.0-rc.2", features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sysinfo = "0.27.7"

--- a/mixnode/Cargo.toml
+++ b/mixnode/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.58.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+axum = { workspace = true }
 anyhow = "1.0.40"
 bs58 = "0.4.0"
 clap = { version = "4.0", features = ["cargo", "derive"] }
@@ -35,15 +36,18 @@ sysinfo = "0.27.7"
 tokio = { version = "1.21.2", features = ["rt-multi-thread", "net", "signal"] }
 tokio-util = { version = "0.7.3", features = ["codec"] }
 toml = "0.5.8"
-url = { version = "2.2", features = ["serde"] }
+url = { workspace = true, features = ["serde"] }
 cfg-if = "1.0.0"
+thiserror = { workspace = true }
 
 ## tracing
 tracing = { version = "0.1.37", optional = true }
 opentelemetry = { version = "0.19.0", optional = true }
 
 
-## internal
+# internal
+nym-node = { path = "../nym-node" }
+
 nym-config = { path = "../common/config" }
 nym-crypto = { path = "../common/crypto" }
 nym-contracts-common = { path = "../common/cosmwasm-smart-contracts/contracts-common" }

--- a/mixnode/src/commands/mod.rs
+++ b/mixnode/src/commands/mod.rs
@@ -7,6 +7,7 @@ use anyhow::anyhow;
 use clap::CommandFactory;
 use clap::Subcommand;
 use colored::Colorize;
+use log::{error, info, warn};
 use nym_bin_common::completions::{fig_generate, ArgShell};
 use nym_bin_common::version_checker;
 use nym_config::defaults::var_names::{BECH32_PREFIX, NYM_API};

--- a/mixnode/src/commands/run.rs
+++ b/mixnode/src/commands/run.rs
@@ -6,11 +6,11 @@ use crate::commands::{override_config, try_load_current_config, version_check};
 use crate::node::MixNode;
 use anyhow::bail;
 use clap::Args;
+use log::error;
 use nym_bin_common::output_format::OutputFormat;
 use nym_config::helpers::SPECIAL_ADDRESSES;
 use nym_validator_client::nyxd;
 use std::net::IpAddr;
-
 #[derive(Args, Clone)]
 pub(crate) struct Run {
     /// Id of the nym-mixnode we want to run

--- a/mixnode/src/commands/sign.rs
+++ b/mixnode/src/commands/sign.rs
@@ -5,14 +5,12 @@ use crate::commands::{try_load_current_config, validate_bech32_address_or_exit};
 use crate::node::MixNode;
 use anyhow::{bail, Result};
 use clap::{ArgGroup, Args};
+use log::error;
 use nym_bin_common::output_format::OutputFormat;
 use nym_crypto::asymmetric::identity;
 use nym_types::helpers::ConsoleSigningOutput;
 use nym_validator_client::nyxd;
 use std::convert::TryFrom;
-
-#[cfg(feature = "cpucycles")]
-use tracing::error;
 
 use super::version_check;
 

--- a/mixnode/src/error.rs
+++ b/mixnode/src/error.rs
@@ -1,0 +1,11 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum MixnodeError {
+    // TODO: in the future this should work the other way, i.e. NymNode depending on Gateway errors
+    #[error(transparent)]
+    NymNodeError(#[from] nym_node::error::NymNodeError),
+}

--- a/mixnode/src/main.rs
+++ b/mixnode/src/main.rs
@@ -1,12 +1,10 @@
 // Copyright 2020-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-#[macro_use]
-extern crate rocket;
-
 use ::nym_config::defaults::setup_env;
 use clap::{crate_name, crate_version, Parser};
 use lazy_static::lazy_static;
+use log::info;
 use nym_bin_common::bin_info;
 
 #[allow(unused_imports)]

--- a/mixnode/src/main.rs
+++ b/mixnode/src/main.rs
@@ -20,6 +20,7 @@ use tracing::instrument;
 
 mod commands;
 mod config;
+pub(crate) mod error;
 mod node;
 
 lazy_static! {

--- a/mixnode/src/node/http/description.rs
+++ b/mixnode/src/node/http/description.rs
@@ -1,14 +1,6 @@
 use crate::node::node_description::NodeDescription;
 use axum::extract::Query;
 use nym_node::http::api::{FormattedResponse, OutputParams};
-use rocket::serde::json::Json;
-use rocket::State;
-
-/// Returns a description of the node and why someone might want to delegate stake to it.
-#[get("/description")]
-pub(crate) fn description(description: &State<NodeDescription>) -> Json<NodeDescription> {
-    Json(description.inner().clone())
-}
 
 /// Returns a description of the node and why someone might want to delegate stake to it.
 pub(crate) async fn description_axum(

--- a/mixnode/src/node/http/description.rs
+++ b/mixnode/src/node/http/description.rs
@@ -3,7 +3,7 @@ use axum::extract::Query;
 use nym_node::http::api::{FormattedResponse, OutputParams};
 
 /// Returns a description of the node and why someone might want to delegate stake to it.
-pub(crate) async fn description_axum(
+pub(crate) async fn description(
     description: NodeDescription,
     Query(output): Query<OutputParams>,
 ) -> MixnodeDescriptionResponse {

--- a/mixnode/src/node/http/description.rs
+++ b/mixnode/src/node/http/description.rs
@@ -1,4 +1,6 @@
 use crate::node::node_description::NodeDescription;
+use axum::extract::Query;
+use nym_node::http::api::{FormattedResponse, OutputParams};
 use rocket::serde::json::Json;
 use rocket::State;
 
@@ -7,3 +9,14 @@ use rocket::State;
 pub(crate) fn description(description: &State<NodeDescription>) -> Json<NodeDescription> {
     Json(description.inner().clone())
 }
+
+/// Returns a description of the node and why someone might want to delegate stake to it.
+pub(crate) async fn description_axum(
+    description: NodeDescription,
+    Query(output): Query<OutputParams>,
+) -> MixnodeDescriptionResponse {
+    let output = output.output.unwrap_or_default();
+    output.to_response(description)
+}
+
+pub type MixnodeDescriptionResponse = FormattedResponse<NodeDescription>;

--- a/mixnode/src/node/http/hardware.rs
+++ b/mixnode/src/node/http/hardware.rs
@@ -24,7 +24,7 @@ pub(crate) struct CryptoHardware {
 }
 
 /// Provides hardware information which Nym can use to optimize mixnet speed over time (memory, crypto hardware, CPU, cores, etc).
-pub(crate) async fn hardware_axum(Query(output): Query<OutputParams>) -> MixnodeHardwareResponse {
+pub(crate) async fn hardware(Query(output): Query<OutputParams>) -> MixnodeHardwareResponse {
     let output = output.output.unwrap_or_default();
     output.to_response(hardware_info())
 }

--- a/mixnode/src/node/http/hardware.rs
+++ b/mixnode/src/node/http/hardware.rs
@@ -1,7 +1,6 @@
 use axum::extract::Query;
 use cupid::TopologyType;
 use nym_node::http::api::{FormattedResponse, OutputParams};
-use rocket::serde::json::Json;
 use serde::Serialize;
 use sysinfo::{System, SystemExt};
 
@@ -25,13 +24,7 @@ pub(crate) struct CryptoHardware {
 }
 
 /// Provides hardware information which Nym can use to optimize mixnet speed over time (memory, crypto hardware, CPU, cores, etc).
-#[get("/hardware")]
-pub(crate) fn hardware() -> Json<Option<Hardware>> {
-    Json(hardware_info())
-}
-
-/// Provides hardware information which Nym can use to optimize mixnet speed over time (memory, crypto hardware, CPU, cores, etc).
-pub(crate) fn hardware_axum(Query(output): Query<OutputParams>) -> MixnodeHardwareResponse {
+pub(crate) async fn hardware_axum(Query(output): Query<OutputParams>) -> MixnodeHardwareResponse {
     let output = output.output.unwrap_or_default();
     output.to_response(hardware_info())
 }

--- a/mixnode/src/node/http/mod.rs
+++ b/mixnode/src/node/http/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod description;
 pub(crate) mod hardware;
+pub(crate) mod state;
 pub(crate) mod stats;
 pub(crate) mod verloc;
 

--- a/mixnode/src/node/http/mod.rs
+++ b/mixnode/src/node/http/mod.rs
@@ -4,9 +4,12 @@ pub(crate) mod state;
 pub(crate) mod stats;
 pub(crate) mod verloc;
 
-use rocket::Request;
+use axum::http::{StatusCode, Uri};
+use axum::response::IntoResponse;
 
-#[catch(404)]
-pub(crate) fn not_found(req: &Request<'_>) -> String {
-    format!("I couldn't find '{}'. Try something else?", req.uri())
+pub(crate) async fn not_found_axum(uri: Uri) -> impl IntoResponse {
+    (
+        StatusCode::NOT_FOUND,
+        format!("I couldn't find '{uri}'. Try something else?"),
+    )
 }

--- a/mixnode/src/node/http/mod.rs
+++ b/mixnode/src/node/http/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod verloc;
 use axum::http::{StatusCode, Uri};
 use axum::response::IntoResponse;
 
-pub(crate) async fn not_found_axum(uri: Uri) -> impl IntoResponse {
+pub(crate) async fn not_found(uri: Uri) -> impl IntoResponse {
     (
         StatusCode::NOT_FOUND,
         format!("I couldn't find '{uri}'. Try something else?"),

--- a/mixnode/src/node/http/state.rs
+++ b/mixnode/src/node/http/state.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::node::node_statistics::SharedNodeStats;
+use axum::extract::FromRef;
+use nym_mixnode_common::verloc::AtomicVerlocResult;
+
+// this is a temporary thing for the transition period
+pub(crate) struct MixnodeAppState {
+    verloc: AtomicVerlocResult,
+    stats: SharedNodeStats,
+}
+
+impl FromRef<MixnodeAppState> for AtomicVerlocResult {
+    fn from_ref(app_state: &MixnodeAppState) -> Self {
+        app_state.verloc.clone()
+    }
+}
+
+impl FromRef<MixnodeAppState> for SharedNodeStats {
+    fn from_ref(app_state: &MixnodeAppState) -> Self {
+        app_state.stats.clone()
+    }
+}

--- a/mixnode/src/node/http/state.rs
+++ b/mixnode/src/node/http/state.rs
@@ -1,17 +1,18 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::node::http::verloc::VerlocState;
 use crate::node::node_statistics::SharedNodeStats;
 use axum::extract::FromRef;
-use nym_mixnode_common::verloc::AtomicVerlocResult;
 
 // this is a temporary thing for the transition period
+#[derive(Clone)]
 pub(crate) struct MixnodeAppState {
-    verloc: AtomicVerlocResult,
-    stats: SharedNodeStats,
+    pub(crate) verloc: VerlocState,
+    pub(crate) stats: SharedNodeStats,
 }
 
-impl FromRef<MixnodeAppState> for AtomicVerlocResult {
+impl FromRef<MixnodeAppState> for VerlocState {
     fn from_ref(app_state: &MixnodeAppState) -> Self {
         app_state.verloc.clone()
     }

--- a/mixnode/src/node/http/stats.rs
+++ b/mixnode/src/node/http/stats.rs
@@ -1,11 +1,14 @@
+use crate::node::http::state::MixnodeAppState;
 use crate::node::node_statistics::{NodeStats, NodeStatsSimple, SharedNodeStats};
+use axum::extract::{Query, State};
+use nym_node::http::api::{FormattedResponse, Output};
 use rocket::serde::json::Json;
-use rocket::State;
-use serde::Serialize;
+use rocket::State as RocketState;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize)]
 #[serde(untagged)]
-pub(crate) enum NodeStatsResponse {
+pub enum NodeStatsResponse {
     Full(NodeStats),
     Simple(NodeStatsSimple),
 }
@@ -13,7 +16,7 @@ pub(crate) enum NodeStatsResponse {
 /// Returns a running stats of the node.
 #[get("/stats?<debug>")]
 pub(crate) async fn stats(
-    stats: &State<SharedNodeStats>,
+    stats: &RocketState<SharedNodeStats>,
     debug: Option<bool>,
 ) -> Json<NodeStatsResponse> {
     let snapshot_data = stats.clone_data().await;
@@ -26,4 +29,31 @@ pub(crate) async fn stats(
     }
 
     Json(NodeStatsResponse::Simple(snapshot_data.simplify()))
+}
+
+pub(crate) async fn stats_axum(
+    Query(params): Query<StatsQueryParams>,
+    State(stats): State<SharedNodeStats>,
+) -> MixnodeStatsResponse {
+    let output = params.output.unwrap_or_default();
+
+    let snapshot_data = stats.clone_data().await;
+
+    // there's no point in returning the entire hashmap of sending destinations in regular mode
+    let response = if params.debug {
+        NodeStatsResponse::Full(snapshot_data)
+    } else {
+        NodeStatsResponse::Simple(snapshot_data.simplify())
+    };
+    output.to_response(response)
+}
+
+pub type MixnodeStatsResponse = FormattedResponse<NodeStatsResponse>;
+
+#[derive(Default, Debug, Serialize, Deserialize, Copy, Clone)]
+// #[derive(Default, Debug, Serialize, Deserialize, Copy, Clone, IntoParams, ToSchema)]
+#[serde(default)]
+pub(crate) struct StatsQueryParams {
+    debug: bool,
+    pub output: Option<Output>,
 }

--- a/mixnode/src/node/http/stats.rs
+++ b/mixnode/src/node/http/stats.rs
@@ -10,7 +10,7 @@ pub enum NodeStatsResponse {
     Simple(NodeStatsSimple),
 }
 
-pub(crate) async fn stats_axum(
+pub(crate) async fn stats(
     Query(params): Query<StatsQueryParams>,
     State(stats): State<SharedNodeStats>,
 ) -> MixnodeStatsResponse {

--- a/mixnode/src/node/http/stats.rs
+++ b/mixnode/src/node/http/stats.rs
@@ -1,9 +1,6 @@
-use crate::node::http::state::MixnodeAppState;
 use crate::node::node_statistics::{NodeStats, NodeStatsSimple, SharedNodeStats};
 use axum::extract::{Query, State};
 use nym_node::http::api::{FormattedResponse, Output};
-use rocket::serde::json::Json;
-use rocket::State as RocketState;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize)]
@@ -11,24 +8,6 @@ use serde::{Deserialize, Serialize};
 pub enum NodeStatsResponse {
     Full(NodeStats),
     Simple(NodeStatsSimple),
-}
-
-/// Returns a running stats of the node.
-#[get("/stats?<debug>")]
-pub(crate) async fn stats(
-    stats: &RocketState<SharedNodeStats>,
-    debug: Option<bool>,
-) -> Json<NodeStatsResponse> {
-    let snapshot_data = stats.clone_data().await;
-
-    // there's no point in returning the entire hashmap of sending destinations in regular mode
-    if let Some(debug) = debug {
-        if debug {
-            return Json(NodeStatsResponse::Full(snapshot_data));
-        }
-    }
-
-    Json(NodeStatsResponse::Simple(snapshot_data.simplify()))
 }
 
 pub(crate) async fn stats_axum(

--- a/mixnode/src/node/http/verloc.rs
+++ b/mixnode/src/node/http/verloc.rs
@@ -17,7 +17,7 @@ impl VerlocState {
 
 /// Provides verifiable location (verloc) measurements for this mixnode - a list of the
 /// round-trip times, in milliseconds, for all other mixnodes that this node knows about.
-pub(crate) async fn verloc_axum(
+pub(crate) async fn verloc(
     State(verloc): State<VerlocState>,
     Query(output): Query<OutputParams>,
 ) -> MixnodeVerlocResponse {

--- a/mixnode/src/node/http/verloc.rs
+++ b/mixnode/src/node/http/verloc.rs
@@ -1,9 +1,8 @@
 use axum::extract::{Query, State};
 use nym_mixnode_common::verloc::{AtomicVerlocResult, VerlocResult};
 use nym_node::http::api::{FormattedResponse, OutputParams};
-use rocket::serde::json::Json;
-use rocket::State as RocketState;
 
+#[derive(Clone)]
 pub(crate) struct VerlocState {
     shared: AtomicVerlocResult,
 }
@@ -14,14 +13,6 @@ impl VerlocState {
             shared: atomic_verloc_result,
         }
     }
-}
-
-/// Provides verifiable location (verloc) measurements for this mixnode - a list of the
-/// round-trip times, in milliseconds, for all other mixnodes that this node knows about.
-#[get("/verloc")]
-pub(crate) async fn verloc(state: &RocketState<VerlocState>) -> Json<VerlocResult> {
-    // since it's impossible to get a mutable reference to the state, we can't cache any results outside the lock : (
-    Json(state.shared.clone_data().await)
 }
 
 /// Provides verifiable location (verloc) measurements for this mixnode - a list of the

--- a/mixnode/src/node/http/verloc.rs
+++ b/mixnode/src/node/http/verloc.rs
@@ -1,6 +1,8 @@
+use axum::extract::{Query, State};
 use nym_mixnode_common::verloc::{AtomicVerlocResult, VerlocResult};
+use nym_node::http::api::{FormattedResponse, OutputParams};
 use rocket::serde::json::Json;
-use rocket::State;
+use rocket::State as RocketState;
 
 pub(crate) struct VerlocState {
     shared: AtomicVerlocResult,
@@ -17,7 +19,19 @@ impl VerlocState {
 /// Provides verifiable location (verloc) measurements for this mixnode - a list of the
 /// round-trip times, in milliseconds, for all other mixnodes that this node knows about.
 #[get("/verloc")]
-pub(crate) async fn verloc(state: &State<VerlocState>) -> Json<VerlocResult> {
+pub(crate) async fn verloc(state: &RocketState<VerlocState>) -> Json<VerlocResult> {
     // since it's impossible to get a mutable reference to the state, we can't cache any results outside the lock : (
     Json(state.shared.clone_data().await)
 }
+
+/// Provides verifiable location (verloc) measurements for this mixnode - a list of the
+/// round-trip times, in milliseconds, for all other mixnodes that this node knows about.
+pub(crate) async fn verloc_axum(
+    State(verloc): State<VerlocState>,
+    Query(output): Query<OutputParams>,
+) -> MixnodeVerlocResponse {
+    let output = output.output.unwrap_or_default();
+    output.to_response(verloc.shared.clone_data().await)
+}
+
+pub type MixnodeVerlocResponse = FormattedResponse<VerlocResult>;

--- a/mixnode/src/node/listener/connection_handler/mod.rs
+++ b/mixnode/src/node/listener/connection_handler/mod.rs
@@ -7,6 +7,8 @@ use crate::node::listener::connection_handler::packet_processing::{
 use crate::node::packet_delayforwarder::PacketDelayForwardSender;
 use crate::node::TaskClient;
 use futures::StreamExt;
+use log::debug;
+use log::{error, info, warn};
 use nym_mixnode_common::measure;
 use nym_sphinx::forwarding::packet::MixPacket;
 use nym_sphinx::framing::codec::NymCodec;
@@ -16,8 +18,9 @@ use std::net::SocketAddr;
 use tokio::net::TcpStream;
 use tokio::time::Instant;
 use tokio_util::codec::Framed;
+
 #[cfg(feature = "cpucycles")]
-use tracing::{error, info, instrument};
+use tracing::instrument;
 
 pub(crate) mod packet_processing;
 

--- a/mixnode/src/node/listener/mod.rs
+++ b/mixnode/src/node/listener/mod.rs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::node::listener::connection_handler::ConnectionHandler;
+use log::{error, info, warn};
 use std::net::SocketAddr;
 use std::process;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
-#[cfg(feature = "cpucycles")]
-use tracing::error;
 
 use super::TaskClient;
 

--- a/mixnode/src/node/mod.rs
+++ b/mixnode/src/node/mod.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Config;
-use crate::node::http::description::description_axum;
-use crate::node::http::hardware::hardware_axum;
-use crate::node::http::not_found_axum;
+use crate::node::http::description::description;
+use crate::node::http::hardware::hardware;
+use crate::node::http::not_found;
 use crate::node::http::state::MixnodeAppState;
-use crate::node::http::stats::stats_axum;
-use crate::node::http::verloc::{verloc_axum, VerlocState};
+use crate::node::http::stats::stats;
+use crate::node::http::verloc::{verloc, VerlocState};
 use crate::node::listener::connection_handler::packet_processing::PacketProcessor;
 use crate::node::listener::connection_handler::ConnectionHandler;
 use crate::node::listener::Listener;
@@ -112,17 +112,17 @@ impl MixNode {
         };
 
         let router = Router::new()
-            .route("/verloc", get(verloc_axum))
+            .route("/verloc", get(verloc))
             .route(
                 "/description",
                 get({
-                    let description = self.descriptor.clone();
-                    move |query| description_axum(description, query)
+                    let descriptor = self.descriptor.clone();
+                    move |query| description(descriptor, query)
                 }),
             )
-            .route("/stats", get(stats_axum))
-            .route("/hardware", get(hardware_axum))
-            .fallback(not_found_axum)
+            .route("/stats", get(stats))
+            .route("/hardware", get(hardware))
+            .fallback(not_found)
             .layer(axum::middleware::from_fn(logging::logger))
             .with_state(state);
 

--- a/mixnode/src/node/node_statistics.rs
+++ b/mixnode/src/node/node_statistics.rs
@@ -80,7 +80,7 @@ impl SharedNodeStats {
 }
 
 #[derive(Serialize, Clone)]
-pub(crate) struct NodeStats {
+pub struct NodeStats {
     #[serde(serialize_with = "humantime_serde::serialize")]
     update_time: SystemTime,
 
@@ -126,7 +126,7 @@ impl NodeStats {
 }
 
 #[derive(Serialize, Clone)]
-pub(crate) struct NodeStatsSimple {
+pub struct NodeStatsSimple {
     #[serde(serialize_with = "humantime_serde::serialize")]
     update_time: SystemTime,
 

--- a/mixnode/src/node/node_statistics.rs
+++ b/mixnode/src/node/node_statistics.rs
@@ -1,6 +1,8 @@
+use super::TaskClient;
 use futures::channel::mpsc;
 use futures::lock::Mutex;
 use futures::StreamExt;
+use log::{debug, info, trace};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::ops::DerefMut;
@@ -8,8 +10,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::sync::{RwLock, RwLockReadGuard};
-
-use super::TaskClient;
 
 // convenience aliases
 type PacketsMap = HashMap<String, u64>;


### PR DESCRIPTION
# Description

This is mostly a clean up PR that replaces `rocket` in our mixnode http api with axum. 
It's also the first step towards https://github.com/nymtech/nym/issues/4070 as it will allow us to combine the routes under the single server.

## testing remarks:
all the routes, i.e. `/verloc`, `/stats`, `/stats?debug=true`, `/description` and `/hardware` should work EXACTLY the same as they did before
