### PR TITLE
ci: switch to github runners for nightly windows builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [stable, beta]
-        os: [ubuntu-20.04, windows10, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
       CARGO_TERM_COLOR: always
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -56,9 +56,18 @@ jobs:
           command: build
           args: --release --workspace --examples
 
-      - name: Set debug to false
+      # To avoid running out of disk space, skip generating debug symbols
+      - name: Set debug to false (unix)
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
         run: |
           sed -i.bak 's/\[profile.dev\]/\[profile.dev\]\ndebug = false/' Cargo.toml
+          git diff
+
+      - name: Set debug to false (win)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          (Get-Content Cargo.toml) -replace '\[profile.dev\]', "`$&`ndebug = false" | Set-Content Cargo.toml
           git diff
 
       - name: Run unit tests

--- a/.github/workflows/nightly-nym-connect-desktop-build.yml
+++ b/.github/workflows/nightly-nym-connect-desktop-build.yml
@@ -1,4 +1,4 @@
-name: nightly-nym-connect-build
+name: nightly-nym-connect-desktop-build
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows10]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/nightly-nym-wallet-build.yml
+++ b/.github/workflows/nightly-nym-wallet-build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows10]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
       CARGO_TERM_COLOR: always


### PR DESCRIPTION
# Description

- Switch nightly-build to github hosted windows-latest
- Switch nightly-nym-wallet-build to windows-latest
- Switch nightly-nym-connect-desktop-build to windows-latest

