### PR TITLE
TUN devices in wireguard and ip-packet-router should have different IP and names

### DIFF
--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -44,7 +44,12 @@ pub async fn start_wireguard(
     //let routing_mode = tun_device::RoutingMode::new_nat();
 
     // Start the tun device that is used to relay traffic outbound
-    let (tun, tun_task_tx, tun_task_response_rx) = tun_device::TunDevice::new(routing_mode);
+    let config = tun_device::TunDeviceConfig {
+        base_name: setup::TUN_BASE_NAME.to_string(),
+        ip: setup::TUN_DEVICE_ADDRESS.parse().unwrap(),
+        netmask: setup::TUN_DEVICE_NETMASK.parse().unwrap(),
+    };
+    let (tun, tun_task_tx, tun_task_response_rx) = tun_device::TunDevice::new(routing_mode, config);
     tun.start();
 
     // We also index peers by a tag

--- a/common/wireguard/src/platform/linux/tun_device.rs
+++ b/common/wireguard/src/platform/linux/tun_device.rs
@@ -10,7 +10,6 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::{
     event::Event,
-    setup::{TUN_BASE_NAME, TUN_DEVICE_ADDRESS, TUN_DEVICE_NETMASK},
     tun_task_channel::{
         tun_task_channel, tun_task_response_channel, TunTaskPayload, TunTaskResponseRx,
         TunTaskResponseTx, TunTaskRx, TunTaskTx,
@@ -79,16 +78,25 @@ pub struct NatInner {
     nat_table: HashMap<IpAddr, u64>,
 }
 
+pub struct TunDeviceConfig {
+    pub base_name: String,
+    pub ip: Ipv4Addr,
+    pub netmask: Ipv4Addr,
+}
+
 impl TunDevice {
     pub fn new(
         routing_mode: RoutingMode,
-        // peers_by_ip: Option<Arc<tokio::sync::Mutex<PeersByIp>>>,
+        config: TunDeviceConfig,
     ) -> (Self, TunTaskTx, TunTaskResponseRx) {
-        let tun = setup_tokio_tun_device(
-            format!("{TUN_BASE_NAME}%d").as_str(),
-            TUN_DEVICE_ADDRESS.parse().unwrap(),
-            TUN_DEVICE_NETMASK.parse().unwrap(),
-        );
+        let TunDeviceConfig {
+            base_name,
+            ip,
+            netmask,
+        } = config;
+        let name = format!("{base_name}%d");
+
+        let tun = setup_tokio_tun_device(&name, ip, netmask);
         log::info!("Created TUN device: {}", tun.name());
 
         // Channels to communicate with the other tasks
@@ -167,10 +175,10 @@ impl TunDevice {
                 }
             }
 
-            // But we do it by consulting the NAT table.
+            // But we can also do it by consulting the NAT table.
             RoutingMode::Nat(ref nat_table) => {
                 if let Some(tag) = nat_table.nat_table.get(&dst_addr) {
-                    log::info!("Forward packet to wg tunnel with tag: {tag}");
+                    log::info!("Forward packet with tag: {tag}");
                     self.tun_task_response_tx
                         .send((*tag, packet.to_vec()))
                         .await

--- a/common/wireguard/src/setup.rs
+++ b/common/wireguard/src/setup.rs
@@ -8,8 +8,8 @@ use log::info;
 pub const WG_ADDRESS: &str = "0.0.0.0";
 
 // The interface used to route traffic
-pub const TUN_BASE_NAME: &str = "nymtun";
-pub const TUN_DEVICE_ADDRESS: &str = "10.0.0.1";
+pub const TUN_BASE_NAME: &str = "nymwg";
+pub const TUN_DEVICE_ADDRESS: &str = "10.1.0.1";
 pub const TUN_DEVICE_NETMASK: &str = "255.255.255.0";
 
 // The private key of the listener
@@ -18,7 +18,7 @@ const PRIVATE_KEY: &str = "AEqXrLFT4qjYq3wmX0456iv94uM6nDj5ugp6Jedcflg=";
 
 // The AllowedIPs for the connected peer, which is one a single IP and the same as the IP that the
 // peer has configured on their side.
-const ALLOWED_IPS: &str = "10.0.0.2";
+const ALLOWED_IPS: &str = "10.1.0.2";
 
 fn decode_base64_key(base64_key: &str) -> [u8; 32] {
     general_purpose::STANDARD

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -21,6 +21,11 @@ pub use crate::config::Config;
 pub mod config;
 pub mod error;
 
+// The interface used to route traffic
+pub const TUN_BASE_NAME: &str = "nymtun";
+pub const TUN_DEVICE_ADDRESS: &str = "10.0.0.1";
+pub const TUN_DEVICE_NETMASK: &str = "255.255.255.0";
+
 pub struct OnStartData {
     // to add more fields as required
     pub address: Recipient,
@@ -123,8 +128,14 @@ impl IpPacketRouterBuilder {
         let self_address = *mixnet_client.nym_address();
 
         // Create the TUN device that we interact with the rest of the world with
+        let config = nym_wireguard::tun_device::TunDeviceConfig {
+            base_name: TUN_BASE_NAME.to_string(),
+            ip: TUN_DEVICE_ADDRESS.parse().unwrap(),
+            netmask: TUN_DEVICE_NETMASK.parse().unwrap(),
+        };
         let (tun, tun_task_tx, tun_task_response_rx) = nym_wireguard::tun_device::TunDevice::new(
             nym_wireguard::tun_device::RoutingMode::new_nat(),
+            config,
         );
         tun.start();
 


### PR DESCRIPTION
# Description

TUN devices in wireguard and ip-packet-router should have different base names and by on different subnets

