### PR TITLE
Disable poisson in ip-packet-router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6668,6 +6668,7 @@ dependencies = [
  "tap",
  "thiserror",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/gateway/src/commands/helpers.rs
+++ b/gateway/src/commands/helpers.rs
@@ -241,9 +241,17 @@ pub(crate) fn override_network_requester_config(
 }
 
 pub(crate) fn override_ip_packet_router_config(
-    cfg: nym_ip_packet_router::Config,
-    _opts: Option<OverrideIpPacketRouterConfig>,
+    mut cfg: nym_ip_packet_router::Config,
+    opts: Option<OverrideIpPacketRouterConfig>,
 ) -> nym_ip_packet_router::Config {
+    let Some(_opts) = opts else { return cfg };
+
+    // disable poisson rate in the BASE client if the IPR option is enabled
+    if cfg.ip_packet_router.disable_poisson_rate {
+        log::info!("Disabling poisson rate for ip packet router");
+        cfg.set_no_poisson_process();
+    }
+
     cfg
 }
 

--- a/service-providers/ip-packet-router/Cargo.toml
+++ b/service-providers/ip-packet-router/Cargo.toml
@@ -26,3 +26,4 @@ serde_json = { workspace = true }
 tap.workspace = true
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
+url.workspace = true


### PR DESCRIPTION
# Description

Closes #4130 

Disable the poisson rate in the ip-packet-router by default
