### PR TITLE
using performance^20 when calculating active set selection weight

### DIFF
--- a/common/cosmwasm-smart-contracts/contracts-common/src/types.rs
+++ b/common/cosmwasm-smart-contracts/contracts-common/src/types.rs
@@ -3,6 +3,7 @@
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Decimal;
+use cosmwasm_std::OverflowError;
 use cosmwasm_std::Uint128;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
@@ -72,19 +73,8 @@ impl Percent {
         truncate_decimal(hundred * self.0).u128() as u8
     }
 
-    pub fn pow(&self, exp: u32) -> Self {
-        match self.0.checked_pow(exp) {
-            Ok(res) => Percent(res),
-            Err(_overflow) => {
-                // since the percent is meant to always be less than 1, this should NEVER hapen, however,
-                // when the inevitable happens because of some misuse, just saturate the result
-                if self.0 < Decimal::one() {
-                    Percent::zero()
-                } else {
-                    Percent(Decimal::MAX)
-                }
-            }
-        }
+    pub fn checked_pow(&self, exp: u32) -> Result<Self, OverflowError> {
+        self.0.checked_pow(exp).map(Percent)
     }
 }
 

--- a/common/cosmwasm-smart-contracts/contracts-common/src/types.rs
+++ b/common/cosmwasm-smart-contracts/contracts-common/src/types.rs
@@ -71,6 +71,16 @@ impl Percent {
         // we know the cast from u128 to u8 is a safe one since the internal value must be within 0 - 1 range
         truncate_decimal(hundred * self.0).u128() as u8
     }
+
+    pub fn pow(&self, exp: u32) -> Self {
+        match self.0.checked_pow(exp) {
+            Ok(res) => Percent(res),
+            Err(overflow) => {
+                // since the percent is meant to always be strictly less than 1, this should NEVER hapen
+                panic!("the percent invariant has been broken. the exponentiation result has overflown: {overflow}");
+            }
+        }
+    }
 }
 
 impl Display for Percent {

--- a/common/cosmwasm-smart-contracts/contracts-common/src/types.rs
+++ b/common/cosmwasm-smart-contracts/contracts-common/src/types.rs
@@ -75,9 +75,14 @@ impl Percent {
     pub fn pow(&self, exp: u32) -> Self {
         match self.0.checked_pow(exp) {
             Ok(res) => Percent(res),
-            Err(overflow) => {
-                // since the percent is meant to always be strictly less than 1, this should NEVER hapen
-                panic!("the percent invariant has been broken. the exponentiation result has overflown: {overflow}");
+            Err(_overflow) => {
+                // since the percent is meant to always be less than 1, this should NEVER hapen, however,
+                // when the inevitable happens because of some misuse, just saturate the result
+                if self.0 < Decimal::one() {
+                    Percent::zero()
+                } else {
+                    Percent(Decimal::MAX)
+                }
             }
         }
     }

--- a/nym-api/src/epoch_operations/rewarded_set_assignment.rs
+++ b/nym-api/src/epoch_operations/rewarded_set_assignment.rs
@@ -24,7 +24,15 @@ struct MixnodeWithStakeAndPerformance {
 
 impl MixnodeWithStakeAndPerformance {
     fn to_selection_weight(&self) -> f64 {
-        let scaled_stake = self.total_stake * self.performance.pow(20);
+        let scaled_performance = match self.performance.checked_pow(20) {
+            Ok(perf) => perf,
+            Err(overflow) => {
+                warn!("the node's performance ({}) has overflow while scaling it by the factor of 20: {overflow}. Setting it to 0 instead.", self.performance);
+                return 0.;
+            }
+        };
+
+        let scaled_stake = self.total_stake * scaled_performance;
         stake_to_f64(scaled_stake)
     }
 }

--- a/nym-api/src/epoch_operations/rewarded_set_assignment.rs
+++ b/nym-api/src/epoch_operations/rewarded_set_assignment.rs
@@ -24,7 +24,7 @@ struct MixnodeWithStakeAndPerformance {
 
 impl MixnodeWithStakeAndPerformance {
     fn to_selection_weight(&self) -> f64 {
-        let scaled_stake = self.total_stake * self.performance;
+        let scaled_stake = self.total_stake * self.performance.pow(20);
         stake_to_f64(scaled_stake)
     }
 }


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
