### PR TITLE
Feature/deb package

### DIFF
--- a/common/config/src/lib.rs
+++ b/common/config/src/lib.rs
@@ -25,12 +25,20 @@ pub const DEFAULT_CONFIG_FILENAME: &str = "config.toml";
 
 #[cfg(feature = "dirs")]
 pub fn must_get_home() -> PathBuf {
-    dirs::home_dir().expect("Failed to evaluate $HOME value")
+    if let Some(home_dir) = std::env::var_os("NYM_HOME_DIR") {
+        home_dir.into()
+    } else {
+        dirs::home_dir().expect("Failed to evaluate $HOME value")
+    }
 }
 
 #[cfg(feature = "dirs")]
 pub fn may_get_home() -> Option<PathBuf> {
-    dirs::home_dir()
+    if let Some(home_dir) = std::env::var_os("NYM_HOME_DIR") {
+        Some(home_dir.into())
+    } else {
+        dirs::home_dir()
+    }
 }
 
 pub trait NymConfigTemplate: Serialize {

--- a/mixnode/Cargo.toml
+++ b/mixnode/Cargo.toml
@@ -81,3 +81,8 @@ cpucycles = [
     "opentelemetry",
     "nym-bin-common/tracing",
 ]
+
+[package.metadata.deb]
+name = "nym-mixnode"
+maintainer-scripts = "debian"
+systemd-units = { enable = false }

--- a/mixnode/debian/postinst
+++ b/mixnode/debian/postinst
@@ -1,0 +1,6 @@
+#DEBHELPER#
+
+useradd nym
+mkdir -p /etc/nym
+chown -R nym /etc/nym
+su nym -c nym-mixnode init --host 0.0.0.0 --id nym-mixnode

--- a/mixnode/debian/postinst
+++ b/mixnode/debian/postinst
@@ -3,4 +3,4 @@
 useradd nym
 mkdir -p /etc/nym
 chown -R nym /etc/nym
-su nym -c nym-mixnode init --host 0.0.0.0 --id nym-mixnode
+su nym -c 'NYM_HOME_DIR=/etc/nym nym-mixnode init --host 0.0.0.0 --id nym-mixnode'

--- a/mixnode/debian/service
+++ b/mixnode/debian/service
@@ -5,6 +5,7 @@ After=network-online.target
 [Service]
 ExecStart=/usr/bin/nym-mixnode run --id nym-mixnode
 User=nym
+Environment="NYM_HOME_DIR=/etc/nym"
 
 [Install]
 WantedBy=multi-user.target

--- a/mixnode/debian/service
+++ b/mixnode/debian/service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Nym Mixnode
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/nym-mixnode run --id nym-mixnode
+User=nym
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Description

Use `cargo-deb` to create a Debian package, `postinst` script inits the mixnode, it also sets up a `nym-mixnode` systemd service.

Allows overriding config home directory with a `NYM_HOME_DIR` env var.

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
