### PR TITLE
Fix clippy for latest rustc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9442,9 +9442,9 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c1d19b288ca9898cd421c7b105fb7269918a7f8e9253a991e228981ca421ad"
+checksum = "395ace5aff9629c7268ca8255aceb945525b2cb644015f3caec5131a6a537c11"
 dependencies = [
  "inventory",
  "libc",
@@ -9459,9 +9459,9 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d7a04caa3ca2224f5ea4ddd850e2629c3b36b2b83621f87a8303bf41020110"
+checksum = "9255504d5467bae9e07d58b8de446ba6739b29bf72e1fa35b2387e30d29dcbfe"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/ephemera/src/block/manager.rs
+++ b/ephemera/src/block/manager.rs
@@ -580,7 +580,9 @@ mod test {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(
+        expected = "Received committed block which isn't last produced block, this is a bug!"
+    )]
     async fn test_on_committed_with_invalid_pending_block() {
         let (mut manager, _) = block_manager_with_defaults();
 

--- a/sdk/lib/socks5-listener/Cargo.toml
+++ b/sdk/lib/socks5-listener/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { workspace = true, features = ["sync", "time"] }
 log = "0.4.17"
 rand = "0.7.3"
 
-safer-ffi = { version = "0.1.0-rc1" }
+safer-ffi = { version = "0.1.4" }
 
 [target.'cfg(target_os="android")'.dependencies]
 jni = { version = "0.21", default-features = false }


### PR DESCRIPTION
# Description

- Upgrade to safer-ffi 0.1.4
- Update test to include expected panic message