### PR TITLE
Fix action controller stopping too early

### DIFF
--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/sent_notification_listener.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/sent_notification_listener.rs
@@ -40,7 +40,7 @@ impl SentNotificationListener {
     pub(super) async fn run_with_shutdown(&mut self, mut shutdown: nym_task::TaskClient) {
         debug!("Started SentNotificationListener with graceful shutdown support");
 
-        while !shutdown.is_shutdown() {
+        loop {
             tokio::select! {
                 frag_id = self.sent_notifier.next() => match frag_id {
                     Some(frag_id) => {
@@ -53,6 +53,7 @@ impl SentNotificationListener {
                 },
                 _ = shutdown.recv_with_delay() => {
                     log::trace!("SentNotificationListener: Received shutdown");
+                    break;
                 }
             }
         }

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -500,11 +500,12 @@ where
         {
             let mut status_timer = tokio::time::interval(Duration::from_secs(5));
 
-            while !shutdown.is_shutdown() {
+            loop {
                 tokio::select! {
                     biased;
                     _ = shutdown.recv_with_delay() => {
                         log::trace!("OutQueueControl: Received shutdown");
+                        break;
                     }
                     _ = status_timer.tick() => {
                         self.log_status(&mut shutdown);

--- a/common/client-core/src/client/replies/reply_storage/mod.rs
+++ b/common/client-core/src/client/replies/reply_storage/mod.rs
@@ -50,7 +50,7 @@ where
         shutdown.recv().await;
 
         info!("PersistentReplyStorage is flushing all reply-related data to underlying storage");
-        warn!("you MUST NOT forcefully shutdown now or you risk data corruption!");
+        info!("you MUST NOT forcefully shutdown now or you risk data corruption!");
         if let Err(err) = self.backend.flush_surb_storage(&mem_state).await {
             error!("failed to flush our reply-related data to the persistent storage: {err}")
         } else {

--- a/common/client-core/src/client/replies/reply_storage/mod.rs
+++ b/common/client-core/src/client/replies/reply_storage/mod.rs
@@ -39,7 +39,7 @@ where
         mem_state: CombinedReplyStorage,
         mut shutdown: nym_task::TaskClient,
     ) {
-        use log::{debug, error, info, warn};
+        use log::{debug, error, info};
 
         debug!("Started PersistentReplyStorage");
         if let Err(err) = self.backend.start_storage_session().await {

--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -493,7 +493,10 @@ impl TaskClient {
 impl Drop for TaskClient {
     fn drop(&mut self) {
         if !self.mode.should_signal_on_drop() {
-            self.log(Level::Trace, "the task client is getting dropped (but instructed to not signal)");
+            self.log(
+                Level::Trace,
+                "the task client is getting dropped (but instructed to not signal)",
+            );
             return;
         } else {
             self.log(Level::Debug, "the task client is getting dropped");

--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -493,10 +493,10 @@ impl TaskClient {
 impl Drop for TaskClient {
     fn drop(&mut self) {
         if !self.mode.should_signal_on_drop() {
-            self.log(Level::Debug, "the task client is getting dropped");
+            self.log(Level::Trace, "the task client is getting dropped (but instructed to not signal)");
             return;
         } else {
-            self.log(Level::Info, "the task client is getting dropped");
+            self.log(Level::Debug, "the task client is getting dropped");
         }
 
         if !self.is_shutdown_poll() {


### PR DESCRIPTION
# Description

- Stop ActionController only after both incoming channels closed
- Downgrade task getting dropped message to debug level
- The warning to the user is not a warning that things didn't work
