### PR TITLE
Implement ip-packet-router connect request response outline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6608,6 +6608,7 @@ dependencies = [
  "bincode",
  "bytes",
  "nym-sphinx",
+ "rand 0.8.5",
  "serde",
 ]
 

--- a/common/ip-packet-requests/Cargo.toml
+++ b/common/ip-packet-requests/Cargo.toml
@@ -14,4 +14,5 @@ license.workspace = true
 bincode = "1.3.3"
 bytes = "1.5.0"
 nym-sphinx = { path = "../nymsphinx" }
+rand = "0.8.5"
 serde = { workspace = true, features = ["derive"] }

--- a/common/ip-packet-requests/src/lib.rs
+++ b/common/ip-packet-requests/src/lib.rs
@@ -183,39 +183,39 @@ pub struct DataResponse {
 
 // ---
 
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct TaggedIpPacket {
-    pub packet: bytes::Bytes,
-    pub return_address: Recipient,
-    pub return_mix_hops: Option<u8>,
-    // pub return_mix_delays: Option<f64>,
-}
-
-impl TaggedIpPacket {
-    pub fn new(
-        packet: bytes::Bytes,
-        return_address: Recipient,
-        return_mix_hops: Option<u8>,
-    ) -> Self {
-        TaggedIpPacket {
-            packet,
-            return_address,
-            return_mix_hops,
-        }
-    }
-
-    pub fn from_reconstructed_message(
-        message: &nym_sphinx::receiver::ReconstructedMessage,
-    ) -> Result<Self, bincode::Error> {
-        use bincode::Options;
-        make_bincode_serializer().deserialize(&message.message)
-    }
-
-    pub fn to_bytes(&self) -> Result<Vec<u8>, bincode::Error> {
-        use bincode::Options;
-        make_bincode_serializer().serialize(self)
-    }
-}
+// #[derive(serde::Serialize, serde::Deserialize)]
+// pub struct TaggedIpPacket {
+//     pub packet: bytes::Bytes,
+//     pub return_address: Recipient,
+//     pub return_mix_hops: Option<u8>,
+//     // pub return_mix_delays: Option<f64>,
+// }
+//
+// impl TaggedIpPacket {
+//     pub fn new(
+//         packet: bytes::Bytes,
+//         return_address: Recipient,
+//         return_mix_hops: Option<u8>,
+//     ) -> Self {
+//         TaggedIpPacket {
+//             packet,
+//             return_address,
+//             return_mix_hops,
+//         }
+//     }
+//
+//     pub fn from_reconstructed_message(
+//         message: &nym_sphinx::receiver::ReconstructedMessage,
+//     ) -> Result<Self, bincode::Error> {
+//         use bincode::Options;
+//         make_bincode_serializer().deserialize(&message.message)
+//     }
+//
+//     pub fn to_bytes(&self) -> Result<Vec<u8>, bincode::Error> {
+//         use bincode::Options;
+//         make_bincode_serializer().serialize(self)
+//     }
+// }
 
 fn make_bincode_serializer() -> impl bincode::Options {
     use bincode::Options;

--- a/common/ip-packet-requests/src/lib.rs
+++ b/common/ip-packet-requests/src/lib.rs
@@ -1,7 +1,192 @@
+use std::net::IpAddr;
+
+use nym_sphinx::addressing::clients::Recipient;
+use serde::{Deserialize, Serialize};
+
+pub const CURRENT_VERSION: u8 = 1;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IpPacketRequest {
+    pub version: u8,
+    pub data: IpPacketRequestData,
+}
+
+impl IpPacketRequest {
+    pub fn new_static_connect_request(
+        ip: IpAddr,
+        reply_to: Recipient,
+        reply_to_hops: Option<u8>,
+        reply_to_avg_mix_delays: Option<f64>,
+    ) -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            data: IpPacketRequestData::StaticConnect(StaticConnectRequest {
+                ip,
+                reply_to,
+                reply_to_hops,
+                reply_to_avg_mix_delays,
+            }),
+        }
+    }
+
+    pub fn new_dynamic_connect_request(
+        reply_to: Recipient,
+        reply_to_hops: Option<u8>,
+        reply_to_avg_mix_delays: Option<f64>,
+    ) -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            data: IpPacketRequestData::DynamicConnect(DynamicConnectRequest {
+                reply_to,
+                reply_to_hops,
+                reply_to_avg_mix_delays,
+            }),
+        }
+    }
+
+    pub fn new_ip_packet(ip_packet: bytes::Bytes) -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            data: IpPacketRequestData::Data(DataRequest { ip_packet }),
+        }
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>, bincode::Error> {
+        use bincode::Options;
+        make_bincode_serializer().serialize(self)
+    }
+
+    pub fn from_reconstructed_message(
+        message: &nym_sphinx::receiver::ReconstructedMessage,
+    ) -> Result<Self, bincode::Error> {
+        use bincode::Options;
+        make_bincode_serializer().deserialize(&message.message)
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum IpPacketRequestData {
+    StaticConnect(StaticConnectRequest),
+    DynamicConnect(DynamicConnectRequest),
+    Data(DataRequest),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StaticConnectRequest {
+    pub ip: IpAddr,
+    pub reply_to: Recipient,
+    pub reply_to_hops: Option<u8>,
+    pub reply_to_avg_mix_delays: Option<f64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DynamicConnectRequest {
+    pub reply_to: Recipient,
+    pub reply_to_hops: Option<u8>,
+    pub reply_to_avg_mix_delays: Option<f64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DataRequest {
+    pub ip_packet: bytes::Bytes,
+}
+
+// ---
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IpPacketResponse {
+    pub version: u8,
+    pub data: IpPacketResponseData,
+}
+
+impl IpPacketResponse {
+    pub fn new_static_connect_success() -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            data: IpPacketResponseData::StaticConnect(StaticConnectResponse::Success),
+        }
+    }
+
+    pub fn new_static_connect_failure() -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            data: IpPacketResponseData::StaticConnect(StaticConnectResponse::Failure),
+        }
+    }
+
+    pub fn new_dynamic_connect_success(ip: IpAddr) -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            data: IpPacketResponseData::DynamicConnect(DynamicConnectResponse::Success(
+                DynamicConnectSuccess { ip },
+            )),
+        }
+    }
+
+    pub fn new_dynamic_connect_failure() -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            data: IpPacketResponseData::DynamicConnect(DynamicConnectResponse::Failure),
+        }
+    }
+
+    pub fn new_ip_packet(ip_packet: bytes::Bytes) -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            data: IpPacketResponseData::Data(DataResponse { ip_packet }),
+        }
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>, bincode::Error> {
+        use bincode::Options;
+        make_bincode_serializer().serialize(self)
+    }
+
+    pub fn from_reconstructed_message(
+        message: &nym_sphinx::receiver::ReconstructedMessage,
+    ) -> Result<Self, bincode::Error> {
+        use bincode::Options;
+        make_bincode_serializer().deserialize(&message.message)
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum IpPacketResponseData {
+    StaticConnect(StaticConnectResponse),
+    DynamicConnect(DynamicConnectResponse),
+    Data(DataResponse),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum StaticConnectResponse {
+    Success,
+    Failure,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum DynamicConnectResponse {
+    Success(DynamicConnectSuccess),
+    Failure,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DynamicConnectSuccess {
+    pub ip: IpAddr,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DataResponse {
+    pub ip_packet: bytes::Bytes,
+}
+
+// ---
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct TaggedIpPacket {
     pub packet: bytes::Bytes,
-    pub return_address: nym_sphinx::addressing::clients::Recipient,
+    pub return_address: Recipient,
     pub return_mix_hops: Option<u8>,
     // pub return_mix_delays: Option<f64>,
 }
@@ -9,7 +194,7 @@ pub struct TaggedIpPacket {
 impl TaggedIpPacket {
     pub fn new(
         packet: bytes::Bytes,
-        return_address: nym_sphinx::addressing::clients::Recipient,
+        return_address: Recipient,
         return_mix_hops: Option<u8>,
     ) -> Self {
         TaggedIpPacket {
@@ -37,4 +222,44 @@ fn make_bincode_serializer() -> impl bincode::Options {
     bincode::DefaultOptions::new()
         .with_big_endian()
         .with_varint_encoding()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_size_of_request() {
+        let connect = IpPacketRequest {
+            version: 4,
+            data: IpPacketRequestData::StaticConnect(
+                StaticConnectRequest {
+                    ip: IpAddr::from([10, 0, 0, 1]),
+                    reply_to: Recipient::try_from_base58_string("D1rrpsysCGCYXy9saP8y3kmNpGtJZUXN9SvFoUcqAsM9.9Ssso1ea5NfkbMASdiseDSjTN1fSWda5SgEVjdSN4CvV@GJqd3ZxpXWSNxTfx7B1pPtswpetH4LnJdFeLeuY5KUuN").unwrap(),
+                    reply_to_hops: None,
+                    reply_to_avg_mix_delays: None,
+                },
+            )
+        };
+
+        // dbg!(&connect);
+        // dbg!(&connect.to_bytes().unwrap());
+        // dbg!(&connect.to_bytes().unwrap().len());
+        assert_eq!(connect.to_bytes().unwrap().len(), 106);
+    }
+
+    #[test]
+    fn check_size_of_data() {
+        let data = IpPacketRequest {
+            version: 4,
+            data: IpPacketRequestData::Data(DataRequest {
+                ip_packet: bytes::Bytes::from(vec![1u8; 32]),
+            }),
+        };
+
+        // dbg!(&data);
+        // dbg!(&data.to_bytes().unwrap());
+        // dbg!(&data.to_bytes().unwrap().len());
+        assert_eq!(data.to_bytes().unwrap().len(), 35);
+    }
 }

--- a/common/ip-packet-requests/src/lib.rs
+++ b/common/ip-packet-requests/src/lib.rs
@@ -267,42 +267,6 @@ pub struct DataResponse {
     pub ip_packet: bytes::Bytes,
 }
 
-// ---
-
-// #[derive(serde::Serialize, serde::Deserialize)]
-// pub struct TaggedIpPacket {
-//     pub packet: bytes::Bytes,
-//     pub return_address: Recipient,
-//     pub return_mix_hops: Option<u8>,
-//     // pub return_mix_delays: Option<f64>,
-// }
-//
-// impl TaggedIpPacket {
-//     pub fn new(
-//         packet: bytes::Bytes,
-//         return_address: Recipient,
-//         return_mix_hops: Option<u8>,
-//     ) -> Self {
-//         TaggedIpPacket {
-//             packet,
-//             return_address,
-//             return_mix_hops,
-//         }
-//     }
-//
-//     pub fn from_reconstructed_message(
-//         message: &nym_sphinx::receiver::ReconstructedMessage,
-//     ) -> Result<Self, bincode::Error> {
-//         use bincode::Options;
-//         make_bincode_serializer().deserialize(&message.message)
-//     }
-//
-//     pub fn to_bytes(&self) -> Result<Vec<u8>, bincode::Error> {
-//         use bincode::Options;
-//         make_bincode_serializer().serialize(self)
-//     }
-// }
-
 fn make_bincode_serializer() -> impl bincode::Options {
     use bincode::Options;
     bincode::DefaultOptions::new()
@@ -328,10 +292,6 @@ mod tests {
                 },
             )
         };
-
-        // dbg!(&connect);
-        // dbg!(&connect.to_bytes().unwrap());
-        // dbg!(&connect.to_bytes().unwrap().len());
         assert_eq!(connect.to_bytes().unwrap().len(), 107);
     }
 
@@ -343,10 +303,6 @@ mod tests {
                 ip_packet: bytes::Bytes::from(vec![1u8; 32]),
             }),
         };
-
-        // dbg!(&data);
-        // dbg!(&data.to_bytes().unwrap());
-        // dbg!(&data.to_bytes().unwrap().len());
         assert_eq!(data.to_bytes().unwrap().len(), 35);
     }
 

--- a/common/tun/src/linux/tun_device.rs
+++ b/common/tun/src/linux/tun_device.rs
@@ -198,7 +198,7 @@ impl TunDevice {
     async fn handle_tun_read(&self, packet: &[u8]) -> Result<(), TunDeviceError> {
         let ParsedAddresses { src_addr, dst_addr } = parse_src_dst_address(packet)?;
         log::info!(
-            "iface: read Packet({src_addr} -> {dst_addr}, {} bytes)",
+            "iface: read Packet({dst_addr} <- {src_addr}, {} bytes)",
             packet.len(),
         );
 

--- a/common/tun/src/linux/tun_device.rs
+++ b/common/tun/src/linux/tun_device.rs
@@ -174,7 +174,7 @@ impl TunDevice {
     async fn handle_tun_write(&mut self, data: TunTaskPayload) -> Result<(), TunDeviceError> {
         let (tag, packet) = data;
         let ParsedAddresses { src_addr, dst_addr } = parse_src_dst_address(&packet)?;
-        log::info!(
+        log::debug!(
             "iface: write Packet({src_addr} -> {dst_addr}, {} bytes)",
             packet.len()
         );
@@ -197,7 +197,7 @@ impl TunDevice {
     // Receive reponse packets from the wild internet
     async fn handle_tun_read(&self, packet: &[u8]) -> Result<(), TunDeviceError> {
         let ParsedAddresses { src_addr, dst_addr } = parse_src_dst_address(packet)?;
-        log::info!(
+        log::debug!(
             "iface: read Packet({dst_addr} <- {src_addr}, {} bytes)",
             packet.len(),
         );

--- a/common/tun/src/linux/tun_device.rs
+++ b/common/tun/src/linux/tun_device.rs
@@ -174,7 +174,7 @@ impl TunDevice {
     async fn handle_tun_write(&mut self, data: TunTaskPayload) -> Result<(), TunDeviceError> {
         let (tag, packet) = data;
         let ParsedAddresses { src_addr, dst_addr } = parse_src_dst_address(&packet)?;
-        log::debug!(
+        log::info!(
             "iface: write Packet({src_addr} -> {dst_addr}, {} bytes)",
             packet.len()
         );
@@ -197,7 +197,7 @@ impl TunDevice {
     // Receive reponse packets from the wild internet
     async fn handle_tun_read(&self, packet: &[u8]) -> Result<(), TunDeviceError> {
         let ParsedAddresses { src_addr, dst_addr } = parse_src_dst_address(packet)?;
-        log::debug!(
+        log::info!(
             "iface: read Packet({src_addr} -> {dst_addr}, {} bytes)",
             packet.len(),
         );

--- a/service-providers/ip-packet-router/src/error.rs
+++ b/service-providers/ip-packet-router/src/error.rs
@@ -30,6 +30,9 @@ pub enum IpPacketRouterError {
     #[error("the entity wrapping the network requester has disconnected")]
     DisconnectedParent,
 
+    #[error("received packet has an invalid version: {0}")]
+    InvalidPacketVersion(u8),
+
     #[error("failed to deserialize tagged packet: {source}")]
     FailedToDeserializeTaggedPacket { source: bincode::Error },
 

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -11,6 +11,7 @@ use nym_client_core::{
     client::mix_traffic::transceiver::GatewayTransceiver,
     config::disk_persistence::CommonClientPaths, HardcodedTopologyProvider, TopologyProvider,
 };
+use nym_ip_packet_requests::IpPacketResponse;
 use nym_sdk::{
     mixnet::{InputMessage, MixnetMessageSender, Recipient},
     NymNetworkDetails,
@@ -335,7 +336,12 @@ impl IpPacketRouter {
                         if let Some(recipient) = recipient {
                             let lane = TransmissionLane::General;
                             let packet_type = None;
-                            let input_message = InputMessage::new_regular(recipient, packet, lane, packet_type);
+                            let response_packet = IpPacketResponse::new_ip_packet(packet.into()).to_bytes();
+                            let Ok(response_packet) = response_packet else {
+                                log::error!("Failed to serialize response packet");
+                                continue;
+                            };
+                            let input_message = InputMessage::new_regular(recipient, response_packet, lane, packet_type);
 
                             if let Err(err) = self.mixnet_client.send(input_message).await {
                                 log::error!("IpPacketRouter [main loop]: failed to send packet to mixnet: {err}");


### PR DESCRIPTION
# Description

Closes: #4178
Closes: #4179 

Rethink request / response types for the ip packet router.
Implement flow how to handle requests and to return responses.

DISCLAIMER: the logic to actually connect clients on the exit side is not yet in place.
