### PR TITLE
Handle dynamic ip allocation in ip packet router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6610,6 +6610,7 @@ dependencies = [
  "nym-sphinx",
  "rand 0.8.5",
  "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/common/ip-packet-requests/Cargo.toml
+++ b/common/ip-packet-requests/Cargo.toml
@@ -16,3 +16,4 @@ bytes = "1.5.0"
 nym-sphinx = { path = "../nymsphinx" }
 rand = "0.8.5"
 serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }

--- a/service-providers/ip-packet-router/src/generate_new_ip.rs
+++ b/service-providers/ip-packet-router/src/generate_new_ip.rs
@@ -1,4 +1,7 @@
-use std::{net::{Ipv4Addr, IpAddr}, collections::HashMap};
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr},
+};
 
 use crate::{ConnectedClient, TUN_DEVICE_ADDRESS};
 

--- a/service-providers/ip-packet-router/src/generate_new_ip.rs
+++ b/service-providers/ip-packet-router/src/generate_new_ip.rs
@@ -1,0 +1,35 @@
+use std::{net::{Ipv4Addr, IpAddr}, collections::HashMap};
+
+use crate::{ConnectedClient, TUN_DEVICE_ADDRESS};
+
+// Find an available IP address in self.connected_clients
+// TODO: make this nicer
+fn generate_random_ip_within_subnet() -> Ipv4Addr {
+    let mut rng = rand::thread_rng();
+    // Generate a random number in the range 1-254
+    let last_octet = rand::Rng::gen_range(&mut rng, 1..=254);
+    Ipv4Addr::new(10, 0, 0, last_octet)
+}
+
+fn is_ip_taken(
+    connected_clients: &HashMap<IpAddr, ConnectedClient>,
+    tun_ip: Ipv4Addr,
+    ip: Ipv4Addr,
+) -> bool {
+    connected_clients.contains_key(&ip.into()) || ip == tun_ip
+}
+
+// TODO: brute force approach. We could consider using a more efficient algorithm
+pub(crate) fn find_new_ip(connected_clients: &HashMap<IpAddr, ConnectedClient>) -> Option<IpAddr> {
+    let mut new_ip = generate_random_ip_within_subnet();
+    let mut tries = 0;
+    let tun_ip = TUN_DEVICE_ADDRESS.parse::<Ipv4Addr>().unwrap();
+    while is_ip_taken(connected_clients, tun_ip, new_ip) {
+        new_ip = generate_random_ip_within_subnet();
+        tries += 1;
+        if tries > 100 {
+            return None;
+        }
+    }
+    Some(new_ip.into())
+}

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -294,7 +294,7 @@ impl IpPacketRouter {
         // with return traffic
         let existing_ip = self.connected_clients.iter().find_map(|(ip, client)| {
             if client.nym_address == reply_to {
-                Some(ip.clone())
+                Some(*ip)
             } else {
                 None
             }
@@ -319,7 +319,8 @@ impl IpPacketRouter {
         // TODO: make this nicer
         fn generate_random_ip_within_subnet() -> Ipv4Addr {
             let mut rng = rand::thread_rng();
-            let last_octet = rand::Rng::gen_range(&mut rng, 1..=254); // Generate a random number in the range 1-254
+            // Generate a random number in the range 1-254
+            let last_octet = rand::Rng::gen_range(&mut rng, 1..=254);
             Ipv4Addr::new(10, 0, 0, last_octet)
         }
 

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -323,11 +323,20 @@ impl IpPacketRouter {
             Ipv4Addr::new(10, 0, 0, last_octet)
         }
 
+        fn is_ip_taken(
+            connected_clients: &HashMap<IpAddr, ConnectedClient>,
+            tun_ip: Ipv4Addr,
+            ip: Ipv4Addr,
+        ) -> bool {
+            connected_clients.contains_key(&ip.into()) || ip == tun_ip
+        }
+
         // TODO: brute force approach. We could consider using a more efficient algorithm
         fn find_new_ip(connected_clients: &HashMap<IpAddr, ConnectedClient>) -> Option<IpAddr> {
             let mut new_ip = generate_random_ip_within_subnet();
             let mut tries = 0;
-            while connected_clients.contains_key(&new_ip.into()) {
+            let tun_ip = TUN_DEVICE_ADDRESS.parse::<Ipv4Addr>().unwrap();
+            while is_ip_taken(connected_clients, tun_ip, new_ip) {
                 new_ip = generate_random_ip_within_subnet();
                 tries += 1;
                 if tries > 100 {

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::HashMap,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, SocketAddr},
     path::Path,
     time::Duration,
 };


### PR DESCRIPTION
# Description

Closes: #4185

- Add dynamic connect support to ip packet router
- Disconnect inactive clients
