### PR TITLE
Sort out task flow in ip packet router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6652,6 +6652,7 @@ dependencies = [
  "tap",
  "thiserror",
  "tokio",
+ "tokio-tun",
  "url",
 ]
 
@@ -10944,9 +10945,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tun"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a67d1405a577ba1f4cd61f46608f1db2cadbb6a9549c3fc2eed7f1195393c9"
+checksum = "bf2efaf33e86779a3a68b1f1d6e9e13a346c1c75ee3cab7a4293235c463b2668"
 dependencies = [
  "libc",
  "nix 0.27.1",

--- a/common/tun/Cargo.toml
+++ b/common/tun/Cargo.toml
@@ -18,4 +18,4 @@ log.workspace = true
 nym-wireguard-types = { path = "../wireguard-types", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tokio-tun = "0.9.0"
+tokio-tun = "0.11.2"

--- a/common/tun/src/linux/tun_device.rs
+++ b/common/tun/src/linux/tun_device.rs
@@ -112,15 +112,7 @@ impl TunDevice {
         routing_mode: RoutingMode,
         config: TunDeviceConfig,
     ) -> (Self, TunTaskTx, TunTaskResponseRx) {
-        let TunDeviceConfig {
-            base_name,
-            ip,
-            netmask,
-        } = config;
-        let name = format!("{base_name}%d");
-
-        let tun = setup_tokio_tun_device(&name, ip, netmask);
-        log::info!("Created TUN device: {}", tun.name());
+        let tun = Self::new_device_only(config);
 
         // Channels to communicate with the other tasks
         let (tun_task_tx, tun_task_rx) = tun_task_channel();
@@ -134,6 +126,19 @@ impl TunDevice {
         };
 
         (tun_device, tun_task_tx, tun_task_response_rx)
+    }
+
+    pub fn new_device_only(config: TunDeviceConfig) -> tokio_tun::Tun {
+        let TunDeviceConfig {
+            base_name,
+            ip,
+            netmask,
+        } = config;
+        let name = format!("{base_name}%d");
+
+        let tun = setup_tokio_tun_device(&name, ip, netmask);
+        log::info!("Created TUN device: {}", tun.name());
+        tun
     }
 
     // Send outbound packets out on the wild internet

--- a/common/tun/src/linux/tun_device.rs
+++ b/common/tun/src/linux/tun_device.rs
@@ -215,7 +215,7 @@ impl TunDevice {
                 // Writing to the TUN device
                 Some(data) = self.tun_task_rx.recv() => {
                     if let Err(err) = self.handle_tun_write(data).await {
-                        log::error!("ifcae: handle_tun_write failed: {err}");
+                        log::error!("iface: handle_tun_write failed: {err}");
                     }
                 }
             }

--- a/common/tun/src/linux/tun_device.rs
+++ b/common/tun/src/linux/tun_device.rs
@@ -182,6 +182,7 @@ impl TunDevice {
             }
 
             RoutingMode::Passthrough => {
+                // WIP(JON): skip the parsing at the top of the function
                 log::debug!("Forward packet without checking anything");
                 return self
                     .tun_task_response_tx

--- a/common/tun/src/linux/tun_device.rs
+++ b/common/tun/src/linux/tun_device.rs
@@ -187,7 +187,7 @@ impl TunDevice {
             }
 
             RoutingMode::Passthrough => {
-                // WIP(JON): skip the parsing at the top of the function
+                // TODO: skip the parsing at the top of the function
                 log::debug!("Forward packet without checking anything");
                 return self
                     .tun_task_response_tx

--- a/service-providers/ip-packet-router/Cargo.toml
+++ b/service-providers/ip-packet-router/Cargo.toml
@@ -34,4 +34,5 @@ serde_json = { workspace = true }
 tap.workspace = true
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
+tokio-tun = "0.11.2"
 url.workspace = true

--- a/service-providers/ip-packet-router/Cargo.toml
+++ b/service-providers/ip-packet-router/Cargo.toml
@@ -34,5 +34,7 @@ serde_json = { workspace = true }
 tap.workspace = true
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
-tokio-tun = "0.11.2"
 url.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tokio-tun = "0.11.2"

--- a/service-providers/ip-packet-router/src/error.rs
+++ b/service-providers/ip-packet-router/src/error.rs
@@ -50,6 +50,9 @@ pub enum IpPacketRouterError {
         source: tokio::sync::mpsc::error::TrySendError<(u64, Vec<u8>)>,
     },
 
+    #[error("failed to write packet to tun")]
+    FailedToWritePacketToTun,
+
     #[error("the provided socket address, '{addr}' is not covered by the exit policy!")]
     AddressNotCoveredByExitPolicy { addr: SocketAddr },
 

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -507,7 +507,7 @@ impl IpPacketRouter {
 
             }
         }
-        log::info!("IpPacketRouter: stopping");
+        log::debug!("IpPacketRouter: stopping");
         Ok(())
     }
 }
@@ -581,7 +581,7 @@ impl TunListener {
                 }
             }
         }
-        log::info!("TunListener: stopping");
+        log::debug!("TunListener: stopping");
         Ok(())
     }
 

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -361,7 +361,7 @@ impl IpPacketRouter {
         &mut self,
         data_request: nym_ip_packet_requests::DataRequest,
     ) -> Result<Option<IpPacketResponse>, IpPacketRouterError> {
-        log::info!("Received data request");
+        log::trace!("Received data request");
 
         // We don't forward packets that we are not able to parse. BUT, there might be a good
         // reason to still forward them.
@@ -564,7 +564,7 @@ impl TunListener {
                                 log::error!("TunListener: failed to send packet to mixnet: {err}");
                             };
                         } else {
-                            log::error!("TunListener: no nym-address recipient for packet");
+                            log::error!("No registered nym-address for packet - dropping");
                         }
                     } else {
                         log::trace!("TunListener: stopping since channel closed");

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -605,8 +605,8 @@ fn parse_packet(packet: &[u8]) -> Result<ParsedPacket, IpPacketRouterError> {
     })?;
 
     let (packet_type, dst_port) = match headers.transport {
-        Some(etherparse::TransportSlice::Udp(header)) => ("ipv4", Some(header.destination_port())),
-        Some(etherparse::TransportSlice::Tcp(header)) => ("ipv6", Some(header.destination_port())),
+        Some(etherparse::TransportSlice::Udp(header)) => ("udp", Some(header.destination_port())),
+        Some(etherparse::TransportSlice::Tcp(header)) => ("tcp", Some(header.destination_port())),
         Some(etherparse::TransportSlice::Icmpv4(_)) => ("icmpv4", None),
         Some(etherparse::TransportSlice::Icmpv6(_)) => ("icmpv6", None),
         Some(etherparse::TransportSlice::Unknown(_)) => ("unknown", None),

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#![cfg_attr(not(target_os = "linux"), allow(unused_imports))]
 
 use std::{
     collections::HashMap,

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -514,7 +514,7 @@ struct TunListener {
     mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
     // task_handle: TaskHandle,
 
-    // A mirror of the tone in IpPacketRouter
+    // A mirror of the one in IpPacketRouter
     connected_clients: HashMap<IpAddr, ConnectedClient>,
     connected_client_rx: tokio::sync::mpsc::Receiver<ConnectedClientEvent>,
 }

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -24,6 +24,7 @@ use nym_sdk::{
 use nym_sphinx::receiver::ReconstructedMessage;
 use nym_task::{connections::TransmissionLane, TaskClient, TaskHandle};
 use request_filter::RequestFilter;
+#[cfg(target_os = "linux")]
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::config::BaseClientConfig;
@@ -201,7 +202,7 @@ impl IpPacketRouterBuilder {
     }
 }
 
-#[cfg_attr(not(target_os = "linux"), allow(unused))]
+#[cfg(target_os = "linux")]
 struct IpPacketRouter {
     _config: Config,
     request_filter: request_filter::RequestFilter,
@@ -218,7 +219,7 @@ struct ConnectedClient {
     last_activity: std::time::Instant,
 }
 
-#[cfg_attr(not(target_os = "linux"), allow(unused))]
+#[cfg(target_os = "linux")]
 impl IpPacketRouter {
     async fn on_static_connect_request(
         &mut self,
@@ -511,6 +512,7 @@ impl IpPacketRouter {
 }
 
 // Reads packet from TUN and writes to mixnet client
+#[cfg(target_os = "linux")]
 struct TunListener {
     tun_reader: tokio::io::ReadHalf<tokio_tun::Tun>,
     mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
@@ -521,6 +523,7 @@ struct TunListener {
     connected_client_rx: tokio::sync::mpsc::UnboundedReceiver<ConnectedClientEvent>,
 }
 
+#[cfg(target_os = "linux")]
 impl TunListener {
     async fn run(mut self) -> Result<(), IpPacketRouterError> {
         let mut buf = [0u8; 65535];

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -530,6 +530,9 @@ impl TunListener {
         let mut buf = [0u8; 65535];
         while !self.task_client.is_shutdown() {
             tokio::select! {
+                _ = self.task_client.recv() => {
+                    log::trace!("TunListener: received shutdown");
+                },
                 event = self.connected_client_rx.recv() => match event {
                     Some(ConnectedClientEvent::Connect(ip, nym_addr)) => {
                         log::trace!("Connect client: {ip}");

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -266,7 +266,10 @@ impl IpPacketRouter {
                     },
                 );
                 self.connected_client_tx
-                    .send(ConnectedClientEvent::Connect(requested_ip, reply_to))
+                    .send(ConnectedClientEvent::Connect(
+                        requested_ip,
+                        Box::new(reply_to),
+                    ))
                     .unwrap();
                 Ok(Some(IpPacketResponse::new_static_connect_success(
                     request_id, reply_to,
@@ -347,7 +350,7 @@ impl IpPacketRouter {
             },
         );
         self.connected_client_tx
-            .send(ConnectedClientEvent::Connect(new_ip, reply_to))
+            .send(ConnectedClientEvent::Connect(new_ip, Box::new(reply_to)))
             .unwrap();
         Ok(Some(IpPacketResponse::new_dynamic_connect_success(
             request_id, reply_to, new_ip,
@@ -527,7 +530,7 @@ impl TunListener {
                     Some(ConnectedClientEvent::Connect(ip, nym_addr)) => {
                         log::trace!("Connect client: {ip}");
                         self.connected_clients.insert(ip, ConnectedClient {
-                            nym_address: nym_addr,
+                            nym_address: *nym_addr,
                             last_activity: std::time::Instant::now(),
                         });
                     },
@@ -586,7 +589,7 @@ impl TunListener {
 
 enum ConnectedClientEvent {
     Disconnect(IpAddr),
-    Connect(IpAddr, Recipient),
+    Connect(IpAddr, Box<Recipient>),
 }
 
 struct ParsedPacket<'a> {

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -562,7 +562,7 @@ impl TunListener {
                                 log::error!("TunListener: failed to send packet to mixnet: {err}");
                             };
                         } else {
-                            log::error!("No registered nym-address for packet - dropping");
+                            log::info!("No registered nym-address for packet - dropping");
                         }
                     } else {
                         log::trace!("TunListener: stopping since channel closed");

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -538,6 +538,15 @@ impl TunListener {
                             log::trace!("Disconnect client: {ip}");
                             self.connected_clients.remove(&ip);
                         },
+                        Some(ConnectedClientEvent::Sync(clients)) => {
+                            log::trace!("Sync clients");
+                            self.connected_clients = clients.into_iter().map(|(ip, nym_addr)| {
+                                (ip, ConnectedClient {
+                                    nym_address: nym_addr,
+                                    last_activity: std::time::Instant::now(),
+                                })
+                            }).collect();
+                        },
                         None => {},
                     }
                 },
@@ -589,6 +598,7 @@ impl TunListener {
 enum ConnectedClientEvent {
     Disconnect(IpAddr),
     Connect(IpAddr, Recipient),
+    Sync(Vec<(IpAddr, Recipient)>),
 }
 
 struct ParsedPacket<'a> {


### PR DESCRIPTION
# Description

In summary, make sure that we have separate tasks for reading and writing, and that we skip the intermediate hop of going via the event loop in nym-tun.

- Split into separate tun listener
- Handle tun device directly in ip-packet router
