### PR TITLE
Enable static_secrets feature to fix build

### DIFF
--- a/common/wireguard-types/Cargo.toml
+++ b/common/wireguard-types/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = { version = "0.10.8", optional = true }
 utoipa = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
-x25519-dalek = "2.0.0"
+x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 
 [dev-dependencies]
 rand = "0.7.3"


### PR DESCRIPTION
# Description

Fix compilation of the wireguard-types crate when it's build standalone.
