### PR TITLE
naively resolve gateway credential spending race condition

### DIFF
--- a/common/client-libs/validator-client/src/nyxd/mod.rs
+++ b/common/client-libs/validator-client/src/nyxd/mod.rs
@@ -43,6 +43,7 @@ pub use cosmrs::tendermint::validator::Info as TendermintValidatorInfo;
 pub use cosmrs::tendermint::Time as TendermintTime;
 pub use cosmrs::tx::Msg;
 pub use cosmrs::tx::{self};
+pub use cosmrs::Any;
 pub use cosmrs::Coin as CosmosCoin;
 pub use cosmrs::Gas;
 pub use cosmrs::{bip32, AccountId, Denom};

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -451,7 +451,7 @@ impl<St> Gateway<St> {
 
         let coconut_verifier = {
             let nyxd_client = self.random_nyxd_client()?;
-            CoconutVerifier::new(nyxd_client)
+            CoconutVerifier::new(nyxd_client).await
         };
 
         let mix_forwarding_channel =


### PR DESCRIPTION
a non-naive solution would require queuing up pending request and batch executing them

second part of BN-25 and actually closes it.

requires https://github.com/nymtech/nym/pull/4227 to be merged first (which itself needs https://github.com/nymtech/nym/pull/4207)