### PR TITLE
Add IPR to nym-node http endpoint

### DIFF
--- a/gateway/src/http/mod.rs
+++ b/gateway/src/http/mod.rs
@@ -130,18 +130,16 @@ fn load_ip_packet_router_details(
         "gateway identity",
     )?;
 
-    Ok(
-        api_requests::v1::ip_packet_router::models::IpPacketRouter {
-            encoded_identity_key: identity_public_key.to_base58_string(),
-            encoded_x25519_key: dh_public_key.to_base58_string(),
-            address: Recipient::new(
-                identity_public_key,
-                dh_public_key,
-                gateway_identity_public_key,
-            )
-            .to_string(),
-        },
-    )
+    Ok(api_requests::v1::ip_packet_router::models::IpPacketRouter {
+        encoded_identity_key: identity_public_key.to_base58_string(),
+        encoded_x25519_key: dh_public_key.to_base58_string(),
+        address: Recipient::new(
+            identity_public_key,
+            dh_public_key,
+            gateway_identity_public_key,
+        )
+        .to_string(),
+    })
 }
 
 pub(crate) struct HttpApiBuilder<'a> {

--- a/gateway/src/http/mod.rs
+++ b/gateway/src/http/mod.rs
@@ -103,10 +103,52 @@ fn load_network_requester_details(
     )
 }
 
+fn load_ip_packet_router_details(
+    config: &Config,
+    ip_packet_router_config: &nym_ip_packet_router::Config,
+) -> Result<api_requests::v1::ip_packet_router::models::IpPacketRouter, GatewayError> {
+    let identity_public_key: identity::PublicKey = load_public_key(
+        &ip_packet_router_config
+            .storage_paths
+            .common_paths
+            .keys
+            .public_identity_key_file,
+        "ip packet router identity",
+    )?;
+
+    let dh_public_key: encryption::PublicKey = load_public_key(
+        &ip_packet_router_config
+            .storage_paths
+            .common_paths
+            .keys
+            .public_encryption_key_file,
+        "ip packet router diffie hellman",
+    )?;
+
+    let gateway_identity_public_key: identity::PublicKey = load_public_key(
+        &config.storage_paths.keys.public_identity_key_file,
+        "gateway identity",
+    )?;
+
+    Ok(
+        api_requests::v1::ip_packet_router::models::IpPacketRouter {
+            encoded_identity_key: identity_public_key.to_base58_string(),
+            encoded_x25519_key: dh_public_key.to_base58_string(),
+            address: Recipient::new(
+                identity_public_key,
+                dh_public_key,
+                gateway_identity_public_key,
+            )
+            .to_string(),
+        },
+    )
+}
+
 pub(crate) struct HttpApiBuilder<'a> {
     gateway_config: &'a Config,
     network_requester_config: Option<&'a nym_network_requester::Config>,
     exit_policy: Option<UsedExitPolicy>,
+    ip_packet_router_config: Option<&'a nym_ip_packet_router::Config>,
 
     identity_keypair: &'a identity::KeyPair,
     // TODO: this should be a wg specific key and not re-used sphinx
@@ -124,6 +166,7 @@ impl<'a> HttpApiBuilder<'a> {
         HttpApiBuilder {
             gateway_config,
             network_requester_config: None,
+            ip_packet_router_config: None,
             exit_policy: None,
             identity_keypair,
             sphinx_keypair,
@@ -188,6 +231,15 @@ impl<'a> HttpApiBuilder<'a> {
     }
 
     #[must_use]
+    pub(crate) fn with_maybe_ip_packet_router(
+        mut self,
+        ip_packet_router_config: Option<&'a nym_ip_packet_router::Config>,
+    ) -> Self {
+        self.ip_packet_router_config = ip_packet_router_config;
+        self
+    }
+
+    #[must_use]
     pub(crate) fn with_wireguard_client_registry(
         mut self,
         client_registry: Arc<GatewayClientRegistry>,
@@ -223,6 +275,13 @@ impl<'a> HttpApiBuilder<'a> {
             if let Some(exit_policy) = self.exit_policy {
                 config = config.with_used_exit_policy(exit_policy)
             }
+        }
+
+        if let Some(ipr_config) = self.ip_packet_router_config {
+            config = config.with_ip_packet_router(load_ip_packet_router_details(
+                self.gateway_config,
+                ipr_config,
+            )?);
         }
 
         let wireguard_private_network = IpNetwork::new(

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -519,6 +519,7 @@ impl<St> Gateway<St> {
         .with_wireguard_client_registry(self.client_registry.clone())
         .with_maybe_network_requester(self.network_requester_opts.as_ref().map(|o| &o.config))
         .with_maybe_network_request_filter(nr_request_filter)
+        .with_maybe_ip_packet_router(self.ip_packet_router_opts.as_ref().map(|o| &o.config))
         .start(shutdown.subscribe().named("http-api"))?;
 
         // Once this is a bit more mature, make this a commandline flag instead of a compile time

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -366,6 +366,9 @@ pub struct NymNodeDescription {
     #[serde(default)]
     pub network_requester: Option<NetworkRequesterDetails>,
 
+    #[serde(default)]
+    pub ip_packet_router: Option<IpPacketRouterDetails>,
+
     // for now we only care about their ws/wss situation, nothing more
     pub mixnet_websockets: WebSockets,
 }
@@ -392,4 +395,10 @@ pub struct NetworkRequesterDetails {
 
     /// flag indicating whether this network requester uses the exit policy rather than the deprecated allow list
     pub uses_exit_policy: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct IpPacketRouterDetails {
+    /// address of the embedded ip packet router
+    pub address: String,
 }

--- a/nym-api/src/node_describe_cache/mod.rs
+++ b/nym-api/src/node_describe_cache/mod.rs
@@ -7,7 +7,9 @@ use crate::support::caching::refresher::{CacheItemProvider, CacheRefresher};
 use crate::support::config;
 use crate::support::config::DEFAULT_NODE_DESCRIBE_BATCH_SIZE;
 use futures_util::{stream, StreamExt};
-use nym_api_requests::models::{NetworkRequesterDetails, NymNodeDescription};
+use nym_api_requests::models::{
+    IpPacketRouterDetails, NetworkRequesterDetails, NymNodeDescription,
+};
 use nym_config::defaults::{mainnet, DEFAULT_NYM_NODE_HTTP_PORT};
 use nym_contracts_common::IdentityKey;
 use nym_mixnet_contract_common::Gateway;
@@ -170,10 +172,19 @@ async fn get_gateway_description(
             None
         };
 
+    let ip_packet_router = if let Ok(ipr) = client.get_ip_packet_router().await {
+        Some(IpPacketRouterDetails {
+            address: ipr.address,
+        })
+    } else {
+        None
+    };
+
     let description = NymNodeDescription {
         host_information: host_info.data,
         build_information: build_info,
         network_requester,
+        ip_packet_router,
         mixnet_websockets: websockets,
     };
 

--- a/nym-node/nym-node-requests/src/api/client.rs
+++ b/nym-node/nym-node-requests/src/api/client.rs
@@ -11,6 +11,7 @@ use nym_bin_common::build_information::BinaryBuildInformationOwned;
 use nym_wireguard_types::{ClientMessage, ClientRegistrationResponse};
 
 use crate::api::v1::health::models::NodeHealth;
+use crate::api::v1::ip_packet_router::models::IpPacketRouter;
 use crate::api::v1::network_requester::exit_policy::models::UsedExitPolicy;
 use crate::api::v1::network_requester::models::NetworkRequester;
 pub use http_api_client::Client;
@@ -51,6 +52,11 @@ pub trait NymNodeApiClientExt: ApiClient {
 
     async fn get_exit_policy(&self) -> Result<UsedExitPolicy, NymNodeApiClientError> {
         self.get_json_from(routes::api::v1::network_requester::exit_policy_absolute())
+            .await
+    }
+
+    async fn get_ip_packet_router(&self) -> Result<IpPacketRouter, NymNodeApiClientError> {
+        self.get_json_from(routes::api::v1::ip_packet_router_absolute())
             .await
     }
 

--- a/nym-node/nym-node-requests/src/api/v1/ip_packet_router/mod.rs
+++ b/nym-node/nym-node-requests/src/api/v1/ip_packet_router/mod.rs
@@ -1,0 +1,4 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod models;

--- a/nym-node/nym-node-requests/src/api/v1/ip_packet_router/models.rs
+++ b/nym-node/nym-node-requests/src/api/v1/ip_packet_router/models.rs
@@ -13,6 +13,6 @@ pub struct IpPacketRouter {
     /// Base58-encoded x25519 public key used for performing key exchange with remote clients.
     pub encoded_x25519_key: String,
 
-    /// Nym address of this network requester.
+    /// Nym address of this ip packet router.
     pub address: String,
 }

--- a/nym-node/nym-node-requests/src/api/v1/ip_packet_router/models.rs
+++ b/nym-node/nym-node-requests/src/api/v1/ip_packet_router/models.rs
@@ -1,0 +1,19 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct IpPacketRouter {
+    /// Base58 encoded ed25519 EdDSA public key of the ip-packet-router.
+    pub encoded_identity_key: String,
+
+    /// Base58-encoded x25519 public key used for performing key exchange with remote clients.
+    pub encoded_x25519_key: String,
+
+    /// Nym address of this network requester.
+    pub address: String,
+}
+

--- a/nym-node/nym-node-requests/src/api/v1/ip_packet_router/models.rs
+++ b/nym-node/nym-node-requests/src/api/v1/ip_packet_router/models.rs
@@ -16,4 +16,3 @@ pub struct IpPacketRouter {
     /// Nym address of this network requester.
     pub address: String,
 }
-

--- a/nym-node/nym-node-requests/src/api/v1/mod.rs
+++ b/nym-node/nym-node-requests/src/api/v1/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod gateway;
 pub mod health;
+pub mod ip_packet_router;
 pub mod mixnode;
 pub mod network_requester;
 pub mod node;

--- a/nym-node/nym-node-requests/src/api/v1/node/models.rs
+++ b/nym-node/nym-node-requests/src/api/v1/node/models.rs
@@ -14,6 +14,7 @@ pub struct NodeRoles {
     pub mixnode_enabled: bool,
     pub gateway_enabled: bool,
     pub network_requester_enabled: bool,
+    pub ip_packet_router_enabled: bool,
 }
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema)]

--- a/nym-node/nym-node-requests/src/lib.rs
+++ b/nym-node/nym-node-requests/src/lib.rs
@@ -33,6 +33,7 @@ pub mod routes {
             pub const GATEWAY: &str = "/gateway";
             pub const MIXNODE: &str = "/mixnode";
             pub const NETWORK_REQUESTER: &str = "/network-requester";
+            pub const IP_PACKET_ROUTER: &str = "/ip-packet-router";
             pub const SWAGGER: &str = "/swagger";
 
             // define helper functions to get absolute routes
@@ -43,6 +44,7 @@ pub mod routes {
             absolute_route!(gateway_absolute, v1_absolute(), GATEWAY);
             absolute_route!(mixnode_absolute, v1_absolute(), MIXNODE);
             absolute_route!(network_requester_absolute, v1_absolute(), NETWORK_REQUESTER);
+            absolute_route!(ip_packet_router_absolute, v1_absolute(), IP_PACKET_ROUTER);
             absolute_route!(swagger_absolute, v1_absolute(), SWAGGER);
 
             pub mod gateway {
@@ -96,6 +98,10 @@ pub mod routes {
                     EXIT_POLICY
                 );
             }
+
+            pub mod ip_packet_router {
+                // use super::*;
+            }
         }
     }
 }
@@ -145,6 +151,10 @@ mod tests {
         assert_eq!(
             "/api/v1/network-requester",
             routes::api::v1::network_requester_absolute()
+        );
+        assert_eq!(
+            "/api/v1/ip-packet-router",
+            routes::api::v1::ip_packet_router_absolute()
         );
     }
 }

--- a/nym-node/src/http/router/api/v1/ip_packet_router/mod.rs
+++ b/nym-node/src/http/router/api/v1/ip_packet_router/mod.rs
@@ -1,0 +1,25 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use axum::routing::get;
+use axum::Router;
+use nym_node_requests::api::v1::ip_packet_router::models;
+use nym_node_requests::routes::api::v1::ip_packet_router;
+
+pub mod root;
+
+#[derive(Debug, Clone, Default)]
+pub struct Config {
+    pub details: Option<models::IpPacketRouter>,
+}
+
+pub(crate) fn routes<S: Send + Sync + 'static + Clone>(config: Config) -> Router<S> {
+    Router::new()
+        .route(
+            "/",
+            get({
+                let ip_packet_router_details = config.details;
+                move |query| root::root_ip_packet_router(ip_packet_router_details, query)
+            }),
+        )
+}

--- a/nym-node/src/http/router/api/v1/ip_packet_router/mod.rs
+++ b/nym-node/src/http/router/api/v1/ip_packet_router/mod.rs
@@ -4,7 +4,6 @@
 use axum::routing::get;
 use axum::Router;
 use nym_node_requests::api::v1::ip_packet_router::models;
-use nym_node_requests::routes::api::v1::ip_packet_router;
 
 pub mod root;
 

--- a/nym-node/src/http/router/api/v1/ip_packet_router/mod.rs
+++ b/nym-node/src/http/router/api/v1/ip_packet_router/mod.rs
@@ -14,12 +14,11 @@ pub struct Config {
 }
 
 pub(crate) fn routes<S: Send + Sync + 'static + Clone>(config: Config) -> Router<S> {
-    Router::new()
-        .route(
-            "/",
-            get({
-                let ip_packet_router_details = config.details;
-                move |query| root::root_ip_packet_router(ip_packet_router_details, query)
-            }),
-        )
+    Router::new().route(
+        "/",
+        get({
+            let ip_packet_router_details = config.details;
+            move |query| root::root_ip_packet_router(ip_packet_router_details, query)
+        }),
+    )
 }

--- a/nym-node/src/http/router/api/v1/ip_packet_router/root.rs
+++ b/nym-node/src/http/router/api/v1/ip_packet_router/root.rs
@@ -1,0 +1,33 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::http::router::api::{FormattedResponse, OutputParams};
+use axum::extract::Query;
+use axum::http::StatusCode;
+use nym_node_requests::api::v1::ip_packet_router::models::IpPacketRouter;
+
+/// Returns root network requester information
+#[utoipa::path(
+    get,
+    path = "",
+    context_path = "/api/v1/ip-packet-router",
+    tag = "IP Packet Router",
+    responses(
+        (status = 501, description = "the endpoint hasn't been implemented yet"),
+        (status = 200, content(
+            ("application/json" = IpPacketRouter),
+            ("application/yaml" = IpPacketRouter)
+        ))
+    ),
+    params(OutputParams)
+)]
+pub(crate) async fn root_ip_packet_router(
+    details: Option<IpPacketRouter>,
+    Query(output): Query<OutputParams>,
+) -> Result<IpPacketRouterResponse, StatusCode> {
+    let details = details.ok_or(StatusCode::NOT_IMPLEMENTED)?;
+    let output = output.output.unwrap_or_default();
+    Ok(output.to_response(details))
+}
+
+pub type IpPacketRouterResponse = FormattedResponse<IpPacketRouter>;

--- a/nym-node/src/http/router/api/v1/mod.rs
+++ b/nym-node/src/http/router/api/v1/mod.rs
@@ -9,6 +9,7 @@ use nym_node_requests::routes::api::v1;
 
 pub mod gateway;
 pub mod health;
+pub mod ip_packet_router;
 pub mod mixnode;
 pub mod network_requester;
 pub mod node;
@@ -20,6 +21,7 @@ pub struct Config {
     pub gateway: gateway::Config,
     pub mixnode: mixnode::Config,
     pub network_requester: network_requester::Config,
+    pub ip_packet_router: ip_packet_router::Config,
 }
 
 pub(super) fn routes(config: Config, initial_wg_state: WireguardAppState) -> Router<AppState> {
@@ -33,6 +35,10 @@ pub(super) fn routes(config: Config, initial_wg_state: WireguardAppState) -> Rou
         .nest(
             v1::NETWORK_REQUESTER,
             network_requester::routes(config.network_requester),
+        )
+        .nest(
+            v1::IP_PACKET_ROUTER,
+            ip_packet_router::routes(config.ip_packet_router),
         )
         .merge(node::routes(config.node))
         .merge(openapi::route())

--- a/nym-node/src/http/router/api/v1/openapi.rs
+++ b/nym-node/src/http/router/api/v1/openapi.rs
@@ -27,6 +27,7 @@ use utoipa_swagger_ui::SwaggerUi;
         api::v1::mixnode::root::root_mixnode,
         api::v1::network_requester::root::root_network_requester,
         api::v1::network_requester::exit_policy::node_exit_policy,
+        api::v1::ip_packet_router::root::root_ip_packet_router,
     ),
     components(
         schemas(
@@ -56,6 +57,7 @@ use utoipa_swagger_ui::SwaggerUi;
             api_requests::v1::network_requester::exit_policy::models::AddressPortPattern,
             api_requests::v1::network_requester::exit_policy::models::PortRange,
             api_requests::v1::network_requester::exit_policy::models::UsedExitPolicy,
+            api_requests::v1::ip_packet_router::models::IpPacketRouter,
         ),
         responses(RequestError)
     )

--- a/nym-node/src/http/router/mod.rs
+++ b/nym-node/src/http/router/mod.rs
@@ -8,6 +8,7 @@ use crate::http::state::AppState;
 use crate::http::NymNodeHTTPServer;
 use axum::Router;
 use nym_node_requests::api::v1::gateway::models::{Gateway, Wireguard};
+use nym_node_requests::api::v1::ip_packet_router::models::IpPacketRouter;
 use nym_node_requests::api::v1::mixnode::models::Mixnode;
 use nym_node_requests::api::v1::network_requester::exit_policy::models::UsedExitPolicy;
 use nym_node_requests::api::v1::network_requester::models::NetworkRequester;
@@ -45,6 +46,7 @@ impl Config {
                     gateway: Default::default(),
                     mixnode: Default::default(),
                     network_requester: Default::default(),
+                    ip_packet_router: Default::default(),
                 },
             },
         }
@@ -92,6 +94,13 @@ impl Config {
     #[must_use]
     pub fn with_used_exit_policy(mut self, exit_policy: UsedExitPolicy) -> Self {
         self.api.v1_config.network_requester.exit_policy = Some(exit_policy);
+        self
+    }
+
+    #[must_use]
+    pub fn with_ip_packet_router(mut self, ip_packet_router: IpPacketRouter) -> Self {
+        self.api.v1_config.node.roles.ip_packet_router_enabled = true;
+        self.api.v1_config.ip_packet_router.details = Some(ip_packet_router);
         self
     }
 }


### PR DESCRIPTION
# Description

Add nym-ip-packet-router to the nym-node endpoint(s).

## Example

```sh
$ http http://x.x.x.x:8080/api/v1/ip-packet-router
HTTP/1.1 200 OK
content-length: 283
content-type: application/json
date: Fri, 08 Dec 2023 08:38:13 GMT

{
    "address": "TULkkPGmYjKbNqNWgroJfBvu2JpM.9mM9gVDAQiYZzQjWyfkecbFoHWiWYhokETS62GnjNV@1MUomK1WVENFEu3iNrftBQqha7bkfxVF3TrEeyZ",
    "encoded_identity_key": "TULkkPGmYjKG9qVX6RnH6BWJfBvu2JpM",
    "encoded_x25519_key": "9mM9gVDzQjWyfkecbWiWKWYhokETS62GnjNV"
}
```
