### PR TITLE
Add ip-packet-router info to node details printout in gateway

### DIFF
--- a/common/types/src/gateway.rs
+++ b/common/types/src/gateway.rs
@@ -77,7 +77,7 @@ impl GatewayBond {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GatewayNodeDetailsResponse {
     pub identity_key: String,
     pub sphinx_key: String,
@@ -88,6 +88,7 @@ pub struct GatewayNodeDetailsResponse {
     pub data_store: String,
 
     pub network_requester: Option<GatewayNetworkRequesterDetails>,
+    pub ip_packet_router: Option<GatewayIpPacketRouterDetails>,
 }
 
 impl fmt::Display for GatewayNodeDetailsResponse {
@@ -107,11 +108,15 @@ impl fmt::Display for GatewayNodeDetailsResponse {
         if let Some(nr) = &self.network_requester {
             nr.fmt(f)?;
         }
+
+        if let Some(ipr) = &self.ip_packet_router {
+            ipr.fmt(f)?;
+        }
         Ok(())
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GatewayNetworkRequesterDetails {
     pub enabled: bool,
 
@@ -149,7 +154,7 @@ impl fmt::Display for GatewayNetworkRequesterDetails {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GatewayIpPacketRouterDetails {
     pub enabled: bool,
 
@@ -164,7 +169,7 @@ pub struct GatewayIpPacketRouterDetails {
 
 impl fmt::Display for GatewayIpPacketRouterDetails {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "IP packet router:")?;
+        writeln!(f, "ip packet router:")?;
         writeln!(f, "\tenabled: {}", self.enabled)?;
         writeln!(f, "\tconfig path: {}", self.config_path)?;
 

--- a/common/types/src/gateway.rs
+++ b/common/types/src/gateway.rs
@@ -99,7 +99,7 @@ impl fmt::Display for GatewayNodeDetailsResponse {
         writeln!(f, "bind address: {}", self.bind_address)?;
         writeln!(
             f,
-            "mix Port: {}, clients port: {}",
+            "mix port: {}, clients port: {}",
             self.mix_port, self.clients_port
         )?;
 

--- a/gateway/src/node/helpers.rs
+++ b/gateway/src/node/helpers.rs
@@ -73,39 +73,39 @@ pub(crate) fn node_details(config: &Config) -> Result<GatewayNodeDetailsResponse
             None
         };
 
-    let ip_packet_router =
-        if let Some(nr_cfg_path) = &config.storage_paths.ip_packet_router_config {
-            let cfg = load_ip_packet_router_config(&config.gateway.id, nr_cfg_path)?;
+    let ip_packet_router = if let Some(nr_cfg_path) = &config.storage_paths.ip_packet_router_config
+    {
+        let cfg = load_ip_packet_router_config(&config.gateway.id, nr_cfg_path)?;
 
-            let nr_identity_public_key: identity::PublicKey = load_public_key(
-                &cfg.storage_paths.common_paths.keys.public_identity_key_file,
-                "ip packet router identity",
-            )?;
+        let nr_identity_public_key: identity::PublicKey = load_public_key(
+            &cfg.storage_paths.common_paths.keys.public_identity_key_file,
+            "ip packet router identity",
+        )?;
 
-            let nr_encryption_key: encryption::PublicKey = load_public_key(
-                &cfg.storage_paths
-                    .common_paths
-                    .keys
-                    .public_encryption_key_file,
-                "ip packet router encryption",
-            )?;
+        let nr_encryption_key: encryption::PublicKey = load_public_key(
+            &cfg.storage_paths
+                .common_paths
+                .keys
+                .public_encryption_key_file,
+            "ip packet router encryption",
+        )?;
 
-            let address = Recipient::new(
-                nr_identity_public_key,
-                nr_encryption_key,
-                gateway_identity_public_key,
-            );
+        let address = Recipient::new(
+            nr_identity_public_key,
+            nr_encryption_key,
+            gateway_identity_public_key,
+        );
 
-            Some(GatewayIpPacketRouterDetails {
-                enabled: config.ip_packet_router.enabled,
-                identity_key: nr_identity_public_key.to_base58_string(),
-                encryption_key: nr_encryption_key.to_base58_string(),
-                address: address.to_string(),
-                config_path: display_path(nr_cfg_path),
-            })
-        } else {
-            None
-        };
+        Some(GatewayIpPacketRouterDetails {
+            enabled: config.ip_packet_router.enabled,
+            identity_key: nr_identity_public_key.to_base58_string(),
+            encryption_key: nr_encryption_key.to_base58_string(),
+            address: address.to_string(),
+            config_path: display_path(nr_cfg_path),
+        })
+    } else {
+        None
+    };
 
     Ok(GatewayNodeDetailsResponse {
         identity_key: gateway_identity_public_key.to_base58_string(),

--- a/gateway/src/node/helpers.rs
+++ b/gateway/src/node/helpers.rs
@@ -8,7 +8,9 @@ use nym_crypto::asymmetric::{encryption, identity};
 use nym_pemstore::traits::{PemStorableKey, PemStorableKeyPair};
 use nym_pemstore::KeyPairPath;
 use nym_sphinx::addressing::clients::Recipient;
-use nym_types::gateway::{GatewayNetworkRequesterDetails, GatewayNodeDetailsResponse};
+use nym_types::gateway::{
+    GatewayIpPacketRouterDetails, GatewayNetworkRequesterDetails, GatewayNodeDetailsResponse,
+};
 use std::path::Path;
 
 fn display_maybe_path<P: AsRef<Path>>(path: Option<P>) -> String {
@@ -71,6 +73,40 @@ pub(crate) fn node_details(config: &Config) -> Result<GatewayNodeDetailsResponse
             None
         };
 
+    let ip_packet_router =
+        if let Some(nr_cfg_path) = &config.storage_paths.ip_packet_router_config {
+            let cfg = load_ip_packet_router_config(&config.gateway.id, nr_cfg_path)?;
+
+            let nr_identity_public_key: identity::PublicKey = load_public_key(
+                &cfg.storage_paths.common_paths.keys.public_identity_key_file,
+                "ip packet router identity",
+            )?;
+
+            let nr_encryption_key: encryption::PublicKey = load_public_key(
+                &cfg.storage_paths
+                    .common_paths
+                    .keys
+                    .public_encryption_key_file,
+                "ip packet router encryption",
+            )?;
+
+            let address = Recipient::new(
+                nr_identity_public_key,
+                nr_encryption_key,
+                gateway_identity_public_key,
+            );
+
+            Some(GatewayIpPacketRouterDetails {
+                enabled: config.ip_packet_router.enabled,
+                identity_key: nr_identity_public_key.to_base58_string(),
+                encryption_key: nr_encryption_key.to_base58_string(),
+                address: address.to_string(),
+                config_path: display_path(nr_cfg_path),
+            })
+        } else {
+            None
+        };
+
     Ok(GatewayNodeDetailsResponse {
         identity_key: gateway_identity_public_key.to_base58_string(),
         sphinx_key: gateway_sphinx_public_key.to_base58_string(),
@@ -80,6 +116,7 @@ pub(crate) fn node_details(config: &Config) -> Result<GatewayNodeDetailsResponse
         config_path: display_maybe_path(config.save_path.as_ref()),
         data_store: display_path(&config.storage_paths.clients_storage),
         network_requester,
+        ip_packet_router,
     })
 }
 


### PR DESCRIPTION
Add `ip-packet-router` info to node details, so that it's printed on `init` and for the `node-details` command

## Example

```
❯ cargo run -p nym-gateway -- node-details --id sdfsd
warning: /home/jon/src/nym/nym/common/client-libs/validator-client/Cargo.toml: `default-features` is ignored for bip32, since `default-features` was not specified for `workspace.dependencies.bip32`, this could become a hard error in the future
warning: /home/jon/src/nym/nym/common/client-libs/validator-client/Cargo.toml: `default-features` is ignored for prost, since `default-features` was not specified for `workspace.dependencies.prost`, this could become a hard error in the future
warning: profile package spec `nym-wasm-sdk` in profile `release` did not match any packages
    Blocking waiting for file lock on build directory
   Compiling nym-gateway v1.1.32 (/home/jon/src/nym/nym/gateway)
    Finished dev [unoptimized + debuginfo] target(s) in 11.39s
     Running `target/x86_64-unknown-linux-gnu/debug/nym-gateway node-details --id sdfsd`


      _ __  _   _ _ __ ___
     | '_ \| | | | '_ \ _ \
     | | | | |_| | | | | | |
     |_| |_|\__, |_| |_| |_|
            |___/

             (nym-gateway - version 1.1.32)


config path: /home/jon/.nym/gateways/sdfsd/config/config.toml
identity key: 31Rg7UZDfwD1adv7dYtN42hxf3psRUFbqgXqF1sdGT93
sphinx key: 8RgpXUHGy1Q5S57bdRGMcvozeqQvuqyESE7Fm6njgnyZ
bind address: 0.0.0.0
mix Port: 1789, clients port: 9000
data store is at: /home/jon/.nym/gateways/sdfsd/data/db.sqlite
ip packet router:
        enabled: true
        config path: /home/jon/.nym/gateways/sdfsd/config/ip_packet_router_config.toml
        identity key: 13UGSiZSteny4WKEwM8DbsJ2rdeaapT2SSSHx8UHg11P
        encryption key: Fz6FpzX7P1jye4TxM3rAQMTDVNeZhjfSbbDxcbWhd6AF
        address: 13UGSiZSteny4WKEwM8DbsJ2rdeaapT2SSSHx8UHg11P.Fz6FpzX7P1jye4TxM3rAQMTDVNeZhjfSbbDxcbWhd6AF@31Rg7UZDfwD1adv7dYtN42hxf3psRUFbqgXqF1sdGT93
```