### PR TITLE
feat(vpn-desktop): add exit node location support

### DIFF
--- a/nym-vpn/ui/README.md
+++ b/nym-vpn/ui/README.md
@@ -40,9 +40,6 @@ For example on Linux the path would be `~/.config/nym-vpn/config.toml`
 # path to the env config file if you provide one
 env_config_file = "$HOME/.config/nym-vpn/qa.env"
 
-# pick a gateway and exit router accordingly to the selected env
-entry_gateway = "xxx"
-exit_router = "xxx"
 ```
 
 ## Dev

--- a/nym-vpn/ui/src-tauri/Cargo.lock
+++ b/nym-vpn/ui/src-tauri/Cargo.lock
@@ -5267,6 +5267,7 @@ dependencies = [
  "nym-task",
  "nym-validator-client",
  "nym-wireguard-types",
+ "rand 0.7.3",
  "serde",
  "serde_json",
  "signature 1.4.0",

--- a/nym-vpn/ui/src-tauri/src/commands/app_data.rs
+++ b/nym-vpn/ui/src-tauri/src/commands/app_data.rs
@@ -14,24 +14,20 @@ pub fn get_node_countries() -> Result<Vec<Country>, CmdError> {
     debug!("get_node_countries");
     let countries: Vec<Country> = vec![
         Country {
-            name: "United States".to_string(),
-            code: "US".to_string(),
-        },
-        Country {
-            name: "France".to_string(),
-            code: "FR".to_string(),
-        },
-        Country {
-            name: "Switzerland".to_string(),
-            code: "CH".to_string(),
-        },
-        Country {
-            name: "Sweden".to_string(),
-            code: "SE".to_string(),
+            name: "Ireland".to_string(),
+            code: "IE".to_string(),
         },
         Country {
             name: "Germany".to_string(),
             code: "DE".to_string(),
+        },
+        Country {
+            name: "Japan".to_string(),
+            code: "JP".to_string(),
+        },
+        Country {
+            name: "Great Britain".to_string(),
+            code: "GB".to_string(),
         },
     ];
     Ok(countries)
@@ -90,6 +86,29 @@ pub async fn set_ui_theme(
         .await
         .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
     app_data.ui_theme = Some(theme);
+    app_data_store.data = app_data;
+    app_data_store
+        .write()
+        .await
+        .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
+    Ok(())
+}
+
+#[instrument(skip(data_state))]
+#[tauri::command]
+pub async fn set_entry_selector(
+    data_state: State<'_, SharedAppData>,
+    entry_selector: bool,
+) -> Result<(), CmdError> {
+    debug!("set_entry_selector");
+
+    // save the selected UI theme to disk
+    let mut app_data_store = data_state.lock().await;
+    let mut app_data = app_data_store
+        .read()
+        .await
+        .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
+    app_data.entry_selector = Some(entry_selector);
     app_data_store.data = app_data;
     app_data_store
         .write()

--- a/nym-vpn/ui/src-tauri/src/commands/app_data.rs
+++ b/nym-vpn/ui/src-tauri/src/commands/app_data.rs
@@ -102,7 +102,6 @@ pub async fn set_entry_location_selector(
 ) -> Result<(), CmdError> {
     debug!("set_entry_location_selector");
 
-    // save the selected UI theme to disk
     let mut app_data_store = data_state.lock().await;
     let mut app_data = app_data_store
         .read()
@@ -116,3 +115,4 @@ pub async fn set_entry_location_selector(
         .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
     Ok(())
 }
+

--- a/nym-vpn/ui/src-tauri/src/commands/app_data.rs
+++ b/nym-vpn/ui/src-tauri/src/commands/app_data.rs
@@ -96,11 +96,11 @@ pub async fn set_ui_theme(
 
 #[instrument(skip(data_state))]
 #[tauri::command]
-pub async fn set_entry_selector(
+pub async fn set_entry_location_selector(
     data_state: State<'_, SharedAppData>,
     entry_selector: bool,
 ) -> Result<(), CmdError> {
-    debug!("set_entry_selector");
+    debug!("set_entry_location_selector");
 
     // save the selected UI theme to disk
     let mut app_data_store = data_state.lock().await;

--- a/nym-vpn/ui/src-tauri/src/commands/app_data.rs
+++ b/nym-vpn/ui/src-tauri/src/commands/app_data.rs
@@ -14,24 +14,20 @@ pub fn get_node_countries() -> Result<Vec<Country>, CmdError> {
     debug!("get_node_countries");
     let countries: Vec<Country> = vec![
         Country {
-            name: "United States".to_string(),
-            code: "US".to_string(),
-        },
-        Country {
-            name: "France".to_string(),
-            code: "FR".to_string(),
-        },
-        Country {
-            name: "Switzerland".to_string(),
-            code: "CH".to_string(),
-        },
-        Country {
-            name: "Sweden".to_string(),
-            code: "SE".to_string(),
+            name: "Ireland".to_string(),
+            code: "IE".to_string(),
         },
         Country {
             name: "Germany".to_string(),
             code: "DE".to_string(),
+        },
+        Country {
+            name: "Japan".to_string(),
+            code: "JP".to_string(),
+        },
+        Country {
+            name: "Great Britain".to_string(),
+            code: "GB".to_string(),
         },
     ];
     Ok(countries)

--- a/nym-vpn/ui/src-tauri/src/commands/app_data.rs
+++ b/nym-vpn/ui/src-tauri/src/commands/app_data.rs
@@ -115,4 +115,3 @@ pub async fn set_entry_location_selector(
         .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
     Ok(())
 }
-

--- a/nym-vpn/ui/src-tauri/src/commands/app_data.rs
+++ b/nym-vpn/ui/src-tauri/src/commands/app_data.rs
@@ -1,6 +1,7 @@
 use tauri::State;
 use tracing::{debug, instrument};
 
+use crate::country::COUNTRIES;
 use crate::states::app::Country;
 use crate::{
     error::{CmdError, CmdErrorSource},
@@ -12,25 +13,8 @@ use crate::{
 #[tauri::command]
 pub fn get_node_countries() -> Result<Vec<Country>, CmdError> {
     debug!("get_node_countries");
-    let countries: Vec<Country> = vec![
-        Country {
-            name: "Ireland".to_string(),
-            code: "IE".to_string(),
-        },
-        Country {
-            name: "Germany".to_string(),
-            code: "DE".to_string(),
-        },
-        Country {
-            name: "Japan".to_string(),
-            code: "JP".to_string(),
-        },
-        Country {
-            name: "Great Britain".to_string(),
-            code: "GB".to_string(),
-        },
-    ];
-    Ok(countries)
+    // TODO fetch the list of countries from some API
+    Ok(COUNTRIES.clone())
 }
 
 #[instrument(skip(state))]

--- a/nym-vpn/ui/src-tauri/src/commands/app_data.rs
+++ b/nym-vpn/ui/src-tauri/src/commands/app_data.rs
@@ -108,7 +108,7 @@ pub async fn set_entry_selector(
         .read()
         .await
         .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
-    app_data.entry_selector = Some(entry_selector);
+    app_data.entry_location_selector = Some(entry_selector);
     app_data_store.data = app_data;
     app_data_store
         .write()

--- a/nym-vpn/ui/src-tauri/src/commands/app_data.rs
+++ b/nym-vpn/ui/src-tauri/src/commands/app_data.rs
@@ -97,3 +97,26 @@ pub async fn set_ui_theme(
         .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
     Ok(())
 }
+
+#[instrument(skip(data_state))]
+#[tauri::command]
+pub async fn set_entry_selector(
+    data_state: State<'_, SharedAppData>,
+    entry_selector: bool,
+) -> Result<(), CmdError> {
+    debug!("set_entry_selector");
+
+    // save the selected UI theme to disk
+    let mut app_data_store = data_state.lock().await;
+    let mut app_data = app_data_store
+        .read()
+        .await
+        .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
+    app_data.entry_selector = Some(entry_selector);
+    app_data_store.data = app_data;
+    app_data_store
+        .write()
+        .await
+        .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
+    Ok(())
+}

--- a/nym-vpn/ui/src-tauri/src/commands/node_location.rs
+++ b/nym-vpn/ui/src-tauri/src/commands/node_location.rs
@@ -1,3 +1,4 @@
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 use tracing::{debug, instrument};
@@ -13,6 +14,11 @@ pub enum NodeType {
     Entry,
     Exit,
 }
+
+static DEFAULT_NODE_LOCATION: Lazy<Country> = Lazy::new(|| Country {
+    code: "DE".to_string(),
+    name: "Germany".to_string(),
+});
 
 #[instrument(skip(app_state, data_state))]
 #[tauri::command]
@@ -56,4 +62,11 @@ pub async fn set_node_location(
         .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
 
     Ok(())
+}
+
+#[instrument]
+#[tauri::command]
+pub async fn get_default_node_location() -> Result<Country, CmdError> {
+    debug!("get_default_node_location");
+    Ok(DEFAULT_NODE_LOCATION.clone())
 }

--- a/nym-vpn/ui/src-tauri/src/country.rs
+++ b/nym-vpn/ui/src-tauri/src/country.rs
@@ -1,0 +1,25 @@
+use once_cell::sync::Lazy;
+
+use crate::states::app::Country;
+
+// TODO use hardcoded country list for now
+pub static COUNTRIES: Lazy<Vec<Country>> = Lazy::new(|| {
+    vec![
+        Country {
+            name: "Ireland".to_string(),
+            code: "IE".to_string(),
+        },
+        Country {
+            name: "Germany".to_string(),
+            code: "DE".to_string(),
+        },
+        Country {
+            name: "Japan".to_string(),
+            code: "JP".to_string(),
+        },
+        Country {
+            name: "Great Britain".to_string(),
+            code: "GB".to_string(),
+        },
+    ]
+});

--- a/nym-vpn/ui/src-tauri/src/fs/config.rs
+++ b/nym-vpn/ui/src-tauri/src/fs/config.rs
@@ -5,5 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct AppConfig {
     /// Path pointing to an env configuration file describing the network
-    pub env_config_file: Option<PathBuf>
+    pub env_config_file: Option<PathBuf>,
+    /// Country code (two letters format, eg. FR)
+    pub entry_node_location: Option<String>,
 }

--- a/nym-vpn/ui/src-tauri/src/fs/config.rs
+++ b/nym-vpn/ui/src-tauri/src/fs/config.rs
@@ -5,9 +5,5 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct AppConfig {
     /// Path pointing to an env configuration file describing the network
-    pub env_config_file: Option<PathBuf>,
-    /// Mixnet public ID of the entry gateway
-    pub entry_gateway: String,
-    /// Mixnet recipient address
-    pub exit_router: String,
+    pub env_config_file: Option<PathBuf>
 }

--- a/nym-vpn/ui/src-tauri/src/fs/data.rs
+++ b/nym-vpn/ui/src-tauri/src/fs/data.rs
@@ -17,6 +17,7 @@ pub struct AppData {
     pub monitoring: Option<bool>,
     pub autoconnect: Option<bool>,
     pub killswitch: Option<bool>,
+    pub entry_selector: Option<bool>,
     pub ui_theme: Option<UiTheme>,
     pub vpn_mode: Option<VpnMode>,
     pub entry_node: Option<NodeConfig>,

--- a/nym-vpn/ui/src-tauri/src/fs/data.rs
+++ b/nym-vpn/ui/src-tauri/src/fs/data.rs
@@ -17,7 +17,7 @@ pub struct AppData {
     pub monitoring: Option<bool>,
     pub autoconnect: Option<bool>,
     pub killswitch: Option<bool>,
-    pub entry_selector: Option<bool>,
+    pub entry_location_selector: Option<bool>,
     pub ui_theme: Option<UiTheme>,
     pub vpn_mode: Option<VpnMode>,
     pub entry_node: Option<NodeConfig>,

--- a/nym-vpn/ui/src-tauri/src/main.rs
+++ b/nym-vpn/ui/src-tauri/src/main.rs
@@ -64,6 +64,8 @@ async fn main() -> Result<()> {
         &app_config_store.full_path.display()
     );
 
+    let app_data = app_data_store.read().await?;
+    debug!("app_data: {app_data:?}");
     let app_config = app_config_store.read().await?;
     debug!("app_config: {app_config:?}");
 
@@ -89,7 +91,7 @@ async fn main() -> Result<()> {
     info!("Starting tauri app");
 
     tauri::Builder::default()
-        .manage(Arc::new(Mutex::new(AppState::default())))
+        .manage(Arc::new(Mutex::new(AppState::from(&app_data))))
         .manage(Arc::new(Mutex::new(app_data_store)))
         .manage(Arc::new(Mutex::new(app_config_store)))
         .setup(|_app| {

--- a/nym-vpn/ui/src-tauri/src/main.rs
+++ b/nym-vpn/ui/src-tauri/src/main.rs
@@ -16,6 +16,7 @@ use nym_vpn_lib::nym_config;
 use crate::fs::{config::AppConfig, data::AppData, storage::AppStorage};
 
 mod commands;
+mod country;
 mod error;
 mod fs;
 mod states;

--- a/nym-vpn/ui/src-tauri/src/main.rs
+++ b/nym-vpn/ui/src-tauri/src/main.rs
@@ -110,6 +110,7 @@ async fn main() -> Result<()> {
             app_data::set_entry_location_selector,
             app_data::get_node_countries,
             node_location::set_node_location,
+            node_location::get_default_node_location,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/nym-vpn/ui/src-tauri/src/main.rs
+++ b/nym-vpn/ui/src-tauri/src/main.rs
@@ -104,7 +104,7 @@ async fn main() -> Result<()> {
             app_data::get_app_data,
             app_data::set_app_data,
             app_data::set_ui_theme,
-            app_data::set_entry_selector,
+            app_data::set_entry_location_selector,
             app_data::get_node_countries,
             node_location::set_node_location,
         ])

--- a/nym-vpn/ui/src-tauri/src/main.rs
+++ b/nym-vpn/ui/src-tauri/src/main.rs
@@ -104,6 +104,7 @@ async fn main() -> Result<()> {
             app_data::get_app_data,
             app_data::set_app_data,
             app_data::set_ui_theme,
+            app_data::set_entry_selector,
             app_data::get_node_countries,
             node_location::set_node_location,
         ])

--- a/nym-vpn/ui/src-tauri/src/main.rs
+++ b/nym-vpn/ui/src-tauri/src/main.rs
@@ -59,6 +59,7 @@ fn main() -> Result<()> {
             app_data::get_app_data,
             app_data::set_app_data,
             app_data::set_ui_theme,
+            app_data::set_entry_selector,
             app_data::get_node_countries,
             node_location::set_node_location,
         ])

--- a/nym-vpn/ui/src-tauri/src/states/app.rs
+++ b/nym-vpn/ui/src-tauri/src/states/app.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use ts_rs::TS;
 
+use crate::fs::data::AppData;
+
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
 #[ts(export)]
 pub struct NodeConfig {
@@ -49,6 +51,17 @@ pub struct AppState {
     pub tunnel: Option<TunnelConfig>,
     pub connection_start_time: Option<OffsetDateTime>,
     pub vpn_ctrl_tx: Option<UnboundedSender<NymVpnCtrlMessage>>,
+}
+
+impl From<&AppData> for AppState {
+    fn from(app_data: &AppData) -> Self {
+        AppState {
+            entry_node_location: app_data.entry_node_location.clone(),
+            exit_node_location: app_data.exit_node_location.clone(),
+            vpn_mode: app_data.vpn_mode.clone().unwrap_or_default(),
+            ..Default::default()
+        }
+    }
 }
 
 #[derive(Default, Serialize, Deserialize, Debug, Clone, TS)]

--- a/nym-vpn/ui/src-tauri/src/vpn_client.rs
+++ b/nym-vpn/ui/src-tauri/src/vpn_client.rs
@@ -1,9 +1,8 @@
-use crate::fs::config::AppConfig;
 use crate::states::{app::ConnectionState, SharedAppState};
 use anyhow::Result;
 use futures::channel::oneshot::Receiver as OneshotReceiver;
 use futures::StreamExt;
-use nym_vpn_lib::gateway_client::Config as GatewayClientConfig;
+use nym_vpn_lib::gateway_client::{Config as GatewayClientConfig, EntryPoint, ExitPoint};
 use nym_vpn_lib::nym_config::OptionalSet;
 use nym_vpn_lib::{NymVpn, NymVpnExitError, NymVpnExitStatusMessage, StatusReceiver};
 use tauri::Manager;
@@ -166,8 +165,8 @@ fn setup_gateway_client_config(private_key: Option<&str>) -> GatewayClientConfig
 }
 
 #[instrument(skip_all)]
-pub fn create_vpn_config(app_config: &AppConfig) -> NymVpn {
-    let mut nym_vpn = NymVpn::new(&app_config.entry_gateway, &app_config.exit_router);
+pub fn create_vpn_config(entry_point: EntryPoint, exit_point: ExitPoint) -> NymVpn {
+    let mut nym_vpn = NymVpn::new(entry_point, exit_point);
     nym_vpn.gateway_config = setup_gateway_client_config(None);
     nym_vpn
 }

--- a/nym-vpn/ui/src-tauri/tauri.conf.json
+++ b/nym-vpn/ui/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "withGlobalTauri": false
   },
   "package": {
-    "productName": "nym-vpn-ui",
+    "productName": "nym-vpn",
     "version": "0.0.0"
   },
   "tauri": {

--- a/nym-vpn/ui/src/constants.ts
+++ b/nym-vpn/ui/src/constants.ts
@@ -11,4 +11,8 @@ export const AppName = 'NymVPN';
 export const ConnectionEvent = 'connection-state';
 export const ProgressEvent = 'connection-progress';
 //putting this here for now until decided how default country is determined
-export const QuickConnectCountry: Country = { name: 'Germany', code: 'DE' };
+export const QuickConnectPrefix = 'Recommended';
+export const QuickConnectCountry: Country = {
+  name: `${QuickConnectPrefix} (Germany)`,
+  code: 'DE',
+};

--- a/nym-vpn/ui/src/constants.ts
+++ b/nym-vpn/ui/src/constants.ts
@@ -11,4 +11,8 @@ export const AppName = 'NymVPN';
 export const ConnectionEvent = 'connection-state';
 export const ProgressEvent = 'connection-progress';
 //putting this here for now until decided how default country is determined
-export const QuickConnectCountry: Country = { name: 'Germany', code: 'DE' };
+export const QuickConnectPrefix = 'Fastest';
+export const QuickConnectCountry: Country = {
+  name: `${QuickConnectPrefix} (Germany)`,
+  code: 'DE',
+};

--- a/nym-vpn/ui/src/constants.ts
+++ b/nym-vpn/ui/src/constants.ts
@@ -11,7 +11,7 @@ export const AppName = 'NymVPN';
 export const ConnectionEvent = 'connection-state';
 export const ProgressEvent = 'connection-progress';
 //putting this here for now until decided how default country is determined
-export const QuickConnectPrefix = 'Recommended';
+export const QuickConnectPrefix = 'Fastest';
 export const QuickConnectCountry: Country = {
   name: `${QuickConnectPrefix} (Germany)`,
   code: 'DE',

--- a/nym-vpn/ui/src/constants.ts
+++ b/nym-vpn/ui/src/constants.ts
@@ -1,5 +1,3 @@
-import { Country } from './types';
-
 export const routes = {
   root: '/',
   settings: '/settings',
@@ -10,12 +8,5 @@ export const routes = {
 export const AppName = 'NymVPN';
 export const ConnectionEvent = 'connection-state';
 export const ProgressEvent = 'connection-progress';
-//putting this here for now until decided how default country is determined
 export const QuickConnectPrefix = 'Fastest';
-
-// TODO use a tauri command to get this value
-// ⚠ keep it in sync with `DEFAULT_NODE_LOCATION` value used in backend side
-export const QuickConnectCountry: Country = {
-  name: `${QuickConnectPrefix} (Germany)`,
-  code: 'DE',
-};
+export const DefaultNodeLocation = { name: 'France', code: 'FR' };

--- a/nym-vpn/ui/src/constants.ts
+++ b/nym-vpn/ui/src/constants.ts
@@ -12,6 +12,9 @@ export const ConnectionEvent = 'connection-state';
 export const ProgressEvent = 'connection-progress';
 //putting this here for now until decided how default country is determined
 export const QuickConnectPrefix = 'Fastest';
+
+// TODO use a tauri command to get this value
+// ⚠ keep it in sync with `DEFAULT_NODE_LOCATION` value used in backend side
 export const QuickConnectCountry: Country = {
   name: `${QuickConnectPrefix} (Germany)`,
   code: 'DE',

--- a/nym-vpn/ui/src/constants.ts
+++ b/nym-vpn/ui/src/constants.ts
@@ -9,4 +9,3 @@ export const AppName = 'NymVPN';
 export const ConnectionEvent = 'connection-state';
 export const ProgressEvent = 'connection-progress';
 export const QuickConnectPrefix = 'Fastest';
-export const DefaultNodeLocation = { name: 'France', code: 'FR' };

--- a/nym-vpn/ui/src/dev/setup.ts
+++ b/nym-vpn/ui/src/dev/setup.ts
@@ -62,7 +62,7 @@ export function mockTauriIPC() {
           monitoring: false,
           autoconnect: false,
           killswitch: false,
-          entry_selector: false,
+          entry_location_selector: false,
           ui_theme: 'Dark',
           vpn_mode: 'TwoHop',
           entry_node: {

--- a/nym-vpn/ui/src/dev/setup.ts
+++ b/nym-vpn/ui/src/dev/setup.ts
@@ -62,6 +62,7 @@ export function mockTauriIPC() {
           monitoring: false,
           autoconnect: false,
           killswitch: false,
+          entry_selector: false,
           ui_theme: 'Dark',
           vpn_mode: 'TwoHop',
           entry_node: {

--- a/nym-vpn/ui/src/dev/setup.ts
+++ b/nym-vpn/ui/src/dev/setup.ts
@@ -1,7 +1,7 @@
 import { mockIPC, mockWindows } from '@tauri-apps/api/mocks';
 import { emit } from '@tauri-apps/api/event';
 import { AppDataFromBackend, ConnectionState, Country } from '../types';
-import { ConnectionEvent, QuickConnectCountry } from '../constants';
+import { ConnectionEvent } from '../constants';
 
 export function mockTauriIPC() {
   mockWindows('main');
@@ -56,6 +56,15 @@ export function mockTauriIPC() {
       );
     }
 
+    if (cmd === 'get_default_node_location') {
+      return new Promise<Country>((resolve) =>
+        resolve({
+          name: 'France',
+          code: 'FR',
+        }),
+      );
+    }
+
     if (cmd === 'get_app_data') {
       return new Promise<AppDataFromBackend>((resolve) =>
         resolve({
@@ -66,12 +75,18 @@ export function mockTauriIPC() {
           ui_theme: 'Dark',
           vpn_mode: 'TwoHop',
           entry_node: {
-            country: QuickConnectCountry,
-            id: QuickConnectCountry.code,
+            country: {
+              name: 'France',
+              code: 'FR',
+            },
+            id: 'nodeOne',
           },
           exit_node: {
-            country: QuickConnectCountry,
-            id: QuickConnectCountry.code,
+            country: {
+              name: 'France',
+              code: 'FR',
+            },
+            id: 'nodeTwo',
           },
           entry_node_location: null,
           exit_node_location: null,

--- a/nym-vpn/ui/src/i18n/en/node-location.json
+++ b/nym-vpn/ui/src/i18n/en/node-location.json
@@ -1,7 +1,6 @@
 {
   "loading": "Loading..",
-  "none-found": "No results found!",
+  "none-found": "No results found. Please try another search",
   "selected": "Selected",
-  "search-country": "Search country",
-  "quick-connect": "Quick connect"
+  "search-country": "Search country"
 }

--- a/nym-vpn/ui/src/i18n/en/settings.json
+++ b/nym-vpn/ui/src/i18n/en/settings.json
@@ -1,1 +1,3 @@
-{}
+{
+  "entry-selector": "Entry location selector"
+}

--- a/nym-vpn/ui/src/pages/home/ConnectionStatus.tsx
+++ b/nym-vpn/ui/src/pages/home/ConnectionStatus.tsx
@@ -66,8 +66,8 @@ function ConnectionStatus() {
           {getStatusText(state.state)}
         </div>
       </div>
-      <div className="flex flex-1">
-        {state.loading && state.progressMessages.length > 0 && (
+      <div className="flex-col flex-1 text-center">
+        {state.loading && state.progressMessages.length > 0 && !state.error && (
           <p className="text-dim-gray dark:text-mercury-mist font-bold">
             {t(
               `connection-progress.${

--- a/nym-vpn/ui/src/pages/home/Home.tsx
+++ b/nym-vpn/ui/src/pages/home/Home.tsx
@@ -12,7 +12,7 @@ import ConnectionStatus from './ConnectionStatus';
 import HopSelect from './HopSelect';
 
 function Home() {
-  const { state, loading, exitNodeLocation } = useMainState();
+  const { state, loading, exitNodeLocation, entryNodeLocation, entrySelector } = useMainState();
   const dispatch = useMainDispatch() as StateDispatch;
   const navigate = useNavigate();
   const { t } = useTranslation('home');
@@ -75,9 +75,9 @@ function Home() {
           <div className="py-2"></div>
           <div className="flex flex-col gap-6">
             <div className="mt-3 font-semibold text-lg">Connect to</div>
-            {state.entrySelector ? (
+            {entrySelector ? (
               <HopSelect
-                country={state.entryNodeLocation ?? QuickConnectCountry}
+                country={entryNodeLocation ?? QuickConnectCountry}
                 onClick={() => navigate(routes.entryNodeLocation)}
                 nodeHop="entry"
               />
@@ -85,7 +85,7 @@ function Home() {
               <></>
             )}
             <HopSelect
-              country={state.exitNodeLocation ?? QuickConnectCountry}
+              country={exitNodeLocation ?? QuickConnectCountry}
               onClick={() => navigate(routes.exitNodeLocation)}
               nodeHop="exit"
             />

--- a/nym-vpn/ui/src/pages/home/Home.tsx
+++ b/nym-vpn/ui/src/pages/home/Home.tsx
@@ -74,7 +74,9 @@ function Home() {
           <NetworkModeSelect />
           <div className="py-2"></div>
           <div className="flex flex-col gap-6">
-            <div className="mt-3 font-semibold text-lg">Connect to</div>
+            <div className="mt-3 font-semibold text-lg">
+              {t('select-node-title')}
+            </div>
             <HopSelect
               country={exitNodeLocation ?? QuickConnectCountry}
               onClick={() => navigate(routes.exitNodeLocation)}

--- a/nym-vpn/ui/src/pages/home/Home.tsx
+++ b/nym-vpn/ui/src/pages/home/Home.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { Button } from '@mui/base';
 import { useNavigate } from 'react-router-dom';
 import { useMainDispatch, useMainState } from '../../contexts';
-import { StateDispatch } from '../../types';
+import { CmdError, StateDispatch } from '../../types';
 import { QuickConnectCountry, routes } from '../../constants';
 import NetworkModeSelect from './NetworkModeSelect';
 import ConnectionStatus from './ConnectionStatus';
@@ -25,9 +25,9 @@ function Home() {
           console.log('disconnect result');
           console.log(result);
         })
-        .catch((e) => {
-          console.log(e);
-          dispatch({ type: 'set-error', error: e });
+        .catch((e: CmdError) => {
+          console.warn(`backend error: ${e.source} - ${e.message}`);
+          dispatch({ type: 'set-error', error: e.message });
         });
     } else if (state === 'Disconnected') {
       dispatch({ type: 'connect' });
@@ -36,9 +36,9 @@ function Home() {
           console.log('connect result');
           console.log(result);
         })
-        .catch((e) => {
-          console.log(e);
-          dispatch({ type: 'set-error', error: e });
+        .catch((e: CmdError) => {
+          console.warn(`backend error: ${e.source} - ${e.message}`);
+          dispatch({ type: 'set-error', error: e.message });
         });
     }
   };

--- a/nym-vpn/ui/src/pages/home/Home.tsx
+++ b/nym-vpn/ui/src/pages/home/Home.tsx
@@ -6,13 +6,14 @@ import { Button } from '@mui/base';
 import { useNavigate } from 'react-router-dom';
 import { useMainDispatch, useMainState } from '../../contexts';
 import { CmdError, StateDispatch } from '../../types';
-import { QuickConnectCountry, routes } from '../../constants';
+import { routes } from '../../constants';
 import NetworkModeSelect from './NetworkModeSelect';
 import ConnectionStatus from './ConnectionStatus';
 import HopSelect from './HopSelect';
 
 function Home() {
-  const { state, loading, exitNodeLocation } = useMainState();
+  const { state, loading, exitNodeLocation, defaultNodeLocation } =
+    useMainState();
   const dispatch = useMainDispatch() as StateDispatch;
   const navigate = useNavigate();
   const { t } = useTranslation('home');
@@ -78,9 +79,11 @@ function Home() {
               {t('select-node-title')}
             </div>
             <HopSelect
-              country={exitNodeLocation ?? QuickConnectCountry}
+              country={exitNodeLocation || defaultNodeLocation}
               onClick={() => {
-                if (state === 'Disconnected') navigate(routes.exitNodeLocation);
+                if (state === 'Disconnected') {
+                  navigate(routes.exitNodeLocation);
+                }
               }}
               nodeHop="exit"
             />

--- a/nym-vpn/ui/src/pages/home/Home.tsx
+++ b/nym-vpn/ui/src/pages/home/Home.tsx
@@ -60,11 +60,23 @@ function Home() {
         <div className="flex flex-col justify-between">
           <NetworkModeSelect />
           <div className="py-2"></div>
-          <HopSelect
-            country={state.exitNodeLocation ?? QuickConnectCountry}
-            onClick={() => navigate(routes.exitNodeLocation)}
-            nodeHop="exit"
-          />
+          <div className="flex flex-col gap-6">
+            <div className="mt-3 font-semibold text-lg">Connect to</div>
+            {state.entrySelector ? (
+              <HopSelect
+                country={state.entryNodeLocation ?? QuickConnectCountry}
+                onClick={() => navigate(routes.entryNodeLocation)}
+                nodeHop="entry"
+              />
+            ) : (
+              <></>
+            )}
+            <HopSelect
+              country={state.exitNodeLocation ?? QuickConnectCountry}
+              onClick={() => navigate(routes.exitNodeLocation)}
+              nodeHop="exit"
+            />
+          </div>
         </div>
         <Button
           className={clsx([

--- a/nym-vpn/ui/src/pages/home/Home.tsx
+++ b/nym-vpn/ui/src/pages/home/Home.tsx
@@ -73,11 +73,23 @@ function Home() {
         <div className="flex flex-col justify-between">
           <NetworkModeSelect />
           <div className="py-2"></div>
-          <HopSelect
-            country={exitNodeLocation ?? QuickConnectCountry}
-            onClick={() => navigate(routes.exitNodeLocation)}
-            nodeHop="exit"
-          />
+          <div className="flex flex-col gap-6">
+            <div className="mt-3 font-semibold text-lg">Connect to</div>
+            {state.entrySelector ? (
+              <HopSelect
+                country={state.entryNodeLocation ?? QuickConnectCountry}
+                onClick={() => navigate(routes.entryNodeLocation)}
+                nodeHop="entry"
+              />
+            ) : (
+              <></>
+            )}
+            <HopSelect
+              country={state.exitNodeLocation ?? QuickConnectCountry}
+              onClick={() => navigate(routes.exitNodeLocation)}
+              nodeHop="exit"
+            />
+          </div>
         </div>
         <Button
           className={clsx([

--- a/nym-vpn/ui/src/pages/home/Home.tsx
+++ b/nym-vpn/ui/src/pages/home/Home.tsx
@@ -12,7 +12,7 @@ import ConnectionStatus from './ConnectionStatus';
 import HopSelect from './HopSelect';
 
 function Home() {
-  const { state, loading, exitNodeLocation, entryNodeLocation, entrySelector } = useMainState();
+  const { state, loading, exitNodeLocation } = useMainState();
   const dispatch = useMainDispatch() as StateDispatch;
   const navigate = useNavigate();
   const { t } = useTranslation('home');
@@ -75,15 +75,6 @@ function Home() {
           <div className="py-2"></div>
           <div className="flex flex-col gap-6">
             <div className="mt-3 font-semibold text-lg">Connect to</div>
-            {entrySelector ? (
-              <HopSelect
-                country={entryNodeLocation ?? QuickConnectCountry}
-                onClick={() => navigate(routes.entryNodeLocation)}
-                nodeHop="entry"
-              />
-            ) : (
-              <></>
-            )}
             <HopSelect
               country={exitNodeLocation ?? QuickConnectCountry}
               onClick={() => navigate(routes.exitNodeLocation)}

--- a/nym-vpn/ui/src/pages/home/Home.tsx
+++ b/nym-vpn/ui/src/pages/home/Home.tsx
@@ -79,7 +79,9 @@ function Home() {
             </div>
             <HopSelect
               country={exitNodeLocation ?? QuickConnectCountry}
-              onClick={() => navigate(routes.exitNodeLocation)}
+              onClick={() => {
+                if (state === 'Disconnected') navigate(routes.exitNodeLocation);
+              }}
               nodeHop="exit"
             />
           </div>

--- a/nym-vpn/ui/src/pages/home/Home.tsx
+++ b/nym-vpn/ui/src/pages/home/Home.tsx
@@ -12,7 +12,7 @@ import ConnectionStatus from './ConnectionStatus';
 import HopSelect from './HopSelect';
 
 function Home() {
-  const { state, loading, exitNodeLocation } = useMainState();
+  const { state, loading, exitNodeLocation, entryNodeLocation, entrySelector } = useMainState();
   const dispatch = useMainDispatch() as StateDispatch;
   const navigate = useNavigate();
   const { t } = useTranslation('home');
@@ -73,11 +73,23 @@ function Home() {
         <div className="flex flex-col justify-between">
           <NetworkModeSelect />
           <div className="py-2"></div>
-          <HopSelect
-            country={exitNodeLocation ?? QuickConnectCountry}
-            onClick={() => navigate(routes.exitNodeLocation)}
-            nodeHop="exit"
-          />
+          <div className="flex flex-col gap-6">
+            <div className="mt-3 font-semibold text-lg">Connect to</div>
+            {entrySelector ? (
+              <HopSelect
+                country={entryNodeLocation ?? QuickConnectCountry}
+                onClick={() => navigate(routes.entryNodeLocation)}
+                nodeHop="entry"
+              />
+            ) : (
+              <></>
+            )}
+            <HopSelect
+              country={exitNodeLocation ?? QuickConnectCountry}
+              onClick={() => navigate(routes.exitNodeLocation)}
+              nodeHop="exit"
+            />
+          </div>
         </div>
         <Button
           className={clsx([

--- a/nym-vpn/ui/src/pages/home/HopSelect.tsx
+++ b/nym-vpn/ui/src/pages/home/HopSelect.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Country, NodeHop } from '../../types';
+import { QuickConnectPrefix } from '../../constants';
 
 interface HopSelectProps {
   country: Country;
@@ -15,7 +16,6 @@ export default function HopSelect({
   const { t } = useTranslation('home');
   return (
     <>
-      <div className="my-3 font-semibold text-lg">Connect to</div>
       <div
         className="relative w-full flex flex-row justify-center cursor-pointer"
         onKeyDown={onClick}
@@ -29,11 +29,18 @@ export default function HopSelect({
           value={country.name}
           className="dark:bg-baltic-sea cursor-pointer pl-11 dark:placeholder-white border border-gun-powder block px-2.5 pb-4 pt-4 w-full text-sm text-gray-900 bg-transparent rounded-lg border-1 border-gray-300 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer"
         />
-        <img
-          src={`./flags/${country.code.toLowerCase()}.svg`}
-          className="h-8 scale-75 pointer-events-none absolute fill-current top-1/2 transform -translate-y-1/2 left-2"
-          alt={country.code}
-        />
+        <div className="top-1/2 transform -translate-y-1/2 left-2 absolute pointer-events-none">
+          {country.name.includes(QuickConnectPrefix) ? (
+            <span className="font-icon cursor-pointer px-2">bolt</span>
+          ) : (
+            <img
+              src={`./flags/${country.code.toLowerCase()}.svg`}
+              className="h-8 scale-75 pointer-events-none fill-current"
+              alt={country.code}
+            />
+          )}
+        </div>
+
         <span className="font-icon scale-125 pointer-events-none absolute fill-current top-1/4 transform -translate-x-1/2 right-2">
           arrow_right
         </span>

--- a/nym-vpn/ui/src/pages/location/CountryList.tsx
+++ b/nym-vpn/ui/src/pages/location/CountryList.tsx
@@ -12,7 +12,7 @@ export default function CountryList({
 }: CountryListProps) {
   const { t } = useTranslation('nodeLocation');
   return (
-    <ul className="flex flex-col w-full items-stretch p-1">
+    <ul className="flex flex-col w-full items-stretch px-6 gap-4">
       {countries && countries.length > 0 ? (
         countries.map((country) => (
           <li key={country.code} className="list-none w-full">
@@ -39,7 +39,7 @@ export default function CountryList({
           </li>
         ))
       ) : (
-        <p>{t('none-found')}</p>
+        <p className="flex justify-center">{t('none-found')}</p>
       )}
     </ul>
   );

--- a/nym-vpn/ui/src/pages/location/NodeLocation.tsx
+++ b/nym-vpn/ui/src/pages/location/NodeLocation.tsx
@@ -11,28 +11,22 @@ import QuickConnect from './QuickConnect';
 
 function NodeLocation({ node }: { node: NodeHop }) {
   const { t } = useTranslation('nodeLocation');
-  const [countries, setCountries] = useState<Country[]>([]);
+  const { entryNodeLocation, exitNodeLocation, countries } = useMainState();
   const [search, setSearch] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [foundCountries, setFoundCountries] = useState<Country[]>([]);
+  const [foundCountries, setFoundCountries] = useState<Country[]>(countries);
 
-  const { entryNodeLocation, exitNodeLocation } = useMainState();
   const dispatch = useMainDispatch() as StateDispatch;
 
   const navigate = useNavigate();
 
+  //request backend to update countries cache
   useEffect(() => {
-    setLoading(true);
     const getNodeCountries = async () => {
       const countries = await invoke<Country[]>('get_node_countries');
-      setTimeout(() => {
-        setCountries(countries);
-        setFoundCountries(countries);
-        setLoading(false);
-      }, 1000);
+      dispatch({ type: 'set-countries', countries });
     };
     getNodeCountries().catch(console.error);
-  }, []);
+  }, [dispatch]);
 
   const filter = (e: InputEvent) => {
     const keyword = e.target.value;
@@ -82,15 +76,11 @@ function NodeLocation({ node }: { node: NodeHop }) {
             placeholder={t('search-country')}
           />
           <span className="mt-3" />
-          {!loading ? (
-            <CountryList
-              countries={foundCountries}
-              onClick={handleCountrySelection}
-              isSelected={isCountrySelected}
-            />
-          ) : (
-            <div>{t('loading')}</div>
-          )}
+          <CountryList
+            countries={foundCountries}
+            onClick={handleCountrySelection}
+            isSelected={isCountrySelected}
+          />
         </div>
       </div>
     </div>

--- a/nym-vpn/ui/src/pages/location/QuickConnect.tsx
+++ b/nym-vpn/ui/src/pages/location/QuickConnect.tsx
@@ -1,25 +1,21 @@
-import { useTranslation } from 'react-i18next';
 import { QuickConnectCountry } from '../../constants';
 interface QuickConnectProps {
   onClick: (name: string, code: string) => void;
 }
 export default function QuickConnect({ onClick }: QuickConnectProps) {
-  const { t } = useTranslation('nodeLocation');
   return (
     <div
       role="presentation"
       onKeyDown={() =>
         onClick(QuickConnectCountry.name, QuickConnectCountry.code)
       }
-      className="flex flex-row w-full py-8 cursor-pointer"
+      className="flex px-5 flex-row w-full py-8 cursor-pointer"
       onClick={() =>
         onClick(QuickConnectCountry.name, QuickConnectCountry.code)
       }
     >
       <span className="font-icon px-4 cursor-pointer">bolt</span>
-      <div className="cursor-pointer">{`${t('quick-connect')} (${
-        QuickConnectCountry.name
-      })`}</div>
+      <div className="cursor-pointer">{QuickConnectCountry.name}</div>
     </div>
   );
 }

--- a/nym-vpn/ui/src/pages/location/QuickConnect.tsx
+++ b/nym-vpn/ui/src/pages/location/QuickConnect.tsx
@@ -1,21 +1,26 @@
-import { QuickConnectCountry } from '../../constants';
+import { useMainState } from '../../contexts';
+import { QuickConnectPrefix } from '../../constants';
+
 interface QuickConnectProps {
   onClick: (name: string, code: string) => void;
 }
+
 export default function QuickConnect({ onClick }: QuickConnectProps) {
+  const { defaultNodeLocation } = useMainState();
+
   return (
     <div
       role="presentation"
       onKeyDown={() =>
-        onClick(QuickConnectCountry.name, QuickConnectCountry.code)
+        onClick(defaultNodeLocation.name, defaultNodeLocation.code)
       }
       className="flex px-5 flex-row w-full py-8 cursor-pointer"
       onClick={() =>
-        onClick(QuickConnectCountry.name, QuickConnectCountry.code)
+        onClick(defaultNodeLocation.name, defaultNodeLocation.code)
       }
     >
       <span className="font-icon px-4 cursor-pointer">bolt</span>
-      <div className="cursor-pointer">{QuickConnectCountry.name}</div>
+      <div className="cursor-pointer">{`${QuickConnectPrefix} ${defaultNodeLocation.name}`}</div>
     </div>
   );
 }

--- a/nym-vpn/ui/src/pages/location/SearchBox.tsx
+++ b/nym-vpn/ui/src/pages/location/SearchBox.tsx
@@ -12,21 +12,21 @@ export default function SearchBox({
   placeholder,
 }: SearchProps) {
   return (
-    <div className="relative w-full flex flex-row justify-center px-1.5">
+    <div className="relative w-full flex flex-row justify-center px-6">
       <input
         type="text"
         id="floating_outlined"
         value={value}
-        className="dark:bg-baltic-sea pl-9 dark:placeholder-white border border-gun-powder block px-2.5 pb-4 pt-4 w-full text-sm text-gray-900 bg-transparent rounded-lg border-1 border-gray-300 appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 peer"
+        className="dark:bg-baltic-sea pl-9 dark:placeholder-white border border-gun-powder block px-2.5 pb-4 pt-4 w-full text-sm text-gray-900 bg-transparent rounded-lg border-1 border-gray-300 appearance-none dark:text-white dark:border-gray-600 focus:outline-none focus:ring-0 peer"
         placeholder={placeholder}
         onChange={onChange}
       />
-      <span className="font-icon scale-125 pointer-events-none absolute fill-current top-1/2 transform -translate-y-1/2 left-4">
+      <span className="font-icon scale-125 pointer-events-none absolute fill-current top-1/2 transform -translate-y-1/2 left-9">
         search
       </span>
       <label
         htmlFor="floating_outlined"
-        className="dark:text-white dark:bg-baltic-sea absolute text-sm text-gray-500 dark:text-gray-400 ml-4 duration-300 transform -translate-y-4 scale-75 top-2 z-10 origin-[0] bg-blanc-nacre dark:bg-gray-900 px-2 peer-placeholder-shown:px-2 peer-placeholder-shown:text-blue-600 peer-placeholder-shown:dark:text-blue-500 peer-placeholder-shown:top-2 peer-placeholder-shown:scale-75 peer-placeholder-shown:-translate-y-4 rtl:peer-placeholder-shown:translate-x-1/4 rtl:peer-placeholder-shown:left-auto start-1"
+        className="dark:text-white dark:bg-baltic-sea absolute text-sm text-gray-500 dark:text-gray-400 ml-8 duration-300 transform -translate-y-4 scale-75 top-2 z-10 origin-[0] bg-blanc-nacre dark:bg-gray-900 px-2 peer-placeholder-shown:px-2 peer-placeholder-shown:top-2 peer-placeholder-shown:scale-75 peer-placeholder-shown:-translate-y-4 rtl:peer-placeholder-shown:translate-x-1/4 rtl:peer-placeholder-shown:left-auto start-1"
       >
         Search
       </label>

--- a/nym-vpn/ui/src/pages/settings/Settings.tsx
+++ b/nym-vpn/ui/src/pages/settings/Settings.tsx
@@ -2,18 +2,26 @@ import { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { invoke } from '@tauri-apps/api';
 import { Switch } from '@headlessui/react';
+import { useTranslation } from 'react-i18next';
 import { useMainDispatch, useMainState } from '../../contexts';
 import { StateDispatch } from '../../types';
+import { QuickConnectCountry } from '../../constants';
 
 function Settings() {
   const state = useMainState();
   const dispatch = useMainDispatch() as StateDispatch;
 
-  const [enabled, setEnabled] = useState(state.uiTheme === 'Dark');
+  const { t } = useTranslation('settings');
+
+  const [darkModeEnabled, setDarkModeEnabled] = useState(
+    state.uiTheme === 'Dark',
+  );
+  const [entrySelector, setEntrySelector] = useState(state.entrySelector);
 
   useEffect(() => {
-    setEnabled(state.uiTheme === 'Dark');
-  }, [state.uiTheme]);
+    setDarkModeEnabled(state.uiTheme === 'Dark');
+    setEntrySelector(state.entrySelector);
+  }, [state]);
 
   const handleThemeChange = async (darkMode: boolean) => {
     if (darkMode && state.uiTheme === 'Light') {
@@ -28,24 +36,77 @@ function Settings() {
     );
   };
 
+  const handleDefaultEntryNodeSelection = async () => {
+    try {
+      await invoke<void>('set_node_location', {
+        nodeType: 'Entry',
+        country: QuickConnectCountry,
+      });
+      dispatch({
+        type: 'set-node-location',
+        payload: { hop: 'entry', country: QuickConnectCountry },
+      });
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const handleEntrySelectorChange = async () => {
+    const isSelected = !state.entrySelector;
+    dispatch({ type: 'set-entry-selector', entrySelector: isSelected });
+    invoke<void>('set_entry_selector', { entrySelector: isSelected }).catch(
+      (e) => {
+        console.log(e);
+      },
+    );
+    if (!isSelected) {
+      handleDefaultEntryNodeSelection();
+    }
+  };
+
   return (
-    <div className="h-full flex flex-col p-4">
+    <div className="h-full flex flex-col p-4 gap-4">
       <div className="flex flex-row justify-between items-center">
         <p className="text-lg text-baltic-sea dark:text-mercury-pinkish">
           Dark Mode
         </p>
         <Switch
-          checked={enabled}
+          checked={darkModeEnabled}
           onChange={handleThemeChange}
           className={clsx([
-            enabled ? 'bg-melon' : 'bg-mercury-pinkish dark:bg-gun-powder',
+            darkModeEnabled
+              ? 'bg-melon'
+              : 'bg-mercury-pinkish dark:bg-gun-powder',
             'relative inline-flex h-6 w-11 items-center rounded-full',
           ])}
         >
           <span className="sr-only">Dark mode</span>
           <span
             className={clsx([
-              enabled ? 'translate-x-6' : 'translate-x-1',
+              darkModeEnabled ? 'translate-x-6' : 'translate-x-1',
+              'inline-block h-4 w-4 transform rounded-full bg-ciment-feet dark:bg-white transition',
+            ])}
+          />
+        </Switch>
+      </div>
+      <div className="flex flex-row justify-between items-center">
+        <p className="text-lg text-baltic-sea dark:text-mercury-pinkish">
+          {t('entry-selector')}
+        </p>
+        <Switch
+          checked={entrySelector}
+          onChange={handleEntrySelectorChange}
+          className={clsx([
+            entrySelector
+              ? 'bg-melon'
+              : 'bg-mercury-pinkish dark:bg-gun-powder',
+            'relative inline-flex h-6 w-11 items-center rounded-full',
+          ])}
+        >
+          <span className="sr-only">{t('entry-selector')}</span>
+          <span
+            className={clsx([
+              entrySelector ? 'translate-x-6' : 'translate-x-1',
               'inline-block h-4 w-4 transform rounded-full bg-ciment-feet dark:bg-white transition',
             ])}
           />

--- a/nym-vpn/ui/src/pages/settings/Settings.tsx
+++ b/nym-vpn/ui/src/pages/settings/Settings.tsx
@@ -2,25 +2,19 @@ import { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { invoke } from '@tauri-apps/api';
 import { Switch } from '@headlessui/react';
-import { useTranslation } from 'react-i18next';
 import { useMainDispatch, useMainState } from '../../contexts';
 import { StateDispatch } from '../../types';
-import { QuickConnectCountry } from '../../constants';
 
 function Settings() {
   const state = useMainState();
   const dispatch = useMainDispatch() as StateDispatch;
 
-  const { t } = useTranslation('settings');
-
   const [darkModeEnabled, setDarkModeEnabled] = useState(
     state.uiTheme === 'Dark',
   );
-  const [entrySelector, setEntrySelector] = useState(state.entrySelector);
 
   useEffect(() => {
     setDarkModeEnabled(state.uiTheme === 'Dark');
-    setEntrySelector(state.entrySelector);
   }, [state]);
 
   const handleThemeChange = async (darkMode: boolean) => {
@@ -34,34 +28,6 @@ function Settings() {
         console.log(e);
       },
     );
-  };
-
-  const handleDefaultEntryNodeSelection = async () => {
-    try {
-      await invoke<void>('set_node_location', {
-        nodeType: 'Entry',
-        country: QuickConnectCountry,
-      });
-      dispatch({
-        type: 'set-node-location',
-        payload: { hop: 'entry', country: QuickConnectCountry },
-      });
-    } catch (e) {
-      console.log(e);
-    }
-  };
-
-  const handleEntrySelectorChange = async () => {
-    const isSelected = !state.entrySelector;
-    dispatch({ type: 'set-entry-selector', entrySelector: isSelected });
-    invoke<void>('set_entry_selector', { entrySelector: isSelected }).catch(
-      (e) => {
-        console.log(e);
-      },
-    );
-    if (!isSelected) {
-      handleDefaultEntryNodeSelection();
-    }
   };
 
   return (
@@ -84,29 +50,6 @@ function Settings() {
           <span
             className={clsx([
               darkModeEnabled ? 'translate-x-6' : 'translate-x-1',
-              'inline-block h-4 w-4 transform rounded-full bg-ciment-feet dark:bg-white transition',
-            ])}
-          />
-        </Switch>
-      </div>
-      <div className="flex flex-row justify-between items-center">
-        <p className="text-lg text-baltic-sea dark:text-mercury-pinkish">
-          {t('entry-selector')}
-        </p>
-        <Switch
-          checked={entrySelector}
-          onChange={handleEntrySelectorChange}
-          className={clsx([
-            entrySelector
-              ? 'bg-melon'
-              : 'bg-mercury-pinkish dark:bg-gun-powder',
-            'relative inline-flex h-6 w-11 items-center rounded-full',
-          ])}
-        >
-          <span className="sr-only">{t('entry-selector')}</span>
-          <span
-            className={clsx([
-              entrySelector ? 'translate-x-6' : 'translate-x-1',
               'inline-block h-4 w-4 transform rounded-full bg-ciment-feet dark:bg-white transition',
             ])}
           />

--- a/nym-vpn/ui/src/state/main.ts
+++ b/nym-vpn/ui/src/state/main.ts
@@ -13,6 +13,7 @@ export type StateAction =
   | { type: 'set-partial-state'; partialState: Partial<AppState> }
   | { type: 'change-connection-state'; state: ConnectionState }
   | { type: 'set-vpn-mode'; mode: VpnMode }
+  | { type: 'set-entry-selector'; entrySelector: boolean }
   | { type: 'set-error'; error: string }
   | { type: 'reset-error' }
   | { type: 'new-progress-message'; message: ConnectProgressMsg }
@@ -23,17 +24,20 @@ export type StateAction =
   | { type: 'set-disconnected' }
   | { type: 'reset' }
   | { type: 'set-ui-theme'; theme: UiTheme }
+  | { type: 'set-countries'; countries: Country[] }
   | { type: 'set-node-location'; payload: { hop: NodeHop; country: Country } };
 
 export const initialState: AppState = {
   state: 'Disconnected',
   loading: false,
   vpnMode: 'Mixnet',
+  entrySelector: false,
   tunnel: { name: 'nym', id: 'nym' },
   uiTheme: 'Light',
   progressMessages: [],
   entryNodeLocation: null,
   exitNodeLocation: null,
+  countries: [],
 };
 
 export function reducer(state: AppState, action: StateAction): AppState {
@@ -53,6 +57,16 @@ export function reducer(state: AppState, action: StateAction): AppState {
       return {
         ...state,
         vpnMode: action.mode,
+      };
+    case 'set-entry-selector':
+      return {
+        ...state,
+        entrySelector: action.entrySelector,
+      };
+    case 'set-countries':
+      return {
+        ...state,
+        countries: action.countries,
       };
     case 'set-partial-state': {
       return { ...state, ...action.partialState };

--- a/nym-vpn/ui/src/state/main.ts
+++ b/nym-vpn/ui/src/state/main.ts
@@ -30,7 +30,7 @@ export type StateAction =
 export const initialState: AppState = {
   state: 'Disconnected',
   loading: false,
-  vpnMode: 'Mixnet',
+  vpnMode: 'TwoHop',
   entrySelector: false,
   tunnel: { name: 'nym', id: 'nym' },
   uiTheme: 'Light',

--- a/nym-vpn/ui/src/state/main.ts
+++ b/nym-vpn/ui/src/state/main.ts
@@ -12,6 +12,7 @@ export type StateAction =
   | { type: 'set-partial-state'; partialState: Partial<AppState> }
   | { type: 'change-connection-state'; state: ConnectionState }
   | { type: 'set-vpn-mode'; mode: VpnMode }
+  | { type: 'set-entry-selector'; entrySelector: boolean }
   | { type: 'set-error'; error: string }
   | { type: 'reset-error' }
   | { type: 'new-progress-message'; message: string }
@@ -22,17 +23,20 @@ export type StateAction =
   | { type: 'set-disconnected' }
   | { type: 'reset' }
   | { type: 'set-ui-theme'; theme: UiTheme }
+  | { type: 'set-countries'; countries: Country[] }
   | { type: 'set-node-location'; payload: { hop: NodeHop; country: Country } };
 
 export const initialState: AppState = {
   state: 'Disconnected',
   loading: false,
   vpnMode: 'TwoHop',
+  entrySelector: false,
   tunnel: { name: 'nym', id: 'nym' },
   uiTheme: 'Light',
   progressMessages: [],
   entryNodeLocation: null,
   exitNodeLocation: null,
+  countries: [],
 };
 
 export function reducer(state: AppState, action: StateAction): AppState {
@@ -52,6 +56,16 @@ export function reducer(state: AppState, action: StateAction): AppState {
       return {
         ...state,
         vpnMode: action.mode,
+      };
+    case 'set-entry-selector':
+      return {
+        ...state,
+        entrySelector: action.entrySelector,
+      };
+    case 'set-countries':
+      return {
+        ...state,
+        countries: action.countries,
       };
     case 'set-partial-state': {
       return { ...state, ...action.partialState };

--- a/nym-vpn/ui/src/state/main.ts
+++ b/nym-vpn/ui/src/state/main.ts
@@ -25,7 +25,8 @@ export type StateAction =
   | { type: 'reset' }
   | { type: 'set-ui-theme'; theme: UiTheme }
   | { type: 'set-countries'; countries: Country[] }
-  | { type: 'set-node-location'; payload: { hop: NodeHop; country: Country } };
+  | { type: 'set-node-location'; payload: { hop: NodeHop; country: Country } }
+  | { type: 'set-default-node-location'; country: Country };
 
 export const initialState: AppState = {
   state: 'Disconnected',
@@ -37,6 +38,10 @@ export const initialState: AppState = {
   progressMessages: [],
   entryNodeLocation: null,
   exitNodeLocation: null,
+  defaultNodeLocation: {
+    name: 'France',
+    code: 'FR',
+  },
   countries: [],
 };
 
@@ -134,6 +139,11 @@ export function reducer(state: AppState, action: StateAction): AppState {
       return {
         ...state,
         uiTheme: action.theme,
+      };
+    case 'set-default-node-location':
+      return {
+        ...state,
+        defaultNodeLocation: action.country,
       };
     case 'reset':
       return initialState;

--- a/nym-vpn/ui/src/state/provider.tsx
+++ b/nym-vpn/ui/src/state/provider.tsx
@@ -60,7 +60,7 @@ export function MainStateProvider({ children }: Props) {
         dispatch({
           type: 'set-partial-state',
           partialState: {
-            entrySelector: data.entry_selector || false,
+            entrySelector: data.entry_location_selector || false,
             uiTheme: data.ui_theme || 'Light',
             vpnMode: data.vpn_mode || 'TwoHop',
             entryNodeLocation: data.entry_node_location || QuickConnectCountry,

--- a/nym-vpn/ui/src/types/app-data.ts
+++ b/nym-vpn/ui/src/types/app-data.ts
@@ -17,6 +17,7 @@ export interface AppDataFromBackend {
   monitoring: boolean | null;
   autoconnect: boolean | null;
   killswitch: boolean | null;
+  entry_selector: boolean | null;
   ui_theme: UiTheme | null;
   vpn_mode: VpnMode | null;
   entry_node: NodeConfig | null;

--- a/nym-vpn/ui/src/types/app-data.ts
+++ b/nym-vpn/ui/src/types/app-data.ts
@@ -17,7 +17,7 @@ export interface AppDataFromBackend {
   monitoring: boolean | null;
   autoconnect: boolean | null;
   killswitch: boolean | null;
-  entry_selector: boolean | null;
+  entry_location_selector: boolean | null;
   ui_theme: UiTheme | null;
   vpn_mode: VpnMode | null;
   entry_node: NodeConfig | null;

--- a/nym-vpn/ui/src/types/app-state.ts
+++ b/nym-vpn/ui/src/types/app-state.ts
@@ -26,8 +26,10 @@ export type AppState = {
   vpnMode: VpnMode;
   tunnel: TunnelConfig;
   uiTheme: 'Light' | 'Dark';
+  entrySelector: boolean;
   entryNodeLocation: Country | null;
   exitNodeLocation: Country | null;
+  countries: Country[];
 };
 
 export type ConnectionEventPayload = {

--- a/nym-vpn/ui/src/types/app-state.ts
+++ b/nym-vpn/ui/src/types/app-state.ts
@@ -29,6 +29,7 @@ export type AppState = {
   entrySelector: boolean;
   entryNodeLocation: Country | null;
   exitNodeLocation: Country | null;
+  defaultNodeLocation: Country;
   countries: Country[];
 };
 


### PR DESCRIPTION
# Description

Add entry node selection setting to settings screen

Toggling off entry node selection resets entry node to default quick selection node

Country list loaded from storage cache on app load

Request update to country list cache on navigation to NodeLocation screen

Set Quick connect text to 'Recommended' and display bolt for recommended country
