### PR TITLE
Replace panic with error for inserting duplicate pending ack

### DIFF
--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/action_controller.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/action_controller.rs
@@ -127,7 +127,9 @@ impl ActionController {
                 .insert(frag_id, (Arc::new(pending_ack), None))
                 .is_some()
             {
-                panic!("Tried to insert duplicate pending ack")
+                // This used to be a panic, however since we've seen this actually happen in the
+                // wild, let's not take the whole client (and possibly gateway) down because of it.
+                error!("Tried to insert duplicate pending ack! This should not be possible!")
             }
         }
     }


### PR DESCRIPTION
Inserting a duplicating pending ack should not be possible. But we've seen this happen in the wild, so we shouldn't take the client (and gateway when the IPR is running) because of it.

Possibly cause is if hitting RNG lottery or if there is a async cancellation happening making the ack being inserted with the future being dropped before it completes.

See #4406 for how to reproduce this