### PR TITLE
Tweak task dropped log verbosity

### DIFF
--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -494,13 +494,13 @@ impl Drop for TaskClient {
     fn drop(&mut self) {
         if !self.mode.should_signal_on_drop() {
             self.log(
-                Level::Debug,
-                "the task client is getting dropped: this is expected during client shutdown",
+                Level::Trace,
+                "the task client is getting dropped but inststructed to not signal: this is expected during client shutdown",
             );
             return;
         } else {
             self.log(
-                Level::Info,
+                Level::Debug,
                 "the task client is getting dropped: this is expected during client shutdown",
             );
         }


### PR DESCRIPTION
# Description

There was some accidental changes of the verbosity of these messages. After discussion it was agreed to restore them to the value before the most recent change
