### PR TITLE
Apply exit policy check on destination ips without port

### DIFF
--- a/common/exit-policy/src/lib.rs
+++ b/common/exit-policy/src/lib.rs
@@ -81,6 +81,15 @@ ExitPolicy accept6 *6:119
 ExitPolicy accept *4:120
 ExitPolicy reject6 [FC00::]/7:*
 
+# Portless
+ExitPolicy accept *:0
+ExitPolicy accept *4:0
+ExitPolicy accept *6:0
+
+ExitPolicy reject *:0
+ExitPolicy reject *4:0
+ExitPolicy reject *6:0
+
 #ExitPolicy accept *:8080 #and another comment here
 
 ExitPolicy reject FE80:0000:0000:0000:0202:B3FF:FE1E:8329:*
@@ -181,6 +190,60 @@ ExitPolicy reject *:*
                     mask: 7,
                 },
                 ports: PortRange::new_all(),
+            },
+        );
+
+        // ExitPolicy accept *:0
+        expected.push(
+            Accept,
+            AddressPortPattern {
+                ip_pattern: IpPattern::Star,
+                ports: PortRange::new_zero(),
+            },
+        );
+
+        // ExitPolicy accept *4:0
+        expected.push(
+            Accept,
+            AddressPortPattern {
+                ip_pattern: IpPattern::V4Star,
+                ports: PortRange::new_zero(),
+            },
+        );
+
+        // ExitPolicy accept *6:0
+        expected.push(
+            Accept,
+            AddressPortPattern {
+                ip_pattern: IpPattern::V6Star,
+                ports: PortRange::new_zero(),
+            },
+        );
+
+        // ExitPolicy reject *:0
+        expected.push(
+            Reject,
+            AddressPortPattern {
+                ip_pattern: IpPattern::Star,
+                ports: PortRange::new_zero(),
+            },
+        );
+
+        // ExitPolicy reject *4:0
+        expected.push(
+            Reject,
+            AddressPortPattern {
+                ip_pattern: IpPattern::V4Star,
+                ports: PortRange::new_zero(),
+            },
+        );
+
+        // ExitPolicy reject *6:0
+        expected.push(
+            Reject,
+            AddressPortPattern {
+                ip_pattern: IpPattern::V6Star,
+                ports: PortRange::new_zero(),
             },
         );
 

--- a/service-providers/ip-packet-router/src/error.rs
+++ b/service-providers/ip-packet-router/src/error.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 pub use nym_client_core::error::ClientCoreError;
 use nym_exit_policy::PolicyError;
@@ -57,8 +57,14 @@ pub enum IpPacketRouterError {
     #[error("the provided socket address, '{addr}' is not covered by the exit policy!")]
     AddressNotCoveredByExitPolicy { addr: SocketAddr },
 
+    #[error("the provided ip address, '{ip}' is not covered by the exit policy!")]
+    IpNotCoveredByExitPolicy { ip: IpAddr },
+
     #[error("failed filter check: '{addr}'")]
     AddressFailedFilterCheck { addr: SocketAddr },
+
+    #[error("failed filter check: '{ip}'")]
+    IpFailedFilterCheck { ip: IpAddr },
 
     #[error("failed to apply the exit policy: {source}")]
     ExitPolicyFailure {


### PR DESCRIPTION
# Description

Closes: #4259 

To be able to apply the exit policy to packets without ports assigned to them we have to be a little creative to not break backwards compatibility.

As a first step we add the ability to parse port 0, which is then interpreted as portless packets.

However since we can't add a rule like `ExitPolicy accept *:0` to the main list without breaking older running gateways, in the match logic we temporarily treat port 0 like a wildcard.

```rust
// For backward compatibility, we treat port 0 as a wildcard until all gateways have
// upgraded, at which point we can add *:0 to the policy list.
if port == 0 {
    self.ip_pattern.matches(addr)
} else {
    self.ip_pattern.matches(addr) && self.ports.contains(port)
}
```

This will give the desired behaviour by coincidence, since the first allow rule `ExitPolicy accept *:20-21 # FTP` will then mean we allow portless packets for all IP that has not yet already have a reject policy applied to them.

Once enough gateways have upgraded to the new version that can parse port 0, we can instead add an entry
```
ExitPolicy accept *:0 # portless packets, like ICMP
```
and revert the match logic, which will make the exit-policy consistent again.