### PR TITLE
feat(vpn-deskop): add ui zoom level setting

### DIFF
--- a/nym-vpn/ui/README.md
+++ b/nym-vpn/ui/README.md
@@ -38,7 +38,7 @@ For example on Linux the path would be `~/.config/nym-vpn/config.toml`
 # example config on Linux
 
 # path to the env config file if you provide one
-env_config_file = "$HOME/.config/nym-vpn/qa.env"
+env_config_file = "/home/<USER>/.config/nym-vpn/qa.env"
 ```
 
 ## Optional config
@@ -46,7 +46,7 @@ env_config_file = "$HOME/.config/nym-vpn/qa.env"
 In the config file `nym-vpn/config.toml`
 
 ```toml
-env_config_file = "$HOME/.config/nym-vpn/qa.env"
+env_config_file = "/home/<USER>/.config/nym-vpn/qa.env"
 
 # set the entry node location to use, as two letter country code
 entry_node_location = "FR"

--- a/nym-vpn/ui/index.html
+++ b/nym-vpn/ui/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="text-[14px]">
+<html lang="en" class="text-[12px]">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/nym-vpn/ui/src-tauri/src/commands/app_data.rs
+++ b/nym-vpn/ui/src-tauri/src/commands/app_data.rs
@@ -80,6 +80,28 @@ pub async fn set_ui_theme(
 
 #[instrument(skip(data_state))]
 #[tauri::command]
+pub async fn set_root_font_size(
+    data_state: State<'_, SharedAppData>,
+    size: u32,
+) -> Result<(), CmdError> {
+    debug!("set_root_font_size");
+
+    let mut app_data_store = data_state.lock().await;
+    let mut app_data = app_data_store
+        .read()
+        .await
+        .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
+    app_data.ui_root_font_size = Some(size);
+    app_data_store.data = app_data;
+    app_data_store
+        .write()
+        .await
+        .map_err(|e| CmdError::new(CmdErrorSource::InternalError, e.to_string()))?;
+    Ok(())
+}
+
+#[instrument(skip(data_state))]
+#[tauri::command]
 pub async fn set_entry_location_selector(
     data_state: State<'_, SharedAppData>,
     entry_selector: bool,

--- a/nym-vpn/ui/src-tauri/src/fs/data.rs
+++ b/nym-vpn/ui/src-tauri/src/fs/data.rs
@@ -19,6 +19,7 @@ pub struct AppData {
     pub killswitch: Option<bool>,
     pub entry_location_selector: Option<bool>,
     pub ui_theme: Option<UiTheme>,
+    pub ui_root_font_size: Option<u32>,
     pub vpn_mode: Option<VpnMode>,
     pub entry_node: Option<NodeConfig>,
     pub exit_node: Option<NodeConfig>,

--- a/nym-vpn/ui/src-tauri/src/main.rs
+++ b/nym-vpn/ui/src-tauri/src/main.rs
@@ -109,6 +109,7 @@ async fn main() -> Result<()> {
             app_data::set_ui_theme,
             app_data::set_entry_location_selector,
             app_data::get_node_countries,
+            app_data::set_root_font_size,
             node_location::set_node_location,
             node_location::get_default_node_location,
         ])

--- a/nym-vpn/ui/src/constants.ts
+++ b/nym-vpn/ui/src/constants.ts
@@ -9,3 +9,5 @@ export const AppName = 'NymVPN';
 export const ConnectionEvent = 'connection-state';
 export const ProgressEvent = 'connection-progress';
 export const QuickConnectPrefix = 'Fastest';
+// TODO ⚠ keep this value in sync with the one declared in `index.html`
+export const DefaultRootFontSize = 12; // in px

--- a/nym-vpn/ui/src/dev/setup.ts
+++ b/nym-vpn/ui/src/dev/setup.ts
@@ -65,6 +65,10 @@ export function mockTauriIPC() {
       );
     }
 
+    if (cmd === 'set_root_font_size') {
+      return new Promise<void>((resolve) => resolve());
+    }
+
     if (cmd === 'get_app_data') {
       return new Promise<AppDataFromBackend>((resolve) =>
         resolve({
@@ -73,6 +77,7 @@ export function mockTauriIPC() {
           killswitch: false,
           entry_location_selector: false,
           ui_theme: 'Dark',
+          ui_root_font_size: 12,
           vpn_mode: 'TwoHop',
           entry_node: {
             country: {

--- a/nym-vpn/ui/src/pages/home/Home.tsx
+++ b/nym-vpn/ui/src/pages/home/Home.tsx
@@ -90,7 +90,9 @@ function Home() {
         </div>
         <Button
           className={clsx([
-            'rounded-lg text-lg font-bold py-4 px-6 h-16 focus:outline-none focus:ring-4 focus:ring-black focus:dark:ring-white shadow',
+            'flex justify-center items-center',
+            'rounded-lg text-lg font-bold py-4 px-6 h-16',
+            'focus:outline-none focus:ring-4 focus:ring-black focus:dark:ring-white shadow',
             (state === 'Disconnected' || state === 'Connecting') &&
               'bg-melon text-white dark:text-baltic-sea',
             (state === 'Connected' || state === 'Disconnecting') &&

--- a/nym-vpn/ui/src/pages/home/HopSelect.tsx
+++ b/nym-vpn/ui/src/pages/home/HopSelect.tsx
@@ -46,7 +46,7 @@ export default function HopSelect({
         />
         <div className="text-base">{country.name}</div>
       </div>
-      <span className="font-icon scale-150 pointer-events-none">
+      <span className="font-icon text-2xl pointer-events-none">
         arrow_right
       </span>
     </div>

--- a/nym-vpn/ui/src/pages/settings/Settings.tsx
+++ b/nym-vpn/ui/src/pages/settings/Settings.tsx
@@ -4,6 +4,7 @@ import { invoke } from '@tauri-apps/api';
 import { Switch } from '@headlessui/react';
 import { useMainDispatch, useMainState } from '../../contexts';
 import { StateDispatch } from '../../types';
+import UiScaler from './UiScaler';
 
 function Settings() {
   const state = useMainState();
@@ -55,6 +56,7 @@ function Settings() {
           />
         </Switch>
       </div>
+      <UiScaler />
     </div>
   );
 }

--- a/nym-vpn/ui/src/pages/settings/UiScaler.tsx
+++ b/nym-vpn/ui/src/pages/settings/UiScaler.tsx
@@ -1,0 +1,47 @@
+import { ChangeEvent, useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api';
+import { useMainDispatch, useMainState } from '../../contexts';
+import { CmdError, StateDispatch } from '../../types';
+
+function UiScaler() {
+  const [slideValue, setSlideValue] = useState(12);
+  const dispatch = useMainDispatch() as StateDispatch;
+  const { rootFontSize } = useMainState();
+
+  useEffect(() => {
+    setSlideValue(rootFontSize);
+  }, [rootFontSize]);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setSlideValue(parseInt(e.target.value));
+    dispatch({ type: 'set-root-font-size', size: slideValue });
+  };
+
+  const setNewFontSize = () => {
+    document.documentElement.style.fontSize = `${slideValue}px`;
+    dispatch({ type: 'set-root-font-size', size: slideValue });
+    invoke('set_root_font_size', { size: slideValue }).catch((e: CmdError) => {
+      console.warn(`backend error: ${e.source} - ${e.message}`);
+    });
+  };
+
+  return (
+    <div className="flex flex-row justify-between items-center gap-10">
+      <p className="text-lg text-baltic-sea dark:text-mercury-pinkish flex-nowrap">
+        {`Zoom level: ${slideValue}`}
+      </p>
+      <input
+        type="range"
+        min="8"
+        max="20"
+        value={slideValue}
+        onChange={handleChange}
+        onMouseUp={setNewFontSize}
+        onKeyUp={setNewFontSize}
+        className="range flex flex-1 accent-melon"
+      />
+    </div>
+  );
+}
+
+export default UiScaler;

--- a/nym-vpn/ui/src/state/main.ts
+++ b/nym-vpn/ui/src/state/main.ts
@@ -26,7 +26,8 @@ export type StateAction =
   | { type: 'set-ui-theme'; theme: UiTheme }
   | { type: 'set-countries'; countries: Country[] }
   | { type: 'set-node-location'; payload: { hop: NodeHop; country: Country } }
-  | { type: 'set-default-node-location'; country: Country };
+  | { type: 'set-default-node-location'; country: Country }
+  | { type: 'set-root-font-size'; size: number };
 
 export const initialState: AppState = {
   state: 'Disconnected',
@@ -43,6 +44,7 @@ export const initialState: AppState = {
     code: 'FR',
   },
   countries: [],
+  rootFontSize: 12,
 };
 
 export function reducer(state: AppState, action: StateAction): AppState {
@@ -144,6 +146,11 @@ export function reducer(state: AppState, action: StateAction): AppState {
       return {
         ...state,
         defaultNodeLocation: action.country,
+      };
+    case 'set-root-font-size':
+      return {
+        ...state,
+        rootFontSize: action.size,
       };
     case 'reset':
       return initialState;

--- a/nym-vpn/ui/src/state/provider.tsx
+++ b/nym-vpn/ui/src/state/provider.tsx
@@ -7,6 +7,7 @@ import {
   ConnectionState,
   Country,
 } from '../types';
+import { DefaultRootFontSize } from '../constants';
 import { initialState, reducer } from './main';
 import { useTauriEvents } from './useTauriEvents';
 
@@ -89,10 +90,16 @@ export function MainStateProvider({ children }: Props) {
       .then((data) => {
         console.log('app data read from disk:');
         console.log(data);
+
+        if (data.ui_root_font_size) {
+          document.documentElement.style.fontSize = `${data.ui_root_font_size}px`;
+        }
+
         const partialState: Partial<typeof initialState> = {
           entrySelector: data.entry_location_selector || false,
           uiTheme: data.ui_theme || 'Light',
           vpnMode: data.vpn_mode || 'TwoHop',
+          rootFontSize: data.ui_root_font_size || DefaultRootFontSize,
         };
         if (data.entry_node_location) {
           partialState.entryNodeLocation = data.entry_node_location;

--- a/nym-vpn/ui/src/types/app-data.ts
+++ b/nym-vpn/ui/src/types/app-data.ts
@@ -19,6 +19,7 @@ export interface AppDataFromBackend {
   killswitch: boolean | null;
   entry_location_selector: boolean | null;
   ui_theme: UiTheme | null;
+  ui_root_font_size: number | null;
   vpn_mode: VpnMode | null;
   entry_node: NodeConfig | null;
   exit_node: NodeConfig | null;

--- a/nym-vpn/ui/src/types/app-state.ts
+++ b/nym-vpn/ui/src/types/app-state.ts
@@ -31,6 +31,7 @@ export type AppState = {
   exitNodeLocation: Country | null;
   defaultNodeLocation: Country;
   countries: Country[];
+  rootFontSize: number;
 };
 
 export type ConnectionEventPayload = {


### PR DESCRIPTION
# Description

![zoom_level](https://github.com/nymtech/nym/assets/6359431/080c77cc-82a9-4cff-8135-0fd341be31a8)

- add a slider to change overall zoom level of the UI in settings
- the level value set is saved on disk and restored after app restart
