### PR TITLE
[DOC]: Remove CCC event pages

### DIFF
--- a/documentation/dev-portal/src/SUMMARY.md
+++ b/documentation/dev-portal/src/SUMMARY.md
@@ -68,9 +68,6 @@
 
 # Events
 
-- [37C3](events/37c3/welcome.md)
-    - [NymVPN](events/37c3/nym-vpn.md)
-    - [FAQ](events/37c3/faq.md) 
 - [Web3Privacy Now](./events/web3-privacy.md)
 - [HCPP23-serinko](./events/hcpp23-serinko.md)
 - [HCPP23-max](./events/hcpp23-max.md)


### PR DESCRIPTION
## Description

A simple PR removing the CCC event guides from Developers Portal `SUMMARY.md`, while leaving their content as a non propagated text for future NymVPN user tutorials and testing sessions. 