### PR TITLE
Feature/delayed dkg start

### DIFF
--- a/common/client-libs/validator-client/src/nyxd/contract_traits/dkg_query_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/dkg_query_client.rs
@@ -7,7 +7,9 @@ use crate::nyxd::error::NyxdError;
 use crate::nyxd::CosmWasmClient;
 use async_trait::async_trait;
 use cosmrs::AccountId;
-use nym_coconut_dkg_common::{
+use serde::Deserialize;
+
+pub use nym_coconut_dkg_common::{
     dealer::{
         DealerDetailsResponse, DealingResponse, DealingStatusResponse, PagedDealerResponse,
         PagedDealingsResponse,
@@ -19,7 +21,6 @@ use nym_coconut_dkg_common::{
     },
     verification_key::{ContractVKShare, PagedVKSharesResponse},
 };
-use serde::Deserialize;
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/dkg_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/dkg_signing_client.rs
@@ -25,6 +25,13 @@ pub trait DkgSigningClient {
         funds: Vec<Coin>,
     ) -> Result<ExecuteResult, NyxdError>;
 
+    async fn initiate_dkg(&self, fee: Option<Fee>) -> Result<ExecuteResult, NyxdError> {
+        let req = DkgExecuteMsg::InitiateDkg {};
+
+        self.execute_dkg_contract(fee, req, "initiating the DKG".to_string(), vec![])
+            .await
+    }
+
     async fn advance_dkg_epoch_state(&self, fee: Option<Fee>) -> Result<ExecuteResult, NyxdError> {
         let req = DkgExecuteMsg::AdvanceEpochState {};
 
@@ -145,6 +152,7 @@ mod tests {
         msg: DkgExecuteMsg,
     ) {
         match msg {
+            DkgExecuteMsg::InitiateDkg {} => client.initiate_dkg(None).ignore(),
             DkgExecuteMsg::RegisterDealer {
                 bte_key_with_proof,
                 identity_key,

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/mod.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/mod.rs
@@ -8,26 +8,26 @@ use std::str::FromStr;
 // TODO: all of those could/should be derived via a macro
 
 // query clients
-mod coconut_bandwidth_query_client;
-mod dkg_query_client;
-mod ephemera_query_client;
-mod group_query_client;
-mod mixnet_query_client;
-mod multisig_query_client;
-mod name_service_query_client;
-mod sp_directory_query_client;
-mod vesting_query_client;
+pub mod coconut_bandwidth_query_client;
+pub mod dkg_query_client;
+pub mod ephemera_query_client;
+pub mod group_query_client;
+pub mod mixnet_query_client;
+pub mod multisig_query_client;
+pub mod name_service_query_client;
+pub mod sp_directory_query_client;
+pub mod vesting_query_client;
 
 // signing clients
-mod coconut_bandwidth_signing_client;
-mod dkg_signing_client;
-mod ephemera_signing_client;
-mod group_signing_client;
-mod mixnet_signing_client;
-mod multisig_signing_client;
-mod name_service_signing_client;
-mod sp_directory_signing_client;
-mod vesting_signing_client;
+pub mod coconut_bandwidth_signing_client;
+pub mod dkg_signing_client;
+pub mod ephemera_signing_client;
+pub mod group_signing_client;
+pub mod mixnet_signing_client;
+pub mod multisig_signing_client;
+pub mod name_service_signing_client;
+pub mod sp_directory_signing_client;
+pub mod vesting_signing_client;
 
 // re-export query traits
 pub use coconut_bandwidth_query_client::{

--- a/common/cosmwasm-smart-contracts/coconut-dkg/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/coconut-dkg/src/msg.rs
@@ -34,6 +34,9 @@ pub struct InstantiateMsg {
 
 #[cw_serde]
 pub enum ExecuteMsg {
+    // we could have just re-used AdvanceEpochState, but imo an explicit message is better
+    InitiateDkg {},
+    
     RegisterDealer {
         bte_key_with_proof: EncodedBTEPublicKeyWithProof,
         identity_key: IdentityKey,

--- a/common/cosmwasm-smart-contracts/coconut-dkg/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/coconut-dkg/src/msg.rs
@@ -36,7 +36,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     // we could have just re-used AdvanceEpochState, but imo an explicit message is better
     InitiateDkg {},
-    
+
     RegisterDealer {
         bte_key_with_proof: EncodedBTEPublicKeyWithProof,
         identity_key: IdentityKey,

--- a/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
+++ b/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
@@ -238,7 +238,7 @@ impl EpochState {
     pub fn first() -> Self {
         EpochState::PublicKeySubmission { resharing: false }
     }
-    
+
     pub fn next(self) -> Option<Self> {
         match self {
             EpochState::WaitingInitialisation => None,

--- a/contracts/coconut-dkg/schema/nym-coconut-dkg.json
+++ b/contracts/coconut-dkg/schema/nym-coconut-dkg.json
@@ -94,6 +94,19 @@
       {
         "type": "object",
         "required": [
+          "initiate_dkg"
+        ],
+        "properties": {
+          "initiate_dkg": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
           "register_dealer"
         ],
         "properties": {
@@ -660,7 +673,6 @@
       "type": "object",
       "required": [
         "epoch_id",
-        "finish_timestamp",
         "state",
         "time_configuration"
       ],
@@ -671,7 +683,14 @@
           "minimum": 0.0
         },
         "finish_timestamp": {
-          "$ref": "#/definitions/Timestamp"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Timestamp"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "state": {
           "$ref": "#/definitions/EpochState"
@@ -687,6 +706,7 @@
             {
               "type": "string",
               "enum": [
+                "waiting_initialisation",
                 "in_progress"
               ]
             },

--- a/contracts/coconut-dkg/schema/raw/execute.json
+++ b/contracts/coconut-dkg/schema/raw/execute.json
@@ -5,6 +5,19 @@
     {
       "type": "object",
       "required": [
+        "initiate_dkg"
+      ],
+      "properties": {
+        "initiate_dkg": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
         "register_dealer"
       ],
       "properties": {

--- a/contracts/coconut-dkg/schema/raw/response_to_get_current_epoch_state.json
+++ b/contracts/coconut-dkg/schema/raw/response_to_get_current_epoch_state.json
@@ -4,7 +4,6 @@
   "type": "object",
   "required": [
     "epoch_id",
-    "finish_timestamp",
     "state",
     "time_configuration"
   ],
@@ -15,7 +14,14 @@
       "minimum": 0.0
     },
     "finish_timestamp": {
-      "$ref": "#/definitions/Timestamp"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Timestamp"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "state": {
       "$ref": "#/definitions/EpochState"
@@ -31,6 +37,7 @@
         {
           "type": "string",
           "enum": [
+            "waiting_initialisation",
             "in_progress"
           ]
         },

--- a/contracts/coconut-dkg/src/dealers/transactions.rs
+++ b/contracts/coconut-dkg/src/dealers/transactions.rs
@@ -79,10 +79,10 @@ pub fn try_add_dealer(
 pub(crate) mod tests {
     use super::*;
     use crate::dealers::storage::current_dealers;
-    use crate::epoch_state::transactions::advance_epoch_state;
+    use crate::epoch_state::transactions::{advance_epoch_state, try_initiate_dkg};
     use crate::support::tests::fixtures::dealer_details_fixture;
     use crate::support::tests::helpers;
-    use crate::support::tests::helpers::{add_fixture_dealer, GROUP_MEMBERS};
+    use crate::support::tests::helpers::{add_fixture_dealer, ADMIN_ADDRESS, GROUP_MEMBERS};
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cw4::Member;
     use nym_coconut_dkg_common::types::{InitialReplacementData, TimeConfiguration};
@@ -139,8 +139,10 @@ pub(crate) mod tests {
     #[test]
     fn invalid_state() {
         let mut deps = helpers::init_contract();
-        let owner = Addr::unchecked("owner");
         let mut env = mock_env();
+        try_initiate_dkg(deps.as_mut(), env.clone(), mock_info(ADMIN_ADDRESS, &[])).unwrap();
+
+        let owner = Addr::unchecked("owner");
         let info = mock_info(owner.as_str(), &[]);
         let bte_key_with_proof = String::from("bte_key_with_proof");
         let identity = String::from("identity");
@@ -167,7 +169,7 @@ pub(crate) mod tests {
             ret,
             ContractError::IncorrectEpochState {
                 current_state: EpochState::DealingExchange { resharing: false }.to_string(),
-                expected_state: EpochState::default().to_string(),
+                expected_state: EpochState::PublicKeySubmission { resharing: false }.to_string(),
             }
         );
     }

--- a/contracts/coconut-dkg/src/dealings/transactions.rs
+++ b/contracts/coconut-dkg/src/dealings/transactions.rs
@@ -65,10 +65,10 @@ pub fn try_commit_dealings(
 pub(crate) mod tests {
     use super::*;
     use crate::epoch_state::storage::CURRENT_EPOCH;
-    use crate::epoch_state::transactions::advance_epoch_state;
+    use crate::epoch_state::transactions::{advance_epoch_state, try_initiate_dkg};
     use crate::support::tests::fixtures::{dealer_details_fixture, partial_dealing_fixture};
     use crate::support::tests::helpers;
-    use crate::support::tests::helpers::add_fixture_dealer;
+    use crate::support::tests::helpers::{add_fixture_dealer, ADMIN_ADDRESS};
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cosmwasm_std::Addr;
     use nym_coconut_dkg_common::dealer::DealerDetails;
@@ -79,8 +79,10 @@ pub(crate) mod tests {
     #[test]
     fn invalid_commit_dealing() {
         let mut deps = helpers::init_contract();
-        let owner = Addr::unchecked("owner1");
         let mut env = mock_env();
+        try_initiate_dkg(deps.as_mut(), env.clone(), mock_info(ADMIN_ADDRESS, &[])).unwrap();
+
+        let owner = Addr::unchecked("owner1");
         let info = mock_info(owner.as_str(), &[]);
         let dealing = partial_dealing_fixture();
 
@@ -89,7 +91,7 @@ pub(crate) mod tests {
         assert_eq!(
             ret,
             ContractError::IncorrectEpochState {
-                current_state: EpochState::default().to_string(),
+                current_state: EpochState::PublicKeySubmission { resharing: false }.to_string(),
                 expected_state: EpochState::DealingExchange { resharing: false }.to_string()
             }
         );

--- a/contracts/coconut-dkg/src/epoch_state/utils.rs
+++ b/contracts/coconut-dkg/src/epoch_state/utils.rs
@@ -33,14 +33,14 @@ pub(crate) mod test {
         let mut deps = init_contract();
         let env = mock_env();
 
-        for fixed_state in EpochState::default().all_until(EpochState::InProgress) {
+        for fixed_state in EpochState::first().all_until(EpochState::InProgress) {
             CURRENT_EPOCH
                 .save(
                     deps.as_mut().storage,
                     &Epoch::new(fixed_state, 0, TimeConfiguration::default(), env.block.time),
                 )
                 .unwrap();
-            for against_state in EpochState::default().all_until(EpochState::InProgress) {
+            for against_state in EpochState::first().all_until(EpochState::InProgress) {
                 let ret = check_epoch_state(deps.as_mut().storage, against_state);
                 if fixed_state == against_state {
                     assert!(ret.is_ok());

--- a/contracts/coconut-dkg/src/error.rs
+++ b/contracts/coconut-dkg/src/error.rs
@@ -15,6 +15,12 @@ pub enum ContractError {
     #[error(transparent)]
     Admin(#[from] AdminError),
 
+    #[error("Dkg hasn't been initialised yet")]
+    WaitingInitialisation,
+
+    #[error("Dkg has already been initialised")]
+    AlreadyInitialised,
+
     #[error("Group contract invalid address '{addr}'")]
     InvalidGroup { addr: String },
 

--- a/contracts/coconut-dkg/src/state/storage.rs
+++ b/contracts/coconut-dkg/src/state/storage.rs
@@ -6,5 +6,8 @@ use cw_storage_plus::Item;
 use nym_coconut_dkg_common::types::State;
 
 // unique items
+pub const DKG_ADMIN: Admin = Admin::new("dkg-admin");
+
 pub const STATE: Item<State> = Item::new("state");
+
 pub const MULTISIG: Admin = Admin::new("multisig");

--- a/contracts/coconut-dkg/src/verification_key_shares/transactions.rs
+++ b/contracts/coconut-dkg/src/verification_key_shares/transactions.rs
@@ -91,9 +91,9 @@ pub fn try_verify_verification_key_share(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::epoch_state::transactions::advance_epoch_state;
+    use crate::epoch_state::transactions::{advance_epoch_state, try_initiate_dkg};
     use crate::support::tests::helpers;
-    use crate::support::tests::helpers::{add_fixture_dealer, MULTISIG_CONTRACT};
+    use crate::support::tests::helpers::{add_fixture_dealer, ADMIN_ADDRESS, MULTISIG_CONTRACT};
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cw_controllers::AdminError;
     use nym_coconut_dkg_common::dealer::DealerDetails;
@@ -103,6 +103,8 @@ mod tests {
     fn current_epoch_id() {
         let mut deps = helpers::init_contract();
         let mut env = mock_env();
+        try_initiate_dkg(deps.as_mut(), env.clone(), mock_info(ADMIN_ADDRESS, &[])).unwrap();
+
         let info = mock_info("requester", &[]);
         let share = "share".to_string();
 
@@ -150,6 +152,8 @@ mod tests {
     fn commit_vk_share() {
         let mut deps = helpers::init_contract();
         let mut env = mock_env();
+        try_initiate_dkg(deps.as_mut(), env.clone(), mock_info(ADMIN_ADDRESS, &[])).unwrap();
+
         let info = mock_info("requester", &[]);
         let share = "share".to_string();
 
@@ -164,7 +168,7 @@ mod tests {
         assert_eq!(
             ret,
             ContractError::IncorrectEpochState {
-                current_state: EpochState::default().to_string(),
+                current_state: EpochState::PublicKeySubmission { resharing: false }.to_string(),
                 expected_state: EpochState::VerificationKeySubmission { resharing: false }
                     .to_string()
             }
@@ -225,6 +229,8 @@ mod tests {
     fn invalid_verify_vk_share() {
         let mut deps = helpers::init_contract();
         let mut env = mock_env();
+        try_initiate_dkg(deps.as_mut(), env.clone(), mock_info(ADMIN_ADDRESS, &[])).unwrap();
+
         let info = mock_info("requester", &[]);
         let owner = Addr::unchecked("owner");
         let multisig_info = mock_info(MULTISIG_CONTRACT, &[]);
@@ -235,7 +241,7 @@ mod tests {
         assert_eq!(
             ret,
             ContractError::IncorrectEpochState {
-                current_state: EpochState::default().to_string(),
+                current_state: EpochState::PublicKeySubmission { resharing: false }.to_string(),
                 expected_state: EpochState::VerificationKeyFinalization { resharing: false }
                     .to_string()
             }
@@ -282,6 +288,8 @@ mod tests {
     fn verify_vk_share() {
         let mut deps = helpers::init_contract();
         let mut env = mock_env();
+        try_initiate_dkg(deps.as_mut(), env.clone(), mock_info(ADMIN_ADDRESS, &[])).unwrap();
+
         let owner = Addr::unchecked("owner");
         let info = mock_info(owner.as_ref(), &[]);
         let share = "share".to_string();

--- a/nym-api/src/coconut/dkg/state.rs
+++ b/nym-api/src/coconut/dkg/state.rs
@@ -73,6 +73,7 @@ pub(crate) trait ConsistentState {
     fn proposal_id_value(&self) -> Result<u64, CoconutError>;
     async fn is_consistent(&self, epoch_state: EpochState) -> Result<(), CoconutError> {
         match epoch_state {
+            EpochState::WaitingInitialisation => {}
             EpochState::PublicKeySubmission { .. } => {}
             EpochState::DealingExchange { .. } => {
                 self.node_index_value()?;


### PR DESCRIPTION
BN-31 train continues.

this PR changes the DKG initiation behaviour so that the process doesn't start immediately upon contract creation. instead it waits for a `initiate_dkg: {}` message to be sent.

the PR dependency: https://github.com/nymtech/nym/pull/4288 => https://github.com/nymtech/nym/pull/4289 => https://github.com/nymtech/nym/pull/4290 => https://github.com/nymtech/nym/pull/4291
