### PR TITLE
Feature/canonical cw3 cw4 step1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cw-plus"]
+	path = cw-plus
+	url = git@github.com:CosmWasm/cw-plus.git

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,22 @@ CONTRACTS_OUT_DIR=contracts/target/wasm32-unknown-unknown/release
 
 contracts: build-release-contracts wasm-opt-contracts
 
+multisig: prepare-cw-plus build-cw3 build-cw4 opt-cw3 opt-cw4
+prepare-cw-plus:
+	git -C cw-plus fetch
+	# make sure to use correct version
+	git -C cw-plus reset --hard v1.0.0
+
+build-cw3:
+	RUSTFLAGS='-C link-arg=-s' cargo build --manifest-path cw-plus/contracts/cw3-flex-multisig/Cargo.toml --release --lib --target wasm32-unknown-unknown
+build-cw4:
+	RUSTFLAGS='-C link-arg=-s' cargo build --manifest-path cw-plus/contracts/cw4-group/Cargo.toml --release --lib --target wasm32-unknown-unknown
+
+opt-cw3:
+	wasm-opt --signext-lowering -Os cw-plus/target/wasm32-unknown-unknown/release/cw3_flex_multisig.wasm -o cw-plus/target/wasm32-unknown-unknown/release/cw3_flex_multisig.wasm
+opt-cw4:
+	wasm-opt --signext-lowering -Os cw-plus/target/wasm32-unknown-unknown/release/cw4_group.wasm -o cw-plus/target/wasm32-unknown-unknown/release/cw4_group.wasm
+
 wasm-opt-contracts:
 	for contract in $(CONTRACTS_WASM); do \
 	  wasm-opt --signext-lowering -Os $(CONTRACTS_OUT_DIR)/$$contract -o $(CONTRACTS_OUT_DIR)/$$contract; \

--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,9 @@ CONTRACTS=vesting_contract mixnet_contract nym_service_provider_directory nym_na
 CONTRACTS_WASM=$(addsuffix .wasm, $(CONTRACTS))
 CONTRACTS_OUT_DIR=contracts/target/wasm32-unknown-unknown/release
 
-contracts: build-release-contracts wasm-opt-contracts
+contracts: build-release-contracts wasm-opt-contracts canonical-multisig
 
-multisig: prepare-cw-plus build-cw3 build-cw4 opt-cw3 opt-cw4
+canonical-multisig: prepare-cw-plus build-cw3 build-cw4 opt-cw3 opt-cw4
 prepare-cw-plus:
 	git -C cw-plus fetch
 	# make sure to use correct version


### PR DESCRIPTION
This is a step 1 towards making us use canonical cw3-flex-multisig and cw4-group contracts. Right now I've just included make directives to build the relevant wasm blobs.

The remaining changes will need to be made in our deployment to:
- use those contracts,
- make the DKG contract and coconut bandwidth contracts non-voting group members after instantiation (i.e. voting power of 0)

However, there will be one change of the behaviour that I'm not 100% sure we want, i.e. the other group members, i.e. the DKG participants will be able to create their own proposals. But is it a problem given that even if there was a malicious proposal, we'd need a quorum to actually pass it? 
For the time being I'm leaving this PR as a draft as the result of this question.

PR chain: https://github.com/nymtech/nym/pull/4288 => https://github.com/nymtech/nym/pull/4289 => https://github.com/nymtech/nym/pull/4290 => https://github.com/nymtech/nym/pull/4291 => https://github.com/nymtech/nym/pull/4292