### PR TITLE
Don't build wg deps where it's not supported

### DIFF
--- a/common/wireguard/Cargo.toml
+++ b/common/wireguard/Cargo.toml
@@ -16,10 +16,12 @@ base64 = "0.21.3"
 # version mismatch with x25519-dalek/curve25519-dalek that is resolved in the
 # latest commit. So pick that for now.
 x25519-dalek = "2.0.0"
-defguard_wireguard_rs = { git = "https://github.com/neacsu/wireguard-rs.git", rev = "c2cd0c1119f699f4bc43f5e6ffd6fc242caa42ed" }
 ip_network = "0.4.1"
 log.workspace = true
 nym-network-defaults = { path = "../network-defaults" }
 nym-task = { path = "../task" }
 nym-wireguard-types = { path = "../wireguard-types" }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
+
+[target."cfg(target_os = \"linux\")".dependencies]
+defguard_wireguard_rs = { git = "https://github.com/neacsu/wireguard-rs.git", rev = "c2cd0c1119f699f4bc43f5e6ffd6fc242caa42ed" }

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -50,5 +50,5 @@ pub async fn start_wireguard(
 
 #[cfg(not(target_os = "linux"))]
 pub async fn start_wireguard() {
-    todo!("WireGuard is currently only supported on Linux")
+    todo!("WireGuard is currently only supported on Linux");
 }

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -8,21 +8,17 @@ pub mod setup;
 use nym_wireguard_types::registration::GatewayClientRegistry;
 use std::sync::Arc;
 
-#[cfg(target_os = "linux")]
-use defguard_wireguard_rs::{
-    host::Peer, key::Key, net::IpAddrMask, InterfaceConfiguration, WGApi, WireguardInterfaceApi,
-};
-
-#[cfg(target_os = "linux")]
-use nym_network_defaults::{WG_PORT, WG_TUN_DEVICE_ADDRESS};
-
 /// Start wireguard device
 #[cfg(target_os = "linux")]
 pub async fn start_wireguard(
     mut task_client: nym_task::TaskClient,
     _gateway_client_registry: Arc<GatewayClientRegistry>,
-) -> Result<WGApi, Box<dyn std::error::Error + Send + Sync + 'static>> {
+) -> Result<defguard_wireguard_rs::WGApi, Box<dyn std::error::Error + Send + Sync + 'static>> {
     use crate::setup::{peer_allowed_ips, peer_static_public_key, PRIVATE_KEY};
+    use defguard_wireguard_rs::{
+        host::Peer, key::Key, net::IpAddrMask, InterfaceConfiguration, WGApi, WireguardInterfaceApi,
+    };
+    use nym_network_defaults::{WG_PORT, WG_TUN_DEVICE_ADDRESS};
 
     let ifname = String::from("wg0");
     let wgapi = WGApi::new(ifname.clone(), false)?;

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -5,14 +5,13 @@
 
 pub mod setup;
 
-use nym_wireguard_types::registration::GatewayClientRegistry;
-use std::sync::Arc;
-
 /// Start wireguard device
 #[cfg(target_os = "linux")]
 pub async fn start_wireguard(
     mut task_client: nym_task::TaskClient,
-    _gateway_client_registry: Arc<GatewayClientRegistry>,
+    _gateway_client_registry: std::sync::Arc<
+        nym_wireguard_types::registration::GatewayClientRegistry,
+    >,
 ) -> Result<defguard_wireguard_rs::WGApi, Box<dyn std::error::Error + Send + Sync + 'static>> {
     use crate::setup::{peer_allowed_ips, peer_static_public_key, PRIVATE_KEY};
     use defguard_wireguard_rs::{

--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -8,14 +8,11 @@ pub mod setup;
 use nym_wireguard_types::registration::GatewayClientRegistry;
 use std::sync::Arc;
 
-// Currently the module related to setting up the virtual network device is platform specific.
-#[cfg(target_os = "linux")]
-use crate::setup::{peer_allowed_ips, peer_static_public_key, PRIVATE_KEY};
-use defguard_wireguard_rs::WGApi;
 #[cfg(target_os = "linux")]
 use defguard_wireguard_rs::{
-    host::Peer, key::Key, net::IpAddrMask, InterfaceConfiguration, WireguardInterfaceApi,
+    host::Peer, key::Key, net::IpAddrMask, InterfaceConfiguration, WGApi, WireguardInterfaceApi,
 };
+
 #[cfg(target_os = "linux")]
 use nym_network_defaults::{WG_PORT, WG_TUN_DEVICE_ADDRESS};
 
@@ -25,6 +22,8 @@ pub async fn start_wireguard(
     mut task_client: nym_task::TaskClient,
     _gateway_client_registry: Arc<GatewayClientRegistry>,
 ) -> Result<WGApi, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    use crate::setup::{peer_allowed_ips, peer_static_public_key, PRIVATE_KEY};
+
     let ifname = String::from("wg0");
     let wgapi = WGApi::new(ifname.clone(), false)?;
     wgapi.create_interface()?;
@@ -48,10 +47,8 @@ pub async fn start_wireguard(
 
     Ok(wgapi)
 }
+
 #[cfg(not(target_os = "linux"))]
-pub async fn start_wireguard(
-    _task_client: nym_task::TaskClient,
-    _gateway_client_registry: Arc<GatewayClientRegistry>,
-) -> Result<WGApi, Box<dyn std::error::Error + Send + Sync + 'static>> {
+pub async fn start_wireguard() {
     todo!("WireGuard is currently only supported on Linux")
 }

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -209,7 +209,7 @@ impl<St> Gateway<St> {
     }
 
     #[cfg(all(feature = "wireguard", not(target_os = "linux")))]
-    async fn start_wireguard(&self, shutdown: TaskClient) {
+    async fn start_wireguard(&self, _shutdown: TaskClient) {
         nym_wireguard::start_wireguard().await
     }
 


### PR DESCRIPTION
# Description

See #4285 as well as nightly windows build. Don't build wireguard dependences on platforms where it is not supported.

