### PR TITLE
Restore BinaryBuildInformation schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,6 +1560,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
+name = "const-str"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aca749d3d3f5b87a0d6100509879f9cf486ab510803a4a4e1001da1ff61c2bd6"
+
+[[package]]
 name = "const_format"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6047,6 +6053,7 @@ dependencies = [
  "clap 4.4.7",
  "clap_complete",
  "clap_complete_fig",
+ "const-str",
  "log",
  "opentelemetry",
  "opentelemetry-jaeger",

--- a/common/bin-common/Cargo.toml
+++ b/common/bin-common/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 
 [dependencies]
 atty = "0.2"
+const-str = "0.5.6"
 clap = { workspace = true, features = ["derive"] }
 clap_complete = "4.0"
 clap_complete_fig = "4.0"

--- a/common/bin-common/src/build_information/mod.rs
+++ b/common/bin-common/src/build_information/mod.rs
@@ -42,7 +42,8 @@ pub struct BinaryBuildInformation {
 
     // VERGEN_CARGO_DEBUG
     /// Provides the cargo debug mode that was used for the build.
-    pub cargo_debug: &'static str,
+    // NOTE: keep the old name cargo_profile instead of cargo_debug for backwards compatibility
+    pub cargo_profile: &'static str,
 }
 
 impl BinaryBuildInformation {
@@ -57,7 +58,7 @@ impl BinaryBuildInformation {
             commit_branch: env!("VERGEN_GIT_BRANCH"),
             rustc_version: env!("VERGEN_RUSTC_SEMVER"),
             rustc_channel: env!("VERGEN_RUSTC_CHANNEL"),
-            cargo_debug: env!("VERGEN_CARGO_DEBUG"),
+            cargo_profile: env!("VERGEN_CARGO_DEBUG"),
         }
     }
 
@@ -71,7 +72,7 @@ impl BinaryBuildInformation {
             commit_branch: self.commit_branch.to_owned(),
             rustc_version: self.rustc_version.to_owned(),
             rustc_channel: self.rustc_channel.to_owned(),
-            cargo_debug: self.cargo_debug.to_owned(),
+            cargo_profile: self.cargo_profile.to_owned(),
         }
     }
 
@@ -117,7 +118,8 @@ pub struct BinaryBuildInformationOwned {
 
     // VERGEN_CARGO_DEBUG
     /// Provides the cargo debug mode that was used for the build.
-    pub cargo_debug: String,
+    // NOTE: keep the old name cargo_profile instead of cargo_debug for backwards compatibility
+    pub cargo_profile: String,
 }
 
 impl Display for BinaryBuildInformationOwned {
@@ -152,7 +154,7 @@ impl Display for BinaryBuildInformationOwned {
             "rustc Channel:",
             self.rustc_channel,
             "cargo Debug:",
-            self.cargo_debug,
+            self.cargo_profile,
         )
     }
 }

--- a/common/bin-common/src/build_information/mod.rs
+++ b/common/bin-common/src/build_information/mod.rs
@@ -49,6 +49,13 @@ pub struct BinaryBuildInformation {
 impl BinaryBuildInformation {
     // explicitly require the build_version to be passed as it's binary specific
     pub const fn new(binary_name: &'static str, build_version: &'static str) -> Self {
+        let cargo_debug = env!("VERGEN_CARGO_DEBUG");
+        let cargo_profile = if const_str::equal!(cargo_debug, "true") {
+            "debug"
+        } else {
+            "release"
+        };
+
         BinaryBuildInformation {
             binary_name,
             build_timestamp: env!("VERGEN_BUILD_TIMESTAMP"),
@@ -58,7 +65,7 @@ impl BinaryBuildInformation {
             commit_branch: env!("VERGEN_GIT_BRANCH"),
             rustc_version: env!("VERGEN_RUSTC_SEMVER"),
             rustc_channel: env!("VERGEN_RUSTC_CHANNEL"),
-            cargo_profile: env!("VERGEN_CARGO_DEBUG"),
+            cargo_profile,
         }
     }
 
@@ -153,7 +160,7 @@ impl Display for BinaryBuildInformationOwned {
             self.rustc_version,
             "rustc Channel:",
             self.rustc_channel,
-            "cargo Debug:",
+            "cargo Profile:",
             self.cargo_profile,
         )
     }


### PR DESCRIPTION
# Description

Upgrading vergen https://github.com/nymtech/nym/pull/4316 introduced a breaking change in the schema for the build information. This unfortunately has a very wide impact across our binaries and endpoints. Restore the old schema while still keeping the new vergen version for now.

This affects among other things:
- build_info commands
- nym-api endpoints such as https://nym-api.nymtech.net/api/v1/gateways/described
- the self reported endpoints on gateways and mixnodes
