### PR TITLE
Upgrade publicsuffix crate to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef"
+dependencies = [
+ "psl",
+ "psl-types",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3989,6 +3999,16 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
@@ -6836,6 +6856,7 @@ dependencies = [
 name = "nym-network-requester"
 version = "1.1.32"
 dependencies = [
+ "addr",
  "anyhow",
  "async-file-watcher",
  "async-trait",
@@ -8565,14 +8586,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "publicsuffix"
-version = "1.5.6"
+name = "psl"
+version = "2.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4ce31ff0a27d93c8de1849cf58162283752f065a90d508f1105fa6c9a213f"
+checksum = "383703acfc34f7a00724846c14dc5ea4407c59e5aedcbbb18a1c0c1a23fe5013"
 dependencies = [
- "idna 0.2.3",
- "native-tls",
- "url",
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
 ]
 
 [[package]]

--- a/service-providers/network-requester/Cargo.toml
+++ b/service-providers/network-requester/Cargo.toml
@@ -16,6 +16,7 @@ name = "nym_network_requester"
 path = "src/lib.rs"
 
 [dependencies]
+addr = "0.15.6"
 async-trait = { workspace = true }
 bs58 = "0.4.0"
 clap = { workspace = true, features = ["cargo", "derive"]}
@@ -26,7 +27,7 @@ ipnetwork = "0.20.0"
 lazy_static = { workspace = true }
 log = { workspace = true }
 pretty_env_logger = "0.4.0"
-publicsuffix = "1.5" # Can't update this until bip updates to support newer idna version
+publicsuffix = "2.2.3"
 rand = "0.7.3"
 regex = "1.8.4"
 reqwest = { workspace = true, features = ["json"] }

--- a/service-providers/network-requester/src/request_filter/allowed_hosts/filter.rs
+++ b/service-providers/network-requester/src/request_filter/allowed_hosts/filter.rs
@@ -5,8 +5,13 @@ use super::HostsStore;
 use crate::request_filter::allowed_hosts::group::HostsGroup;
 use crate::request_filter::allowed_hosts::standard_list::StandardList;
 use crate::request_filter::allowed_hosts::stored_allowed_hosts::StoredAllowedHosts;
-use std::net::{IpAddr, SocketAddr};
+use publicsuffix::Psl;
+use std::{
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+};
 use tokio::sync::Mutex;
+use url::Url;
 
 #[derive(Debug)]
 enum RequestHost {
@@ -35,6 +40,23 @@ pub(crate) struct OutboundRequestFilter {
     unknown_hosts: Mutex<HostsStore>,
 }
 
+/// The official URL of the list
+pub const LIST_URL: &str = "https://publicsuffix.org/list/public_suffix_list.dat";
+
+async fn request(u: Url) -> String {
+    reqwest::get(u)
+        .await
+        .expect("failed to get LIST_URL")
+        .text()
+        .await
+        .expect("failed to get text")
+}
+
+async fn fetch_list() -> publicsuffix::List {
+    let str = request(Url::parse(LIST_URL).unwrap()).await;
+    publicsuffix::List::from_str(&str).unwrap()
+}
+
 impl OutboundRequestFilter {
     /// Create a new `OutboundRequestFilter` with the given `allowed_hosts` and `unknown_hosts` lists.
     ///
@@ -43,15 +65,12 @@ impl OutboundRequestFilter {
     ///
     /// Automatcially fetches the latest standard allowed list from the Nym website, so that all
     /// requesters are able to support the same minimal functionality out of the box.
-    pub(crate) fn new(
+    pub(crate) async fn new(
         allowed_hosts: StoredAllowedHosts,
         standard_list: StandardList,
         unknown_hosts: HostsStore,
     ) -> OutboundRequestFilter {
-        let domain_list = match publicsuffix::List::fetch() {
-            Ok(list) => list,
-            Err(err) => panic!("Couldn't fetch domain list for request filtering, do you have an internet connection?: {err}"),
-        };
+        let domain_list = fetch_list().await;
 
         OutboundRequestFilter {
             allowed_hosts,
@@ -163,17 +182,19 @@ impl OutboundRequestFilter {
     /// If the domain is itself registered in publicsuffix (e.g. s3.amazonaws.com),
     /// then just use the full address as root.
     fn get_domain_root(&self, host: &str) -> Option<String> {
-        match self.root_domain_list.parse_domain(host) {
-            Ok(d) => Some(
-                d.root()
-                    .map(|root| root.to_string())
-                    .unwrap_or_else(|| d.full().to_string()),
-            ),
-            Err(_) => {
-                log::warn!("Error parsing domain: {:?}", host);
-                None // domain couldn't be parsed
+        if let Some(domain) = self.root_domain_list.domain(host.as_bytes()) {
+            return String::from_utf8(domain.as_bytes().to_vec()).ok();
+        } else {
+            if let Some(suffix) = self.root_domain_list.suffix(host.as_bytes()) {
+                if suffix.is_known() {
+                    return String::from_utf8(suffix.as_bytes().to_vec()).ok();
+                } else {
+                    return None;
+                }
             }
         }
+        log::warn!("Error parsing domain: {:?}", host);
+        None // domain couldn't be parsed
     }
 }
 
@@ -235,14 +256,14 @@ mod tests {
     }
 
     impl OutboundRequestFilterFixture {
-        fn new() -> OutboundRequestFilterFixture {
+        async fn new() -> OutboundRequestFilterFixture {
             let allow_tmp_file = tempfile::NamedTempFile::new().unwrap();
             let unknown_tmp_file = tempfile::NamedTempFile::new().unwrap();
             let allowed = HostsStore::new(&allow_tmp_file);
             let unknown = HostsStore::new(&unknown_tmp_file);
             let standard = StandardList::new();
 
-            let inner = OutboundRequestFilter::new(allowed.into(), standard, unknown);
+            let inner = OutboundRequestFilter::new(allowed.into(), standard, unknown).await;
             OutboundRequestFilterFixture {
                 inner,
                 _allow_tmp_file: allow_tmp_file,
@@ -251,11 +272,11 @@ mod tests {
         }
     }
 
-    fn setup_empty() -> OutboundRequestFilterFixture {
-        OutboundRequestFilterFixture::new()
+    async fn setup_empty() -> OutboundRequestFilterFixture {
+        OutboundRequestFilterFixture::new().await
     }
 
-    fn setup_with_allowed(allowed: &[&str]) -> OutboundRequestFilterFixture {
+    async fn setup_with_allowed(allowed: &[&str]) -> OutboundRequestFilterFixture {
         let allow_tmp_file = tempfile::NamedTempFile::new().unwrap();
         let unknown_tmp_file = tempfile::NamedTempFile::new().unwrap();
         let mut allowed_store = HostsStore::new(&allow_tmp_file);
@@ -266,7 +287,7 @@ mod tests {
             allowed_store.add_host(allow)
         }
 
-        let inner = OutboundRequestFilter::new(allowed_store.into(), standard, unknown);
+        let inner = OutboundRequestFilter::new(allowed_store.into(), standard, unknown).await;
         OutboundRequestFilterFixture {
             inner,
             _allow_tmp_file: allow_tmp_file,
@@ -295,51 +316,52 @@ mod tests {
     mod getting_the_domain_root {
         use super::*;
 
-        #[test]
-        fn leaves_a_com_alone() {
-            let filter = setup_empty();
+        #[tokio::test]
+        async fn leaves_a_com_alone() {
+            let filter = setup_empty().await;
             assert_eq!(
                 Some("domain.com".to_string()),
                 filter.get_domain_root("domain.com")
             )
         }
 
-        #[test]
-        fn trims_subdomains_from_com() {
-            let filter = setup_empty();
+        #[tokio::test]
+        async fn trims_subdomains_from_com() {
+            let filter = setup_empty().await;
             assert_eq!(
                 Some("domain.com".to_string()),
                 filter.get_domain_root("foomp.domain.com")
             )
         }
 
-        #[test]
-        fn works_for_non_com_roots() {
-            let filter = setup_empty();
+        #[tokio::test]
+        async fn works_for_non_com_roots() {
+            let filter = setup_empty().await;
             assert_eq!(
                 Some("domain.co.uk".to_string()),
                 filter.get_domain_root("domain.co.uk")
             )
         }
 
-        #[test]
-        fn works_for_non_com_roots_with_subdomains() {
-            let filter = setup_empty();
+        #[tokio::test]
+        async fn works_for_non_com_roots_with_subdomains() {
+            let filter = setup_empty().await;
             assert_eq!(
                 Some("domain.co.uk".to_string()),
                 filter.get_domain_root("foomp.domain.co.uk")
             )
         }
 
-        #[test]
-        fn returns_none_on_garbage() {
-            let filter = setup_empty();
+        #[tokio::test]
+        async fn returns_none_on_garbage() {
+            let filter = setup_empty().await;
             assert_eq!(None, filter.get_domain_root("::/&&%@"));
         }
 
-        #[test]
-        fn returns_full_on_suffix_domains() {
-            let filter = setup_empty();
+        #[tokio::test]
+        async fn returns_full_on_suffix_domains() {
+            let filter = setup_empty().await;
+            dbg!(filter.get_domain_root("s3.amazonaws.com"));
             assert_eq!(
                 Some("s3.amazonaws.com".to_string()),
                 filter.get_domain_root("s3.amazonaws.com")
@@ -354,14 +376,14 @@ mod tests {
         #[tokio::test]
         async fn are_not_allowed() {
             let host = "unknown.com";
-            let filter = setup_empty();
+            let filter = setup_empty().await;
             assert!(!filter.check(host).await);
         }
 
         #[tokio::test]
         async fn get_appended_once_to_the_unknown_hosts_list() {
             let host = "unknown.com";
-            let filter = setup_empty();
+            let filter = setup_empty().await;
             filter.check(host).await;
             assert_eq!(1, filter.unknown_hosts.lock().await.data.domains.len());
             assert!(filter
@@ -391,7 +413,7 @@ mod tests {
         async fn are_allowed() {
             let host = "nymtech.net";
 
-            let filter = setup_with_allowed(&["nymtech.net"]);
+            let filter = setup_with_allowed(&["nymtech.net"]).await;
             assert!(filter.check(host).await);
         }
 
@@ -399,13 +421,13 @@ mod tests {
         async fn are_allowed_for_subdomains() {
             let host = "foomp.nymtech.net";
 
-            let filter = setup_with_allowed(&["nymtech.net"]);
+            let filter = setup_with_allowed(&["nymtech.net"]).await;
             assert!(filter.check(host).await);
         }
 
         #[tokio::test]
         async fn are_not_appended_to_file() {
-            let filter = setup_with_allowed(&["nymtech.net"]);
+            let filter = setup_with_allowed(&["nymtech.net"]).await;
 
             // test initial state
             let lines =
@@ -428,7 +450,7 @@ mod tests {
             let address_good_port = "1.1.1.1:1234";
             let address_bad = "1.1.1.2";
 
-            let filter = setup_with_allowed(&["1.1.1.1"]);
+            let filter = setup_with_allowed(&["1.1.1.1"]).await;
             assert!(filter.check(address_good).await);
             assert!(filter.check(address_good_port).await);
             assert!(!filter.check(address_bad).await);
@@ -445,8 +467,9 @@ mod tests {
 
             let ip_v6_loopback_port = "[::1]:1234";
 
-            let filter1 = setup_with_allowed(&[ip_v6_full, ip_v6_semi, "::1"]);
-            let filter2 = setup_with_allowed(&[ip_v6_full_rendered, ip_v6_semi_rendered, "::1"]);
+            let filter1 = setup_with_allowed(&[ip_v6_full, ip_v6_semi, "::1"]).await;
+            let filter2 =
+                setup_with_allowed(&[ip_v6_full_rendered, ip_v6_semi_rendered, "::1"]).await;
 
             assert!(filter1.check(ip_v6_full).await);
             assert!(filter1.check(ip_v6_full_rendered).await);
@@ -473,7 +496,7 @@ mod tests {
 
             let outside_range2 = "1.2.2.4";
 
-            let filter = setup_with_allowed(&[range1, range2]);
+            let filter = setup_with_allowed(&[range1, range2]).await;
             assert!(filter.check("127.0.0.1").await);
             assert!(filter.check("127.0.0.1:1234").await);
             assert!(filter.check(bottom_range2).await);
@@ -491,7 +514,7 @@ mod tests {
             let top = "2620:0:ffff:ffff:ffff:ffff:ffff:ffff";
             let mid = "2620:0:42::42";
 
-            let filter = setup_with_allowed(&[range]);
+            let filter = setup_with_allowed(&[range]).await;
             assert!(filter.check(bottom1).await);
             assert!(filter.check(bottom2).await);
             assert!(filter.check(top).await);

--- a/service-providers/network-requester/src/request_filter/allowed_hosts/filter.rs
+++ b/service-providers/network-requester/src/request_filter/allowed_hosts/filter.rs
@@ -184,13 +184,11 @@ impl OutboundRequestFilter {
     fn get_domain_root(&self, host: &str) -> Option<String> {
         if let Some(domain) = self.root_domain_list.domain(host.as_bytes()) {
             return String::from_utf8(domain.as_bytes().to_vec()).ok();
-        } else {
-            if let Some(suffix) = self.root_domain_list.suffix(host.as_bytes()) {
-                if suffix.is_known() {
-                    return String::from_utf8(suffix.as_bytes().to_vec()).ok();
-                } else {
-                    return None;
-                }
+        } else if let Some(suffix) = self.root_domain_list.suffix(host.as_bytes()) {
+            if suffix.is_known() {
+                return String::from_utf8(suffix.as_bytes().to_vec()).ok();
+            } else {
+                return None;
             }
         }
         log::warn!("Error parsing domain: {:?}", host);

--- a/service-providers/network-requester/src/request_filter/mod.rs
+++ b/service-providers/network-requester/src/request_filter/mod.rs
@@ -38,7 +38,7 @@ impl RequestFilter {
     pub(crate) async fn new(config: &Config) -> Result<Self, NetworkRequesterError> {
         if config.network_requester.use_deprecated_allow_list {
             info!("setting up allow-list based 'OutboundRequestFilter'...");
-            Ok(Self::new_allow_list_request_filter(config))
+            Ok(Self::new_allow_list_request_filter(config).await)
         } else {
             info!("setting up ExitPolicy based request filter...");
             Self::new_exit_policy_filter(config).await
@@ -89,7 +89,7 @@ impl RequestFilter {
         }
     }
 
-    fn new_allow_list_request_filter(config: &Config) -> Self {
+    async fn new_allow_list_request_filter(config: &Config) -> Self {
         let standard_list = StandardList::new();
         let allowed_hosts = StoredAllowedHosts::new(&config.storage_paths.allowed_list_location);
         let unknown_hosts =
@@ -99,7 +99,8 @@ impl RequestFilter {
         RequestFilter {
             inner: Arc::new(RequestFilterInner::AllowList {
                 open_proxy: config.network_requester.open_proxy,
-                filter: OutboundRequestFilter::new(allowed_hosts, standard_list, unknown_hosts),
+                filter: OutboundRequestFilter::new(allowed_hosts, standard_list, unknown_hosts)
+                    .await,
             }),
         }
     }


### PR DESCRIPTION
# Description

CT-25

Upgrading publicsuffix as a step towards removing dependencies on OpenSSL.

Affects `nym-network-requester` and its ability to handle the allowlist.
