### PR TITLE
Publish deb packages to builds.ci

### DIFF
--- a/.github/workflows/ci-build-upload-binaries.yml
+++ b/.github/workflows/ci-build-upload-binaries.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build deb packages
         shell: bash
-        run: make ppa
+        run: scripts/ppa.sh ${{ secrets.PPA_SIGNING_KEY }}
 
       - name: Prepare build output
         shell: bash

--- a/.github/workflows/ci-build-upload-binaries.yml
+++ b/.github/workflows/ci-build-upload-binaries.yml
@@ -4,18 +4,18 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'clients/**'
-      - 'common/**'
-      - 'explorer-api/**'
-      - 'gateway/**'
-      - 'integrations/**'
-      - 'mixnode/**'
-      - 'sdk/rust/nym-sdk/**'
-      - 'service-providers/**'
-      - 'nym-api/**'
-      - 'nym-outfox/**'
-      - 'tools/nym-cli/**'
-      - 'tools/ts-rs-cli/**'
+      - "clients/**"
+      - "common/**"
+      - "explorer-api/**"
+      - "gateway/**"
+      - "integrations/**"
+      - "mixnode/**"
+      - "sdk/rust/nym-sdk/**"
+      - "service-providers/**"
+      - "nym-api/**"
+      - "nym-outfox/**"
+      - "tools/nym-cli/**"
+      - "tools/ts-rs-cli/**"
 
 jobs:
   publish-nym:
@@ -53,6 +53,10 @@ jobs:
           command: build
           args: --workspace --release
 
+      - name: Build deb packages
+        shell: bash
+        run: make ppa
+
       - name: Prepare build output
         shell: bash
         env:
@@ -67,6 +71,7 @@ jobs:
           cp target/release/nym-network-statistics $OUTPUT_DIR
           cp target/release/nym-cli $OUTPUT_DIR
           cp target/release/explorer-api $OUTPUT_DIR
+          cp ppa/debian/* $OUTPUT_DIR
 
       - name: Deploy branch to CI www
         continue-on-error: true

--- a/.github/workflows/ci-build-upload-binaries.yml
+++ b/.github/workflows/ci-build-upload-binaries.yml
@@ -53,6 +53,12 @@ jobs:
           command: build
           args: --workspace --release
 
+      - name: Install cargo-deb
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-deb
+
       - name: Build deb packages
         shell: bash
         run: scripts/ppa.sh ${{ secrets.PPA_SIGNING_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -177,5 +177,5 @@ run-api-tests:
 
 # Build debian package, and update PPA
 # Requires base64 encode GPG key to be set up in environment PPA_SIGNING_KEY
-ppa: build-nym-mixnode build-nym-gateway
-	scripts/ppa.sh
+# ppa: build-nym-mixnode build-nym-gateway
+# 	scripts/ppa.sh

--- a/scripts/ppa.sh
+++ b/scripts/ppa.sh
@@ -1,8 +1,8 @@
 #/bin/bash
 # Run from repository root
-# Needs PPA_SIGNING_KEY base64 encoded in env var
+# Takes PPA_SIGNING_KEY base64 encoded as first argument
 
-echo ${PPA_SIGNING_KEY} | base64 -d >ppa-signing-key.asc
+echo $1 | base64 -d >ppa-signing-key.asc
 gpg --import ppa-signing-key.asc
 rm ppa-signing-key.asc
 


### PR DESCRIPTION
[Example](https://builds.ci.nymte.ch/build-ci-deb)

+ `deb` packages can get installed via `dpkg -i`
+ for gateway and mixnode binaries it will also create a service file and run `init`