### PR TITLE
[DOC]: Update NymVPN Guides to `v0.0.3`

### DIFF
--- a/documentation/dev-portal/book.toml
+++ b/documentation/dev-portal/book.toml
@@ -52,7 +52,7 @@ minimum_rust_version = "1.66"
 wallet_release_version = "1.2.8"
 
 # nym-vpn related variables
-nym_vpn_latest_binary_url = "https://github.com/nymtech/nym/releases/tag/nym-vpn-alpha-0.0.2"
+nym_vpn_latest_binary_url = "https://github.com/nymtech/nym/releases/tag/nym-vpn-alpha-0.0.3"
 nym_vpn_form_url = "https://opnform.com/forms/nymvpn-user-research-at-37c3-yccqko-2"
 
 [preprocessor.last-changed]

--- a/documentation/dev-portal/src/nymvpn/cli-linux.md
+++ b/documentation/dev-portal/src/nymvpn/cli-linux.md
@@ -12,7 +12,7 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 2. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
-# Example:
+# example:
 echo "0e4abb461e86b2c168577e0294112a3bacd3a24bf8565b49783bfebd9b530e23  nym-vpn-cli_0.1.0_ubuntu-22.04_amd64.zip" | shasum -a 256 -c
 ```
 3. Extract files with `unzip` command or manually as you are used to

--- a/documentation/dev-portal/src/nymvpn/cli-linux.md
+++ b/documentation/dev-portal/src/nymvpn/cli-linux.md
@@ -13,7 +13,7 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
 
-# choose a correct one according to the your binary, this is just an example
+# choose a correct one according to your binary, this is just an example
 echo "0e4abb461e86b2c168577e0294112a3bacd3a24bf8565b49783bfebd9b530e23  nym-vpn-cli_0.1.0_ubuntu-22.04_amd64.zip" | shasum -a 256 -c
 ```
 3. Extract files with `unzip` command or manually as you are used to

--- a/documentation/dev-portal/src/nymvpn/cli-linux.md
+++ b/documentation/dev-portal/src/nymvpn/cli-linux.md
@@ -9,17 +9,18 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 > Any syntax in `<>` brackets is a user's/version unique variable. Exchange with a corresponding name without the `<>` brackets.
 
 1. Open Github [releases page]({{nym_vpn_latest_binary_url}}) and download the binary for Debian based Linux
-2. Open terminal in the same directory and check the the `sha256sum` by running:
+2. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
-sha256sum ./nym-vpn-cli_0.1.0_ubuntu-22.04_amd64.zip
+echo "<SHA_STRING>" | shasum -a 256 -c
+# Example:
+echo "0e4abb461e86b2c168577e0294112a3bacd3a24bf8565b49783bfebd9b530e23  nym-vpn-cli_0.1.0_ubuntu-22.04_amd64.zip" | shasum -a 256 -c
 ```
-3. Compare the output with the sha256 hash shared on the [release page]({{nym_vpn_latest_binary_url}})
-4. Extract files with `unzip` command or manually as you are used to
-5. Make executable by running:
+3. Extract files with `unzip` command or manually as you are used to
+4. Make executable by running:
 ```sh
 chmod u+x ./nym-vpn-cli
 ```
-6. Create Sandbox environment config file by saving [this](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) as `sandbox.env` in the same directory as your NymVPN binaries by running:
+5. Create Sandbox environment config file by saving [this](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) as `sandbox.env` in the same directory as your NymVPN binaries by running:
 ```sh
 curl -o sandbox.env -L https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env
 ```
@@ -30,7 +31,7 @@ curl -o sandbox.env -L https://raw.githubusercontent.com/nymtech/nym/develop/env
 
 Make sure your terminal is open in the same directory as your `nym-vpn-cli` binary.
 
-1. Go to [nymvpn.com/en/alpha](https://nymvpn.com/en/alpha) to get the entire command with all the needed arguments' values and your wireguard private key for testing purposes 
+1. Go to [nymvpn.com/en/alpha](https://nymvpn.com/en/alpha) to get the entire command with all the needed arguments' values and your wireguard private key for testing purposes
 2. Run it as root with `sudo` - the command will look like this with specified arguments:
 ```sh
 sudo ./nym-vpn-cli -c ./sandbox.env --entry-gateway-id <ENTRY_GATEWAY_ID> --exit-router-address <EXIT_ROUTER_ADDRESS> --enable-wireguard --private-key <PRIVATE_KEY> --wg-ip <WIREGUARD_IP>
@@ -67,7 +68,7 @@ Options:
       --exit-router-address <EXIT_ROUTER_ADDRESS>
           Mixnet recipient address
       --exit-gateway-id <EXIT_GATEWAY_ID>
-          
+
       --exit-router-country <EXIT_ROUTER_COUNTRY>
           Mixnet recipient address
       --enable-wireguard
@@ -96,7 +97,7 @@ Options:
 
 Here is a list of the options and their descriptions. Some are essential, some are more technical and not needed to be adjusted by users.
 
-**Fundamental commands and arguments**  
+**Fundamental commands and arguments**
 
 - `-c` is a path to the [Sandbox config](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) file saved as `sandbox.env`
 - `--entry-gateway-id`: paste one of the values labeled with a key `"identityKey"` (without `" "`) from [here](https://nymvpn.com/en/alpha/api/gateways)

--- a/documentation/dev-portal/src/nymvpn/cli-linux.md
+++ b/documentation/dev-portal/src/nymvpn/cli-linux.md
@@ -12,7 +12,8 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 2. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
-# example:
+
+# choose a correct one according to the your binary, this is just an example
 echo "0e4abb461e86b2c168577e0294112a3bacd3a24bf8565b49783bfebd9b530e23  nym-vpn-cli_0.1.0_ubuntu-22.04_amd64.zip" | shasum -a 256 -c
 ```
 3. Extract files with `unzip` command or manually as you are used to

--- a/documentation/dev-portal/src/nymvpn/cli-mac.md
+++ b/documentation/dev-portal/src/nymvpn/cli-mac.md
@@ -9,21 +9,18 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 > Any syntax in `<>` brackets is a user's/version unique variable. Exchange with a corresponding name without the `<>` brackets.
 
 1. Open Github [releases page]({{nym_vpn_latest_binary_url}}) and download the binary for MacOS
-2. Open terminal in the same directory and check the the `sha256sum` by running:
+2. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
-# x86_64
-sha256sum ./nym-vpn-cli_0.1.0_macos_x86_64.zip
-
-# aarch64
-sha256sum ./nym-vpn-cli_0.1.0_macos_aarch64.zip
+echo "<SHA_STRING>" | shasum -a 256 -c
+# Example:
+echo "96623ccc69bc4cc0e4e3e18528b6dae6be69f645d0a592d926a3158ce2d0c269  nym-vpn-cli_0.1.0_macos_x86_64.zip" | shasum -a 256 -c
 ```
-3. Compare the output with the sha256 hash shared on the [release page]({{nym_vpn_latest_binary_url}})
-4. Extract files with `unzip` command or manually as you are used to
-5. Make executable by running:
+5. Extract files with `unzip` command or manually as you are used to
+6. Make executable by running:
 ```sh
 chmod u+x ./nym-vpn-cli
 ```
-6. Create Sandbox environment config file by saving [this](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) as `sandbox.env` in the same directory as your NymVPN binaries by running:
+7. Create Sandbox environment config file by saving [this](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) as `sandbox.env` in the same directory as your NymVPN binaries by running:
 ```sh
 curl -L "https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env" -o sandbox.env
 ```
@@ -35,7 +32,7 @@ curl -L "https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env"
 Make sure your terminal is open in the same directory as your `nym-vpn-cli` binary.
 
 
-1. Go to [nymvpn.com/en/alpha](https://nymvpn.com/en/alpha) to get the entire command with all the needed arguments' values and your wireguard private key for testing purposes 
+1. Go to [nymvpn.com/en/alpha](https://nymvpn.com/en/alpha) to get the entire command with all the needed arguments' values and your wireguard private key for testing purposes
 2. Run it as root with `sudo` - the command will look like this with specified arguments:
 ```sh
 sudo ./nym-vpn-cli -c ./sandbox.env --entry-gateway-id <ENTRY_GATEWAY_ID> --exit-router-address <EXIT_ROUTER_ADDRESS> --enable-wireguard --private-key <PRIVATE_KEY> --wg-ip <WIREGUARD_IP>
@@ -72,7 +69,7 @@ Options:
       --exit-router-address <EXIT_ROUTER_ADDRESS>
           Mixnet recipient address
       --exit-gateway-id <EXIT_GATEWAY_ID>
-          
+
       --exit-router-country <EXIT_ROUTER_COUNTRY>
           Mixnet recipient address
       --enable-wireguard
@@ -101,7 +98,7 @@ Options:
 
 Here is a list of the options and their descriptions. Some are essential, some are more technical and not needed to be adjusted by users.
 
-**Fundamental commands and arguments**  
+**Fundamental commands and arguments**
 
 - `-c` is a path to the [Sandbox config](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) file saved as `sandbox.env`
 - `--entry-gateway-id`: paste one of the values labeled with a key `"identityKey"` (without `" "`) from [here](https://nymvpn.com/en/alpha/api/gateways)

--- a/documentation/dev-portal/src/nymvpn/cli-mac.md
+++ b/documentation/dev-portal/src/nymvpn/cli-mac.md
@@ -13,7 +13,7 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
 
-# choose a correct one according to the your binary, this is just an example
+# choose a correct one according to your binary, this is just an example
 echo "96623ccc69bc4cc0e4e3e18528b6dae6be69f645d0a592d926a3158ce2d0c269  nym-vpn-cli_0.1.0_macos_x86_64.zip" | shasum -a 256 -c
 ```
 5. Extract files with `unzip` command or manually as you are used to

--- a/documentation/dev-portal/src/nymvpn/cli-mac.md
+++ b/documentation/dev-portal/src/nymvpn/cli-mac.md
@@ -12,7 +12,7 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 2. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
-# Example:
+# example:
 echo "96623ccc69bc4cc0e4e3e18528b6dae6be69f645d0a592d926a3158ce2d0c269  nym-vpn-cli_0.1.0_macos_x86_64.zip" | shasum -a 256 -c
 ```
 5. Extract files with `unzip` command or manually as you are used to

--- a/documentation/dev-portal/src/nymvpn/cli-mac.md
+++ b/documentation/dev-portal/src/nymvpn/cli-mac.md
@@ -12,7 +12,8 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 2. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
-# example:
+
+# choose a correct one according to the your binary, this is just an example
 echo "96623ccc69bc4cc0e4e3e18528b6dae6be69f645d0a592d926a3158ce2d0c269  nym-vpn-cli_0.1.0_macos_x86_64.zip" | shasum -a 256 -c
 ```
 5. Extract files with `unzip` command or manually as you are used to

--- a/documentation/dev-portal/src/nymvpn/cli.md
+++ b/documentation/dev-portal/src/nymvpn/cli.md
@@ -24,11 +24,11 @@ chmod u+x execute-nym-vpn-cli-binary.sh
 ```
 3. Run the script as root, turn of any VPN and run
 ```sh
-sudo ./execute-nym-vpn-cli-binary.sh
+sudo -E ./execute-nym-vpn-cli-binary.sh
 ```
 4. Verify the `nym-vpn-cli` binary: When prompted to verify `sha256sum` paste your correct one from the [release page]({{nym_vpn_latest_binary_url}}) including the binary name (all as one input with a space in between), for example:
 ```sh
-# Choose one according to the system you use, this is just an example
+# choose one according to the system you use, this is just an example
 96623ccc69bc4cc0e4e3e18528b6dae6be69f645d0a592d926a3158ce2d0c269  nym-vpn-cli_0.1.0_macos_x86_64.zip
 ```
 5. The script will automatically start the client. Follow the instructions:  

--- a/documentation/dev-portal/src/nymvpn/cli.md
+++ b/documentation/dev-portal/src/nymvpn/cli.md
@@ -28,7 +28,7 @@ sudo -E ./execute-nym-vpn-cli-binary.sh
 ```
 4. Verify the `nym-vpn-cli` binary: When prompted to verify `sha256sum` paste your correct one from the [release page]({{nym_vpn_latest_binary_url}}) including the binary name (all as one input with a space in between), for example:
 ```sh
-# choose one according to the system you use, this is just an example
+# choose a correct one according to your binary, this is just an example
 96623ccc69bc4cc0e4e3e18528b6dae6be69f645d0a592d926a3158ce2d0c269  nym-vpn-cli_0.1.0_macos_x86_64.zip
 ```
 5. The script will automatically start the client. Follow the instructions:  

--- a/documentation/dev-portal/src/nymvpn/gui-linux.md
+++ b/documentation/dev-portal/src/nymvpn/gui-linux.md
@@ -14,7 +14,8 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 2. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
-# example:
+
+# choose a correct one according to the your binary, this is just an example
 echo "a5f91f20d587975e30b6a75d3a9e195234cf1269eac278139a5b9c39b039e807  nym-vpn-desktop_0.0.3_ubuntu-22.04_x86_64.zip" | shasum -a 256 -c
 ```
 3. Extract files with `unzip` command or manually as you are used to
@@ -22,14 +23,13 @@ echo "a5f91f20d587975e30b6a75d3a9e195234cf1269eac278139a5b9c39b039e807  nym-vpn-
 ```sh
 chmod u+x ./appimage/nym-vpn_0.0.2_amd64.AppImage
 ```
-5. If you prefer to use the `.deb` version for installation (Linux only), open terminal in the same directory and run:
+5. If you prefer to use the `.deb` version for installation (works on Debian based Linux only), open terminal in the same directory and run:
 ```sh
 cd deb
 
-sudo dpkg -i ./nym-vpn_0.0.2_amd64.deb
+sudo dpkg -i ./nym-vpn_0.0.3_amd64.deb
 # or
-sudo apt-get install -f ./nym-vpn_0.0.2_amd64.deb
-
+sudo apt-get install -f ./nym-vpn_0.0.3_amd64.deb
 ```
 
 ### Configuration

--- a/documentation/dev-portal/src/nymvpn/gui-linux.md
+++ b/documentation/dev-portal/src/nymvpn/gui-linux.md
@@ -15,7 +15,7 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
 
-# choose a correct one according to the your binary, this is just an example
+# choose a correct one according to your binary, this is just an example
 echo "a5f91f20d587975e30b6a75d3a9e195234cf1269eac278139a5b9c39b039e807  nym-vpn-desktop_0.0.3_ubuntu-22.04_x86_64.zip" | shasum -a 256 -c
 ```
 3. Extract files with `unzip` command or manually as you are used to

--- a/documentation/dev-portal/src/nymvpn/gui-linux.md
+++ b/documentation/dev-portal/src/nymvpn/gui-linux.md
@@ -14,7 +14,7 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 2. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
-# Example:
+# example:
 echo "a5f91f20d587975e30b6a75d3a9e195234cf1269eac278139a5b9c39b039e807  nym-vpn-desktop_0.0.3_ubuntu-22.04_x86_64.zip" | shasum -a 256 -c
 ```
 3. Extract files with `unzip` command or manually as you are used to

--- a/documentation/dev-portal/src/nymvpn/gui-linux.md
+++ b/documentation/dev-portal/src/nymvpn/gui-linux.md
@@ -11,17 +11,18 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 ### Installation
 
 1. Open Github [releases page]({{nym_vpn_latest_binary_url}}) and download the binary for Debian based Linux
-2. Open terminal in the same directory and check the the `sha256sum` by running:
+2. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
-sha256sum ./nym-vpn-ui_0.0.2_ubuntu-22.04_amd64.zip
+echo "<SHA_STRING>" | shasum -a 256 -c
+# Example:
+echo "a5f91f20d587975e30b6a75d3a9e195234cf1269eac278139a5b9c39b039e807  nym-vpn-desktop_0.0.3_ubuntu-22.04_x86_64.zip" | shasum -a 256 -c
 ```
-3. Compare the output with the sha256 hash shared on the [release page]({{nym_vpn_latest_binary_url}})
-4. Extract files with `unzip` command or manually as you are used to
-5. If you prefer to run `.AppImage` make executable by running:
+3. Extract files with `unzip` command or manually as you are used to
+4. If you prefer to run `.AppImage` make executable by running:
 ```sh
 chmod u+x ./appimage/nym-vpn_0.0.2_amd64.AppImage
 ```
-6. If you prefer to use the `.deb` version for installation (Linux only), open terminal in the same directory and run:
+5. If you prefer to use the `.deb` version for installation (Linux only), open terminal in the same directory and run:
 ```sh
 cd deb
 
@@ -33,16 +34,16 @@ sudo apt-get install -f ./nym-vpn_0.0.2_amd64.deb
 
 ### Configuration
 
-7. Create a NymVPN config directory called `nym-vpn` in your `~/.config`, either manually or by a command:
+6. Create a NymVPN config directory called `nym-vpn` in your `~/.config`, either manually or by a command:
 ```sh
 mkdir $HOME/.config/nym-vpn/
 ```
-8. Create the network config by saving [this](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) as `sandbox.env` in the directory `~/.config/nym-vpn/` you just created by running:
+7. Create the network config by saving [this](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) as `sandbox.env` in the directory `~/.config/nym-vpn/` you just created by running:
 ```sh
 curl -o $HOME/.config/nym-vpn/sandbox.env -L https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env
 ```
 
-9. Create NymVPN main config file called `config.toml` in the same directory `~/.config/nym-vpn/` with this content:
+8. Create NymVPN main config file called `config.toml` in the same directory `~/.config/nym-vpn/` with this content:
 ```toml
 # change <USER> to your username
 env_config_file = "/home/<USER>/.config/nym-vpn/sandbox.env"
@@ -51,7 +52,7 @@ entry_node_location = "DE" # two letters country code
 # DE, UK, FR, IE
 ```
 
-## Run NymVPN 
+## Run NymVPN
 
 **For NymVPN to work, all other VPNs must be switched off!** At this alpha stage of NymVPN, the network connection (wifi) must be reconnected after or in between the testing rounds.
 
@@ -68,4 +69,3 @@ sudo -E nym-vpn
 ```
 
 In case of errors, see [troubleshooting section](troubleshooting.md).
-

--- a/documentation/dev-portal/src/nymvpn/gui-mac.md
+++ b/documentation/dev-portal/src/nymvpn/gui-mac.md
@@ -18,7 +18,8 @@ mkdir -p "$HOME/nym-vpn-latest"
 3. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
-# example:
+
+# choose a correct one according to the your binary, this is just an example
 echo "da4c0bf8e8b52658312d341fa3581954cfcb6efd516d9a448c76d042a454b5df  nym-vpn-desktop_0.0.3_macos_x86_64.zip" | shasum -a 256 -c
 ```
 4. Extract files with `unzip` command or manually as you are used to

--- a/documentation/dev-portal/src/nymvpn/gui-mac.md
+++ b/documentation/dev-portal/src/nymvpn/gui-mac.md
@@ -15,38 +15,34 @@ NymVPN is an experimental software and it's for [testing](./testing.md) purposes
 mkdir -p "$HOME/nym-vpn-latest"
 ```
 2. Open Github [releases page]({{nym_vpn_latest_binary_url}}) and download the binary for MacOS
-3. Open terminal in the same directory and check the the `sha256sum` by running:
+3. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
-# aarch64
-sha256sum ./nym-vpn-ui_0.0.2_macos_aarch64.zip
-
-# x86_64
-sha256sum ./nym-vpn-ui_0.0.2_macos_x86_64.zip
+echo "<SHA_STRING>" | shasum -a 256 -c
+# Example:
+echo "da4c0bf8e8b52658312d341fa3581954cfcb6efd516d9a448c76d042a454b5df  nym-vpn-desktop_0.0.3_macos_x86_64.zip" | shasum -a 256 -c
 ```
-4. Compare the output with the sha256 hash shared on the [release page]({{nym_vpn_latest_binary_url}})
-
-5. Extract files with `unzip` command or manually as you are used to
-6. Move to the application directory and make executable
+4. Extract files with `unzip` command or manually as you are used to
+5. Move to the application directory and make executable
 ```sh
 cd "macos/nym-vpn.app/Contents/MacOS"
 
 chmod u+x nym-vpn
 ```
-7. Move `nym-vpn` to your `~/nym-vpn-latest` directory
+6. Move `nym-vpn` to your `~/nym-vpn-latest` directory
 ```sh
 mv nym-vpn "$HOME/nym-vpn-latest"
 ```
 
 ### Configuration
 
-8. Create the configuration file by opening a text editor and saving the lines below as `config.toml` in the same directory `~/nym-vpn-latest`
+7. Create the configuration file by opening a text editor and saving the lines below as `config.toml` in the same directory `~/nym-vpn-latest`
 ```toml
 env_config_file = ".env"
 entry_node_location = "DE" # two letters country code
 # You can choose different entry by entering one of the following two letter country codes:
 # DE, UK, FR, IE
 ```
-9. Create testnet configuration file by saving [this](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) as `.env` in the same directory `~/nym-vpn-latest`
+8. Create testnet configuration file by saving [this](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) as `.env` in the same directory `~/nym-vpn-latest`
 ```sh
 curl -L "https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env" -o "$HOME/nym-vpn-latest/.env"
 ```
@@ -60,5 +56,3 @@ sudo ./nym-vpn
 ```
 
 In case of errors check out the [troubleshooting](troubleshooting.html#installing-gui-on-macos-not-working) section.
-
-

--- a/documentation/dev-portal/src/nymvpn/gui-mac.md
+++ b/documentation/dev-portal/src/nymvpn/gui-mac.md
@@ -18,7 +18,7 @@ mkdir -p "$HOME/nym-vpn-latest"
 3. Verify sha hash of your downloaded binary with the one listed on the [releases page]({{nym_vpn_latest_binary_url}}). You can use a simple `shasum` command and compare strings (ie with Python) or run in the same directory the following command, exchanging `<SHA_STRING>` with the one of your binary, like in the example:
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
-# Example:
+# example:
 echo "da4c0bf8e8b52658312d341fa3581954cfcb6efd516d9a448c76d042a454b5df  nym-vpn-desktop_0.0.3_macos_x86_64.zip" | shasum -a 256 -c
 ```
 4. Extract files with `unzip` command or manually as you are used to

--- a/documentation/dev-portal/src/nymvpn/gui-mac.md
+++ b/documentation/dev-portal/src/nymvpn/gui-mac.md
@@ -19,7 +19,7 @@ mkdir -p "$HOME/nym-vpn-latest"
 ```sh
 echo "<SHA_STRING>" | shasum -a 256 -c
 
-# choose a correct one according to the your binary, this is just an example
+# choose a correct one according to your binary, this is just an example
 echo "da4c0bf8e8b52658312d341fa3581954cfcb6efd516d9a448c76d042a454b5df  nym-vpn-desktop_0.0.3_macos_x86_64.zip" | shasum -a 256 -c
 ```
 4. Extract files with `unzip` command or manually as you are used to

--- a/documentation/dev-portal/src/nymvpn/gui.md
+++ b/documentation/dev-portal/src/nymvpn/gui.md
@@ -6,7 +6,7 @@ Our alpha testing round is done with participants at live workshop events. This 
 **If you commit to test NymVPN alpha, please start with the [user research form]({{nym_vpn_form_url}}) where all the steps will be provided**. If you disagree with any of the conditions listed, please leave this page.
 ```
 
-This is the alpha version of NymVPN application - the GUI. A demo of how the client will look like for majority of day-to-day users. For qualitative testing the [CLI](cli.md) is a necessity but to run the GUI holds the same importance as it provides the user with an experience of the actual app and the developers with a valuable feedback from the users. 
+This is the alpha version of NymVPN application - the GUI. A demo of how the client will look like for majority of day-to-day users. For qualitative testing the [CLI](cli.md) is a necessity but to run the GUI holds the same importance as it provides the user with an experience of the actual app and the developers with a valuable feedback from the users.
 
 Follow the simple [automated script](#automated-script-for-gui-installation) below to install and run NymVPN GUI. If you prefer to do a manual setup follow the steps in the guide for [Linux](gui-linux.md) or [MacOS](gui-mac.md).
 
@@ -29,14 +29,14 @@ sudo ./nym-vpn-client-installer.sh
 4. Verify the `nym-vpn` binary: When prompted to verify `sha256sum` paste your correct one from the [release page]({{nym_vpn_latest_binary_url}}) including the binary name (all as one input with a space in between), for example:
 ```sh
 # Choose one according to the system you use, this is just an example
-06c7c82f032f230187da1002a9a9a88242d3bbf6c5c09dc961a71df151d768d0  nym-vpn-ui_0.0.2_macos_x86_64.zip
+0a5f91f20d587975e30b6a75d3a9e195234cf1269eac278139a5b9c39b039e807  nym-vpn-desktop_0.0.3_ubuntu-22.04_x86_64.zip
 ```
 5. The script will run the application and it will prompt you for a country code to exit, chose one of the offered options in the same format as listed
 
 6. To start the application again, reconnect your wifi and run
 ```sh
 # Linux
-sudo -E ~/nym-vpn-latest/nym-vpn_0.0.2_amd64.AppImage
+sudo -E ~/nym-vpn-latest/nym-vpn_0.0.3_amd64.AppImage
 
 # MacOS
 sudo $nym_vpn_dir/nym-vpn

--- a/documentation/dev-portal/src/nymvpn/gui.md
+++ b/documentation/dev-portal/src/nymvpn/gui.md
@@ -31,7 +31,7 @@ sudo -E nym-vpn-client-install-run.sh
 
 5. Verify the `nym-vpn` binary: When prompted to verify `sha256sum` paste your correct one from the [release page]({{nym_vpn_latest_binary_url}}) including the binary name (all as one input with a space in between), for example:
 ```sh
-# choose a correct one according to the your binary, this is just an example
+# choose a correct one according to your binary, this is just an example
 0a5f91f20d587975e30b6a75d3a9e195234cf1269eac278139a5b9c39b039e807  nym-vpn-desktop_0.0.3_ubuntu-22.04_x86_64.zip
 ```
 6. The script will run the application and it will prompt you for a country code to exit, chose one of the offered options in the same format as listed

--- a/documentation/dev-portal/src/nymvpn/gui.md
+++ b/documentation/dev-portal/src/nymvpn/gui.md
@@ -16,20 +16,16 @@ We wrote a [script](https://gist.github.com/tommyv1987/7d210d4daa8f7abc61f9a696d
 
 1. To download the script, open a terminal in a directory where you want to download the script and run:
 ```sh
-curl -o nym-vpn-client-install-run.sh -L https://gist.githubusercontent.com/tommyv1987/7d210d4daa8f7abc61f9a696d0321f19/raw/d67bfc1df720639955a998a22247bf31baec7306/nym-vpn-client-installer.sh
+curl -o nym-vpn-client-install-run.sh -L https://gist.githubusercontent.com/tommyv1987/7d210d4daa8f7abc61f9a696d0321f19/raw/bc5b0923e53a08b936f3e449c0ab840c6dc1b2f6/nym-vpn-client-install-run.sh
 ```
-
-
-
-
 
 2. Make the script executable
 ```sh
-chmod u+x nym-vpn-client-installer.sh
+chmod u+x nym-vpn-client-install-run.sh
 ```
 3. Run the script as root, turn off any VPN and run
 ```sh
-sudo -E ./nym-vpn-client-installer.sh
+sudo -E nym-vpn-client-install-run.sh
 ```
 4. Follow the prompts in the program.
 

--- a/documentation/dev-portal/src/nymvpn/gui.md
+++ b/documentation/dev-portal/src/nymvpn/gui.md
@@ -16,24 +16,31 @@ We wrote a [script](https://gist.github.com/tommyv1987/7d210d4daa8f7abc61f9a696d
 
 1. To download the script, open a terminal in a directory where you want to download the script and run:
 ```sh
-curl -o nym-vpn-client-installer.sh -L https://gist.githubusercontent.com/tommyv1987/7d210d4daa8f7abc61f9a696d0321f19/raw/181968941ce268a3937e82239ddfd293dd96bb60/nym-vpn-client-installer.sh
+curl -o nym-vpn-client-install-run.sh -L https://gist.githubusercontent.com/tommyv1987/7d210d4daa8f7abc61f9a696d0321f19/raw/d67bfc1df720639955a998a22247bf31baec7306/nym-vpn-client-installer.sh
 ```
+
+
+
+
+
 2. Make the script executable
 ```sh
 chmod u+x nym-vpn-client-installer.sh
 ```
 3. Run the script as root, turn off any VPN and run
 ```sh
-sudo ./nym-vpn-client-installer.sh
+sudo -E ./nym-vpn-client-installer.sh
 ```
-4. Verify the `nym-vpn` binary: When prompted to verify `sha256sum` paste your correct one from the [release page]({{nym_vpn_latest_binary_url}}) including the binary name (all as one input with a space in between), for example:
+4. Follow the prompts in the program.
+
+5. Verify the `nym-vpn` binary: When prompted to verify `sha256sum` paste your correct one from the [release page]({{nym_vpn_latest_binary_url}}) including the binary name (all as one input with a space in between), for example:
 ```sh
-# Choose one according to the system you use, this is just an example
+# choose a correct one according to the your binary, this is just an example
 0a5f91f20d587975e30b6a75d3a9e195234cf1269eac278139a5b9c39b039e807  nym-vpn-desktop_0.0.3_ubuntu-22.04_x86_64.zip
 ```
-5. The script will run the application and it will prompt you for a country code to exit, chose one of the offered options in the same format as listed
+6. The script will run the application and it will prompt you for a country code to exit, chose one of the offered options in the same format as listed
 
-6. To start the application again, reconnect your wifi and run
+7. To start the application again, reconnect your wifi and run
 ```sh
 # Linux
 sudo -E ~/nym-vpn-latest/nym-vpn_0.0.3_amd64.AppImage

--- a/documentation/dev-portal/src/nymvpn/intro.md
+++ b/documentation/dev-portal/src/nymvpn/intro.md
@@ -2,7 +2,7 @@
 
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/897010658?h=1f55870fe6&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="NYMVPN alpha demo 37C3"></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 
-**Nym proudly presents NymVPN Alpha** - a client that uses [Nym Mixnet](https://nymtech.net) to anonymise all of a user's internet traffic through either a 5-hop mixnet (for a full network privacy) or the faster 2-hop decentralised VPN (with some extra features). 
+**Nym proudly presents NymVPN alpha** - a client that uses [Nym Mixnet](https://nymtech.net) to anonymise all of a user's internet traffic through either a 5-hop mixnet (for a full network privacy) or the faster 2-hop decentralised VPN (with some extra features).
 
 
 **You are invited to take part in the alpha testing** of this new application. The following pages provide a how-to guide, explaining steps to install and run NymVPN [CLI](cli.md) and [GUI](gui.md) on the Sandbox testnet environment as well as provide some scripts for [qualitative testing](testing.md).
@@ -19,7 +19,7 @@
 
 ***NymVPN Alpha testing will last from 15th of January - 15th of February.***
 
-*NOTE: NymVPN Alpha is experimental software for [testing purposes](testing.md) only.* 
+*NOTE: NymVPN Alpha is experimental software for [testing purposes](testing.md) only.*
 
 
 ## NymVPN Overview

--- a/documentation/dev-portal/src/nymvpn/intro.md
+++ b/documentation/dev-portal/src/nymvpn/intro.md
@@ -17,9 +17,9 @@
 6. Fill and submit the [form!]({{nym_vpn_form_url}})
 7. Join the [NymVPN matrix channel](https://matrix.to/#/#NymVPN:nymtech.chat) if you have any questions, comments or blockers
 
-***NymVPN Alpha testing will last from 15th of January - 15th of February.***
+***NymVPN alpha testing will last from 15th of January - 15th of February.***
 
-*NOTE: NymVPN Alpha is experimental software for [testing purposes](testing.md) only.*
+*NOTE: NymVPN alpha is experimental software for [testing purposes](testing.md) only.*
 
 
 ## NymVPN Overview

--- a/documentation/dev-portal/src/nymvpn/testing.md
+++ b/documentation/dev-portal/src/nymvpn/testing.md
@@ -15,11 +15,11 @@ One of the main aims of NymVPN alpha release is testing; your results will help 
 1. Create a directory called `nym-vpn-tests` and copy your `nym-vpn-cli` binary ([download here]({{nym_vpn_latest_binary_url}})) and [`sandbox.env`](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) to that directory
 2. Copy the [block below](#testssh) and save it as `tests.sh` to the same folder
 3. Open terminal in the same directory
-4. Turn off any existing VPN's (including the NymVPN instances), reconnect your wifi and make the script executable by running 
+4. Turn off any existing VPN's (including the NymVPN instances), reconnect your wifi and make the script executable by running
 ```sh
 chmod u+x ./tests.sh
 ```
-5. Run the `tests.sh` script: 
+5. Run the `tests.sh` script:
 ```sh
 sudo ./tests.sh
 ````

--- a/documentation/dev-portal/src/nymvpn/troubleshooting.md
+++ b/documentation/dev-portal/src/nymvpn/troubleshooting.md
@@ -58,7 +58,7 @@ When running `sudo sh ./test.sh` you may see an error like: `93: current_time: n
 
 In case the automatic download of all the Gateways fail (and it shouldn't), you do an easy manual work around:
 
-1. Open the list of Gateways created by API [here](https://nymvpn.com/en/ccc/api/gateways)
+1. Open the list of Gateways created by API [here](https://nymvpn.com/en/alpha/api/gateways)
 2. On top click on `JSON` option (shall be default view) and `Save`
 3. Save it as `data.json` to the `nym-vpn-tests` folder
 4. Replace line 3 in the [script `tests.sh`](testing.md#testssh) with:


### PR DESCRIPTION
# Description

NymVPN alpha has a [new release](https://github.com/nymtech/nym/releases/tag/nym-vpn-alpha-0.0.3). Upgrade guides and fix flaws. 

- [x] Fix flaws from feedback
- [x] Change version to `v0.0.3`
- [x] Change release page var
- [x] Update sha verification and the example strings
- [x] Ping @tommyv1987 to change vars in his scripts 