### PR TITLE
Add config to run the block signing in monitoring mode only

### DIFF
--- a/nym-validator-rewarder/src/cli/mod.rs
+++ b/nym-validator-rewarder/src/cli/mod.rs
@@ -54,6 +54,9 @@ pub struct ConfigOverridableArgs {
     pub disable_block_signing_rewarding: bool,
 
     #[clap(long)]
+    pub block_signing_monitoring_only: bool,
+
+    #[clap(long)]
     pub disable_credential_issuance_rewarding: bool,
 
     #[clap(long)]

--- a/nym-validator-rewarder/src/config/mod.rs
+++ b/nym-validator-rewarder/src/config/mod.rs
@@ -240,8 +240,11 @@ pub struct NyxdScraper {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BlockSigning {
-    /// Specifies whether credential issuance for block signing is enabled.
+    /// Specifies whether rewards for block signing is enabled.
     pub enabled: bool,
+
+    /// Specifies whether to only monitor and not send rewards.
+    pub monitor_only: bool,
 
     /// List of validators that will receive rewards for block signing.
     /// If not on the list, the validator will be treated as if it had 0 voting power.
@@ -252,6 +255,7 @@ impl Default for BlockSigning {
     fn default() -> Self {
         BlockSigning {
             enabled: true,
+            monitor_only: false,
             whitelist: vec![],
         }
     }

--- a/nym-validator-rewarder/src/config/override.rs
+++ b/nym-validator-rewarder/src/config/override.rs
@@ -14,6 +14,10 @@ impl ConfigOverride for ConfigOverridableArgs {
             config.block_signing.enabled = false
         }
 
+        if self.block_signing_monitoring_only {
+            config.block_signing.monitor_only = true
+        }
+
         if self.disable_credential_issuance_rewarding {
             config.issuance_monitor.enabled = false
         }

--- a/nym-validator-rewarder/src/config/template.rs
+++ b/nym-validator-rewarder/src/config/template.rs
@@ -38,8 +38,11 @@ credential_verification = {{ rewarding.ratios.credential_verification }}
     
     
 [block_signing]
-# Specifies whether credential issuance for block signing is enabled.
+# Specifies whether rewarding for block signing is enabled.
 enabled = {{ block_signing.enabled }}
+
+# Specifies whether to only monitor and not send rewards.
+monitor_only = {{ block_signing.monitor_only }}
 
 # List of validators that will receive rewards for block signing.
 # If not on the list, the validator will be treated as if it had 0 voting power.

--- a/nym-validator-rewarder/src/rewarder/mod.rs
+++ b/nym-validator-rewarder/src/rewarder/mod.rs
@@ -209,6 +209,11 @@ impl Rewarder {
         &self,
         amounts: Vec<(AccountId, Vec<Coin>)>,
     ) -> Result<Hash, NymRewarderError> {
+        if self.config.block_signing.monitor_only {
+            info!("skipping sending rewards, monitoring mode only");
+            return Ok(Hash::Sha256([0u8; 32]));
+        }
+
         info!("sending rewards");
         self.nyxd_client
             .send_rewards(self.current_epoch, amounts)


### PR DESCRIPTION
When true, sending reward tokens is skipped and a zero hash will be returned and written to db.

