### PR TITLE
Connected client handler in the IPR

### DIFF
--- a/common/ip-packet-requests/src/request.rs
+++ b/common/ip-packet-requests/src/request.rs
@@ -121,6 +121,8 @@ pub enum IpPacketRequestData {
     Data(DataRequest),
 }
 
+// A static connect request is when the client provides the internal IP address it will use on the
+// ip packet router.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct StaticConnectRequest {
     pub request_id: u64,
@@ -135,6 +137,8 @@ pub struct StaticConnectRequest {
     pub reply_to_avg_mix_delays: Option<f64>,
 }
 
+// A dynamic connect request is when the client does not provide the internal IP address it will use
+// on the ip packet router, and instead requests one to be assigned to it.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct DynamicConnectRequest {
     pub request_id: u64,
@@ -148,6 +152,8 @@ pub struct DynamicConnectRequest {
     pub reply_to_avg_mix_delays: Option<f64>,
 }
 
+// A disconnect request is when the client wants to disconnect from the ip packet router and free
+// up the allocated IP address.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct DisconnectRequest {
     pub request_id: u64,
@@ -155,6 +161,7 @@ pub struct DisconnectRequest {
     pub reply_to: Recipient,
 }
 
+// A data request is when the client wants to send an IP packet to a destination.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct DataRequest {
     pub ip_packet: bytes::Bytes,

--- a/common/ip-packet-requests/src/response.rs
+++ b/common/ip-packet-requests/src/response.rs
@@ -64,6 +64,48 @@ impl IpPacketResponse {
         }
     }
 
+    pub fn new_disconnect_success(request_id: u64, reply_to: Recipient) -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            data: IpPacketResponseData::Disconnect(DisconnectResponse {
+                request_id,
+                reply_to,
+                reply: DisconnectResponseReply::Success,
+            }),
+        }
+    }
+
+    pub fn new_disconnect_failure(
+        request_id: u64,
+        reply_to: Recipient,
+        reason: DisconnectFailureReason,
+    ) -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            data: IpPacketResponseData::Disconnect(DisconnectResponse {
+                request_id,
+                reply_to,
+                reply: DisconnectResponseReply::Failure(reason),
+            }),
+        }
+    }
+
+    // TODO
+    // pub fn new_unrequested_disconnect(
+    //     request_id: u64,
+    //     reply_to: Recipient,
+    //     reason: UnrequestedDisconnectReason,
+    // ) -> Self {
+    //     Self {
+    //         version: CURRENT_VERSION,
+    //         data: IpPacketResponseData::Disconnect(DisconnectResponse {
+    //             request_id: 0,
+    //             reply_to: Recipient::new(),
+    //             reply: DisconnectResponseReply::Failure(DisconnectFailureReason::Unrequested),
+    //         }),
+    //     }
+    // }
+
     pub fn new_ip_packet(ip_packet: bytes::Bytes) -> Self {
         Self {
             version: CURRENT_VERSION,

--- a/service-providers/ip-packet-router/src/connected_client_handler.rs
+++ b/service-providers/ip-packet-router/src/connected_client_handler.rs
@@ -68,8 +68,7 @@ impl ConnectedClientHandler {
         loop {
             tokio::select! {
                 _ = &mut self.close_rx => {
-                    // WIP(JON): downgrade to trace once confirmed to work
-                    log::warn!("ConnectedClientHandler: received shutdown");
+                    log::trace!("ConnectedClientHandler: received shutdown");
                     break;
                 },
                 packet = self.forward_from_tun_rx.recv() => match packet {
@@ -86,8 +85,7 @@ impl ConnectedClientHandler {
             }
         }
 
-        // WIP(JON): downgrade to debug once confirmed to work
-        log::warn!("ConnectedClientHandler: exiting");
+        log::debug!("ConnectedClientHandler: exiting");
         Ok(())
     }
 }

--- a/service-providers/ip-packet-router/src/connected_client_handler.rs
+++ b/service-providers/ip-packet-router/src/connected_client_handler.rs
@@ -79,11 +79,11 @@ impl ConnectedClientHandler {
         loop {
             tokio::select! {
                 _ = &mut self.close_rx => {
-                    log::trace!("ConnectedClientHandler: received shutdown");
+                    log::info!("ConnectedClientHandler: received shutdown");
                     break;
                 },
                 _ = self.activity_timeout.tick() => {
-                    log::debug!("ConnectedClientHandler: activity timeout reached for {}", self.nym_address);
+                    log::info!("ConnectedClientHandler: activity timeout reached for {}", self.nym_address);
                     break;
                 }
                 packet = self.forward_from_tun_rx.recv() => match packet {
@@ -93,21 +93,21 @@ impl ConnectedClientHandler {
                         }
                     },
                     None => {
-                        log::debug!("connected client handler: tun channel closed");
+                        log::info!("connected client handler: tun channel closed");
                         break;
                     }
                 },
             }
         }
 
-        log::debug!("ConnectedClientHandler: exiting");
+        log::info!("ConnectedClientHandler: exiting");
         Ok(())
     }
 }
 
 impl Drop for ConnectedClientHandler {
     fn drop(&mut self) {
-        log::trace!("ConnectedClientHandler: dropping");
+        log::info!("ConnectedClientHandler: dropping");
         if let Some(finished_tx) = self.finished_tx.take() {
             let _ = finished_tx.send(());
         }

--- a/service-providers/ip-packet-router/src/connected_client_handler.rs
+++ b/service-providers/ip-packet-router/src/connected_client_handler.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::time::Duration;
+
 use nym_ip_packet_requests::response::IpPacketResponse;
 use nym_sdk::mixnet::{MixnetMessageSender, Recipient};
 
@@ -8,6 +10,8 @@ use crate::{
     error::{IpPacketRouterError, Result},
     util::create_message::create_input_message,
 };
+
+const ACTIVITY_TIMEOUT_SEC: u64 = 15 * 60;
 
 // Data flow
 // Out: mixnet_listener -> decode -> handle_packet -> write_to_tun
@@ -21,18 +25,22 @@ pub(crate) struct ConnectedClientHandler {
     forward_from_tun_rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
     mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
     close_rx: tokio::sync::oneshot::Receiver<()>,
+    finished_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    activity_timeout: tokio::time::Interval,
 }
 
 impl ConnectedClientHandler {
-    pub(crate) fn launch(
+    pub(crate) fn start(
         reply_to: Recipient,
         reply_to_hops: Option<u8>,
         mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
     ) -> (
         tokio::sync::mpsc::UnboundedSender<Vec<u8>>,
         tokio::sync::oneshot::Sender<()>,
+        tokio::sync::oneshot::Receiver<()>,
     ) {
         let (close_tx, close_rx) = tokio::sync::oneshot::channel();
+        let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
         let (forward_from_tun_tx, forward_from_tun_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let connected_client_handler = ConnectedClientHandler {
@@ -41,6 +49,8 @@ impl ConnectedClientHandler {
             forward_from_tun_rx,
             mixnet_client_sender,
             close_rx,
+            finished_tx: Some(finished_tx),
+            activity_timeout: tokio::time::interval(Duration::from_secs(ACTIVITY_TIMEOUT_SEC)),
         };
 
         tokio::spawn(async move {
@@ -49,10 +59,11 @@ impl ConnectedClientHandler {
             }
         });
 
-        (forward_from_tun_tx, close_tx)
+        (forward_from_tun_tx, close_tx, finished_rx)
     }
 
     async fn handle_packet(&mut self, packet: Vec<u8>) -> Result<()> {
+        self.activity_timeout.reset();
         let response_packet = IpPacketResponse::new_ip_packet(packet.into())
             .to_bytes()
             .map_err(|err| IpPacketRouterError::FailedToSerializeResponsePacket { source: err })?;
@@ -71,6 +82,10 @@ impl ConnectedClientHandler {
                     log::trace!("ConnectedClientHandler: received shutdown");
                     break;
                 },
+                _ = self.activity_timeout.tick() => {
+                    log::debug!("ConnectedClientHandler: activity timeout reached for {}", self.nym_address);
+                    break;
+                }
                 packet = self.forward_from_tun_rx.recv() => match packet {
                     Some(packet) => {
                         if let Err(err) = self.handle_packet(packet).await {
@@ -81,11 +96,20 @@ impl ConnectedClientHandler {
                         log::debug!("connected client handler: tun channel closed");
                         break;
                     }
-                }
+                },
             }
         }
 
         log::debug!("ConnectedClientHandler: exiting");
         Ok(())
+    }
+}
+
+impl Drop for ConnectedClientHandler {
+    fn drop(&mut self) {
+        log::trace!("ConnectedClientHandler: dropping");
+        if let Some(finished_tx) = self.finished_tx.take() {
+            let _ = finished_tx.send(());
+        }
     }
 }

--- a/service-providers/ip-packet-router/src/connected_client_handler.rs
+++ b/service-providers/ip-packet-router/src/connected_client_handler.rs
@@ -1,0 +1,92 @@
+use std::{collections::HashMap, net::IpAddr};
+
+use nym_ip_packet_requests::response::IpPacketResponse;
+use nym_sdk::mixnet::{MixnetMessageSender, Recipient};
+use nym_task::TaskClient;
+#[cfg(target_os = "linux")]
+use tokio::io::AsyncReadExt;
+
+use crate::{
+    error::{IpPacketRouterError, Result},
+    mixnet_listener::{self},
+    util::{create_message::create_input_message, parse_ip::parse_dst_addr},
+};
+
+// Data flow
+// Out: mixnet_listener -> decode -> handle_packet -> write_to_tun
+// In: tun_listener -> [connected_client_handler -> encode] -> mixnet_sender
+
+// This handler is spawned as a task, and it listens to IP packets passed from the tun_listener,
+// encodes it, and then sends to mixnet.
+pub(crate) struct ConnectedClientHandler {
+    nym_address: Recipient,
+    mix_hops: Option<u8>,
+    tun_rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+    mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
+    close_rx: tokio::sync::oneshot::Receiver<()>,
+}
+
+impl ConnectedClientHandler {
+    pub(crate) fn new(
+        nym_address: Recipient,
+        mix_hops: Option<u8>,
+        tun_rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+        mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
+        close_rx: tokio::sync::oneshot::Receiver<()>,
+    ) -> Self {
+        ConnectedClientHandler {
+            nym_address,
+            mix_hops,
+            tun_rx,
+            mixnet_client_sender,
+            close_rx,
+        }
+    }
+
+    async fn handle_packet(&mut self, packet: Vec<u8>) -> Result<()> {
+        let response_packet = IpPacketResponse::new_ip_packet(packet.into())
+            .to_bytes()
+            .map_err(|err| IpPacketRouterError::FailedToSerializeResponsePacket { source: err })?;
+        let input_message = create_input_message(self.nym_address, response_packet, self.mix_hops);
+
+        self.mixnet_client_sender
+            .send(input_message)
+            .await
+            .map_err(|err| IpPacketRouterError::FailedToSendPacketToMixnet { source: err })?;
+
+        Ok(())
+    }
+
+    async fn run(mut self) -> Result<()> {
+        loop {
+            tokio::select! {
+                _ = &mut self.close_rx => {
+                    log::warn!("ConnectedClientHandler: received shutdown");
+                    break;
+                },
+                packet = self.tun_rx.recv() => match packet {
+                    Some(packet) => {
+                        if let Err(err) = self.handle_packet(packet).await {
+                            log::error!("connected client handler: failed to handle packet: {err}");
+                        }
+                    },
+                    None => {
+                        log::error!("connected client handler: tun channel closed");
+                        break;
+                    }
+                }
+            }
+        }
+
+        log::warn!("ConnectedClientHandler: exiting");
+        Ok(())
+    }
+
+    pub(crate) fn start(self) {
+        tokio::spawn(async move {
+            if let Err(err) = self.run().await {
+                log::error!("connected client handler has failed: {err}")
+            }
+        });
+    }
+}

--- a/service-providers/ip-packet-router/src/constants.rs
+++ b/service-providers/ip-packet-router/src/constants.rs
@@ -5,5 +5,12 @@ pub const TUN_BASE_NAME: &str = "nymtun";
 pub const TUN_DEVICE_ADDRESS: &str = "10.0.0.1";
 pub const TUN_DEVICE_NETMASK: &str = "255.255.255.0";
 
+// We routinely check if any clients needs to be disconnected at this interval
 pub(crate) const DISCONNECT_TIMER_INTERVAL: Duration = Duration::from_secs(10);
-pub(crate) const CLIENT_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+// We consider a client inactive if it hasn't sent any mixnet packets in this duration
+pub(crate) const CLIENT_MIXNET_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+// We consider a client handler inactive if it hasn't received any packets from the tun device in
+// this duration
+pub(crate) const CLIENT_HANDLER_ACTIVITY_TIMEOUT: Duration = Duration::from_secs(10 * 60);

--- a/service-providers/ip-packet-router/src/ip_packet_router.rs
+++ b/service-providers/ip-packet-router/src/ip_packet_router.rs
@@ -142,11 +142,9 @@ impl IpPacketRouter {
         // Channel used by the IpPacketRouter to signal connected and disconnected clients to the
         // TunListener
         let (connected_clients, connected_clients_rx) = mixnet_listener::ConnectedClients::new();
-        // let (connected_client_tx, connected_client_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let tun_listener = tun_listener::TunListener {
             tun_reader,
-            mixnet_client_sender: mixnet_client.split_sender(),
             task_client: task_handle.get_handle(),
             connected_clients: connected_clients_rx,
         };
@@ -162,7 +160,6 @@ impl IpPacketRouter {
             mixnet_client,
             task_handle,
             connected_clients,
-            // connected_client_tx,
         };
 
         log::info!("The address of this client is: {self_address}");

--- a/service-providers/ip-packet-router/src/lib.rs
+++ b/service-providers/ip-packet-router/src/lib.rs
@@ -5,6 +5,7 @@ pub use crate::config::Config;
 pub use ip_packet_router::{IpPacketRouter, OnStartData};
 
 pub mod config;
+mod connected_client_handler;
 mod constants;
 pub mod error;
 mod ip_packet_router;

--- a/service-providers/ip-packet-router/src/main.rs
+++ b/service-providers/ip-packet-router/src/main.rs
@@ -3,6 +3,8 @@ mod cli;
 #[cfg(target_os = "linux")]
 mod config;
 #[cfg(target_os = "linux")]
+mod connected_client_handler;
+#[cfg(target_os = "linux")]
 mod constants;
 #[cfg(target_os = "linux")]
 mod error;

--- a/service-providers/ip-packet-router/src/mixnet_listener.rs
+++ b/service-providers/ip-packet-router/src/mixnet_listener.rs
@@ -169,11 +169,9 @@ impl ConnectedClient {
 
 impl Drop for ConnectedClient {
     fn drop(&mut self) {
-        // WIP(JON): downgrade to trace once confirmed to work
-        log::info!("Dropping connected client: {}", self.nym_address);
+        log::info!("Dropping client: {}", self.nym_address);
         if let Some(close_tx) = self.close_tx.take() {
-            // WIP(JON): downgrade to trace once confirmed to work
-            log::info!("Sending close signal to connected client handler");
+            log::trace!("Sending close signal to connected client handler");
             close_tx.send(()).unwrap();
         }
     }

--- a/service-providers/ip-packet-router/src/mixnet_listener.rs
+++ b/service-providers/ip-packet-router/src/mixnet_listener.rs
@@ -213,7 +213,7 @@ impl Drop for ConnectedClient {
         log::info!("Dropping client: {}", self.nym_address);
         if let Some(close_tx) = self.close_tx.take() {
             log::trace!("Sending close signal to connected client handler");
-            close_tx.send(()).unwrap();
+            close_tx.send(()).ok();
         }
     }
 }
@@ -416,7 +416,7 @@ impl MixnetListener {
         } = parse_packet(&data_request.ip_packet)?;
 
         let dst_str = dst.map_or(dst_addr.to_string(), |dst| dst.to_string());
-        log::info!("Received packet: {packet_type}: {src_addr} -> {dst_str}");
+        log::debug!("Received packet: {packet_type}: {src_addr} -> {dst_str}");
 
         if let Some(connected_client) = self.connected_clients.get_client_from_ip_mut(&src_addr) {
             // Keep track of activity so we can disconnect inactive clients

--- a/service-providers/ip-packet-router/src/tun_listener.rs
+++ b/service-providers/ip-packet-router/src/tun_listener.rs
@@ -1,15 +1,14 @@
 use std::{collections::HashMap, net::IpAddr};
 
-use nym_ip_packet_requests::response::IpPacketResponse;
-use nym_sdk::mixnet::{MixnetMessageSender, Recipient};
+use nym_sdk::mixnet::Recipient;
 use nym_task::TaskClient;
 #[cfg(target_os = "linux")]
 use tokio::io::AsyncReadExt;
 
 use crate::{
-    error::{IpPacketRouterError, Result},
+    error::Result,
     mixnet_listener::{self},
-    util::{create_message::create_input_message, parse_ip::parse_dst_addr},
+    util::parse_ip::parse_dst_addr,
 };
 
 pub(crate) struct ConnectedClientMirror {
@@ -76,7 +75,7 @@ impl ConnectedClientsListener {
 #[cfg(target_os = "linux")]
 pub(crate) struct TunListener {
     pub(crate) tun_reader: tokio::io::ReadHalf<tokio_tun::Tun>,
-    pub(crate) mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
+    // pub(crate) mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
     pub(crate) task_client: TaskClient,
     pub(crate) connected_clients: ConnectedClientsListener,
 }
@@ -98,18 +97,6 @@ impl TunListener {
         {
             let packet = buf[..len].to_vec();
             forward_from_tun_tx.send(packet).unwrap();
-
-            // let response_packet = IpPacketResponse::new_ip_packet(packet.into())
-            //     .to_bytes()
-            //     .map_err(|err| IpPacketRouterError::FailedToSerializeResponsePacket {
-            //         source: err,
-            //     })?;
-            // let input_message = create_input_message(*nym_address, response_packet, *mix_hops);
-            //
-            // self.mixnet_client_sender
-            //     .send(input_message)
-            //     .await
-            //     .map_err(|err| IpPacketRouterError::FailedToSendPacketToMixnet { source: err })?;
         } else {
             log::info!("No registered nym-address for packet - dropping");
         }

--- a/service-providers/ip-packet-router/src/tun_listener.rs
+++ b/service-providers/ip-packet-router/src/tun_listener.rs
@@ -93,7 +93,9 @@ impl TunListener {
                     ));
             }
         } else {
-            log::info!("No registered client for packet with destination {dst_addr} - dropping");
+            log::info!(
+                "dropping packet from network: no registered client for destination: {dst_addr}"
+            );
         }
 
         Ok(())


### PR DESCRIPTION
# Description

To support multi ip packets per sphinx packets in the ip packet router, we need separate connection handlers per connected client to track accumulated buffer per client.
