### PR TITLE
Tweak retransmission log info

### DIFF
--- a/common/client-core/src/client/packet_statistics_control.rs
+++ b/common/client-core/src/client/packet_statistics_control.rs
@@ -288,6 +288,7 @@ impl PacketRates {
     }
 }
 
+#[derive(Debug)]
 pub(crate) enum PacketStatisticsEvent {
     // The real packets sent. Recall that acks are sent by the gateway, so it's not included here.
     RealPacketSent(usize),
@@ -443,7 +444,11 @@ impl PacketStatisticsControl {
             // Check what the number of retransmissions was during the recording window
             if let Some((_, start_stats)) = self.history.front() {
                 let delta = self.stats.clone() - start_stats.clone();
-                log::info!("retransmissions: {}", delta.retransmissions_queued,);
+                log::info!(
+                    "mix packet retransmissions/real mix packets: {}/{}",
+                    delta.retransmissions_queued,
+                    delta.real_packets_queued,
+                );
             } else {
                 log::warn!("Unable to check retransmissions during recording window");
             }


### PR DESCRIPTION
# Description

Tweak logging of retransmissions to give a sense of ratio between total packets sent
