### PR TITLE
Handle multiple IP packets in ip-packet-router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6732,6 +6732,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "bytes",
+ "nym-bin-common",
  "nym-sphinx",
  "rand 0.8.5",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6776,6 +6776,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tun",
+ "tokio-util",
  "url",
 ]
 

--- a/common/ip-packet-requests/Cargo.toml
+++ b/common/ip-packet-requests/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 [dependencies]
 bincode = "1.3.3"
 bytes = "1.5.0"
+nym-bin-common = { path = "../bin-common" }
 nym-sphinx = { path = "../nymsphinx" }
 rand = "0.8.5"
 serde = { workspace = true, features = ["derive"] }

--- a/common/ip-packet-requests/src/lib.rs
+++ b/common/ip-packet-requests/src/lib.rs
@@ -2,7 +2,7 @@ pub mod codec;
 pub mod request;
 pub mod response;
 
-pub const CURRENT_VERSION: u8 = 2;
+pub const CURRENT_VERSION: u8 = 3;
 
 fn make_bincode_serializer() -> impl bincode::Options {
     use bincode::Options;

--- a/common/ip-packet-requests/src/request.rs
+++ b/common/ip-packet-requests/src/request.rs
@@ -226,7 +226,7 @@ mod tests {
                 },
             )
         };
-        assert_eq!(connect.to_bytes().unwrap().len(), 107);
+        assert_eq!(connect.to_bytes().unwrap().len(), 108);
     }
 
     #[test]

--- a/common/ip-packet-requests/src/request.rs
+++ b/common/ip-packet-requests/src/request.rs
@@ -74,10 +74,10 @@ impl IpPacketRequest {
         )
     }
 
-    pub fn new_ip_packet(ip_packet: bytes::Bytes) -> Self {
+    pub fn new_data_request(ip_packets: bytes::Bytes) -> Self {
         Self {
             version: CURRENT_VERSION,
-            data: IpPacketRequestData::Data(DataRequest { ip_packet }),
+            data: IpPacketRequestData::Data(DataRequest { ip_packets }),
         }
     }
 
@@ -164,7 +164,7 @@ pub struct DisconnectRequest {
 // A data request is when the client wants to send an IP packet to a destination.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct DataRequest {
-    pub ip_packet: bytes::Bytes,
+    pub ip_packets: bytes::Bytes,
 }
 
 #[cfg(test)]
@@ -193,7 +193,7 @@ mod tests {
         let data = IpPacketRequest {
             version: 4,
             data: IpPacketRequestData::Data(DataRequest {
-                ip_packet: bytes::Bytes::from(vec![1u8; 32]),
+                ip_packets: bytes::Bytes::from(vec![1u8; 32]),
             }),
         };
         assert_eq!(data.to_bytes().unwrap().len(), 35);
@@ -204,7 +204,7 @@ mod tests {
         let data = IpPacketRequest {
             version: 4,
             data: IpPacketRequestData::Data(DataRequest {
-                ip_packet: bytes::Bytes::from(vec![1, 2, 4, 2, 5]),
+                ip_packets: bytes::Bytes::from(vec![1, 2, 4, 2, 5]),
             }),
         };
 
@@ -221,7 +221,7 @@ mod tests {
         assert_eq!(
             deserialized.data,
             IpPacketRequestData::Data(DataRequest {
-                ip_packet: bytes::Bytes::from(vec![1, 2, 4, 2, 5]),
+                ip_packets: bytes::Bytes::from(vec![1, 2, 4, 2, 5]),
             })
         );
     }

--- a/common/ip-packet-requests/src/request.rs
+++ b/common/ip-packet-requests/src/request.rs
@@ -92,6 +92,7 @@ impl IpPacketRequest {
             IpPacketRequestData::Disconnect(request) => Some(request.request_id),
             IpPacketRequestData::Data(_) => None,
             IpPacketRequestData::Ping(request) => Some(request.request_id),
+            IpPacketRequestData::Health(request) => Some(request.request_id),
         }
     }
 
@@ -102,6 +103,7 @@ impl IpPacketRequest {
             IpPacketRequestData::Disconnect(request) => Some(&request.reply_to),
             IpPacketRequestData::Data(_) => None,
             IpPacketRequestData::Ping(request) => Some(&request.reply_to),
+            IpPacketRequestData::Health(request) => Some(&request.reply_to),
         }
     }
 
@@ -126,6 +128,7 @@ pub enum IpPacketRequestData {
     Disconnect(DisconnectRequest),
     Data(DataRequest),
     Ping(PingRequest),
+    Health(HealthRequest),
 }
 
 // A static connect request is when the client provides the internal IP address it will use on the
@@ -192,6 +195,13 @@ pub struct DataRequest {
 // A ping request is when the client wants to check if the ip packet router is still alive.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct PingRequest {
+    pub request_id: u64,
+    // The nym-address the response should be sent back to
+    pub reply_to: Recipient,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct HealthRequest {
     pub request_id: u64,
     // The nym-address the response should be sent back to
     pub reply_to: Recipient,

--- a/common/ip-packet-requests/src/request.rs
+++ b/common/ip-packet-requests/src/request.rs
@@ -91,6 +91,7 @@ impl IpPacketRequest {
             IpPacketRequestData::DynamicConnect(request) => Some(request.request_id),
             IpPacketRequestData::Disconnect(request) => Some(request.request_id),
             IpPacketRequestData::Data(_) => None,
+            IpPacketRequestData::Ping(request) => Some(request.request_id),
         }
     }
 
@@ -100,6 +101,7 @@ impl IpPacketRequest {
             IpPacketRequestData::DynamicConnect(request) => Some(&request.reply_to),
             IpPacketRequestData::Disconnect(request) => Some(&request.reply_to),
             IpPacketRequestData::Data(_) => None,
+            IpPacketRequestData::Ping(request) => Some(&request.reply_to),
         }
     }
 
@@ -123,6 +125,7 @@ pub enum IpPacketRequestData {
     DynamicConnect(DynamicConnectRequest),
     Disconnect(DisconnectRequest),
     Data(DataRequest),
+    Ping(PingRequest),
 }
 
 // A static connect request is when the client provides the internal IP address it will use on the
@@ -184,6 +187,14 @@ pub struct DisconnectRequest {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct DataRequest {
     pub ip_packets: bytes::Bytes,
+}
+
+// A ping request is when the client wants to check if the ip packet router is still alive.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct PingRequest {
+    pub request_id: u64,
+    // The nym-address the response should be sent back to
+    pub reply_to: Recipient,
 }
 
 #[cfg(test)]

--- a/common/ip-packet-requests/src/request.rs
+++ b/common/ip-packet-requests/src/request.rs
@@ -23,6 +23,7 @@ impl IpPacketRequest {
         reply_to: Recipient,
         reply_to_hops: Option<u8>,
         reply_to_avg_mix_delays: Option<f64>,
+        buffer_timeout: Option<u64>,
     ) -> (Self, u64) {
         let request_id = generate_random();
         (
@@ -34,6 +35,7 @@ impl IpPacketRequest {
                     reply_to,
                     reply_to_hops,
                     reply_to_avg_mix_delays,
+                    buffer_timeout,
                 }),
             },
             request_id,
@@ -44,6 +46,7 @@ impl IpPacketRequest {
         reply_to: Recipient,
         reply_to_hops: Option<u8>,
         reply_to_avg_mix_delays: Option<f64>,
+        buffer_timeout: Option<u64>,
     ) -> (Self, u64) {
         let request_id = generate_random();
         (
@@ -54,6 +57,7 @@ impl IpPacketRequest {
                     reply_to,
                     reply_to_hops,
                     reply_to_avg_mix_delays,
+                    buffer_timeout,
                 }),
             },
             request_id,
@@ -126,15 +130,23 @@ pub enum IpPacketRequestData {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct StaticConnectRequest {
     pub request_id: u64,
+
     pub ip: IpAddr,
+
     // The nym-address the response should be sent back to
     pub reply_to: Recipient,
+
     // The number of mix node hops that responses should take, in addition to the entry and exit
     // node. Zero means only client -> entry -> exit -> client.
     pub reply_to_hops: Option<u8>,
+
     // The average delay at each mix node, in milliseconds. Currently this is not supported by the
     // ip packet router.
     pub reply_to_avg_mix_delays: Option<f64>,
+
+    // The maximum time in milliseconds the IPR should wait when filling up a mix packet
+    // with ip packets.
+    pub buffer_timeout: Option<u64>,
 }
 
 // A dynamic connect request is when the client does not provide the internal IP address it will use
@@ -142,14 +154,21 @@ pub struct StaticConnectRequest {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct DynamicConnectRequest {
     pub request_id: u64,
+
     // The nym-address the response should be sent back to
     pub reply_to: Recipient,
+
     // The number of mix node hops that responses should take, in addition to the entry and exit
     // node. Zero means only client -> entry -> exit -> client.
     pub reply_to_hops: Option<u8>,
+
     // The average delay at each mix node, in milliseconds. Currently this is not supported by the
     // ip packet router.
     pub reply_to_avg_mix_delays: Option<f64>,
+
+    // The maximum time in milliseconds the IPR should wait when filling up a mix packet
+    // with ip packets.
+    pub buffer_timeout: Option<u64>,
 }
 
 // A disconnect request is when the client wants to disconnect from the ip packet router and free
@@ -182,6 +201,7 @@ mod tests {
                     reply_to: Recipient::try_from_base58_string("D1rrpsysCGCYXy9saP8y3kmNpGtJZUXN9SvFoUcqAsM9.9Ssso1ea5NfkbMASdiseDSjTN1fSWda5SgEVjdSN4CvV@GJqd3ZxpXWSNxTfx7B1pPtswpetH4LnJdFeLeuY5KUuN").unwrap(),
                     reply_to_hops: None,
                     reply_to_avg_mix_delays: None,
+                    buffer_timeout: None,
                 },
             )
         };

--- a/common/ip-packet-requests/src/response.rs
+++ b/common/ip-packet-requests/src/response.rs
@@ -147,6 +147,7 @@ impl IpPacketResponse {
             IpPacketResponseData::Disconnect(response) => Some(response.request_id),
             IpPacketResponseData::UnrequestedDisconnect(_) => None,
             IpPacketResponseData::Data(_) => None,
+            IpPacketResponseData::Pong(response) => Some(response.request_id),
             IpPacketResponseData::Error(response) => Some(response.request_id),
         }
     }
@@ -158,6 +159,7 @@ impl IpPacketResponse {
             IpPacketResponseData::Disconnect(response) => Some(&response.reply_to),
             IpPacketResponseData::UnrequestedDisconnect(response) => Some(&response.reply_to),
             IpPacketResponseData::Data(_) => None,
+            IpPacketResponseData::Pong(response) => Some(&response.reply_to),
             IpPacketResponseData::Error(response) => Some(&response.reply_to),
         }
     }
@@ -192,6 +194,9 @@ pub enum IpPacketResponseData {
 
     // Response to a data request
     Data(DataResponse),
+
+    // Response to ping request
+    Pong(PongResponse),
 
     // Error response
     Error(ErrorResponse),
@@ -306,6 +311,12 @@ pub enum UnrequestedDisconnectReason {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DataResponse {
     pub ip_packet: bytes::Bytes,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PongResponse {
+    pub request_id: u64,
+    pub reply_to: Recipient,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/common/ip-packet-requests/src/response.rs
+++ b/common/ip-packet-requests/src/response.rs
@@ -148,6 +148,7 @@ impl IpPacketResponse {
             IpPacketResponseData::UnrequestedDisconnect(_) => None,
             IpPacketResponseData::Data(_) => None,
             IpPacketResponseData::Pong(response) => Some(response.request_id),
+            IpPacketResponseData::Health(response) => Some(response.request_id),
             IpPacketResponseData::Error(response) => Some(response.request_id),
         }
     }
@@ -160,6 +161,7 @@ impl IpPacketResponse {
             IpPacketResponseData::UnrequestedDisconnect(response) => Some(&response.reply_to),
             IpPacketResponseData::Data(_) => None,
             IpPacketResponseData::Pong(response) => Some(&response.reply_to),
+            IpPacketResponseData::Health(response) => Some(&response.reply_to),
             IpPacketResponseData::Error(response) => Some(&response.reply_to),
         }
     }
@@ -197,6 +199,9 @@ pub enum IpPacketResponseData {
 
     // Response to ping request
     Pong(PongResponse),
+
+    // Response for a health request
+    Health(HealthResponse),
 
     // Error response
     Error(ErrorResponse),
@@ -317,6 +322,21 @@ pub struct DataResponse {
 pub struct PongResponse {
     pub request_id: u64,
     pub reply_to: Recipient,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HealthResponse {
+    pub request_id: u64,
+    pub reply_to: Recipient,
+    pub reply: HealthResponseReply,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HealthResponseReply {
+    // Return the binary build information of the IPR
+    pub build_info: nym_bin_common::build_information::BinaryBuildInformationOwned,
+    // Return if the IPR has performed a successful routing test.
+    pub routable: Option<bool>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/service-providers/ip-packet-router/Cargo.toml
+++ b/service-providers/ip-packet-router/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = { workspace = true }
 tap.workspace = true
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
+tokio-util = { workspace = true, features = ["codec"] }
 url.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/service-providers/ip-packet-router/src/mixnet_listener.rs
+++ b/service-providers/ip-packet-router/src/mixnet_listener.rs
@@ -529,6 +529,10 @@ impl MixnetListener {
                 Ok(vec![self.on_disconnect_request(disconnect_request)])
             }
             IpPacketRequestData::Data(data_request) => self.on_data_request(data_request).await,
+            IpPacketRequestData::Ping(_) => {
+                log::info!("Received ping request: not implemented, dropping");
+                Ok(vec![])
+            }
         }
     }
 

--- a/service-providers/ip-packet-router/src/mixnet_listener.rs
+++ b/service-providers/ip-packet-router/src/mixnet_listener.rs
@@ -262,6 +262,8 @@ impl MixnetListener {
         let requested_ip = connect_request.ip;
         let reply_to = connect_request.reply_to;
         let reply_to_hops = connect_request.reply_to_hops;
+        // TODO: add to connect request
+        let buffer_timeout = nym_ip_packet_requests::codec::BUFFER_TIMEOUT;
         // TODO: ignoring reply_to_avg_mix_delays for now
 
         // Check that the IP is available in the set of connected clients
@@ -292,6 +294,7 @@ impl MixnetListener {
                     connected_client_handler::ConnectedClientHandler::start(
                         reply_to,
                         reply_to_hops,
+                        buffer_timeout,
                         self.mixnet_client.split_sender(),
                     );
 
@@ -339,6 +342,8 @@ impl MixnetListener {
         let request_id = connect_request.request_id;
         let reply_to = connect_request.reply_to;
         let reply_to_hops = connect_request.reply_to_hops;
+        // TODO: add to connect request
+        let buffer_timeout = nym_ip_packet_requests::codec::BUFFER_TIMEOUT;
         // TODO: ignoring reply_to_avg_mix_delays for now
 
         // Check if it's the same client connecting again, then we just reuse the same IP
@@ -375,6 +380,7 @@ impl MixnetListener {
             connected_client_handler::ConnectedClientHandler::start(
                 reply_to,
                 reply_to_hops,
+                buffer_timeout,
                 self.mixnet_client.split_sender(),
             );
 
@@ -456,7 +462,6 @@ impl MixnetListener {
         data_request: nym_ip_packet_requests::request::DataRequest,
     ) -> Result<Vec<PacketHandleResult>> {
         let mut responses = Vec::new();
-        // TODO: set timeout per connected client
         let mut decoder = MultiIpPacketCodec::new(nym_ip_packet_requests::codec::BUFFER_TIMEOUT);
         let mut bytes = BytesMut::new();
         bytes.extend_from_slice(&data_request.ip_packets);

--- a/service-providers/ip-packet-router/src/mixnet_listener.rs
+++ b/service-providers/ip-packet-router/src/mixnet_listener.rs
@@ -533,6 +533,10 @@ impl MixnetListener {
                 log::info!("Received ping request: not implemented, dropping");
                 Ok(vec![])
             }
+            IpPacketRequestData::Health(_) => {
+                log::info!("Received health request: not implemented, dropping");
+                Ok(vec![])
+            }
         }
     }
 


### PR DESCRIPTION
# Description

The last step in adding support for bundling multiple IP packets per mix packet.
Also takes the opportunity to add a few request response types for the future when we anyway are bumping the protocol version.

- Handle incoming multi-ip packets in IPR
- Encode packets in connection handler
- Add buffer timeout to connect request
- Add message for unrequested disconnect on the IPR
- Add ping pong request response
- Add health request response
