### PR TITLE
Generic prom wrapper idea

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,12 +2296,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.5",
+ "darling_macro 0.20.5",
 ]
 
 [[package]]
@@ -2334,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
 dependencies = [
  "fnv",
  "ident_case",
@@ -2370,11 +2370,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.5",
  "quote",
  "syn 2.0.38",
 ]
@@ -6309,6 +6309,7 @@ dependencies = [
  "nym-task",
  "nym-topology",
  "nym-validator-client",
+ "prometheus",
  "rand 0.7.3",
  "reqwest",
  "serde",
@@ -8545,6 +8546,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.1",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8666,10 +8682,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "psl"
-version = "2.1.14"
+name = "protobuf"
+version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383703acfc34f7a00724846c14dc5ea4407c59e5aedcbbb18a1c0c1a23fe5013"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "psl"
+version = "2.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc74a6e6a56708be1cf5c4c4d1a0dc21d33b2dcaa24e731b7fa9c287ce4f916f"
 dependencies = [
  "psl-types",
 ]
@@ -10029,9 +10051,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.4.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
 dependencies = [
  "base64 0.21.4",
  "chrono",
@@ -10046,11 +10068,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.4.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.5",
  "proc-macro2",
  "quote",
  "syn 2.0.38",

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -27,9 +27,12 @@ tap = "1.0.1"
 thiserror = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 tungstenite = { workspace = true, default-features = false }
-tokio = { workspace = true, features = ["macros"]}
+tokio = { workspace = true, features = ["macros"] }
 time = "0.3.17"
 zeroize = { workspace = true }
+
+# prometheus
+prometheus = { version = "0.13" }
 
 # internal
 nym-bandwidth-controller = { path = "../bandwidth-controller" }
@@ -91,11 +94,15 @@ tempfile = "3.1.0"
 
 [build-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate"] }
+sqlx = { workspace = true, features = [
+    "runtime-tokio-rustls",
+    "sqlite",
+    "macros",
+    "migrate",
+] }
 
 [features]
 default = []
 cli = ["clap"]
 fs-surb-storage = ["sqlx"]
 wasm = ["nym-gateway-client/wasm"]
-

--- a/common/client-core/src/client/mod.rs
+++ b/common/client-core/src/client/mod.rs
@@ -13,3 +13,4 @@ pub mod received_buffer;
 pub mod replies;
 pub mod topology_control;
 pub(crate) mod transmission_buffer;
+pub(crate) mod prometheus_metrics_controller;

--- a/common/client-core/src/client/packet_statistics_control.rs
+++ b/common/client-core/src/client/packet_statistics_control.rs
@@ -3,6 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use serde::Serialize;
 use si_scale::helpers::bibytes2;
 
 use crate::spawn_future;
@@ -17,7 +18,7 @@ const SNAPSHOT_INTERVAL_MS: u64 = 500;
 // Also, set it larger than the packet report interval so that we don't miss notable singular events
 const RECORDING_WINDOW_MS: u64 = 2300;
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize)]
 struct PacketStatistics {
     // Sent
     real_packets_sent: u64,
@@ -147,7 +148,7 @@ impl std::ops::Sub for PacketStatistics {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 struct PacketRates {
     real_packets_sent: f64,
     real_packets_sent_size: f64,

--- a/common/client-core/src/client/prometheus_metrics_controller.rs
+++ b/common/client-core/src/client/prometheus_metrics_controller.rs
@@ -1,0 +1,126 @@
+use std::collections::HashMap;
+
+use prometheus::{Gauge, Registry};
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::error::MetricsError;
+
+// Generic helper to recursively register prometheus metrics from a given struct, nested fields are handled by by concating field names with a dot
+// Integers and floats are registered as [gauges](https://prometheus.io/docs/concepts/metric_types/#gauge),
+// since gauge api is more robust and can be used to display counters as well
+pub struct PrometheusMetrics<'a, T: Serialize + 'a> {
+    registry: Registry,
+    source: &'a T,
+    metrics: HashMap<String, Gauge>,
+}
+
+struct MetricValue {
+    name: String,
+    value: f64,
+}
+
+struct PromMetric {
+    name: String,
+    gauge: Gauge,
+}
+
+impl<'a, T: Serialize> PrometheusMetrics<'a, T> {
+    pub fn init(registry: Registry, source: &'a T) -> Result<Self, MetricsError> {
+        let mut p = PrometheusMetrics {
+            registry,
+            source,
+            metrics: HashMap::new(),
+        };
+        let metrics = p.init_metrics()?;
+        for metric in metrics {
+            p.registry.register(Box::new(metric.gauge.clone()))?;
+            p.metrics.insert(metric.name, metric.gauge);
+        }
+        Ok(p)
+    }
+
+    pub fn update(&self) -> Result<(), MetricsError> {
+        let metrics_map: Map<String, Value> = serde_json::to_value(self.source)?
+            .as_object()
+            .ok_or_else(|| MetricsError::NotAnObject)?
+            .clone();
+        let metric_values = flatten_all(metrics_map.iter().map(|(k, v)| collect_metric(k, v)))?;
+        for metric in metric_values {
+            self.metrics
+                .get(&metric.name)
+                .ok_or_else(|| MetricsError::PrometheusError {
+                    source: prometheus::Error::Msg(format!(
+                        "metric {} not found in the registry",
+                        metric.name
+                    )),
+                })?
+                .set(metric.value);
+        }
+        Ok(())
+    }
+
+    pub fn init_metrics(&self) -> Result<Vec<PromMetric>, MetricsError> {
+        let metrics_map: Map<String, Value> = serde_json::to_value(self.source)?
+            .as_object()
+            .ok_or_else(|| MetricsError::NotAnObject)?
+            .clone();
+        let metrics = flatten_all(metrics_map.iter().map(|(k, v)| init_metric(k, v)))?;
+        Ok(metrics)
+    }
+}
+
+fn init_gauge(name: &str) -> Result<PromMetric, MetricsError> {
+    Ok(PromMetric {
+        name: name.to_string(),
+        gauge: prometheus::Gauge::new(name, "")?,
+    })
+}
+
+fn init_metric(name: &str, value: &Value) -> Result<Option<Vec<PromMetric>>, MetricsError> {
+    match value {
+        Value::String(_) | Value::Bool(_) | Value::Null => Ok(None),
+        Value::Number(v) => Ok(Some(vec![init_gauge(name)?])),
+        Value::Array(arr) => {
+            Ok(Some(flatten_all(arr.iter().enumerate().map(|(i, v)| {
+                init_metric(&format!("{}.{}", name, i), v)
+            }))?))
+        }
+        Value::Object(obj) => {
+            Ok(Some(flatten_all(obj.iter().map(|(k, v)| {
+                init_metric(&format!("{}.{}", name, k), v)
+            }))?))
+        }
+    }
+}
+
+fn collect_metric(name: &str, value: &Value) -> Result<Option<Vec<MetricValue>>, MetricsError> {
+    match value {
+        Value::String(_) | Value::Bool(_) | Value::Null => Ok(None),
+        Value::Number(v) => Ok(Some(vec![MetricValue {
+            name: name.to_string(),
+            value: v.as_f64().ok_or_else(|| MetricsError::NotANumber)?,
+        }])),
+        Value::Array(arr) => {
+            Ok(Some(flatten_all(arr.iter().enumerate().map(|(i, v)| {
+                collect_metric(&format!("{}.{}", name, i), v)
+            }))?))
+        }
+        Value::Object(obj) => {
+            Ok(Some(flatten_all(obj.iter().map(|(k, v)| {
+                collect_metric(&format!("{}.{}", name, k), v)
+            }))?))
+        }
+    }
+}
+
+fn flatten_all<T>(
+    it: impl Iterator<Item = Result<Option<Vec<T>>, MetricsError>>,
+) -> Result<Vec<T>, MetricsError> {
+    Ok(it
+        .collect::<Result<Vec<Option<Vec<T>>>, MetricsError>>()?
+        .into_iter()
+        .filter_map(|x| x)
+        .flatten()
+        .collect::<Vec<T>>())
+}

--- a/common/client-core/src/error.rs
+++ b/common/client-core/src/error.rs
@@ -165,3 +165,23 @@ pub enum ClientCoreStatusMessage {
     #[error("The connected gateway is very slow, or the connection to it is very slow")]
     GatewayIsVerySlow,
 }
+
+#[derive(thiserror::Error, Debug)]
+pub enum MetricsError {
+    #[error("Prometheus error: {source}")]
+    PrometheusError {
+        #[from]
+        source: prometheus::Error,
+    },
+    #[error("Serde error: {source}")]
+    SerdeJson {
+        #[from]
+        source: serde_json::Error,
+    },
+    #[error(
+        "Associated type does not deserialize into an object, this is not supported at the moment"
+    )]
+    NotAnObject,
+    #[error("Value detected as a number, but it is not a valid number")]
+    NotANumber,
+}


### PR DESCRIPTION
# Description

Generic helper to recursively register prometheus metrics from a given struct, nested fields are handled by by concating field names with a dot. Integers and floats are registered as [gauges](https://prometheus.io/docs/concepts/metric_types/#gauge), since gauge api is more robust and can be used to display counters as well