### PR TITLE
sandbox nym-mixnode on OpenBSD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5745,6 +5745,7 @@ dependencies = [
  "nym-types",
  "nym-validator-client",
  "opentelemetry",
+ "pledge",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -5754,6 +5755,7 @@ dependencies = [
  "tokio-util",
  "toml 0.5.11",
  "tracing",
+ "unveil",
  "url",
 ]
 
@@ -7214,6 +7216,15 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "pledge"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252599417b7d9a43b7fdc63dd790b0848666a8910b2ebe1a25118309c3c981e5"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "platforms"
@@ -10416,6 +10427,15 @@ name = "unwind_safe"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0976c77def3f1f75c4ef892a292c31c0bbe9e3d0702c63044d7c76db298171a3"
+
+[[package]]
+name = "unveil"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7fa867d559102001ec694165ed17d5f82e95213060a65f9c8b6280084bbfec"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "url"

--- a/mixnode/Cargo.toml
+++ b/mixnode/Cargo.toml
@@ -62,6 +62,8 @@ nym-topology = { path = "../common/topology" }
 nym-validator-client = { path = "../common/client-libs/validator-client" }
 nym-bin-common = { path = "../common/bin-common", features = ["output_format"] }
 cpu-cycles = { path = "../cpu-cycles", optional = true }
+unveil = "0.3.2"
+pledge = "0.4.2"
 
 [dev-dependencies]
 tokio = { workspace = true, features = [

--- a/mixnode/src/commands/build_info.rs
+++ b/mixnode/src/commands/build_info.rs
@@ -5,6 +5,8 @@ use clap::Args;
 use nym_bin_common::bin_info_owned;
 use nym_bin_common::output_format::OutputFormat;
 
+use pledge::pledge;
+
 #[derive(Args)]
 pub(crate) struct BuildInfo {
     #[clap(short, long, default_value_t = OutputFormat::default())]
@@ -12,5 +14,7 @@ pub(crate) struct BuildInfo {
 }
 
 pub(crate) fn execute(args: BuildInfo) {
+    pledge("stdio rpath", None).unwrap();
+
     println!("{}", args.output.format(&bin_info_owned!()))
 }

--- a/mixnode/src/commands/describe.rs
+++ b/mixnode/src/commands/describe.rs
@@ -8,6 +8,8 @@ use colored::Colorize;
 use std::io;
 use std::io::Write;
 
+use pledge::pledge;
+
 #[derive(Args)]
 pub(crate) struct Describe {
     /// The id of the mixnode you want to describe
@@ -39,6 +41,8 @@ fn read_user_input() -> String {
 }
 
 pub(crate) fn execute(args: Describe) -> anyhow::Result<()> {
+    pledge("stdio rpath wpath cpath", None).unwrap();
+
     // ensure that the mixnode has in fact been initialized
     let config = try_load_current_config(&args.id)?;
 

--- a/mixnode/src/commands/init.rs
+++ b/mixnode/src/commands/init.rs
@@ -13,6 +13,8 @@ use nym_crypto::asymmetric::{encryption, identity};
 use std::net::IpAddr;
 use std::{fs, io};
 
+use pledge::pledge;
+
 #[derive(Args, Clone)]
 pub(crate) struct Init {
     /// Id of the mixnode we want to create config for
@@ -63,6 +65,8 @@ fn init_paths(id: &str) -> io::Result<()> {
 }
 
 pub(crate) fn execute(args: &Init) -> anyhow::Result<()> {
+    pledge("stdio rpath cpath wpath fattr", None).unwrap();
+
     let override_config_fields = OverrideConfig::from(args.clone());
     let id = override_config_fields.id.clone();
     eprintln!("Initialising mixnode {id}...");

--- a/mixnode/src/commands/node_details.rs
+++ b/mixnode/src/commands/node_details.rs
@@ -6,6 +6,8 @@ use crate::node::MixNode;
 use clap::Args;
 use nym_bin_common::output_format::OutputFormat;
 
+use pledge::pledge;
+
 #[derive(Args)]
 pub(crate) struct NodeDetails {
     /// The id of the mixnode you want to show details for
@@ -17,6 +19,8 @@ pub(crate) struct NodeDetails {
 }
 
 pub(crate) fn execute(args: &NodeDetails) -> anyhow::Result<()> {
+    pledge("stdio rpath", None).unwrap();
+
     let config = try_load_current_config(&args.id)?;
 
     MixNode::new(config)?.print_node_details(args.output);

--- a/mixnode/src/commands/sign.rs
+++ b/mixnode/src/commands/sign.rs
@@ -14,6 +14,8 @@ use std::convert::TryFrom;
 
 use super::version_check;
 
+use pledge::pledge;
+
 #[derive(Args, Clone)]
 #[clap(group(ArgGroup::new("sign").required(true).args(&["wallet_address", "text", "contract_msg"])))]
 pub(crate) struct Sign {
@@ -113,6 +115,8 @@ fn print_signed_contract_msg(
 }
 
 pub(crate) fn execute(args: &Sign) -> anyhow::Result<()> {
+    pledge("stdio rpath", None).unwrap();
+
     let config = try_load_current_config(&args.id)?;
 
     if !version_check(&config) {
@@ -128,6 +132,8 @@ pub(crate) fn execute(args: &Sign) -> anyhow::Result<()> {
         }
     };
     let identity_keypair = load_identity_keys(&config)?;
+
+    pledge("stdio", None).unwrap();
 
     match signed_target {
         SignedTarget::Text(text) => {

--- a/mixnode/src/main.rs
+++ b/mixnode/src/main.rs
@@ -16,6 +16,8 @@ use nym_mixnode_common::measure;
 #[cfg(feature = "cpucycles")]
 use tracing::instrument;
 
+use pledge::pledge;
+
 mod commands;
 mod config;
 pub(crate) mod error;
@@ -59,6 +61,8 @@ async fn main() -> anyhow::Result<()> {
     if !args.no_banner {
         maybe_print_banner(crate_name!(), crate_version!());
     }
+
+    pledge("stdio rpath cpath wpath fattr inet dns unveil", None).unwrap();
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "cpucycles")] {


### PR DESCRIPTION
These patches [pledge(2)](https://man.openbsd.org/pledge.2) and [unveil(2)](https://man.openbsd.org/unveil.2) the nym-mixnode daemon so that it can be run with more confidence that it won't disrupt or interfere with other processes running on the same system. Roughly speaking, pledge is like Linux seccomp and unveil can be compared with [Landlock](https://docs.kernel.org/security/landlock.html).

I know this is a bit of a wild shot, but would the project be interested in incorporating patches like these?