### PR TITLE
fix: localnet script fix typo to attach tmux session

### DIFF
--- a/scripts/localnet_start.sh
+++ b/scripts/localnet_start.sh
@@ -73,4 +73,4 @@ tmux send-keys -t localnet:1 "time curl -x socks5h://127.0.0.1:1080 https://test
 tmux select-layout -t localnet:0 tiled
 tmux select-layout -t localnet:1 tiled
 
-tmux attach -tlocalnet
+tmux attach -t localnet


### PR DESCRIPTION
# Description

Fixes typo to attach to tmux session properly
