### PR TITLE
temporarily remove the debian builder from gh action

### DIFF
--- a/.github/workflows/ci-build-upload-binaries.yml
+++ b/.github/workflows/ci-build-upload-binaries.yml
@@ -79,15 +79,15 @@ jobs:
           command: build
           args: --workspace --release ${{ env.CARGO_FEATURES }}
 
-      - name: Install cargo-deb
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-deb
+      # - name: Install cargo-deb
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: install
+      #     args: cargo-deb
 
-      - name: Build deb packages
-        shell: bash
-        run: make deb
+      # - name: Build deb packages
+      #   shell: bash
+      #   run: make deb
 
       # If this was a manual workflow_dispatch, publish binaries.
 
@@ -124,7 +124,7 @@ jobs:
           cp target/release/nym-network-statistics $OUTPUT_DIR
           cp target/release/nym-cli $OUTPUT_DIR
           cp target/release/explorer-api $OUTPUT_DIR
-          cp target/debian/*.deb $OUTPUT_DIR
+          # cp target/debian/*.deb $OUTPUT_DIR
 
       - name: Deploy branch to CI www
         # if: github.event_name == 'schedule' || github.event_name == 'pull_request'

--- a/.github/workflows/ci-build-upload-binaries.yml
+++ b/.github/workflows/ci-build-upload-binaries.yml
@@ -13,6 +13,11 @@ on:
         required: true
         default: false
         type: boolean
+      enable_deb:
+        description: "True to enable cargo-deb installation and .deb package building"
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: '14 0 * * *'
   pull_request:
@@ -79,17 +84,17 @@ jobs:
           command: build
           args: --workspace --release ${{ env.CARGO_FEATURES }}
 
-      # - name: Install cargo-deb
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: install
-      #     args: cargo-deb
+      - name: Install cargo-deb
+        if: github.event_name == 'workflow_dispatch' && inputs.enable_deb == true
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-deb
 
-      # - name: Build deb packages
-      #   shell: bash
-      #   run: make deb
-
-      # If this was a manual workflow_dispatch, publish binaries.
+      - name: Build deb packages
+        if: github.event_name == 'workflow_dispatch' && inputs.enable_deb == true
+        shell: bash
+        run: make deb
 
       - name: Upload Artifact
         if: github.event_name == 'workflow_dispatch'
@@ -124,10 +129,11 @@ jobs:
           cp target/release/nym-network-statistics $OUTPUT_DIR
           cp target/release/nym-cli $OUTPUT_DIR
           cp target/release/explorer-api $OUTPUT_DIR
-          # cp target/debian/*.deb $OUTPUT_DIR
+          if [ ${{ github.event_name == 'workflow_dispatch' && inputs.enable_deb == true }} = true ]; then
+            cp target/debian/*.deb $OUTPUT_DIR
+          fi
 
       - name: Deploy branch to CI www
-        # if: github.event_name == 'schedule' || github.event_name == 'pull_request'
         continue-on-error: true
         uses: easingthemes/ssh-deploy@main
         env:

--- a/.github/workflows/ci-build-upload-binaries.yml
+++ b/.github/workflows/ci-build-upload-binaries.yml
@@ -9,7 +9,7 @@ on:
         default: false
         type: boolean
       enable_wireguard:
-        description: 'Add --features wireguard'
+        description: "Add --features wireguard"
         required: true
         default: false
         type: boolean
@@ -19,7 +19,7 @@ on:
         default: false
         type: boolean
   schedule:
-    - cron: '14 0 * * *'
+    - cron: "14 0 * * *"
   pull_request:
     paths:
       - "clients/**"
@@ -85,16 +85,16 @@ jobs:
           args: --workspace --release ${{ env.CARGO_FEATURES }}
 
       - name: Install cargo-deb
-        if: github.event_name == 'workflow_dispatch' && inputs.enable_deb == true
         uses: actions-rs/cargo@v1
         with:
           command: install
           args: cargo-deb
+        if: github.event_name == 'workflow_dispatch' && inputs.enable_deb == true
 
       - name: Build deb packages
-        if: github.event_name == 'workflow_dispatch' && inputs.enable_deb == true
         shell: bash
         run: make deb
+        if: github.event_name == 'workflow_dispatch' && inputs.enable_deb == true
 
       - name: Upload Artifact
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
- at the moment it's not needed but in the future we may want to re-activate it, currently commenting it out
