### PR TITLE
proof of concept: env-configurable mixnode

### DIFF
--- a/mixnode/Cargo.toml
+++ b/mixnode/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.58.1"
 axum = { workspace = true }
 anyhow = { workspace = true }
 bs58 = { workspace = true }
-clap = { workspace = true, features = ["cargo", "derive"] }
+clap = { workspace = true, features = ["cargo", "derive", "env"] }
 colored = "2.0"
 cupid = "0.6.1"
 dirs = "4.0"

--- a/mixnode/src/commands/build_info.rs
+++ b/mixnode/src/commands/build_info.rs
@@ -1,13 +1,14 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use crate::env::vars::*;
 use clap::Args;
 use nym_bin_common::bin_info_owned;
 use nym_bin_common::output_format::OutputFormat;
 
 #[derive(Args)]
 pub(crate) struct BuildInfo {
-    #[clap(short, long, default_value_t = OutputFormat::default())]
+    #[clap(short, long, default_value_t = OutputFormat::default(), env = MIXNODE_OUTPUT_ARG)]
     output: OutputFormat,
 }
 

--- a/mixnode/src/commands/describe.rs
+++ b/mixnode/src/commands/describe.rs
@@ -1,7 +1,9 @@
 // Copyright 2021-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use super::DEFAULT_MIXNODE_ID;
 use crate::commands::try_load_current_config;
+use crate::env::vars::*;
 use crate::node::node_description::NodeDescription;
 use clap::Args;
 use colored::Colorize;
@@ -11,7 +13,7 @@ use std::io::Write;
 #[derive(Args)]
 pub(crate) struct Describe {
     /// The id of the mixnode you want to describe
-    #[clap(long)]
+    #[clap(long, default_value = DEFAULT_MIXNODE_ID, env = MIXNODE_ID_ARG)]
     id: String,
 
     /// Human readable name of this node

--- a/mixnode/src/commands/mod.rs
+++ b/mixnode/src/commands/mod.rs
@@ -16,6 +16,8 @@ use nym_crypto::bech32_address_validation;
 use std::net::IpAddr;
 use std::process;
 
+pub const DEFAULT_MIXNODE_ID: &str = "nym-mixnode";
+
 mod build_info;
 mod describe;
 mod init;
@@ -54,7 +56,7 @@ pub(crate) enum Commands {
 // Configuration that can be overridden.
 struct OverrideConfig {
     id: String,
-    host: Option<IpAddr>,
+    listening_address: Option<IpAddr>,
     mix_port: Option<u16>,
     verloc_port: Option<u16>,
     http_api_port: Option<u16>,
@@ -79,7 +81,7 @@ pub(crate) async fn execute(args: Cli) -> anyhow::Result<()> {
 
 fn override_config(config: Config, args: OverrideConfig) -> Config {
     config
-        .with_optional(Config::with_listening_address, args.host)
+        .with_optional(Config::with_listening_address, args.listening_address)
         .with_optional(Config::with_mix_port, args.mix_port)
         .with_optional(Config::with_verloc_port, args.verloc_port)
         .with_optional(Config::with_http_api_port, args.http_api_port)

--- a/mixnode/src/commands/node_details.rs
+++ b/mixnode/src/commands/node_details.rs
@@ -1,7 +1,9 @@
-// Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
+// Copyright 2021-2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use super::DEFAULT_MIXNODE_ID;
 use crate::commands::try_load_current_config;
+use crate::env::vars::*;
 use crate::node::MixNode;
 use clap::Args;
 use nym_bin_common::output_format::OutputFormat;
@@ -9,7 +11,7 @@ use nym_bin_common::output_format::OutputFormat;
 #[derive(Args)]
 pub(crate) struct NodeDetails {
     /// The id of the mixnode you want to show details for
-    #[clap(long)]
+    #[clap(long, default_value = DEFAULT_MIXNODE_ID, env = MIXNODE_ID_ARG)]
     id: String,
 
     #[clap(short, long, default_value_t = OutputFormat::default())]

--- a/mixnode/src/commands/run.rs
+++ b/mixnode/src/commands/run.rs
@@ -2,28 +2,26 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use super::OverrideConfig;
+use super::DEFAULT_MIXNODE_ID;
 use crate::commands::{override_config, try_load_current_config, version_check};
+use crate::env::vars::*;
 use crate::node::MixNode;
 use anyhow::bail;
 use clap::Args;
 use log::error;
 use nym_bin_common::output_format::OutputFormat;
 use nym_config::helpers::SPECIAL_ADDRESSES;
-use nym_validator_client::nyxd;
 use std::net::IpAddr;
+
 #[derive(Args, Clone)]
 pub(crate) struct Run {
     /// Id of the nym-mixnode we want to run
-    #[clap(long)]
+    #[clap(long, default_value = DEFAULT_MIXNODE_ID, env = MIXNODE_ID_ARG)]
     id: String,
 
     /// The custom host on which the mixnode will be running
-    #[clap(long)]
-    host: Option<IpAddr>,
-
-    /// The wallet address you will use to bond this mixnode, e.g. nymt1z9egw0knv47nmur0p8vk4rcx59h9gg4zuxrrr9
-    #[clap(long)]
-    wallet_address: Option<nyxd::AccountId>,
+    #[clap(long, alias = "host")]
+    listening_address: Option<IpAddr>,
 
     /// The port on which the mixnode will be listening for mix packets
     #[clap(long)]
@@ -42,7 +40,7 @@ pub(crate) struct Run {
     #[clap(long, alias = "validators", value_delimiter = ',')]
     nym_apis: Option<Vec<url::Url>>,
 
-    #[clap(short, long, default_value_t = OutputFormat::default())]
+    #[clap(short, long, default_value_t = OutputFormat::default(), env = MIXNODE_OUTPUT_ARG)]
     output: OutputFormat,
 }
 
@@ -50,7 +48,7 @@ impl From<Run> for OverrideConfig {
     fn from(run_config: Run) -> Self {
         OverrideConfig {
             id: run_config.id,
-            host: run_config.host,
+            listening_address: run_config.listening_address,
             mix_port: run_config.mix_port,
             verloc_port: run_config.verloc_port,
             http_api_port: run_config.http_api_port,

--- a/mixnode/src/commands/run.rs
+++ b/mixnode/src/commands/run.rs
@@ -20,24 +20,24 @@ pub(crate) struct Run {
     id: String,
 
     /// The custom host on which the mixnode will be running
-    #[clap(long, alias = "host")]
+    #[clap(long, alias = "host", env = MIXNODE_LISTENING_ADDRESS_ARG)]
     listening_address: Option<IpAddr>,
 
     /// The port on which the mixnode will be listening for mix packets
-    #[clap(long)]
+    #[clap(long, env = MIXNODE_MIX_PORT_ARG)]
     mix_port: Option<u16>,
 
     /// The port on which the mixnode will be listening for verloc packets
-    #[clap(long)]
+    #[clap(long, env = MIXNODE_VERLOC_PORT_ARG)]
     verloc_port: Option<u16>,
 
     /// The port on which the mixnode will be listening for http requests
-    #[clap(long)]
+    #[clap(long, env = MIXNODE_HTTP_API_PORT_ARG)]
     http_api_port: Option<u16>,
 
     /// Comma separated list of nym-api endpoints of the validators
     // the alias here is included for backwards compatibility (1.1.4 and before)
-    #[clap(long, alias = "validators", value_delimiter = ',')]
+    #[clap(long, alias = "validators", value_delimiter = ',', env = MIXNODE_NYM_APIS_ARG)]
     nym_apis: Option<Vec<url::Url>>,
 
     #[clap(short, long, default_value_t = OutputFormat::default(), env = MIXNODE_OUTPUT_ARG)]

--- a/mixnode/src/commands/sign.rs
+++ b/mixnode/src/commands/sign.rs
@@ -1,7 +1,10 @@
 // Copyright 2020-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use super::version_check;
+use super::DEFAULT_MIXNODE_ID;
 use crate::commands::{try_load_current_config, validate_bech32_address_or_exit};
+use crate::env::vars::*;
 use crate::node::helpers::load_identity_keys;
 use anyhow::{bail, Result};
 use clap::{ArgGroup, Args};
@@ -12,13 +15,11 @@ use nym_types::helpers::ConsoleSigningOutput;
 use nym_validator_client::nyxd;
 use std::convert::TryFrom;
 
-use super::version_check;
-
 #[derive(Args, Clone)]
 #[clap(group(ArgGroup::new("sign").required(true).args(&["wallet_address", "text", "contract_msg"])))]
 pub(crate) struct Sign {
     /// The id of the mixnode you want to sign with
-    #[clap(long)]
+    #[clap(long, default_value = DEFAULT_MIXNODE_ID, env = MIXNODE_ID_ARG)]
     id: String,
 
     /// Signs your blockchain address with your identity key
@@ -34,7 +35,7 @@ pub(crate) struct Sign {
     #[clap(long)]
     contract_msg: Option<String>,
 
-    #[clap(short, long, default_value_t = OutputFormat::default())]
+    #[clap(short, long, default_value_t = OutputFormat::default(), env = MIXNODE_OUTPUT_ARG)]
     output: OutputFormat,
 }
 

--- a/mixnode/src/env.rs
+++ b/mixnode/src/env.rs
@@ -1,0 +1,12 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+pub mod vars {
+    pub const MIXNODE_ID_ARG: &str = "NYM_MIXNODE_ID";
+    pub const MIXNODE_LISTENING_ADDRESS_ARG: &str = "NYM_MIXNODE_LISTENING_ADDRESS";
+    pub const MIXNODE_MIX_PORT_ARG: &str = "NYM_MIXNODE_MIX_PORT";
+    pub const MIXNODE_VERLOC_PORT_ARG: &str = "NYM_MIXNODE_VERLOC_PORT";
+    pub const MIXNODE_HTTP_API_PORT_ARG: &str = "NYM_MIXNODE_HTTP_API_PORT";
+    pub const MIXNODE_NYM_APIS_ARG: &str = "NYM_MIXNODE_NYM_APIS";
+    pub const MIXNODE_OUTPUT_ARG: &str = "NYM_MIXNODE_OUTPUT";
+}

--- a/mixnode/src/main.rs
+++ b/mixnode/src/main.rs
@@ -18,6 +18,7 @@ use tracing::instrument;
 
 mod commands;
 mod config;
+mod env;
 pub(crate) mod error;
 mod node;
 


### PR DESCRIPTION
# Description

A simple proof of concept of to allow us to initialise (and run) our binaries by fully configuring them using environmental variables.

For now I've just implemented it for the mixnode, but it can be extended to other binaries like the gateway, nym-api, etc.