### PR TITLE
Add severity level to IPR response and downgrade filter check failed

### DIFF
--- a/common/ip-packet-requests/src/lib.rs
+++ b/common/ip-packet-requests/src/lib.rs
@@ -8,7 +8,8 @@ pub mod response;
 
 // version 3: initial version
 // version 4: IPv6 support
-pub const CURRENT_VERSION: u8 = 4;
+// version 5: Add severity level to info response
+pub const CURRENT_VERSION: u8 = 5;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct IpPair {

--- a/service-providers/ip-packet-router/src/mixnet_listener.rs
+++ b/service-providers/ip-packet-router/src/mixnet_listener.rs
@@ -8,7 +8,7 @@ use nym_ip_packet_requests::{
     codec::MultiIpPacketCodec,
     request::{IpPacketRequest, IpPacketRequestData},
     response::{
-        DynamicConnectFailureReason, ErrorResponseReply, IpPacketResponse,
+        DynamicConnectFailureReason, InfoResponseReply, IpPacketResponse,
         StaticConnectFailureReason,
     },
     IpPair,
@@ -482,7 +482,7 @@ impl MixnetListener {
                 log::info!("Denied filter check: {dst}");
                 Ok(Some(IpPacketResponse::new_data_error_response(
                     connected_client.nym_address,
-                    ErrorResponseReply::ExitPolicyFilterCheckFailed {
+                    InfoResponseReply::ExitPolicyFilterCheckFailed {
                         dst: dst.to_string(),
                     },
                 )))

--- a/service-providers/ip-packet-router/src/mixnet_listener.rs
+++ b/service-providers/ip-packet-router/src/mixnet_listener.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, net::SocketAddr};
 
 use bytes::{Bytes, BytesMut};
 use futures::StreamExt;
+use nym_ip_packet_requests::response::InfoLevel;
 use nym_ip_packet_requests::{
     codec::MultiIpPacketCodec,
     request::{IpPacketRequest, IpPacketRequestData},
@@ -480,11 +481,12 @@ impl MixnetListener {
                 Ok(None)
             } else {
                 log::info!("Denied filter check: {dst}");
-                Ok(Some(IpPacketResponse::new_data_error_response(
+                Ok(Some(IpPacketResponse::new_data_info_response(
                     connected_client.nym_address,
                     InfoResponseReply::ExitPolicyFilterCheckFailed {
                         dst: dst.to_string(),
                     },
+                    InfoLevel::Warn,
                 )))
             }
         } else {


### PR DESCRIPTION
Not all responses from the IPR should be considered errors. Rename to info response and add a severity level so that the client can chill about less bad messages.

This is a **_backwards incompatible_** change to the request / response types, so the version is bumped

- Add info level to response from ipr
- Downgrade exit policy filter check failed to warning