### PR TITLE
Create TaskStatusTrait

### DIFF
--- a/common/client-core/src/error.rs
+++ b/common/client-core/src/error.rs
@@ -4,6 +4,7 @@
 use crate::client::mix_traffic::transceiver::ErasedGatewayError;
 use nym_crypto::asymmetric::identity::Ed25519RecoveryError;
 use nym_gateway_client::error::GatewayClientError;
+use nym_task::manager::TaskStatusTrait;
 use nym_topology::gateway::GatewayConversionError;
 use nym_topology::NymTopologyError;
 use nym_validator_client::ValidatorClientError;
@@ -165,3 +166,14 @@ pub enum ClientCoreStatusMessage {
     #[error("The connected gateway is very slow, or the connection to it is very slow")]
     GatewayIsVerySlow,
 }
+
+// impl TaskStatusTrait for ClientCoreStatusMessage {}
+// impl<T: std::fmt::Debug + std::fmt::Display + Send + Sync + Any + 'static> TaskStatusTrait for T {
+//     fn as_any(&self) -> &dyn Any {
+//         self
+//     }
+//
+//     fn as_any_mut(&mut self) -> &mut dyn Any {
+//         self
+//     }
+// }

--- a/common/socks5-client-core/src/error.rs
+++ b/common/socks5-client-core/src/error.rs
@@ -1,6 +1,7 @@
 use crate::socks::types::SocksProxyError;
 use nym_client_core::error::ClientCoreError;
 use nym_socks5_requests::{ConnectionError, ConnectionId};
+use nym_task::manager::TaskStatusTrait;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Socks5ClientCoreError {
@@ -19,6 +20,14 @@ pub enum Socks5ClientCoreError {
         error: String,
     },
 }
+
+#[derive(thiserror::Error, Debug)]
+pub enum Socks5ClientCoreStatusMessage {
+    #[error(transparent)]
+    Socks5Error(#[from] Socks5ClientCoreError),
+}
+
+// impl TaskStatusTrait for Socks5ClientCoreStatusMessage {}
 
 impl From<ConnectionError> for Socks5ClientCoreError {
     fn from(value: ConnectionError) -> Self {

--- a/common/socks5-client-core/src/socks/mixnet_responses.rs
+++ b/common/socks5-client-core/src/socks/mixnet_responses.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::Socks5ClientCoreError;
+use crate::error::{Socks5ClientCoreError, Socks5ClientCoreStatusMessage};
 use futures::channel::mpsc;
 use futures::StreamExt;
 use log::*;
@@ -136,7 +136,8 @@ impl MixnetResponseListener {
                     if let Some(received_responses) = received_responses {
                         for reconstructed_message in received_responses {
                             if let Err(err) = self.on_message(reconstructed_message) {
-                                self.shutdown.send_status_msg(Box::new(err));
+                                let msg = Socks5ClientCoreStatusMessage::from(err);
+                                self.shutdown.send_status_msg(Box::new(msg));
                             }
                         }
                     } else {

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -655,6 +655,7 @@ where
                 .next()
                 .await
                 .ok_or(Error::Socks5NotStarted)?
+                .as_any()
                 .downcast_ref::<TaskStatus>()
                 .ok_or(Error::Socks5NotStarted)?
             {


### PR DESCRIPTION
Create TaskStatusTrait. The idea is that we want something with a little more structure than `Box<dyn Error>` for status messages.
