### PR TITLE
Add TaskStatus::ReadyWithGateway

### DIFF
--- a/common/socks5-client-core/src/lib.rs
+++ b/common/socks5-client-core/src/lib.rs
@@ -23,6 +23,7 @@ use nym_client_core::init::types::GatewaySetup;
 use nym_credential_storage::storage::Storage as CredentialStorage;
 use nym_sphinx::addressing::clients::Recipient;
 use nym_sphinx::params::PacketType;
+use nym_task::manager::TaskStatus;
 use nym_task::{TaskClient, TaskHandle};
 
 use anyhow::anyhow;
@@ -177,7 +178,9 @@ where
             ))?;
 
         // Listen to status messages from task, that we forward back to the caller
-        shutdown.start_status_listener(sender).await;
+        shutdown
+            .start_status_listener(sender, TaskStatus::Ready)
+            .await;
 
         let res = tokio::select! {
             biased;

--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -163,10 +163,14 @@ impl TaskManager {
         self.notify_tx.send(())
     }
 
-    pub async fn start_status_listener(&mut self, mut sender: StatusSender) {
+    pub async fn start_status_listener(
+        &mut self,
+        mut sender: StatusSender,
+        start_status: TaskStatus,
+    ) {
         // Announce that we are operational. This means that in the application where this is used,
         // everything is up and running and ready to go.
-        if let Err(msg) = sender.send(Box::new(TaskStatus::Ready)).await {
+        if let Err(msg) = sender.send(Box::new(start_status)).await {
             log::error!("Error sending status message: {}", msg);
         };
 

--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -46,6 +46,8 @@ enum TaskError {
 pub enum TaskStatus {
     #[error("Ready")]
     Ready,
+    #[error("Ready and connected to gateway: {0}")]
+    ReadyWithGateway(String),
 }
 
 /// Listens to status and error messages from tasks, as well as notifying them to gracefully

--- a/nym-connect/desktop/src-tauri/src/events.rs
+++ b/nym-connect/desktop/src-tauri/src/events.rs
@@ -39,7 +39,7 @@ pub async fn handle_task_status(
     window: &tauri::Window,
 ) {
     match task_status {
-        TaskStatus::Ready => {
+        TaskStatus::Ready | TaskStatus::ReadyWithGateway(_) => {
             {
                 let mut state_w = state.write().await;
                 state_w.mark_connected(window);

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -650,7 +650,9 @@ where
 
         // TODO: more graceful handling here, surely both variants should work... I think?
         if let TaskHandle::Internal(task_manager) = &mut started_client.task_handle {
-            task_manager.start_status_listener(socks5_status_tx).await;
+            task_manager
+                .start_status_listener(socks5_status_tx, TaskStatus::Ready)
+                .await;
             match socks5_status_rx
                 .next()
                 .await

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -661,6 +661,9 @@ where
                 TaskStatus::Ready => {
                     log::debug!("Socks5 connected");
                 }
+                TaskStatus::ReadyWithGateway(gateway) => {
+                    log::debug!("Socks5 connected to {gateway}");
+                }
             }
         } else {
             return Err(Error::new_unsupported(


### PR DESCRIPTION
Add `TaskStatus::WithGateway(String)` enum. The purpose is to be able to signal back what gateway we ended up being connected to, since this isn't always decided up front by the client caller.