### PR TITLE
Feature Noise XKpsk3 IP from bond

### DIFF
--- a/common/client-libs/mixnet-client/src/client.rs
+++ b/common/client-libs/mixnet-client/src/client.rs
@@ -135,7 +135,6 @@ impl Client {
                             Default::default(),
                             &topology,
                             epoch_id,
-                            local_identity.public_key(),
                             local_identity.private_key(),
                         )
                         .await

--- a/common/nymnoise/src/lib.rs
+++ b/common/nymnoise/src/lib.rs
@@ -15,10 +15,11 @@ pub mod connection;
 pub mod error;
 pub mod stream;
 
+const NOISE_PSK_PREFIX: &[u8] = b"NYMTECH_NOISE_dQw4w9WgXcQ";
+
 pub async fn upgrade_noise_initiator(
     conn: TcpStream,
     pattern: NoisePattern,
-    local_public_key: Option<&encryption::PublicKey>,
     local_private_key: &encryption::PrivateKey,
     remote_pub_key: &encryption::PublicKey,
     epoch: u32,
@@ -27,9 +28,7 @@ pub async fn upgrade_noise_initiator(
 
     //In case the local key cannot be known by the remote party, e.g. in a client-gateway connection
     let secret = [
-        local_public_key
-            .map(|k| k.to_bytes().to_vec())
-            .unwrap_or_default(),
+        NOISE_PSK_PREFIX.to_vec(),
         remote_pub_key.to_bytes().to_vec(),
         epoch.to_be_bytes().to_vec(),
     ]
@@ -52,7 +51,6 @@ pub async fn upgrade_noise_initiator_with_topology(
     pattern: NoisePattern,
     topology: &NymTopology,
     epoch: u32,
-    local_public_key: &encryption::PublicKey,
     local_private_key: &encryption::PrivateKey,
 ) -> Result<Connection, NoiseError> {
     //Get init material
@@ -61,7 +59,7 @@ pub async fn upgrade_noise_initiator_with_topology(
         Error::Prereq(Prerequisite::RemotePublicKey)
     })?;
 
-    let remote_pub_key = match topology.find_node_key_by_mix_host(responder_addr) {
+    let remote_pub_key = match topology.find_node_key_by_mix_host(responder_addr, true) {
         Ok(Some(key)) => encryption::PublicKey::from_base58_string(key)?,
         Ok(None) => {
             warn!(
@@ -79,15 +77,7 @@ pub async fn upgrade_noise_initiator_with_topology(
         }
     };
 
-    upgrade_noise_initiator(
-        conn,
-        pattern,
-        Some(local_public_key),
-        local_private_key,
-        &remote_pub_key,
-        epoch,
-    )
-    .await
+    upgrade_noise_initiator(conn, pattern, local_private_key, &remote_pub_key, epoch).await
 }
 
 pub async fn upgrade_noise_responder(
@@ -95,16 +85,13 @@ pub async fn upgrade_noise_responder(
     pattern: NoisePattern,
     local_public_key: &encryption::PublicKey,
     local_private_key: &encryption::PrivateKey,
-    remote_pub_key: Option<&encryption::PublicKey>,
     epoch: u32,
 ) -> Result<Connection, NoiseError> {
     trace!("Perform Noise Handshake, responder side");
 
     //If the remote_key cannot be kwnown, e.g. in a client-gateway connection
     let secret = [
-        remote_pub_key
-            .map(|k| k.to_bytes().to_vec())
-            .unwrap_or_default(),
+        NOISE_PSK_PREFIX.to_vec(),
         local_public_key.to_bytes().to_vec(),
         epoch.to_be_bytes().to_vec(),
     ]
@@ -139,31 +126,26 @@ pub async fn upgrade_noise_responder_with_topology(
     };
 
     //SW : for private gateway, we could try to perform the handshake without that key?
-    let remote_pub_key = match topology.find_node_key_by_mix_host(initiator_addr) {
-        Ok(Some(key)) => encryption::PublicKey::from_base58_string(key)?,
+    match topology.find_node_key_by_mix_host(initiator_addr, false) {
+        Ok(Some(_)) => {
+            //Existing node supporting Noise
+            upgrade_noise_responder(conn, pattern, local_public_key, local_private_key, epoch).await
+        }
         Ok(None) => {
+            //Existing node not supporting Noise yet
             warn!(
                 "{:?} can't speak Noise yet, falling back to TCP",
                 initiator_addr
             );
-            return Ok(Connection::Tcp(conn));
+            Ok(Connection::Tcp(conn))
         }
         Err(_) => {
+            //Non existing node
             error!(
                 "Cannot find public key for node with address {:?}",
                 initiator_addr
             ); //Do we still pursue a TCP connection with that node or not?
-            return Err(Error::Prereq(Prerequisite::RemotePublicKey).into());
+            Err(Error::Prereq(Prerequisite::RemotePublicKey).into())
         }
-    };
-
-    upgrade_noise_responder(
-        conn,
-        pattern,
-        local_public_key,
-        local_private_key,
-        Some(&remote_pub_key),
-        epoch,
-    )
-    .await
+    }
 }

--- a/common/nymsphinx/src/receiver.rs
+++ b/common/nymsphinx/src/receiver.rs
@@ -237,7 +237,7 @@ mod message_receiver {
                 mix_id: 123,
                 owner: "foomp1".to_string(),
                 host: "10.20.30.40".parse().unwrap(),
-                mix_host: "10.20.30.40:1789".parse().unwrap(),
+                mix_hosts: vec!["10.20.30.40:1789".parse().unwrap()],
                 identity_key: identity::PublicKey::from_base58_string(
                     "3ebjp1Fb9hdcS1AR6AZihgeJiMHkB5jjJUsvqNnfQwU7",
                 )
@@ -257,7 +257,7 @@ mod message_receiver {
                 mix_id: 234,
                 owner: "foomp2".to_string(),
                 host: "11.21.31.41".parse().unwrap(),
-                mix_host: "11.21.31.41:1789".parse().unwrap(),
+                mix_hosts: vec!["11.21.31.41:1789".parse().unwrap()],
                 identity_key: identity::PublicKey::from_base58_string(
                     "D6YaMzLSY7mANtSQRKXsmMZpqgqiVkeiagKM4V4oFPFr",
                 )
@@ -277,7 +277,7 @@ mod message_receiver {
                 mix_id: 456,
                 owner: "foomp3".to_string(),
                 host: "12.22.32.42".parse().unwrap(),
-                mix_host: "12.22.32.42:1789".parse().unwrap(),
+                mix_hosts: vec!["12.22.32.42:1789".parse().unwrap()],
                 identity_key: identity::PublicKey::from_base58_string(
                     "GkWDysw4AjESv1KiAiVn7JzzCMJeksxNSXVfr1PpX8wD",
                 )
@@ -297,7 +297,7 @@ mod message_receiver {
             vec![gateway::Node {
                 owner: "foomp4".to_string(),
                 host: "1.2.3.4".parse().unwrap(),
-                mix_host: "1.2.3.4:1789".parse().unwrap(),
+                mix_hosts: vec!["1.2.3.4:1789".parse().unwrap()],
                 clients_ws_port: 9000,
                 clients_wss_port: None,
                 identity_key: identity::PublicKey::from_base58_string(

--- a/common/topology/src/gateway.rs
+++ b/common/topology/src/gateway.rs
@@ -46,8 +46,8 @@ pub enum GatewayConversionError {
 pub struct Node {
     pub owner: String,
     pub host: NetworkAddress,
-    // we're keeping this as separate resolved field since we do not want to be resolving the potential
-    // hostname every time we want to construct a path via this node
+    // we're keeping all resolved IPs as a separate field since we do not want to be resolving the potential
+    // hostname every time we want to construct a path via this node. When we need one, we default to the first one
     pub mix_hosts: Vec<SocketAddr>,
 
     // #[serde(alias = "clients_port")]

--- a/common/topology/src/lib.rs
+++ b/common/topology/src/lib.rs
@@ -211,11 +211,10 @@ impl NymTopology {
                 let ip_addresses = sock_addr.iter().map(|addr| addr.ip()).collect::<Vec<_>>();
                 if ip_addresses.contains(&mix_host.ip()) {
                     //we have our node
-                    if description.is_some()
-                        && description.as_ref().unwrap().noise_information.supported
-                    //SAFETY: We checked that `description` wasn't None
-                    {
-                        return Ok(Some(sphinx_key.to_string()));
+                    if let Some(d) = description {
+                        if d.noise_information.supported {
+                            return Ok(Some(sphinx_key.to_string()));
+                        }
                     }
                     return Ok(None);
                 }

--- a/common/topology/src/lib.rs
+++ b/common/topology/src/lib.rs
@@ -539,7 +539,7 @@ mod converting_mixes_to_vec {
                 mix_id: 42,
                 owner: "N/A".to_string(),
                 host: "3.3.3.3".parse().unwrap(),
-                mix_host: "3.3.3.3:1789".parse().unwrap(),
+                mix_hosts: vec!["3.3.3.3:1789".parse().unwrap()],
                 identity_key: identity::PublicKey::from_base58_string(
                     "3ebjp1Fb9hdcS1AR6AZihgeJiMHkB5jjJUsvqNnfQwU7",
                 )

--- a/common/topology/src/mix.rs
+++ b/common/topology/src/mix.rs
@@ -34,8 +34,8 @@ pub struct Node {
     pub mix_id: MixId,
     pub owner: String,
     pub host: NetworkAddress,
-    // we're keeping this as separate resolved field since we do not want to be resolving the potential
-    // hostname every time we want to construct a path via this node
+    // we're keeping all resolved IPs as a separate field since we do not want to be resolving the potential
+    // hostname every time we want to construct a path via this node. When we need one, we default to the first one
     pub mix_hosts: Vec<SocketAddr>,
     pub identity_key: identity::PublicKey,
     pub sphinx_key: encryption::PublicKey, // TODO: or nymsphinx::PublicKey? both are x25519

--- a/common/topology/src/mix.rs
+++ b/common/topology/src/mix.rs
@@ -36,7 +36,7 @@ pub struct Node {
     pub host: NetworkAddress,
     // we're keeping this as separate resolved field since we do not want to be resolving the potential
     // hostname every time we want to construct a path via this node
-    pub mix_host: SocketAddr,
+    pub mix_hosts: Vec<SocketAddr>,
     pub identity_key: identity::PublicKey,
     pub sphinx_key: encryption::PublicKey, // TODO: or nymsphinx::PublicKey? both are x25519
     pub layer: Layer,
@@ -49,7 +49,7 @@ impl std::fmt::Debug for Node {
             .field("mix_id", &self.mix_id)
             .field("owner", &self.owner)
             .field("host", &self.host)
-            .field("mix_host", &self.mix_host)
+            .field("mix_hosts", &self.mix_hosts)
             .field("identity_key", &self.identity_key.to_base58_string())
             .field("sphinx_key", &self.sphinx_key.to_base58_string())
             .field("layer", &self.layer)
@@ -70,13 +70,12 @@ impl Node {
     pub fn extract_mix_host(
         host: &NetworkAddress,
         mix_port: u16,
-    ) -> Result<SocketAddr, MixnodeConversionError> {
-        Ok(host.to_socket_addrs(mix_port).map_err(|err| {
-            MixnodeConversionError::InvalidAddress {
+    ) -> Result<Vec<SocketAddr>, MixnodeConversionError> {
+        host.to_socket_addrs(mix_port)
+            .map_err(|err| MixnodeConversionError::InvalidAddress {
                 value: host.to_string(),
                 source: err,
-            }
-        })?[0])
+            })
     }
 }
 
@@ -89,7 +88,7 @@ impl filter::Versioned for Node {
 
 impl<'a> From<&'a Node> for SphinxNode {
     fn from(node: &'a Node) -> Self {
-        let node_address_bytes = NymNodeRoutingAddress::from(node.mix_host)
+        let node_address_bytes = NymNodeRoutingAddress::from(node.mix_hosts[0])
             .try_into()
             .unwrap();
 
@@ -105,13 +104,13 @@ impl<'a> TryFrom<&'a MixNodeBond> for Node {
 
         // try to completely resolve the host in the mix situation to avoid doing it every
         // single time we want to construct a path
-        let mix_host = Self::extract_mix_host(&host, bond.mix_node.mix_port)?;
+        let mix_hosts = Self::extract_mix_host(&host, bond.mix_node.mix_port)?;
 
         Ok(Node {
             mix_id: bond.mix_id,
             owner: bond.owner.as_str().to_owned(),
             host,
-            mix_host,
+            mix_hosts,
             identity_key: identity::PublicKey::from_base58_string(&bond.mix_node.identity_key)?,
             sphinx_key: encryption::PublicKey::from_base58_string(&bond.mix_node.sphinx_key)?,
             layer: bond.layer,

--- a/nym-connect/desktop/Cargo.lock
+++ b/nym-connect/desktop/Cargo.lock
@@ -5541,7 +5541,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -6508,7 +6507,7 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
- "webpki-roots 0.22.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -7478,7 +7477,6 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.21.7",
  "sha1",
  "thiserror",
  "url",
@@ -7921,12 +7919,6 @@ checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webview2-com"

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -4444,7 +4444,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -6271,12 +6270,6 @@ dependencies = [
  "soup2-sys",
  "system-deps 6.1.1",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webview2-com"

--- a/sdk/rust/nym-sdk/examples/manually_overwrite_topology.rs
+++ b/sdk/rust/nym-sdk/examples/manually_overwrite_topology.rs
@@ -23,7 +23,7 @@ async fn main() {
             mix_id: 63,
             owner: "n1k52k5n45cqt5qpjh8tcwmgqm0wkt355yy0g5vu".to_string(),
             host: "172.105.92.48".parse().unwrap(),
-            mix_host: "172.105.92.48:1789".parse().unwrap(),
+            mix_hosts: vec!["172.105.92.48:1789".parse().unwrap()],
             identity_key: "GLdR2NRVZBiCoCbv4fNqt9wUJZAnNjGXHkx3TjVAUzrK"
                 .parse()
                 .unwrap(),
@@ -40,7 +40,7 @@ async fn main() {
             mix_id: 23,
             owner: "n1fzv4jc7fanl9s0qj02ge2ezk3kts545kjtek47".to_string(),
             host: "178.79.143.65".parse().unwrap(),
-            mix_host: "178.79.143.65:1789".parse().unwrap(),
+            mix_hosts: vec!["178.79.143.65:1789".parse().unwrap()],
             identity_key: "4Yr4qmEHd9sgsuQ83191FR2hD88RfsbMmB4tzhhZWriz"
                 .parse()
                 .unwrap(),
@@ -57,7 +57,7 @@ async fn main() {
             mix_id: 66,
             owner: "n1ae2pjd7q9p0dea65pqkvcm4x9s264v4fktpyru".to_string(),
             host: "139.162.247.97".parse().unwrap(),
-            mix_host: "139.162.247.97:1789".parse().unwrap(),
+            mix_hosts: vec!["139.162.247.97:1789".parse().unwrap()],
             identity_key: "66UngapebhJRni3Nj52EW1qcNsWYiuonjkWJzHFsmyYY"
                 .parse()
                 .unwrap(),


### PR DESCRIPTION
# Description

PR on top of #4360.
This PR remove the need of accurate information in the `self-described` API (apart from the noise support)
IPs are retrieved from the bond, if it is a hostname, it will use the same resolving mechanism that currently exists. All resolved IPs are kept instead of just one.


# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
