### PR TITLE
Explictly add rustls to gateway-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9947,6 +9947,7 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.21.10",
  "tokio",
  "tungstenite",
 ]

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -19,14 +19,14 @@ futures = { workspace = true }
 humantime-serde = "1.0"
 log = { workspace = true }
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }
-reqwest = { workspace = true, features = ["rustls"] }
+reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
 tap = "1.0.1"
 thiserror = { workspace = true }
 url = { workspace = true, features = ["serde"] }
-tungstenite = { workspace = true, default-features = false, features = ["rustls"] }
+tungstenite = { workspace = true, default-features = false }
 tokio = { workspace = true, features = ["macros"]}
 time = "0.3.17"
 zeroize = { workspace = true }

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -27,7 +27,7 @@ tap = "1.0.1"
 thiserror = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 tungstenite = { workspace = true, default-features = false }
-tokio = { workspace = true, features = ["macros"]}
+tokio = { workspace = true, features = ["macros"] }
 time = "0.3.17"
 zeroize = { workspace = true }
 

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -19,15 +19,15 @@ futures = { workspace = true }
 humantime-serde = "1.0"
 log = { workspace = true }
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["rustls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
 tap = "1.0.1"
 thiserror = { workspace = true }
 url = { workspace = true, features = ["serde"] }
-tungstenite = { workspace = true, default-features = false }
-tokio = { workspace = true, features = ["macros"] }
+tungstenite = { workspace = true, default-features = false, features = ["rustls"] }
+tokio = { workspace = true, features = ["macros"]}
 time = "0.3.17"
 zeroize = { workspace = true }
 
@@ -72,6 +72,7 @@ features = ["time"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio-tungstenite]
 version = "0.20.1"
+features = ["rustls"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.sqlx]
 workspace = true

--- a/common/client-libs/gateway-client/Cargo.toml
+++ b/common/client-libs/gateway-client/Cargo.toml
@@ -49,6 +49,13 @@ workspace = true
 # the choice of this particular tls feature was arbitrary;
 # if you reckon a different one would be more appropriate, feel free to change it
 # features = ["native-tls"]
+# NOTE: when testing I've run into cases where it's needed to add
+# rustls-tls-*-roots feature flags, otherwise we get errors claiming TLS not
+# compiled in. However the current setup works fine when connecting to the
+# latest gateway version, so let's not force a decision for native vs webpki
+# here.
+# features = ["rustls", "rustls-tls-native-roots"]
+features = ["rustls"]
 
 # wasm-only dependencies
 [target."cfg(target_arch = \"wasm32\")".dependencies.wasm-bindgen]

--- a/nym-connect/desktop/Cargo.lock
+++ b/nym-connect/desktop/Cargo.lock
@@ -7273,6 +7273,7 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.21.7",
  "tokio",
  "tungstenite",
 ]
@@ -7454,6 +7455,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls 0.21.7",
  "sha1",
  "thiserror",
  "url",


### PR DESCRIPTION
# Description

Explictly add rustls to gateway-client and client-core to try to avoid future feature unification issues, but only for not wasm.
