### PR TITLE
[Bugfix] Packet_router gets drop without handling its shutdown

### DIFF
--- a/common/client-libs/gateway-client/src/packet_router.rs
+++ b/common/client-libs/gateway-client/src/packet_router.rs
@@ -69,6 +69,10 @@ impl PacketRouter {
         }
         Ok(())
     }
+
+    pub fn mark_as_success(&mut self) {
+        self.shutdown.mark_as_success();
+    }
 }
 
 impl GatewayPacketRouter for PacketRouter {

--- a/common/client-libs/gateway-client/src/socket_state.rs
+++ b/common/client-libs/gateway-client/src/socket_state.rs
@@ -97,7 +97,7 @@ impl PartiallyDelegated {
 
     pub(crate) fn split_and_listen_for_mixnet_messages(
         conn: WsConn,
-        packet_router: PacketRouter,
+        mut packet_router: PacketRouter,
         shared_key: Arc<SharedKeys>,
         mut shutdown: TaskClient,
     ) -> Self {
@@ -140,6 +140,7 @@ impl PartiallyDelegated {
             if match ret_err {
                 Err(err) => stream_sender.send(Err(err)),
                 Ok(_) => {
+                    packet_router.mark_as_success();
                     shutdown.mark_as_success();
                     stream_sender.send(Ok(stream))
                 }


### PR DESCRIPTION
# Description

When [`recover_socket_connection`](https://github.com/nymtech/nym/blob/c1e67cdc15caa14d440a72a808871c41e268ccfe/common/client-libs/gateway-client/src/client.rs#L738) is called after [`split_and_listen_for_mixnet_message`](https://github.com/nymtech/nym/blob/c1e67cdc15caa14d440a72a808871c41e268ccfe/common/client-libs/gateway-client/src/socket_state.rs#L100C19-L100C55), its [task](https://github.com/nymtech/nym/blob/c1e67cdc15caa14d440a72a808871c41e268ccfe/common/client-libs/gateway-client/src/socket_state.rs#L115) is stopped and dropped. The task's `shutdown` is correctly marked as success, but not the `PacketRouter`'s `shutdown` owned by that task.

This PR mark as success said `shutdown`, preventing a premature client's shutdown.
