### PR TITLE
Fix TLS connection error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9948,7 +9948,9 @@ dependencies = [
  "futures-util",
  "log",
  "rustls 0.21.10",
+ "rustls-native-certs",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tungstenite",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ log = "0.4"
 once_cell = "1.7.2"
 parking_lot = "0.12.1"
 rand = "0.8.5"
-reqwest = { version = "0.11.22", default_features = false }
+reqwest = { version = "0.11.22", default-features = false }
 schemars = "0.8.1"
 serde = "1.0.152"
 serde_json = "1.0.91"

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -72,7 +72,7 @@ features = ["time"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio-tungstenite]
 version = "0.20.1"
-features = ["rustls"]
+features = ["rustls-tls-native-roots"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.sqlx]
 workspace = true

--- a/common/client-libs/gateway-client/Cargo.toml
+++ b/common/client-libs/gateway-client/Cargo.toml
@@ -49,13 +49,7 @@ workspace = true
 # the choice of this particular tls feature was arbitrary;
 # if you reckon a different one would be more appropriate, feel free to change it
 # features = ["native-tls"]
-# NOTE: when testing I've run into cases where it's needed to add
-# rustls-tls-*-roots feature flags, otherwise we get errors claiming TLS not
-# compiled in. However the current setup works fine when connecting to the
-# latest gateway version, so let's not force a decision for native vs webpki
-# here.
-# features = ["rustls", "rustls-tls-native-roots"]
-features = ["rustls"]
+features = ["rustls-tls-native-roots"]
 
 # wasm-only dependencies
 [target."cfg(target_arch = \"wasm32\")".dependencies.wasm-bindgen]

--- a/common/client-libs/gateway-client/src/socket_state.rs
+++ b/common/client-libs/gateway-client/src/socket_state.rs
@@ -44,9 +44,7 @@ pub(crate) fn ws_fd(_conn: &WsConn) -> Option<RawFd> {
     #[cfg(unix)]
     match _conn.get_ref() {
         MaybeTlsStream::Plain(stream) => Some(stream.as_raw_fd()),
-        &_ => unreachable!(
-            "If tls features are enabled, the inner stream needs to be unpacked into raw fd"
-        ),
+        &_ => None,
     }
     #[cfg(not(unix))]
     None


### PR DESCRIPTION
Fix the TLS connection issue ` TLS support not compiled in` by making sure we use the `rustls-tls-native-roots` feature flag to tungstenite in gateway-client and client-core.

The fix can be checked with
```sh
cargo run -p nym-client -- init --id sdaf1 --gateway EBT8jTD8o4tKng2NXrrcrzVhJiBnKpT1bJy5CMeArt2w
```

which failed before and now succeeds
