### PR TITLE
IPR codec improvements for icmp beacon

### DIFF
--- a/common/ip-packet-requests/src/codec.rs
+++ b/common/ip-packet-requests/src/codec.rs
@@ -34,6 +34,13 @@ impl MultiIpPacketCodec {
         }
     }
 
+    pub fn bundle_one_packet(packet: Bytes) -> Bytes {
+        let mut bundled_packets = BytesMut::new();
+        bundled_packets.extend_from_slice(&(packet.len() as u16).to_be_bytes());
+        bundled_packets.extend_from_slice(&packet);
+        bundled_packets.freeze()
+    }
+
     // Append a packet to the buffer and return the buffer if it's full
     pub fn append_packet(&mut self, packet: Bytes) -> Option<Bytes> {
         let mut bundled_packets = BytesMut::new();
@@ -47,7 +54,7 @@ impl MultiIpPacketCodec {
     }
 
     // Flush the current buffer and return it.
-    fn flush_current_buffer(&mut self) -> Bytes {
+    pub fn flush_current_buffer(&mut self) -> Bytes {
         let mut output_buffer = BytesMut::new();
         std::mem::swap(&mut output_buffer, &mut self.buffer);
         output_buffer.freeze()

--- a/sdk/rust/nym-sdk/src/mixnet/native_client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/native_client.rs
@@ -174,6 +174,7 @@ impl MixnetClient {
     }
 }
 
+#[derive(Clone)]
 pub struct MixnetClientSender {
     client_input: ClientInput,
     packet_type: Option<PacketType>,


### PR DESCRIPTION
Some minor tweaks to support the new icmp connection beacon in the vpn client

- Add ability to create a single bundles IP packet directly
- MixnetClientSender derive Clone
