### PR TITLE
Floating point errors on the explorer - DO NOT MERGE

### DIFF
--- a/explorer-api/src/mix_node/models.rs
+++ b/explorer-api/src/mix_node/models.rs
@@ -112,12 +112,12 @@ pub(crate) struct NodeStats {
     )]
     previous_update_time: SystemTime,
 
-    packets_received_since_startup: u64,
-    packets_sent_since_startup: u64,
-    packets_explicitly_dropped_since_startup: u64,
-    packets_received_since_last_update: u64,
-    packets_sent_since_last_update: u64,
-    packets_explicitly_dropped_since_last_update: u64,
+    packets_received_since_startup: f64,
+    packets_sent_since_startup: f64,
+    packets_explicitly_dropped_since_startup: f64,
+    packets_received_since_last_update: f64,
+    packets_sent_since_last_update: f64,
+    packets_explicitly_dropped_since_last_update: f64,
 }
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
# Description

Since releasing fast and furious, a few nodes were not returning the stats correctly when querying the `/stats` endpoint:
```
Unable to get description for 21 on 65.109.1.171:8000 -> error decoding response body: invalid type: floating point `1961270`, expected u64 at line 1 column 146
```

changing the struct to f64 fixes this, tested and deployed to the explorer:

```
curl -s  http://65.109.1.171:8000/stats | jq .
{
  "update_time": "2024-03-27T11:15:50.113803703Z",
  "previous_update_time": "2024-03-27T11:15:20.113224255Z",
  "packets_received_since_startup": 1965440,
  "packets_sent_since_startup": 1963271,
  "packets_explicitly_dropped_since_startup": 0,
  "packets_received_since_last_update": 2041,
  "packets_sent_since_last_update": 2041,
  "packets_explicitly_dropped_since_last_update": 0
}
: curl -s  https://explorer.nymtech.net/api/v1/mix-node/21/stats | jq .
{
  "update_time": "2024-03-27T11:15:50.113803703Z",
  "previous_update_time": "2024-03-27T11:15:20.113224255Z",
  "packets_received_since_startup": 1965440,
  "packets_sent_since_startup": 1963271,
  "packets_explicitly_dropped_since_startup": 0,
  "packets_received_since_last_update": 2041,
  "packets_sent_since_last_update": 2041,
  "packets_explicitly_dropped_since_last_update": 0
}
