### PR TITLE
Re-export TransmissionLane type

### DIFF
--- a/sdk/rust/nym-sdk/src/mixnet.rs
+++ b/sdk/rust/nym-sdk/src/mixnet.rs
@@ -77,6 +77,7 @@ pub use nym_sphinx::{
     anonymous_replies::requests::AnonymousSenderTag,
     receiver::ReconstructedMessage,
 };
+pub use nym_task::connections::TransmissionLane;
 pub use nym_topology::{provider_trait::TopologyProvider, NymTopology};
 pub use paths::StoragePaths;
 pub use socks5_client::Socks5MixnetClient;


### PR DESCRIPTION
# Description

Re-export TransmissionLane type in Rust SDK
