### PR TITLE
[bugfix] Prevent generation of free passes with expiry date in the past

### DIFF
--- a/common/commands/src/coconut/generate_freepass.rs
+++ b/common/commands/src/coconut/generate_freepass.rs
@@ -148,6 +148,10 @@ pub async fn execute(args: Args, client: SigningClient) -> anyhow::Result<()> {
         bail!("the provided free pass request has too long expiry (expiry is set to on {expiration_date})")
     }
 
+    if expiration_date < now {
+        bail!("the provided free pass expiry is set in the past!")
+    }
+
     // issuance start
     block_until_coconut_is_available(&client).await?;
 

--- a/nym-api/src/coconut/api_routes/mod.rs
+++ b/nym-api/src/coconut/api_routes/mod.rs
@@ -67,6 +67,10 @@ fn validate_freepass_public_attributes(res: &FreePassRequest) -> Result<()> {
         return Err(CoconutError::TooLongFreePass { expiry_date });
     }
 
+    if expiry_date < now {
+        return Err(CoconutError::FreePassExpiryInThePast { expiry_date });
+    }
+
     Ok(())
 }
 

--- a/nym-api/src/coconut/error.rs
+++ b/nym-api/src/coconut/error.rs
@@ -82,6 +82,9 @@ pub enum CoconutError {
     )]
     TooLongFreePass { expiry_date: OffsetDateTime },
 
+    #[error("the provided free pass expiry is set in the past!")]
+    FreePassExpiryInThePast { expiry_date: OffsetDateTime },
+
     #[error("the received bandwidth voucher did not contain deposit value")]
     MissingBandwidthValue,
 


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- If appropriate, insert relevant description here -->

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
