### PR TITLE
Add rustls-tls to reqwest in validator-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,7 +4384,7 @@ dependencies = [
  "rw-stream-sink",
  "soketto",
  "url",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -8335,6 +8335,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -9500,7 +9501,7 @@ dependencies = [
  "time",
  "tokio-stream",
  "url",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -11182,6 +11183,12 @@ checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki 0.22.4",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webrtc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10164,10 +10164,10 @@ dependencies = [
  "futures-util",
  "log",
  "rustls 0.21.11",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.24.1",
  "tungstenite",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -10602,6 +10602,7 @@ dependencies = [
  "thiserror",
  "url",
  "utf-8",
+ "webpki-roots 0.24.0",
 ]
 
 [[package]]
@@ -11182,6 +11183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki 0.22.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -82,6 +82,7 @@ features = ["rustls-tls-webpki-roots"]
 
 [target."cfg(target_arch = \"wasm32\")".dependencies.tungstenite]
 workspace = true
+default-features = false
 
 [target."cfg(target_arch = \"wasm32\")".dependencies.wasm-bindgen-futures]
 workspace = true

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -25,7 +25,6 @@ si-scale = "0.2.2"
 tap = "1.0.1"
 thiserror = { workspace = true }
 url = { workspace = true, features = ["serde"] }
-tungstenite = { workspace = true, default-features = false }
 tokio = { workspace = true, features = ["macros"] }
 time = { workspace = true }
 zeroize = { workspace = true }
@@ -74,8 +73,15 @@ workspace = true
 features = ["time"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio-tungstenite]
-version = "0.20.1"
-features = ["rustls-tls-native-roots"]
+workspace = true
+features = ["rustls-tls-webpki-roots"]
+
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies.tungstenite]
+workspace = true
+features = ["rustls-tls-webpki-roots"]
+
+[target."cfg(target_arch = \"wasm32\")".dependencies.tungstenite]
+workspace = true
 
 [target."cfg(target_arch = \"wasm32\")".dependencies.wasm-bindgen-futures]
 workspace = true

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -78,6 +78,7 @@ features = ["rustls-tls-webpki-roots"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tungstenite]
 workspace = true
+default-features = true
 features = ["rustls-tls-webpki-roots"]
 
 [target."cfg(target_arch = \"wasm32\")".dependencies.tungstenite]

--- a/common/client-libs/gateway-client/Cargo.toml
+++ b/common/client-libs/gateway-client/Cargo.toml
@@ -48,10 +48,7 @@ features = ["net", "sync", "time"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio-tungstenite]
 workspace = true
-# the choice of this particular tls feature was arbitrary;
-# if you reckon a different one would be more appropriate, feel free to change it
-# features = ["native-tls"]
-features = ["rustls-tls-native-roots"]
+features = ["rustls-tls-webpki-roots"]
 
 # wasm-only dependencies
 [target."cfg(target_arch = \"wasm32\")".dependencies.wasm-bindgen]

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -24,7 +24,6 @@ nym-group-contract-common = { path = "../../cosmwasm-smart-contracts/group-contr
 nym-service-provider-directory-common = { path = "../../cosmwasm-smart-contracts/service-provider-directory" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 nym-http-api-client = { path = "../../../common/http-api-client"}
 thiserror = { workspace = true }
 log = { workspace = true }
@@ -66,6 +65,14 @@ cosmwasm-std = { workspace = true }
 [target."cfg(target_arch = \"wasm32\")".dependencies.wasmtimer]
 workspace = true
 features = ["tokio"]
+
+[target."cfg(target_arch = \"wasm32\")".dependencies.reqwest]
+workspace = true
+features = ["json"]
+
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies.reqwest]
+workspace = true
+features = ["json", "rustls-tls"]
 
 [dev-dependencies]
 bip39 = { workspace = true }

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -24,7 +24,7 @@ nym-group-contract-common = { path = "../../cosmwasm-smart-contracts/group-contr
 nym-service-provider-directory-common = { path = "../../cosmwasm-smart-contracts/service-provider-directory" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 nym-http-api-client = { path = "../../../common/http-api-client"}
 thiserror = { workspace = true }
 log = { workspace = true }


### PR DESCRIPTION
What this PR tries to address is that it's possible to end up in a situation where use use the validator-client but without functioning TLS support. For the monorepo this is masked by cargo feature unification, but becomes a problem for outside consumers, as as been noticed in many of the vpn client implementations

In validator-client
- reqwest, enable rustls-tls for non-wasm32 

In client-core
- Use default features enabled for non-wasm32
- Switch to webpki roots, since that's what we're using with reqwest anyway

In gateway-client
- Switch to webpki roots, since that's what we're using with reqwest anyway
