### PR TITLE
Quickfix for unused warnings after manually disabling legacy routes for release

### DIFF
--- a/mixnode/src/node/http/legacy/mod.rs
+++ b/mixnode/src/node/http/legacy/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+#![allow(unused)]
+
 use crate::node::http::legacy::description::description;
 use crate::node::http::legacy::hardware::hardware;
 use crate::node::http::legacy::state::MixnodeAppState;


### PR DESCRIPTION
# Description

Mute the clippy errors caused by disabling legacy routes for the release
