### PR TITLE
HOTFIX ci-docs

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Remove existing Nym config directory (`~/.nym/`)
         run: cd documentation && ./remove_existing_config.sh
         continue-on-error: false
-# This is the original flow
-      - name: Build all projects in documentation/ & move to ~/dist/docs/
-        run: cd documentation && ./build_all_to_dist.sh
 
 # This is the original flow
 #      - name: Build all projects in documentation/ & move to ~/dist/docs/

--- a/documentation/operators/src/nodes/bonding.md
+++ b/documentation/operators/src/nodes/bonding.md
@@ -25,7 +25,7 @@ Do not bond your node to the API if the previous steps weren't finished. Bad con
 You can bond your `nym-node` via the Desktop wallet.
 
 1. Open your wallet, and head to the `Bond` page, then select the node type `Mixnode` and input your node details. Press `Next`.
-  - To find out your `nym-node` details, run `./nym-node bonding-information`
+  - To find out your `nym-node` details, run `./nym-node bonding-information --id <ID>`
   - To get a correct host address, run `echo "$(curl -4 https://ifconfig.me)"`
 
 


### PR DESCRIPTION
Cheat to make `ci-doc` ***TEMP** work and allow devrel to re-build docs (edits, updates etc).
