### PR TITLE
Include nym-node endpoint

### DIFF
--- a/explorer-api/Cargo.toml
+++ b/explorer-api/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.82"
 chrono = { version = "0.4.31", features = ["serde"] }
 clap = { workspace = true, features = ["cargo", "derive"] }
 dotenvy = { workspace = true }

--- a/explorer-api/src/mix_node/http.rs
+++ b/explorer-api/src/mix_node/http.rs
@@ -65,7 +65,7 @@ async fn get_mix_node_stats(host: &str, port: u16) -> Result<NodeStats, ReqwestE
         reqwest::Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to fetch stats from both endpoints".into())
-            .unwrap()
+            .unwrap(),
     ))
 }
 

--- a/explorer-api/src/mix_node/http.rs
+++ b/explorer-api/src/mix_node/http.rs
@@ -9,9 +9,10 @@ use crate::mix_node::models::{
     EconomicDynamicsStats, NodeDescription, NodeStats, SummedDelegations,
 };
 use crate::state::ExplorerApiStateContext;
+use log::debug;
 use nym_explorer_api_requests::PrettyDetailedMixNodeBond;
 use nym_mixnet_contract_common::{Delegation, MixId};
-use reqwest::{Error as ReqwestError, Response, StatusCode};
+use reqwest::{Error as ReqwestError, StatusCode};
 use rocket::response::status::NotFound;
 use rocket::serde::json::Json;
 use rocket::{Route, State};
@@ -61,12 +62,8 @@ async fn get_mix_node_stats(host: &str, port: u16) -> Result<NodeStats, ReqwestE
         return response.json::<NodeStats>().await;
     }
 
-    Err(reqwest::Error::from(
-        reqwest::Response::builder()
-            .status(StatusCode::INTERNAL_SERVER_ERROR)
-            .body("Failed to fetch stats from both endpoints".into())
-            .unwrap(),
-    ))
+    debug!("Failed to fetch stats from both endpoints: {primary_url} and {secondary_url}");
+    Err(reqwest::Error::status(StatusCode::INTERNAL_SERVER_ERROR))
 }
 
 #[openapi(tag = "mix_nodes")]

--- a/explorer-api/src/mix_node/http.rs
+++ b/explorer-api/src/mix_node/http.rs
@@ -9,9 +9,11 @@ use crate::mix_node::models::{
     EconomicDynamicsStats, NodeDescription, NodeStats, SummedDelegations,
 };
 use crate::state::ExplorerApiStateContext;
+use crate::mix_node::models::{NewModelDescription, OldModelDescription};
 use anyhow::{Context, Result};
 
 use nym_explorer_api_requests::PrettyDetailedMixNodeBond;
+
 use nym_mixnet_contract_common::{Delegation, MixId};
 use rocket::response::status::NotFound;
 use rocket::serde::json::Json;

--- a/explorer-api/src/mix_node/http.rs
+++ b/explorer-api/src/mix_node/http.rs
@@ -41,10 +41,10 @@ async fn get_mix_node_description(host: &str, port: u16) -> Result<NodeDescripti
     if let Ok(description) = first_response
         .error_for_status()
         .context("Nym-mixnodes /stats url returned error status")?
-        .json::<NodeDescription>()
+        .json::<OldModelDescription>()
         .await
     {
-        return Ok(description);
+        return Ok(description.into());
     }
 
     let second_url = format!("http://{host}:{port}/api/v1/description");
@@ -53,14 +53,15 @@ async fn get_mix_node_description(host: &str, port: u16) -> Result<NodeDescripti
         second_url
     ))?;
 
-    second_response
+    let description = second_response
         .error_for_status()
         .context("Nym-node /api/v1/description url returned error status")?
-        .json::<NodeDescription>()
+        .json::<NewModelDescription>()
         .await
-        .context("Failed to parse JSON from nym-node /api/v1/description url")
-}
+        .context("Failed to parse JSON from nym-node /api/v1/description url")?;
 
+    Ok(description.into())
+}
 pub async fn get_mix_node_stats(host: &str, port: u16) -> Result<NodeStats> {
     let primary_url = format!("http://{host}:{port}/stats");
     let secondary_url = format!("http://{host}:{port}/api/v1/metrics/mixing");

--- a/explorer-api/src/mix_node/http.rs
+++ b/explorer-api/src/mix_node/http.rs
@@ -11,7 +11,7 @@ use crate::mix_node::models::{
 use crate::state::ExplorerApiStateContext;
 use nym_explorer_api_requests::PrettyDetailedMixNodeBond;
 use nym_mixnet_contract_common::{Delegation, MixId};
-use reqwest::Error as ReqwestError;
+use reqwest::{Error as ReqwestError, Response, StatusCode};
 use rocket::response::status::NotFound;
 use rocket::serde::json::Json;
 use rocket::{Route, State};
@@ -61,8 +61,14 @@ async fn get_mix_node_stats(host: &str, port: u16) -> Result<NodeStats, ReqwestE
         return response.json::<NodeStats>().await;
     }
 
-    Err("failed to fetch stats from both endpoints")
+    Err(reqwest::Error::from(
+        reqwest::Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body("Failed to fetch stats from both endpoints".into())
+            .unwrap()
+    ))
 }
+
 #[openapi(tag = "mix_nodes")]
 #[get("/<mix_id>")]
 pub(crate) async fn get_by_id(

--- a/explorer-api/src/mix_node/http.rs
+++ b/explorer-api/src/mix_node/http.rs
@@ -9,6 +9,7 @@ use crate::mix_node::models::{
     EconomicDynamicsStats, NodeDescription, NodeStats, SummedDelegations,
 };
 use crate::state::ExplorerApiStateContext;
+use anyhow::{anyhow, Result};
 use log::debug;
 use nym_explorer_api_requests::PrettyDetailedMixNodeBond;
 use nym_mixnet_contract_common::{Delegation, MixId};
@@ -44,7 +45,7 @@ async fn get_mix_node_description(host: &str, port: u16) -> Result<NodeDescripti
     }
 }
 
-async fn get_mix_node_stats(host: &str, port: u16) -> Result<NodeStats, ReqwestError> {
+async fn get_mix_node_stats(host: &str, port: u16) -> Result<NodeStats, anyhow::Error> {
     // old endpoint for nym-mixnodes
     let primary_url = format!("http://{host}:{port}/stats");
     // new endpoint for nym-nodes
@@ -63,7 +64,7 @@ async fn get_mix_node_stats(host: &str, port: u16) -> Result<NodeStats, ReqwestE
     }
 
     debug!("Failed to fetch stats from both endpoints: {primary_url} and {secondary_url}");
-    Err(reqwest::Error::status(StatusCode::INTERNAL_SERVER_ERROR))
+    Err(anyhow!("Failed to fetch stats from both endpoints"))
 }
 
 #[openapi(tag = "mix_nodes")]

--- a/explorer-api/src/mix_node/models.rs
+++ b/explorer-api/src/mix_node/models.rs
@@ -98,25 +98,30 @@ pub(crate) struct NodeDescription {
     pub(crate) location: String,
 }
 
-#[derive(Serialize, Clone, Deserialize, JsonSchema)]
+#[derive(Serialize, Clone, Deserialize, JsonSchema, Debug)]
 pub(crate) struct NodeStats {
     #[serde(
         serialize_with = "humantime_serde::serialize",
         deserialize_with = "humantime_serde::deserialize"
     )]
     update_time: SystemTime,
-
     #[serde(
         serialize_with = "humantime_serde::serialize",
         deserialize_with = "humantime_serde::deserialize"
     )]
     previous_update_time: SystemTime,
 
+    #[serde(alias = "received_since_startup", default)]
     packets_received_since_startup: u64,
+    #[serde(alias = "sent_since_startup", default)]
     packets_sent_since_startup: u64,
+    #[serde(alias = "dropped_since_startup", default)]
     packets_explicitly_dropped_since_startup: u64,
+    #[serde(alias = "received_since_last_update", default)]
     packets_received_since_last_update: u64,
+    #[serde(alias = "sent_since_last_update", default)]
     packets_sent_since_last_update: u64,
+    #[serde(alias = "dropped_since_last_update", default)]
     packets_explicitly_dropped_since_last_update: u64,
 }
 

--- a/explorer-api/src/mix_node/models.rs
+++ b/explorer-api/src/mix_node/models.rs
@@ -92,10 +92,60 @@ impl ThreadsafeMixNodeCache {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, JsonSchema)]
 pub(crate) struct NodeDescription {
-    pub(crate) name: String,
-    pub(crate) description: String,
-    pub(crate) link: String,
-    pub(crate) location: String,
+    pub(crate) name: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) link: Option<String>,
+    pub(crate) location: Option<String>,
+    pub(crate) moniker: Option<String>,
+    pub(crate) website: Option<String>,
+    pub(crate) security_contact: Option<String>,
+    pub(crate) details: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OldModelDescription {
+    name: String,
+    description: String,
+    link: String,
+    location: String,
+}
+
+#[derive(Deserialize)]
+struct NewModelDescription {
+    moniker: String,
+    website: String,
+    security_contact: String,
+    details: String,
+}
+
+impl From<OldModelDescription> for NodeDescription {
+    fn from(old: OldModelDescription) -> Self {
+        NodeDescription {
+            name: Some(old.name),
+            description: Some(old.description),
+            link: Some(old.link),
+            location: Some(old.location),
+            moniker: None,
+            website: None,
+            security_contact: None,
+            details: None,
+        }
+    }
+}
+
+impl From<NewModelDescription> for NodeDescription {
+    fn from(new: NewModelDescription) -> Self {
+        NodeDescription {
+            name: None,
+            description: Some(new.details),
+            link: Some(new.website),
+            location: None,
+            moniker: Some(new.moniker),
+            website: None,
+            security_contact: Some(new.security_contact),
+            details: None,
+        }
+    }
 }
 
 #[derive(Serialize, Clone, Deserialize, JsonSchema, Debug)]

--- a/explorer-api/src/mix_node/models.rs
+++ b/explorer-api/src/mix_node/models.rs
@@ -103,19 +103,19 @@ pub(crate) struct NodeDescription {
 }
 
 #[derive(Deserialize)]
-struct OldModelDescription {
-    name: String,
-    description: String,
-    link: String,
-    location: String,
+pub struct OldModelDescription {
+    pub name: String,
+    pub description: String,
+    pub link: String,
+    pub location: String,
 }
 
 #[derive(Deserialize)]
-struct NewModelDescription {
-    moniker: String,
-    website: String,
-    security_contact: String,
-    details: String,
+pub struct NewModelDescription {
+    pub moniker: String,
+    pub website: String,
+    pub security_contact: String,
+    pub details: String,
 }
 
 impl From<OldModelDescription> for NodeDescription {

--- a/explorer-api/src/mix_node/models.rs
+++ b/explorer-api/src/mix_node/models.rs
@@ -111,17 +111,17 @@ pub(crate) struct NodeStats {
     )]
     previous_update_time: SystemTime,
 
-    #[serde(alias = "received_since_startup", default)]
+    #[serde(alias = "received_since_startup")]
     packets_received_since_startup: u64,
-    #[serde(alias = "sent_since_startup", default)]
+    #[serde(alias = "sent_since_startup")]
     packets_sent_since_startup: u64,
-    #[serde(alias = "dropped_since_startup", default)]
+    #[serde(alias = "dropped_since_startup")]
     packets_explicitly_dropped_since_startup: u64,
-    #[serde(alias = "received_since_last_update", default)]
+    #[serde(alias = "received_since_last_update")]
     packets_received_since_last_update: u64,
-    #[serde(alias = "sent_since_last_update", default)]
+    #[serde(alias = "sent_since_last_update")]
     packets_sent_since_last_update: u64,
-    #[serde(alias = "dropped_since_last_update", default)]
+    #[serde(alias = "dropped_since_last_update")]
     packets_explicitly_dropped_since_last_update: u64,
 }
 

--- a/explorer/src/components/MixNodes/DetailSection.tsx
+++ b/explorer/src/components/MixNodes/DetailSection.tsx
@@ -11,11 +11,14 @@ interface MixNodeDetailProps {
   mixnodeDescription: MixNodeDescriptionResponse;
 }
 
-export const MixNodeDetailSection: FCWithChildren<MixNodeDetailProps> = ({ mixNodeRow, mixnodeDescription }) => {
+export const MixNodeDetailSection: React.FC<MixNodeDetailProps> = ({ mixNodeRow, mixnodeDescription }) => {
   const theme = useTheme();
-  const palette = [theme.palette.text.primary];
   const isMobile = useIsMobile();
   const statusText = React.useMemo(() => getMixNodeStatusText(mixNodeRow.status), [mixNodeRow.status]);
+
+  const title = mixnodeDescription.name || mixnodeDescription.moniker || "Unknown Node";
+  const description = mixnodeDescription.description || mixnodeDescription.details || "No description available.";
+  const link = mixnodeDescription.link || mixnodeDescription.website || '#';
 
   return (
     <Grid container>
@@ -35,11 +38,11 @@ export const MixNodeDetailSection: FCWithChildren<MixNodeDetailProps> = ({ mixNo
               placeItems: 'center',
             }}
           >
-            <Identicon size={43} string={mixNodeRow.identity_key} palette={palette} />
+            <Identicon size={43} string={mixNodeRow.identity_key} />
           </Box>
           <Box ml={isMobile ? 0 : 2} mt={isMobile ? 2 : 0}>
-            <Typography fontSize={21}>{mixnodeDescription.name}</Typography>
-            <Typography>{(mixnodeDescription.description || '').slice(0, 1000)}</Typography>
+            <Typography fontSize={21}>{title}</Typography>
+            <Typography>{description.slice(0, 1000)}</Typography>
             <Button
               component="a"
               variant="text"
@@ -49,7 +52,7 @@ export const MixNodeDetailSection: FCWithChildren<MixNodeDetailProps> = ({ mixNo
                 fontWeight: 600,
                 padding: 0,
               }}
-              href={mixnodeDescription.link}
+              href={link}
               target="_blank"
             >
               <Typography
@@ -59,7 +62,7 @@ export const MixNodeDetailSection: FCWithChildren<MixNodeDetailProps> = ({ mixNo
                 overflow="hidden"
                 maxWidth="250px"
               >
-                {mixnodeDescription.link}
+                Visit Node
               </Typography>
             </Button>
           </Box>

--- a/explorer/src/typeDefs/explorer-api.ts
+++ b/explorer/src/typeDefs/explorer-api.ts
@@ -169,10 +169,14 @@ export interface GatewayReportResponse {
 export type GatewayHistoryResponse = StatsResponse;
 
 export interface MixNodeDescriptionResponse {
-  name: string;
-  description: string;
-  link: string;
-  location: string;
+  name?: string;
+  description?: string;
+  link?: string;
+  location?: string;
+  moniker?: string;
+  website?: string;
+  security_contact?: string;
+  details?: string;
 }
 
 export type MixNodeStatsResponse = StatsResponse;


### PR DESCRIPTION
# Description

Fixes the newly updated endpoints for nym-node for the explorer - for now until everyone has updated, use the `/stats` then query for the new `/api/v1/`