### PR TITLE
Exlicitly drop packet router when shutdown detected

### DIFF
--- a/common/client-libs/gateway-client/src/socket_state.rs
+++ b/common/client-libs/gateway-client/src/socket_state.rs
@@ -158,6 +158,9 @@ impl PartiallyDelegated {
                     _ = shutdown.recv() => {
                         log::trace!("GatewayClient listener: Received shutdown");
                         log::debug!("GatewayClient listener: Exiting");
+                        // The packet router a task client, and as such we need to make
+                        // sure it's dropped to not stall the shutdown process.
+                        drop(packet_router);
                         return;
                     }
                     _ = &mut notify_receiver => {


### PR DESCRIPTION
In the vpn client I've observed that 2 out of 3 times the disconnect procedure stalls out.

Investigating in the logs these 5 are still running when we hit shutdown timeout.

```
[TaskClient-nym_vpn_lib-mixnet_client_main-real_traffic_controller-ack_control-retransmission_request_listener] Polling shutdown failed: channel closed
[TaskClient-nym_vpn_lib-mixnet_client_main-real_traffic_controller-out_queue_control] Polling shutdown failed: channel closed
[TaskClient-gateway-packet-router] Polling shutdown failed: channel closed
[TaskClient-nym_vpn_lib-mixnet_client_main-gateway_transceiver] Polling shutdown failed: channel closed
[TaskClient-nym_vpn_lib-mixnet_client_main-mix_traffic_controller] Polling shutdown failed: channel closed
```

I _think_ what was causing the problem here is that the task client in the packet router is not being awaited in an event loop like other client instances.

Explictly drop it in the socket state to make sure it's not blocking shutdown.

It's also possible that's not the underlying cause. An interesting symptom here is that when the disconnect stalls, the MixTrafficController doesn't print that is receives the shutdown message, indicating that the MixTrafficController task is stuck awaiting something that will not resolve.
