### PR TITLE
Timeout on ws send in mix traffic controller

### DIFF
--- a/common/client-core/src/client/mix_traffic/transceiver.rs
+++ b/common/client-core/src/client/mix_traffic/transceiver.rs
@@ -79,8 +79,10 @@ impl<G: GatewayTransceiver + ?Sized + Send> GatewayTransceiver for Box<G> {
 impl<G: GatewaySender + ?Sized + Send> GatewaySender for Box<G> {
     #[inline]
     async fn send_mix_packet(&mut self, packet: MixPacket) -> Result<(), ErasedGatewayError> {
-        log::info!("Box<GatewaySender>::send_mix_packet - sending a packet");
-        (**self).send_mix_packet(packet).await
+        log::info!("JON: Box<GatewaySender>::send_mix_packet - sending a packet");
+        let r = (**self).send_mix_packet(packet).await;
+        log::info!("JON: Box<GatewaySender>::send_mix_packet - sent a packet");
+        r
     }
 
     #[inline]
@@ -88,7 +90,10 @@ impl<G: GatewaySender + ?Sized + Send> GatewaySender for Box<G> {
         &mut self,
         packets: Vec<MixPacket>,
     ) -> Result<(), ErasedGatewayError> {
-        (**self).batch_send_mix_packets(packets).await
+        log::info!("JON: Box<GatewaySender>::batch_send_mix_packets - sending {} packets", packets.len());
+        let r = (**self).batch_send_mix_packets(packets).await;
+        log::info!("JON: Box<GatewaySender>::batch_send_mix_packets - sent packets");
+        r
     }
 }
 
@@ -132,22 +137,26 @@ where
     St: Send,
 {
     async fn send_mix_packet(&mut self, packet: MixPacket) -> Result<(), ErasedGatewayError> {
-        log::info!("RemoteGateway::send_mix_packet - sending a packet");
-        self.gateway_client
+        log::info!("JON: RemoteGateway::send_mix_packet - sending a packet");
+        let r = self.gateway_client
             .send_mix_packet(packet)
             .await
-            .map_err(erase_err)
+            .map_err(erase_err);
+        log::info!("JON: RemoteGateway::send_mix_packet - sent a packet");
+        r
     }
 
     async fn batch_send_mix_packets(
         &mut self,
         packets: Vec<MixPacket>,
     ) -> Result<(), ErasedGatewayError> {
-        log::info!("RemoteGateway::batch_send_mix_packets - sending {} packets", packets.len());
-        self.gateway_client
+        log::info!("JON: RemoteGateway::batch_send_mix_packets - sending {} packets", packets.len());
+        let r = self.gateway_client
             .batch_send_mix_packets(packets)
             .await
-            .map_err(erase_err)
+            .map_err(erase_err);
+        log::info!("JON: RemoteGateway::batch_send_mix_packets - sent packets");
+        r
     }
 }
 
@@ -207,11 +216,13 @@ mod nonwasm_sealed {
     #[async_trait]
     impl GatewaySender for LocalGateway {
         async fn send_mix_packet(&mut self, packet: MixPacket) -> Result<(), ErasedGatewayError> {
-            log::info!("LocalGateway::send_mix_packet - sending a packet");
-            self.packet_forwarder
+            log::info!("JON: LocalGateway::send_mix_packet - sending a packet");
+            let r = self.packet_forwarder
                 .unbounded_send(packet)
                 .map_err(|err| err.into_send_error())
-                .map_err(erase_err)
+                .map_err(erase_err);
+            log::info!("JON: LocalGateway::send_mix_packet - sent a packet");
+            r
         }
     }
 

--- a/common/client-core/src/client/mix_traffic/transceiver.rs
+++ b/common/client-core/src/client/mix_traffic/transceiver.rs
@@ -40,6 +40,7 @@ pub trait GatewaySender {
         &mut self,
         packets: Vec<MixPacket>,
     ) -> Result<(), ErasedGatewayError> {
+        log::info!("GatewaySender::batch_send_mix_packets - sending {} packets", packets.len());
         // allow for optimisation when sending multiple packets
         for packet in packets {
             self.send_mix_packet(packet).await?;
@@ -78,6 +79,7 @@ impl<G: GatewayTransceiver + ?Sized + Send> GatewayTransceiver for Box<G> {
 impl<G: GatewaySender + ?Sized + Send> GatewaySender for Box<G> {
     #[inline]
     async fn send_mix_packet(&mut self, packet: MixPacket) -> Result<(), ErasedGatewayError> {
+        log::info!("Box<GatewaySender>::send_mix_packet - sending a packet");
         (**self).send_mix_packet(packet).await
     }
 
@@ -130,6 +132,7 @@ where
     St: Send,
 {
     async fn send_mix_packet(&mut self, packet: MixPacket) -> Result<(), ErasedGatewayError> {
+        log::info!("RemoteGateway::send_mix_packet - sending a packet");
         self.gateway_client
             .send_mix_packet(packet)
             .await
@@ -140,6 +143,7 @@ where
         &mut self,
         packets: Vec<MixPacket>,
     ) -> Result<(), ErasedGatewayError> {
+        log::info!("RemoteGateway::batch_send_mix_packets - sending {} packets", packets.len());
         self.gateway_client
             .batch_send_mix_packets(packets)
             .await
@@ -203,6 +207,7 @@ mod nonwasm_sealed {
     #[async_trait]
     impl GatewaySender for LocalGateway {
         async fn send_mix_packet(&mut self, packet: MixPacket) -> Result<(), ErasedGatewayError> {
+            log::info!("LocalGateway::send_mix_packet - sending a packet");
             self.packet_forwarder
                 .unbounded_send(packet)
                 .map_err(|err| err.into_send_error())
@@ -261,6 +266,7 @@ impl GatewayReceiver for MockGateway {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl GatewaySender for MockGateway {
     async fn send_mix_packet(&mut self, packet: MixPacket) -> Result<(), ErasedGatewayError> {
+        log::info!("MockGateway::send_mix_packet - sending a packet");
         self.sent.push(packet);
         Ok(())
     }

--- a/common/client-core/src/client/mix_traffic/transceiver.rs
+++ b/common/client-core/src/client/mix_traffic/transceiver.rs
@@ -19,6 +19,12 @@ use futures::channel::{mpsc, oneshot};
 #[error(transparent)]
 pub struct ErasedGatewayError(Box<dyn std::error::Error + Send + Sync>);
 
+impl ErasedGatewayError {
+    pub fn downcast<T: std::error::Error + 'static>(&self) -> Option<&T> {
+        self.0.downcast_ref::<T>()
+    }
+}
+
 fn erase_err<E: std::error::Error + Send + Sync + 'static>(err: E) -> ErasedGatewayError {
     ErasedGatewayError(Box::new(err))
 }

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -632,15 +632,23 @@ where
     }
 
     pub(crate) fn update_ack_delay(&self, id: FragmentIdentifier, new_delay: Delay) {
-        self.action_sender
+        if self
+            .action_sender
             .unbounded_send(Action::UpdateDelay(id, new_delay))
-            .expect("action control task has died")
+            .is_err()
+        {
+            log::debug!("action control task has died");
+        }
     }
 
     pub(crate) fn insert_pending_acks(&self, pending_acks: Vec<PendingAcknowledgement>) {
-        self.action_sender
+        if self
+            .action_sender
             .unbounded_send(Action::new_insert(pending_acks))
-            .expect("action control task has died")
+            .is_err()
+        {
+            log::debug!("action control task has died");
+        }
     }
 
     // tells real message sender (with the poisson timer) to send this to the mix network

--- a/common/client-core/src/error.rs
+++ b/common/client-core/src/error.rs
@@ -78,6 +78,9 @@ pub enum ClientCoreError {
         source: tungstenite::Error,
     },
 
+    #[error("max number of retries for gateway connection has been exceeded")]
+    GatewayMaxRetriesExceeded,
+
     #[cfg(target_arch = "wasm32")]
     #[error("failed to establish gateway connection (wasm)")]
     GatewayJsConnectionFailure,
@@ -87,6 +90,11 @@ pub enum ClientCoreError {
 
     #[error("timed out while trying to establish gateway connection")]
     GatewayConnectionTimeout,
+
+    #[error("failed to send sphinx packet to the gateway: {gateway_client_error}")]
+    GatewayClientSendError {
+        gateway_client_error: String,
+    },
 
     #[error("no ping measurements for the gateway ({identity}) performed")]
     NoGatewayMeasurements { identity: String },

--- a/common/client-libs/gateway-client/src/client.rs
+++ b/common/client-libs/gateway-client/src/client.rs
@@ -358,6 +358,7 @@ impl<C, St> GatewayClient<C, St> {
         &mut self,
         messages: Vec<Message>,
     ) -> Result<(), GatewayClientError> {
+        log::info!("GatewayClient: Sending a batch of messages to the gateway");
         match self.connection {
             SocketState::Available(ref mut conn) => {
                 let stream_messages: Vec<_> = messages.into_iter().map(Ok).collect();
@@ -658,6 +659,7 @@ impl<C, St> GatewayClient<C, St> {
         &mut self,
         packets: Vec<MixPacket>,
     ) -> Result<(), GatewayClientError> {
+        info!("GatewayClient: Sending {} sphinx packets to the gateway", packets.len());
         debug!("Sending {} mix packets", packets.len());
 
         if !self.authenticated {
@@ -688,6 +690,7 @@ impl<C, St> GatewayClient<C, St> {
             .batch_send_websocket_messages_without_response(messages)
             .await
         {
+            log::error!("GatewayClient: Failed to send sphinx packets to the gateway: {err}");
             if err.is_closed_connection() && self.should_reconnect_on_failure {
                 self.attempt_reconnection().await
             } else {
@@ -702,6 +705,7 @@ impl<C, St> GatewayClient<C, St> {
         &mut self,
         msg: Message,
     ) -> Result<(), GatewayClientError> {
+        log::info!("GatewayClient: Sending a message to the gateway");
         if let Err(err) = self.send_websocket_message_without_response(msg).await {
             if err.is_closed_connection() && self.should_reconnect_on_failure {
                 debug!("Going to attempt a reconnection");
@@ -731,6 +735,7 @@ impl<C, St> GatewayClient<C, St> {
         &mut self,
         mix_packet: MixPacket,
     ) -> Result<(), GatewayClientError> {
+        log::info!("GatewayClient: Sending a sphinx packet to the gateway");
         if !self.authenticated {
             return Err(GatewayClientError::NotAuthenticated);
         }

--- a/common/client-libs/gateway-client/src/error.rs
+++ b/common/client-libs/gateway-client/src/error.rs
@@ -93,6 +93,7 @@ pub enum GatewayClientError {
 
 impl GatewayClientError {
     pub fn is_closed_connection(&self) -> bool {
+        log::info!("GatewayClientError::is_closed_connection");
         match self {
             GatewayClientError::NetworkError(ws_err) => match ws_err {
                 WsError::AlreadyClosed | WsError::ConnectionClosed => true,

--- a/common/client-libs/gateway-client/src/error.rs
+++ b/common/client-libs/gateway-client/src/error.rs
@@ -74,6 +74,9 @@ pub enum GatewayClientError {
     #[error("Timed out")]
     Timeout,
 
+    #[error("timeout sending ws message to the gateway")]
+    TimeoutOnSendingWs,
+
     #[error("Failed to send mixnet message")]
     MixnetMsgSenderFailedToSend,
 

--- a/common/client-libs/gateway-client/src/socket_state.rs
+++ b/common/client-libs/gateway-client/src/socket_state.rs
@@ -160,7 +160,7 @@ impl PartiallyDelegated {
                         log::debug!("GatewayClient listener: Exiting");
                         // The packet router a task client, and as such we need to make
                         // sure it's dropped to not stall the shutdown process.
-                        drop(packet_router);
+                        // drop(packet_router);
                         return;
                     }
                     _ = &mut notify_receiver => {

--- a/common/client-libs/gateway-client/src/socket_state.rs
+++ b/common/client-libs/gateway-client/src/socket_state.rs
@@ -222,14 +222,14 @@ impl PartiallyDelegated {
         // Ok(r?)
         let r = tokio::time::timeout(Duration::from_secs(3), self.sink_half.send(msg)).await;
         let rr = match r {
-            Ok(rr) => rr,
+            Ok(rr) => Ok(rr?),
             Err(_) => {
                 log::error!("JON: PartiallyDelegated::send_without_response - timeout sending a message");
-                Ok(())
+                Err(GatewayClientError::TimeoutOnSendingWs)
             }
         };
         log::info!("JON: PartiallyDelegated::send_without_response - sent a message: {rr:?}");
-        Ok(rr?)
+        rr
     }
 
     pub(crate) async fn batch_send_without_response(

--- a/common/client-libs/gateway-client/src/socket_state.rs
+++ b/common/client-libs/gateway-client/src/socket_state.rs
@@ -158,6 +158,9 @@ impl PartiallyDelegated {
                     _ = shutdown.recv() => {
                         log::trace!("GatewayClient listener: Received shutdown");
                         log::debug!("GatewayClient listener: Exiting");
+                        // The packet router a task client, and as such we need to make
+                        // sure it's dropped to not stall the shutdown process.
+                        drop(packet_router);
                         return;
                     }
                     _ = &mut notify_receiver => {


### PR DESCRIPTION
I've noticed that the mix traffic controller can block on sending websocket messages, and in particular it ends up stalling shutdown when it's connected to a gateway that is not cooperating. Explicitly add timeout on the websocket send, and propagate errors back up to the mix traffic controller so that it can act on it appropriately, since it will depend on if shutdown is triggered or not.
