### PR TITLE
Explicitly handle constraint unique violation when importing credential

### DIFF
--- a/common/credential-storage/src/error.rs
+++ b/common/credential-storage/src/error.rs
@@ -18,4 +18,7 @@ pub enum StorageError {
 
     #[error("No unused credential in database. You need to buy at least one")]
     NoCredential,
+
+    #[error("Database unique constraint violation. Is the credential already imported?")]
+    ContraintUnique,
 }


### PR DESCRIPTION
# Description

So that the vpn lib can handle this, add a strong type for when a duplicate credential is imported
