### PR TITLE
Use rfc3339 for last_polled in described nym-api endpoint

### DIFF
--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -414,7 +414,9 @@ const fn unix_epoch() -> OffsetDateTime {
 
 // for all intents and purposes it's just OffsetDateTime, but we need JsonSchema...
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-pub struct OffsetDateTimeJsonSchemaWrapper(#[serde(default = "unix_epoch")] pub OffsetDateTime);
+pub struct OffsetDateTimeJsonSchemaWrapper(
+    #[serde(default = "unix_epoch", with = "time::serde::rfc3339")] pub OffsetDateTime,
+);
 
 impl Default for OffsetDateTimeJsonSchemaWrapper {
     fn default() -> Self {


### PR DESCRIPTION
# Description

Currently there is an issue where the validator-client can't parse the nym-api response for the described endpoint, in particular the `latest_polled` field that was recently added.

Fix this by making the field use rfc3339

NOTE: this will require upgrading nym-api and everything that depends on the described endpoint

This can be tested locally using the sdk examples

```sh
~/src/nym/nym/sdk/rust/nym-sdk
❯ cargo run --example simple
```

```
thread 'main' panicked at sdk/rust/nym-sdk/examples/simple.rs:9:64:
called Result::unwrap() on an Err value: ClientCoreError(ValidatorClientError(NymAPIError { source: ReqwestClientError { source: reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, 
```