### PR TITLE
allow using explicit admin address for issuing freepasses

### DIFF
--- a/nym-api/Cargo.toml
+++ b/nym-api/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
     "Drazen Urch <durch@users.noreply.github.com>",
 ]
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.76.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -48,7 +48,7 @@ tokio = { version = "1.24.1", features = [
 tokio-stream = "0.1.11"
 url = { workspace = true }
 
-ts-rs = { workspace = true, optional = true}
+ts-rs = { workspace = true, optional = true }
 
 anyhow = { workspace = true }
 getset = "0.1.1"

--- a/nym-api/src/coconut/error.rs
+++ b/nym-api/src/coconut/error.rs
@@ -37,10 +37,20 @@ pub enum CoconutError {
     #[error("failed to derive the admin account from the provided public key: {formatted_source}")]
     AdminAccountDerivationFailure { formatted_source: String },
 
-    #[error("the requester of the free pass ({requester}) is not authorised. the only allowed account is {authorised_admin}.")]
+    #[error("failed to query for the authorised freepass requester address: {source}")]
+    FreepassAuthorisedFreepassRequesterQueryFailure {
+        #[from]
+        source: reqwest::Error,
+    },
+
+    #[error("the provided authorised freepass requester address ({address}) is not a valid cosmos address")]
+    MalformedAuthorisedFreepassRequesterAddress { address: String },
+
+    #[error("the requester of the free pass ({requester}) is not authorised. the only allowed account is {explicit_admin:?} or {bandwidth_contract_admin:?}.")]
     UnauthorisedFreePassAccount {
         requester: AccountId,
-        authorised_admin: AccountId,
+        explicit_admin: Option<AccountId>,
+        bandwidth_contract_admin: Option<AccountId>,
     },
 
     #[error("failed to verify signature on the provided free pass request")]


### PR DESCRIPTION
# Description

testing: make sure you can obtain freepass by using either the explicit admin (ask @mmsinclair for the mnemonic) or bandwidth contract admin; make sure that if the contract admin is not available, the thing doesn't crash (like how our mainnet is going to be deployed)