### PR TITLE
Python CLI to self diagnose Nym nodes

### DIFF
--- a/scripts/api_endpoints.json
+++ b/scripts/api_endpoints.json
@@ -19,8 +19,25 @@
 	        "/status/gateway/{identity}/core-status-count",
 		"/status/gateway/{identity}/avg_uptime"
 
+	],
+
+	"swagger":[
+		"/roles",
+		"/build-information",
+		"/description",
+		"/host-information",
+		"/system-info",
+		"/gateway",
+		"/gateway/client-interfaces",
+		"/gateway/client-interfaces/mixnet-websockets",
+		"/gateway/client-interfaces/wireguard",
+		"/health",
+		"/ip-packet-router",
+		"/metrics/mixing",
+		"/metrics/prometheus",
+		"/metrics/verloc",
+		"/mixnode",
+		"/network-requester",
+		"/network-requester/exit-policy"
 	]
-
-
-
 }

--- a/scripts/api_endpoints.json
+++ b/scripts/api_endpoints.json
@@ -1,0 +1,26 @@
+{
+	"mixnode":[
+		"/status/mixnode/{mix_id}/report",
+		"/status/mixnode/{mix_id}/history",
+		"/status/mixnode/{mix_id}/core-status-count",
+		"/status/mixnode/{mix_id}/status",
+		"/status/mixnode/{mix_id}/reward-estimation",
+		"/status/mixnode/{mix_id}/compute-reward-estimation",
+		"/status/mixnode/{mix_id}/stake-saturation",
+		"/status/mixnode/{mix_id}/inclusion-probability",
+		"/status/mixnode/{mix_id}/avg_uptime"
+
+
+
+	],
+	"gateway":[
+		"/status/gateway/{identity}/report",
+		"/status/gateway/{identity}/history",
+	        "/status/gateway/{identity}/core-status-count",
+		"/status/gateway/{identity}/avg_uptime"
+
+	]
+
+
+
+}

--- a/scripts/node_api_check.py
+++ b/scripts/node_api_check.py
@@ -163,30 +163,53 @@ class MainFunctions:
 
     def get_swagger_data(self,host,swagger,swagger_data):
         print("INFO: Starting to query SWAGGER API page...")
-        for key in swagger:
-            try:
-                url = f"http://{host}:8080/api/v1{key}"
-                print(f"Querying {url}")
-                value = r.get(url, timeout=3).json()
-                swagger_data[key] = value
-            except r.exceptions.ConnectionError:
-                url = f"https://{host}/api/v1{key}"
-                value = r.get(url, timeout=3).json()
-                swagger_data[key] = value
-            except r.exceptions.ConnectionError:
-                url = f"http://{host}/api/v1{key}"
-                value = r.get(url,timeout=3).json()
-                swagger_data[key] = value
-            except r.exceptions.ConnectionError as e:
-                print(f"Error: The request to pull data from /api/v1/{key} returns {e}!")
-            except urllib3.exceptions.ProtocolError as e:
-                print(f"Error: The request to pull data from /api/v1/{key} returns {e}!")
-            except (JSONDecodeError, json.JSONDecodeError, r.exceptions.JSONDecodeError, ConnectionResetError, r.exceptions.ConnectionError) as e:
-                print(f"Error: Swagger endpoint {url} results in 404: Not Found! {e}")
-            except r.exceptions.ConnectTimeout as e:
-                print(f"Error: The request to pull data from /api/v1/{key} returns {e}! We are likely quering a deprecated version of nym-mixnode.")
-            except Exception as e:
-                print(f"Error: {e}: {url} not responding. Maybe you querying a deprecated version of nym-mixnode?")
+        urls = [
+                f"http://{host}:8080/api/v1",
+                f"https://{host}/api/v1",
+                f"http://{host}/api/v1"
+            ]
+        for endpoint in swagger:
+                for base_url in urls:
+                    url = f"{base_url}{endpoint}"
+                    try:
+                        print(f"Querying {url}")
+                        value = r.get(url, timeout=3).json()
+                        swagger_data[endpoint] = value
+                        break
+                    except (r.exceptions.ConnectionError, urllib3.exceptions.ProtocolError) as e:
+                        print(f"Error: Connection error when querying {url}: {e}") # No break because you could be dealing with a different protocol
+                    except (JSONDecodeError, json.JSONDecodeError, r.exceptions.JSONDecodeError, ConnectionResetError) as e:
+                        print(f"Error: JSON decode error when querying {url}: {e}")
+                    except r.exceptions.ConnectTimeout as e:
+                        print(f"Error: Connection timeout when querying {url}: {e}")
+                    except Exception as e:
+                        print(f"Error: An unexpected error occurred when querying {url}: {e}")
+
+
+#        for key in swagger:
+#            try:
+#                url = f"http://{host}:8080/api/v1{key}"
+#                print(f"Querying {url}")
+#                value = r.get(url, timeout=3).json()
+#                swagger_data[key] = value
+#            except r.exceptions.ConnectionError:
+#                url = f"https://{host}/api/v1{key}"
+#                value = r.get(url, timeout=3).json()
+#                swagger_data[key] = value
+#            except r.exceptions.ConnectionError:
+#                url = f"http://{host}/api/v1{key}"
+#                value = r.get(url,timeout=3).json()
+#                swagger_data[key] = value
+#            except r.exceptions.ConnectionError as e:
+#                print(f"Error: The request to pull data from /api/v1/{key} returns {e}!")
+#            except urllib3.exceptions.ProtocolError as e:
+#                print(f"Error: The request to pull data from /api/v1/{key} returns {e}!")
+#            except (JSONDecodeError, json.JSONDecodeError, r.exceptions.JSONDecodeError, ConnectionResetError, r.exceptions.ConnectionError) as e:
+#                print(f"Error: Swagger endpoint {url} results in 404: Not Found! {e}")
+#            except r.exceptions.ConnectTimeout as e:
+#                print(f"Error: The request to pull data from /api/v1/{key} returns {e}! We are likely quering a deprecated version of nym-mixnode.")
+#            except Exception as e:
+#                print(f"Error: {e}: {url} not responding. Maybe you querying a deprecated version of nym-mixnode?")
         return swagger_data
 
     def _set_index_to_empty(self, df):

--- a/scripts/node_api_check.py
+++ b/scripts/node_api_check.py
@@ -86,10 +86,6 @@ class MainFunctions:
         mixnodes_unfiltered = r.get(f"{self.api_url}/status/mixnodes/detailed-unfiltered").json()
         return gateways_unfiltered, mixnodes_unfiltered
 
-    def get_mixnode_data(self, node_df, id_key):
-        mix_id = int(node_df["mixnode_details.bond_information.mix_id"])
-
-
     def get_node_data(self,mode, node_dict, id_key, args):
         #endpoint_json = self.get_api_endpoints()
         identity = id_key
@@ -160,10 +156,6 @@ class MainFunctions:
 
         return host, version, mix_id, role, api_data, swagger_data, routing_history
 
-#    def get_api_endpoints(self):
-#        endpoint_json = r.get(self.api_existing_endpoints_url).json()
-#        return endpoint_json
-
     def _set_index_to_empty(self, df):
         index_len = pd.RangeIndex(len(df.index))
         new_index = []
@@ -217,8 +209,8 @@ class ArgParser:
         parser.add_argument("-V","--version", action="version", version='%(prog)s 0.1.0')
 
         # sub-command parsers
-        subparsers = parser.add_subparsers(help="{subcommand}[-h] shows all the options")
-        parser_pull_stats = subparsers.add_parser('pull_stats',help='Run with node identity key', aliases=['p','P','pull'])
+        subparsers = parser.add_subparsers()
+        parser_pull_stats = subparsers.add_parser('pull_stats',help='Run with node identity key', aliases=['p'])
 
         # pull_stats arguments
         parser_pull_stats.add_argument("id", help="supply nym-node identity key")
@@ -232,10 +224,17 @@ class ArgParser:
         args = parser.parse_args()
 
         try:
-            args.func(args)
-        except AttributeError as e:
-            msg = f"{e}.\nPlease run __file__ --help"
-            self.panic(msg)
+            func = args.func
+            try:
+                args.func(args)
+            except AttributeError as e:
+                msg = f"{e}.\nPlease run python {__file__} --help"
+                self.panic(msg)
+            except UnboundLocalError as e:
+                msg = f"{e}.\nPlease provide a correct node identity key."
+                self.panic(msg)
+        except AttributeError:
+            parser.print_help(sys.stderr)
 
 
     def panic(self,msg):

--- a/scripts/node_api_check.py
+++ b/scripts/node_api_check.py
@@ -6,6 +6,7 @@ import sys
 import pandas as pd
 import json
 from json import JSONDecodeError
+from tabulate import tabulate
 
 class MainFunctions:
 
@@ -193,11 +194,64 @@ class MainFunctions:
         df = pd.json_normalize(json)
         return df
 
+
+class VersionCount()
+
+    def __init__(self):
+        self.functions = MainFunctions()
+        self.mixnode_version_column = 'mixnode_details.bond_information.mix_node.version'
+        self.gateways_version_column = 'gateway_bond.gateway.version'
+
+
+    def display_results(self, args):
+
+        gateways_unfiltered, mixnodes_unfiltered = self.functions.get_unfiltered_data()
+        df_gateways = self.functions._json_to_dataframe(gateways_unfiltered)
+        df_mixnodes = self.functions._json_to_dataframe(mixnodes_unfiltered)
+        versions = list(args.version)
+        mixnode_sum = self.version_count(df_mixnodes, self.mixnodes_version_column, versions, "mixnode")
+        gateways_sum = self.version_count(df_gateways. self.gateways_version_column, versions, "gateway")
+        df_final = self.final_summary(mixnodes_sum, gateways_sum)
+        if args.markdown:
+            table = df_final.to_markdown(index=False)
+        else:
+            table = tabulate(df_final)
+        #if args.output:
+        print(table)
+
+    def version_count(self, df, column, versions, mode):
+        count_all = []
+        for version in versions:
+            version_sum = df[f'{column}'].value_counts()[f'{version}']
+            result = {"Node type": mode, "Version": version, "Summary":version_sum)
+            count_all.append(result)
+        return count_all
+
+    def final_summary(self, mixnodes_sum, gateways_sum, versions):
+        list_final = mixnodes_sum + gateways_sum
+        df_final = pd.DataFrame(list_final)
+        #mixnodes_total =
+        #gateways_total =
+        #nym-node each versions total =
+        #all together count
+        #append these totals to the d
+        return df_final
+
+    def count_total(self, df):
+
+
+#    def apply_function(self,df,column):
+#
+#    def _convert_string_to_integer(self,string):
+#
+
+
 class ArgParser:
 
     def __init__(self):
         """init for parser"""
         self.functions = MainFunctions()
+        self.version_count = VersionCount()
 
     def parser_main(self):
         """Main function initializing ArgumentParser, storing arguments and executing commands."""
@@ -211,15 +265,19 @@ class ArgParser:
         # sub-command parsers
         subparsers = parser.add_subparsers()
         parser_pull_stats = subparsers.add_parser('pull_stats',help='Run with node identity key', aliases=['p'])
+        parser_version_count = subparsers.add_parser('version_count', help='Sum of nodes in given version', aliases='v','V')
 
         # pull_stats arguments
         parser_pull_stats.add_argument("id", help="supply nym-node identity key")
         parser_pull_stats.add_argument("-n","--no_routing_history", help="Display node stats without routing history", action="store_true")
         parser_pull_stats.add_argument("-m","--markdown",help="Display node stats in markdown format", action="store_true")
         parser_pull_stats.add_argument("-o","--output",help="Save results to file")
-
-
         parser_pull_stats.set_defaults(func=self.functions.display_results)
+
+
+        # version_count arguments
+        parser_version_count.add_adrgument('version', help="supply node versions separated with space", nargs='+')
+        parser_version_count.set_defaults(func=self.version_count.display_results)
 
         args = parser.parse_args()
 

--- a/scripts/node_api_check.py
+++ b/scripts/node_api_check.py
@@ -1,0 +1,116 @@
+#!/usr/bin/python3
+
+import requests as r
+import argparse
+import sys
+import pandas as pd
+import json
+
+class MainFunctions:
+
+    def __init__(self):
+        self.api_url = "https://validator.nymtech.net/api/v1"
+        #self.api_existing_endpoints_url = "https://validator.nymtech.net/api/v1/openapi.json"
+        self.api_endpoints_json = "api_endpoints.json"
+
+    def display_results(self,args):
+        id_key = args.id
+        gateways_unfiltered, mixnodes_unfiltered = self.get_unfiltered_data()
+        gateways_df = self._json_to_dataframe(gateways_unfiltered)
+        mixnodes_df = self._json_to_dataframe(mixnodes_unfiltered)
+        mode, node_series = self.node_type_check(id_key, gateways_df, mixnodes_df)
+        print(f"mode = {mode}")
+        node_data = self.get_node_data(mode, node_series, id_key)
+        print(node_series.T, node_data)
+
+    def node_type_check(self,id_key, gateways_df, mixnodes_df):
+        if id_key in mixnodes_df['mixnode_details.bond_information.mix_node.identity_key'].values:
+
+            node = mixnodes_df.loc[mixnodes_df['mixnode_details.bond_information.mix_node.identity_key'] == id_key]
+            mode = "mixnode"
+        elif id_key in gateways_df['gateway_bond.gateway.identity_key'].values:
+            node = gateways_df.loc[gateways_df['gateway_bond.gateway.identity_key'] == id_key]
+            mode = "gateway"
+        else:
+            print(f"The identity key '{id_key}' does not exist.")
+
+        return mode, node
+
+    def get_unfiltered_data(self):
+        gateways_unfiltered = r.get(f"{self.api_url}/status/gateways/detailed-unfiltered").json()
+        mixnodes_unfiltered = r.get(f"{self.api_url}/status/mixnodes/detailed-unfiltered").json()
+        return gateways_unfiltered, mixnodes_unfiltered
+
+    def get_mixnode_data(self, node_series, id_key):
+        mix_id = int(node_series["mixnode_details.bond_information.mix_id"])
+
+
+    def get_node_data(self,mode, node_series, id_key):
+        #endpoint_json = self.get_api_endpoints()
+        identity = id_key
+        endpoint_json = self.api_endpoints_json
+        with open(endpoint_json, "r") as f:
+            dicts = json.load(f)
+            enpoints = dicts[mode]
+        node_data = {}
+        if mode == "gateway":
+            for key in enpoints:
+                url = f"{self.api_url}{key}"
+                value = r.get(url)
+                node_data[key] = value
+        elif mode == "mixnode":
+            mix_id = int(node_series["mixnode_details.bond_information.mix_id"])
+        else:
+            print(f"The mode type {mode} is not recognized!")
+            sys.exit(-1)
+        return node_data
+
+
+#    def get_api_endpoints(self):
+#        endpoint_json = r.get(self.api_existing_endpoints_url).json()
+#        return endpoint_json
+#
+    def _json_to_dataframe(self,json):
+        df = pd.json_normalize(json)
+        return df
+
+class ArgParser:
+
+    def __init__(self):
+        """init for parser"""
+        self.functions = MainFunctions()
+
+    def parser_main(self):
+        """Main function initializing ArgumentParser, storing arguments and executing commands."""
+        # Top level parser
+        parser = argparse.ArgumentParser(
+                prog= "Nym-node API check",
+                description='''Run through all endpoints and print results.'''
+            )
+        parser.add_argument("-V","--version", action="version", version='%(prog)s 0.1.0')
+
+        # sub-command parsers
+        subparsers = parser.add_subparsers(help="{subcommand}[-h] shows all the options")
+        parser_check = subparsers.add_parser('check',help='Run with node identity key', aliases=['c','C'])
+
+        # check - arguments
+        parser_check.add_argument("id", help="supply nym-node identity key")
+        parser_check.set_defaults(func=self.functions.display_results)
+
+        args = parser.parse_args()
+
+        try:
+            args.func(args)
+        except AttributeError as e:
+            msg = f"{e}.\nPlease run __file__ --help"
+            self.panic(msg)
+
+
+    def panic(self,msg):
+        """Error message print"""
+        print(f"error: {msg}", file=sys.stderr)
+        sys.exit(-1)
+
+if __name__ == '__main__':
+    node_check = ArgParser()
+    node_check.parser_main()

--- a/scripts/node_api_check.py
+++ b/scripts/node_api_check.py
@@ -13,78 +13,133 @@ class MainFunctions:
         #self.api_existing_endpoints_url = "https://validator.nymtech.net/api/v1/openapi.json"
         self.api_endpoints_json = "api_endpoints.json"
 
-    def display_results(self,args):
+    def display_results(self, args):
+        mode, host, node_df, node_dict, api_data, swagger_data, routing_history = self.collect_all_results(args)
+        print(f"Node type = {mode}")
+        print(f"Node Identity Key = {args.id}")
+        #print(f"Node host = {host}")
+        #api_data = self.format_dataframe(api_data)
+        print("\n\nNODE RESULTS FROM UNFILTERED QUERY\n")
+        self.print_neat_dict(node_dict)
+        print(f"\n\nNODE RESULTS FROM {self.api_url.upper()}\n")
+        self.print_neat_dict(api_data)
+#        print(node_df.T.to_markdown(), "\n")
+#        print(api_data.to_markdown(), "\n")
+        if swagger_data:
+            print(f"\n\nNODE RESULTS FROM SWAGGER PAGE\n")
+            self.print_neat_dict(swagger_data)
+            print(f"\n\nNODE UPTIME HISTORY\n")
+            self.print_neat_dict(routing_history)
+#            swagger_data = self.format_dataframe(swagger_data)
+#            routing_history = self.format_dataframe(routing_history)
+#            print(swagger_data.to_markdown())
+#            print(routing_history.to_markdown())
+
+    def collect_all_results(self,args):
         id_key = args.id
         gateways_unfiltered, mixnodes_unfiltered = self.get_unfiltered_data()
         gateways_df = self._json_to_dataframe(gateways_unfiltered)
+        gateways_df = self._set_index_to_empty(gateways_df)
         mixnodes_df = self._json_to_dataframe(mixnodes_unfiltered)
-        mode, node_series = self.node_type_check(id_key, gateways_df, mixnodes_df)
-        print(f"Node type = {mode}")
-        api_data, swagger_data = self.get_node_data(mode, node_series, id_key)
-        api_data = pd.Series(api_data)
-        swagger_data = pd.Series(swagger_data)
-        print(node_series.T, "\n")
-        print(api_data, "\n")
-        print(swagger_data)
+        mixnodes_df = self._set_index_to_empty(mixnodes_df)
+        mode, node_df, node_dict = self.get_node_df(id_key, gateways_df, mixnodes_df)
+        api_data, swagger_data, host, routing_history = self.get_node_data(mode, node_dict, id_key)
+        #drop_index = f"/status/gateway/{id_key}/history.history"
+        #api_data = api_data.drop(index=drop_index)
 
-    def node_type_check(self,id_key, gateways_df, mixnodes_df):
+        return mode, host, node_df, node_dict, api_data, swagger_data, routing_history
+
+    def get_node_df(self,id_key, gateways_df, mixnodes_df):
         if id_key in mixnodes_df['mixnode_details.bond_information.mix_node.identity_key'].values:
 
-            node = mixnodes_df.loc[mixnodes_df['mixnode_details.bond_information.mix_node.identity_key'] == id_key]
+            node_df = mixnodes_df.loc[mixnodes_df['mixnode_details.bond_information.mix_node.identity_key'] == id_key]
             mode = "mixnode"
         elif id_key in gateways_df['gateway_bond.gateway.identity_key'].values:
-            node = gateways_df.loc[gateways_df['gateway_bond.gateway.identity_key'] == id_key]
+
+            node_df = gateways_df.loc[gateways_df['gateway_bond.gateway.identity_key'] == id_key]
             mode = "gateway"
         else:
             print(f"The identity key '{id_key}' does not exist.")
 
-        return mode, node
+        node_dict = node_df.to_dict()
+
+        return mode, node_df, node_dict
 
     def get_unfiltered_data(self):
         gateways_unfiltered = r.get(f"{self.api_url}/status/gateways/detailed-unfiltered").json()
         mixnodes_unfiltered = r.get(f"{self.api_url}/status/mixnodes/detailed-unfiltered").json()
         return gateways_unfiltered, mixnodes_unfiltered
 
-    def get_mixnode_data(self, node_series, id_key):
-        mix_id = int(node_series["mixnode_details.bond_information.mix_id"])
+    def get_mixnode_data(self, node_df, id_key):
+        mix_id = int(node_df["mixnode_details.bond_information.mix_id"])
 
 
-    def get_node_data(self,mode, node_series, id_key):
+    def get_node_data(self,mode, node_dict, id_key):
         #endpoint_json = self.get_api_endpoints()
         identity = id_key
         endpoint_json = self.api_endpoints_json
+        #node_series = node_series.reset_index(drop=True)
         with open(endpoint_json, "r") as f:
             dicts = json.load(f)
             enpoints = dicts[mode]
             swagger = dicts["swagger"]
         api_data = {}
         swagger_data = {}
+        routing_history = {}
         if mode == "gateway":
-            host = str(node_series["gateway_bond.gateway.host"])
-            api_data["API ENPOINTS"] = "RESPONSE"
+            host = node_dict["gateway_bond.gateway.host"][""]
+                        #api_data["API ENPOINTS"] = "RESPONSE"
+
             for key in enpoints:
                 endpoint = key.replace("{identity}", identity)
                 url = f"{self.api_url}{endpoint}"
-                value = r.get(url)
+                value = r.get(url).json()
                 api_data[endpoint] = value
-            swagger_data["SWAGGER ENDPOINTS"] = "RESPONSE"
+            routing_history = api_data[f"/status/gateway/{identity}/history"]["history"]
+            del api_data[f"/status/gateway/{identity}/history"]["history"]
+            #swagger_data["SWAGGER ENDPOINTS"] = "RESPONSE"
             for key in swagger:
                 swagger_url = f"https://{host}:8080/api/v1{key}"
-                value = r.get(url)
+                value = r.get(url).json()
                 swagger_data[key] = value
-
         elif mode == "mixnode":
             mix_id = int(node_series["mixnode_details.bond_information.mix_id"])
         else:
             print(f"The mode type {mode} is not recognized!")
             sys.exit(-1)
-        return api_data, swagger_data
+        host = str(host)
+        return api_data, swagger_data, host, routing_history
 
 
 #    def get_api_endpoints(self):
 #        endpoint_json = r.get(self.api_existing_endpoints_url).json()
 #        return endpoint_json
-#
+
+    def _set_index_to_empty(self, df):
+        index_len = pd.RangeIndex(len(df.index))
+        new_index = []
+        for x in index_len:
+            x = ""
+            new_index.append(x)
+        df.index = new_index
+        return df
+
+
+    def format_dataframe(self, df):
+        #df = pd.DataFrame(df)
+        df = self._json_to_dataframe(df)
+        df = df.T
+        #df.columns = ["API ENDPOINT", "RESULTS"]
+        return df
+
+    def print_neat_dict(self, dictionary, indent=4):
+        neat_dictionary = self._json_neat_format(dictionary)
+        print(neat_dictionary)
+
+    def _json_neat_format(self,dictionary,indent=4):
+        dictionary = json.dumps(dictionary, indent = indent)
+        return dictionary
+
     def _json_to_dataframe(self,json):
         df = pd.json_normalize(json)
         return df

--- a/scripts/node_api_check.py
+++ b/scripts/node_api_check.py
@@ -193,19 +193,12 @@ class MainFunctions:
             value = r.get(url, timeout=2).json()
         except (r.exceptions.ConnectionError, urllib3.exceptions.ProtocolError) as e:
             print(f"Error: Connection error when querying {url}: {e}") # No break because you could be dealing with a different protocol
-#            error = f"Error: Connection error when querying {url}: {e}" # No break because you could be dealing with a different protocol
-#            count, error_list = self.error_count(len_urls,count, error, error_dict, 1)
         except (JSONDecodeError, json.JSONDecodeError, r.exceptions.JSONDecodeError, ConnectionResetError) as e:
             print(f"Error: JSON decode error when querying {url}: {e}")
-#            error = f"Error: JSON decode error when querying {url}: {e}"
-#            count, error_list = self.error_count(len_urls, count, error, error_dict, 2)
         except r.exceptions.ConnectTimeout as e:
             print(f"Error: Connection timeout when querying {url}: {e}")
-#            error = f"Error: Connection timeout when querying {url}: {e}"
-#            count, error_list = self.error_count(len_urls, count, error, error_dict, 3)
         except Exception as e:
             print(f"Error: An unexpected error occurred when querying {url}: {e}")
-#            count, error_list = self.error_count(len_urls, count, error, error_dict, 4)
         return value
 
     def get_swagger_response(self,urls):
@@ -221,15 +214,6 @@ class MainFunctions:
                 print(f"Swagger API was unreachable via {base_url}, we cannot proceed with querying Swagger end points!")
         return responding_url
 
-#    def error_count(self,len_urls,count, error, error_dict, error_index):
-#        count += 1
-#        error_dict[error] = error_index
-#        if count == len_urls and len(set(error_dict.values())) == 1:
-#            for key in error_dict.keys():
-#                print(key)
-#            count = 0
-#            error_dict = {}
-#        return count, error_dict
 
     def _set_index_to_empty(self, df):
         index_len = pd.RangeIndex(len(df.index))


### PR DESCRIPTION
# Description

Python CLI for devrel and operators, simplifying diagnose of a any node, especially if ran side by side with `nym-gateway-probe`.

`query_stats` command runs over all possible API checks based on nodes identity key. An example like:
`./node_api_check.py query_stats <IDENTITY_KEY>` will return all stats about any bonded node. 

Optional flags: 
- `--output <PATH>` - export output to a txt file
- `--markdown` - will output stats in markdown format
- `--no_routing_history` - excludes sometimes lengthy routing history from output

`version_count` command returns a table of node summary in the given version. For example `./node_api_check.py version_count <VERSION_1> <VERSION_2> <VERSION_3> --markdown` will return a neat markdown table counting all nodes in version 1, 2, and 3. Use Nym binary versioning (ie `1.1.3`) separated by space.

## Tasks

- [x] Checks whether the nodes is a `mixnode` or a `gateway` or the identity keys doesn't exist
- [x] Queries and prints all the associated endpoint stats
    - [x] pulls IP to run all swagger checks
    - [x] Add check if https/http and associate a port to it
- [x] Output to file for easier debugging
- [x] Version counter 

**Future steps:**

- [ ] Simplify by using nym-node APIs when they are released
- [ ] Replace hardcoded [`api_endpoints.json`](https://github.com/nymtech/nym/blob/feature/node-api-check/scripts/api_endpoints.json) and use endpoints from dynamic [`openapi.json`](https://validator.nymtech.net/api/v1/openapi.json)