### PR TITLE
Handle v6 and v7 requests in the IPR, but reply with v6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,6 +4826,7 @@ dependencies = [
  "serde_json",
  "tap",
  "thiserror",
+ "time",
  "tokio",
  "tokio-tun",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4781,6 +4781,7 @@ dependencies = [
  "bincode",
  "bytes",
  "nym-bin-common",
+ "nym-crypto",
  "nym-sphinx",
  "rand 0.8.5",
  "serde",

--- a/common/ip-packet-requests/Cargo.toml
+++ b/common/ip-packet-requests/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 bincode = { workspace = true }
 bytes = { workspace = true }
 nym-bin-common = { path = "../bin-common" }
+nym-crypto = { path = "../crypto" }
 nym-sphinx = { path = "../nymsphinx" }
 rand = "0.8.5"
 serde = { workspace = true, features = ["derive"] }

--- a/common/ip-packet-requests/src/v6/mod.rs
+++ b/common/ip-packet-requests/src/v6/mod.rs
@@ -1,2 +1,4 @@
 pub mod request;
 pub mod response;
+
+const VERSION: u8 = 6;

--- a/common/ip-packet-requests/src/v6/request.rs
+++ b/common/ip-packet-requests/src/v6/request.rs
@@ -1,7 +1,9 @@
 use nym_sphinx::addressing::clients::Recipient;
 use serde::{Deserialize, Serialize};
 
-use crate::{make_bincode_serializer, IpPair, CURRENT_VERSION};
+use crate::{make_bincode_serializer, IpPair};
+
+use super::VERSION;
 
 fn generate_random() -> u64 {
     use rand::RngCore;
@@ -26,7 +28,7 @@ impl IpPacketRequest {
         let request_id = generate_random();
         (
             Self {
-                version: CURRENT_VERSION,
+                version: VERSION,
                 data: IpPacketRequestData::StaticConnect(StaticConnectRequest {
                     request_id,
                     ips,
@@ -49,7 +51,7 @@ impl IpPacketRequest {
         let request_id = generate_random();
         (
             Self {
-                version: CURRENT_VERSION,
+                version: VERSION,
                 data: IpPacketRequestData::DynamicConnect(DynamicConnectRequest {
                     request_id,
                     reply_to,
@@ -66,7 +68,7 @@ impl IpPacketRequest {
         let request_id = generate_random();
         (
             Self {
-                version: CURRENT_VERSION,
+                version: VERSION,
                 data: IpPacketRequestData::Disconnect(DisconnectRequest {
                     request_id,
                     reply_to,
@@ -78,7 +80,7 @@ impl IpPacketRequest {
 
     pub fn new_data_request(ip_packets: bytes::Bytes) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketRequestData::Data(DataRequest { ip_packets }),
         }
     }
@@ -87,7 +89,7 @@ impl IpPacketRequest {
         let request_id = generate_random();
         (
             Self {
-                version: CURRENT_VERSION,
+                version: VERSION,
                 data: IpPacketRequestData::Ping(PingRequest {
                     request_id,
                     reply_to,
@@ -101,7 +103,7 @@ impl IpPacketRequest {
         let request_id = generate_random();
         (
             Self {
-                version: CURRENT_VERSION,
+                version: VERSION,
                 data: IpPacketRequestData::Health(HealthRequest {
                     request_id,
                     reply_to,

--- a/common/ip-packet-requests/src/v6/response.rs
+++ b/common/ip-packet-requests/src/v6/response.rs
@@ -1,7 +1,9 @@
 use nym_sphinx::addressing::clients::Recipient;
 use serde::{Deserialize, Serialize};
 
-use crate::{make_bincode_serializer, IpPair, CURRENT_VERSION};
+use crate::{make_bincode_serializer, IpPair};
+
+use super::VERSION;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IpPacketResponse {
@@ -12,7 +14,7 @@ pub struct IpPacketResponse {
 impl IpPacketResponse {
     pub fn new_static_connect_success(request_id: u64, reply_to: Recipient) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::StaticConnect(StaticConnectResponse {
                 request_id,
                 reply_to,
@@ -27,7 +29,7 @@ impl IpPacketResponse {
         reason: StaticConnectFailureReason,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::StaticConnect(StaticConnectResponse {
                 request_id,
                 reply_to,
@@ -38,7 +40,7 @@ impl IpPacketResponse {
 
     pub fn new_dynamic_connect_success(request_id: u64, reply_to: Recipient, ips: IpPair) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::DynamicConnect(DynamicConnectResponse {
                 request_id,
                 reply_to,
@@ -53,7 +55,7 @@ impl IpPacketResponse {
         reason: DynamicConnectFailureReason,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::DynamicConnect(DynamicConnectResponse {
                 request_id,
                 reply_to,
@@ -64,7 +66,7 @@ impl IpPacketResponse {
 
     pub fn new_disconnect_success(request_id: u64, reply_to: Recipient) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Disconnect(DisconnectResponse {
                 request_id,
                 reply_to,
@@ -79,7 +81,7 @@ impl IpPacketResponse {
         reason: DisconnectFailureReason,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Disconnect(DisconnectResponse {
                 request_id,
                 reply_to,
@@ -93,7 +95,7 @@ impl IpPacketResponse {
         reason: UnrequestedDisconnectReason,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::UnrequestedDisconnect(UnrequestedDisconnect {
                 reply_to,
                 reason,
@@ -103,7 +105,7 @@ impl IpPacketResponse {
 
     pub fn new_ip_packet(ip_packet: bytes::Bytes) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Data(DataResponse { ip_packet }),
         }
     }
@@ -115,7 +117,7 @@ impl IpPacketResponse {
         our_version: u8,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Info(InfoResponse {
                 request_id,
                 reply_to,
@@ -134,7 +136,7 @@ impl IpPacketResponse {
         level: InfoLevel,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Info(InfoResponse {
                 request_id: 0,
                 reply_to,
@@ -146,7 +148,7 @@ impl IpPacketResponse {
 
     pub fn new_pong(request_id: u64, reply_to: Recipient) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Pong(PongResponse {
                 request_id,
                 reply_to,
@@ -161,7 +163,7 @@ impl IpPacketResponse {
         routable: Option<bool>,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Health(HealthResponse {
                 request_id,
                 reply_to,

--- a/common/ip-packet-requests/src/v7/conversion.rs
+++ b/common/ip-packet-requests/src/v7/conversion.rs
@@ -1,0 +1,124 @@
+use time::OffsetDateTime;
+
+use crate::{v6, v7};
+
+impl From<v6::request::IpPacketRequest> for v7::request::IpPacketRequest {
+    fn from(ip_packet_request: v6::request::IpPacketRequest) -> Self {
+        Self {
+            version: 7,
+            data: ip_packet_request.data.into(),
+        }
+    }
+}
+
+impl From<v6::request::IpPacketRequestData> for v7::request::IpPacketRequestData {
+    fn from(ip_packet_request_data: v6::request::IpPacketRequestData) -> Self {
+        match ip_packet_request_data {
+            v6::request::IpPacketRequestData::StaticConnect(r) => {
+                v7::request::IpPacketRequestData::StaticConnect(
+                    v7::request::SignedStaticConnectRequest {
+                        request: r.into(),
+                        signature: None,
+                    },
+                )
+            }
+            v6::request::IpPacketRequestData::DynamicConnect(r) => {
+                v7::request::IpPacketRequestData::DynamicConnect(
+                    v7::request::SignedDynamicConnectRequest {
+                        request: r.into(),
+                        signature: None,
+                    },
+                )
+            }
+            v6::request::IpPacketRequestData::Disconnect(r) => {
+                v7::request::IpPacketRequestData::Disconnect(v7::request::SignedDisconnectRequest {
+                    request: r.into(),
+                    signature: None,
+                })
+            }
+            v6::request::IpPacketRequestData::Data(r) => {
+                v7::request::IpPacketRequestData::Data(r.into())
+            }
+            v6::request::IpPacketRequestData::Ping(r) => {
+                v7::request::IpPacketRequestData::Ping(r.into())
+            }
+            v6::request::IpPacketRequestData::Health(r) => {
+                v7::request::IpPacketRequestData::Health(r.into())
+            }
+        }
+    }
+}
+
+impl From<v6::request::StaticConnectRequest> for v7::request::StaticConnectRequest {
+    fn from(static_connect_request: v6::request::StaticConnectRequest) -> Self {
+        Self {
+            request_id: static_connect_request.request_id,
+            ips: static_connect_request.ips,
+            reply_to: static_connect_request.reply_to,
+            reply_to_hops: static_connect_request.reply_to_hops,
+            reply_to_avg_mix_delays: static_connect_request.reply_to_avg_mix_delays,
+            buffer_timeout: static_connect_request.buffer_timeout,
+            timestamp: OffsetDateTime::now_utc(),
+        }
+    }
+}
+
+impl From<v6::request::DynamicConnectRequest> for v7::request::DynamicConnectRequest {
+    fn from(dynamic_connect_request: v6::request::DynamicConnectRequest) -> Self {
+        Self {
+            request_id: dynamic_connect_request.request_id,
+            reply_to: dynamic_connect_request.reply_to,
+            reply_to_hops: dynamic_connect_request.reply_to_hops,
+            reply_to_avg_mix_delays: dynamic_connect_request.reply_to_avg_mix_delays,
+            buffer_timeout: dynamic_connect_request.buffer_timeout,
+            timestamp: OffsetDateTime::now_utc(),
+        }
+    }
+}
+
+impl From<v6::request::DisconnectRequest> for v7::request::SignedDisconnectRequest {
+    fn from(disconnect_request: v6::request::DisconnectRequest) -> Self {
+        Self {
+            request: disconnect_request.into(),
+            signature: None,
+        }
+    }
+}
+
+impl From<v6::request::DisconnectRequest> for v7::request::DisconnectRequest {
+    fn from(disconnect_request: v6::request::DisconnectRequest) -> Self {
+        Self {
+            request_id: disconnect_request.request_id,
+            reply_to: disconnect_request.reply_to,
+            timestamp: OffsetDateTime::now_utc(),
+        }
+    }
+}
+
+impl From<v6::request::DataRequest> for v7::request::DataRequest {
+    fn from(data_request: v6::request::DataRequest) -> Self {
+        Self {
+            ip_packets: data_request.ip_packets,
+        }
+    }
+}
+
+impl From<v6::request::PingRequest> for v7::request::PingRequest {
+    fn from(ping_request: v6::request::PingRequest) -> Self {
+        Self {
+            request_id: ping_request.request_id,
+            reply_to: ping_request.reply_to,
+            timestamp: OffsetDateTime::now_utc(),
+        }
+    }
+}
+
+impl From<v6::request::HealthRequest> for v7::request::HealthRequest {
+    fn from(health_request: v6::request::HealthRequest) -> Self {
+        Self {
+            request_id: health_request.request_id,
+            reply_to: health_request.reply_to,
+            timestamp: OffsetDateTime::now_utc(),
+        }
+    }
+}

--- a/common/ip-packet-requests/src/v7/mod.rs
+++ b/common/ip-packet-requests/src/v7/mod.rs
@@ -1,2 +1,5 @@
+pub mod conversion;
 pub mod request;
 pub mod response;
+
+const VERSION: u8 = 7;

--- a/common/ip-packet-requests/src/v7/mod.rs
+++ b/common/ip-packet-requests/src/v7/mod.rs
@@ -1,5 +1,6 @@
 pub mod conversion;
 pub mod request;
 pub mod response;
+pub mod signature;
 
 const VERSION: u8 = 7;

--- a/common/ip-packet-requests/src/v7/request.rs
+++ b/common/ip-packet-requests/src/v7/request.rs
@@ -2,7 +2,9 @@ use nym_sphinx::addressing::clients::Recipient;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-use crate::{make_bincode_serializer, IpPair, CURRENT_VERSION};
+use crate::{make_bincode_serializer, IpPair};
+
+use super::VERSION;
 
 fn generate_random() -> u64 {
     use rand::RngCore;
@@ -27,7 +29,7 @@ impl IpPacketRequest {
         let request_id = generate_random();
         (
             Self {
-                version: CURRENT_VERSION,
+                version: VERSION,
                 data: IpPacketRequestData::StaticConnect(SignedStaticConnectRequest {
                     request: StaticConnectRequest {
                         request_id,
@@ -54,7 +56,7 @@ impl IpPacketRequest {
         let request_id = generate_random();
         (
             Self {
-                version: CURRENT_VERSION,
+                version: VERSION,
                 data: IpPacketRequestData::DynamicConnect(SignedDynamicConnectRequest {
                     request: DynamicConnectRequest {
                         request_id,
@@ -75,7 +77,7 @@ impl IpPacketRequest {
         let request_id = generate_random();
         (
             Self {
-                version: CURRENT_VERSION,
+                version: VERSION,
                 data: IpPacketRequestData::Disconnect(SignedDisconnectRequest {
                     request: DisconnectRequest {
                         request_id,
@@ -91,7 +93,7 @@ impl IpPacketRequest {
 
     pub fn new_data_request(ip_packets: bytes::Bytes) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketRequestData::Data(DataRequest { ip_packets }),
         }
     }
@@ -100,7 +102,7 @@ impl IpPacketRequest {
         let request_id = generate_random();
         (
             Self {
-                version: CURRENT_VERSION,
+                version: VERSION,
                 data: IpPacketRequestData::Ping(PingRequest {
                     request_id,
                     reply_to,
@@ -115,7 +117,7 @@ impl IpPacketRequest {
         let request_id = generate_random();
         (
             Self {
-                version: CURRENT_VERSION,
+                version: VERSION,
                 data: IpPacketRequestData::Health(HealthRequest {
                     request_id,
                     reply_to,

--- a/common/ip-packet-requests/src/v7/request.rs
+++ b/common/ip-packet-requests/src/v7/request.rs
@@ -257,6 +257,10 @@ impl SignedRequest for SignedStaticConnectRequest {
     fn signature(&self) -> Option<&Vec<u8>> {
         self.signature.as_ref()
     }
+
+    fn timestamp(&self) -> OffsetDateTime {
+        self.request.timestamp
+    }
 }
 
 // A dynamic connect request is when the client does not provide the internal IP address it will use
@@ -314,6 +318,10 @@ impl SignedRequest for SignedDynamicConnectRequest {
     fn signature(&self) -> Option<&Vec<u8>> {
         self.signature.as_ref()
     }
+
+    fn timestamp(&self) -> OffsetDateTime {
+        self.request.timestamp
+    }
 }
 
 // A disconnect request is when the client wants to disconnect from the ip packet router and free
@@ -358,6 +366,10 @@ impl SignedRequest for SignedDisconnectRequest {
 
     fn signature(&self) -> Option<&Vec<u8>> {
         self.signature.as_ref()
+    }
+
+    fn timestamp(&self) -> OffsetDateTime {
+        self.request.timestamp
     }
 }
 

--- a/common/ip-packet-requests/src/v7/request.rs
+++ b/common/ip-packet-requests/src/v7/request.rs
@@ -179,19 +179,19 @@ pub enum IpPacketRequestData {
 }
 
 impl IpPacketRequestData {
-    pub fn add_signature(&mut self, signature: Vec<u8>) -> Option<Vec<u8>> {
+    pub fn add_signature(&mut self, signature: identity::Signature) -> Option<identity::Signature> {
         match self {
             IpPacketRequestData::StaticConnect(request) => {
                 request.signature = Some(signature);
-                request.signature.clone()
+                request.signature
             }
             IpPacketRequestData::DynamicConnect(request) => {
                 request.signature = Some(signature);
-                request.signature.clone()
+                request.signature
             }
             IpPacketRequestData::Disconnect(request) => {
                 request.signature = Some(signature);
-                request.signature.clone()
+                request.signature
             }
             IpPacketRequestData::Data(_)
             | IpPacketRequestData::Ping(_)
@@ -237,7 +237,7 @@ impl StaticConnectRequest {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SignedStaticConnectRequest {
     pub request: StaticConnectRequest,
-    pub signature: Option<Vec<u8>>,
+    pub signature: Option<identity::Signature>,
 }
 
 impl SignedRequest for SignedStaticConnectRequest {
@@ -254,7 +254,7 @@ impl SignedRequest for SignedStaticConnectRequest {
             })
     }
 
-    fn signature(&self) -> Option<&Vec<u8>> {
+    fn signature(&self) -> Option<&identity::Signature> {
         self.signature.as_ref()
     }
 
@@ -298,7 +298,7 @@ impl DynamicConnectRequest {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SignedDynamicConnectRequest {
     pub request: DynamicConnectRequest,
-    pub signature: Option<Vec<u8>>,
+    pub signature: Option<identity::Signature>,
 }
 
 impl SignedRequest for SignedDynamicConnectRequest {
@@ -315,7 +315,7 @@ impl SignedRequest for SignedDynamicConnectRequest {
             })
     }
 
-    fn signature(&self) -> Option<&Vec<u8>> {
+    fn signature(&self) -> Option<&identity::Signature> {
         self.signature.as_ref()
     }
 
@@ -347,7 +347,7 @@ impl DisconnectRequest {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SignedDisconnectRequest {
     pub request: DisconnectRequest,
-    pub signature: Option<Vec<u8>>,
+    pub signature: Option<identity::Signature>,
 }
 
 impl SignedRequest for SignedDisconnectRequest {
@@ -364,7 +364,7 @@ impl SignedRequest for SignedDisconnectRequest {
             })
     }
 
-    fn signature(&self) -> Option<&Vec<u8>> {
+    fn signature(&self) -> Option<&identity::Signature> {
         self.signature.as_ref()
     }
 

--- a/common/ip-packet-requests/src/v7/response.rs
+++ b/common/ip-packet-requests/src/v7/response.rs
@@ -1,7 +1,9 @@
 use nym_sphinx::addressing::clients::Recipient;
 use serde::{Deserialize, Serialize};
 
-use crate::{make_bincode_serializer, IpPair, CURRENT_VERSION};
+use crate::{make_bincode_serializer, IpPair};
+
+use super::VERSION;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IpPacketResponse {
@@ -12,7 +14,7 @@ pub struct IpPacketResponse {
 impl IpPacketResponse {
     pub fn new_static_connect_success(request_id: u64, reply_to: Recipient) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::StaticConnect(StaticConnectResponse {
                 request_id,
                 reply_to,
@@ -27,7 +29,7 @@ impl IpPacketResponse {
         reason: StaticConnectFailureReason,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::StaticConnect(StaticConnectResponse {
                 request_id,
                 reply_to,
@@ -38,7 +40,7 @@ impl IpPacketResponse {
 
     pub fn new_dynamic_connect_success(request_id: u64, reply_to: Recipient, ips: IpPair) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::DynamicConnect(DynamicConnectResponse {
                 request_id,
                 reply_to,
@@ -53,7 +55,7 @@ impl IpPacketResponse {
         reason: DynamicConnectFailureReason,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::DynamicConnect(DynamicConnectResponse {
                 request_id,
                 reply_to,
@@ -64,7 +66,7 @@ impl IpPacketResponse {
 
     pub fn new_disconnect_success(request_id: u64, reply_to: Recipient) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Disconnect(DisconnectResponse {
                 request_id,
                 reply_to,
@@ -79,7 +81,7 @@ impl IpPacketResponse {
         reason: DisconnectFailureReason,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Disconnect(DisconnectResponse {
                 request_id,
                 reply_to,
@@ -93,7 +95,7 @@ impl IpPacketResponse {
         reason: UnrequestedDisconnectReason,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::UnrequestedDisconnect(UnrequestedDisconnect {
                 reply_to,
                 reason,
@@ -103,7 +105,7 @@ impl IpPacketResponse {
 
     pub fn new_ip_packet(ip_packet: bytes::Bytes) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Data(DataResponse { ip_packet }),
         }
     }
@@ -115,7 +117,7 @@ impl IpPacketResponse {
         our_version: u8,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Info(InfoResponse {
                 request_id,
                 reply_to,
@@ -134,7 +136,7 @@ impl IpPacketResponse {
         level: InfoLevel,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Info(InfoResponse {
                 request_id: 0,
                 reply_to,
@@ -146,7 +148,7 @@ impl IpPacketResponse {
 
     pub fn new_pong(request_id: u64, reply_to: Recipient) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Pong(PongResponse {
                 request_id,
                 reply_to,
@@ -161,7 +163,7 @@ impl IpPacketResponse {
         routable: Option<bool>,
     ) -> Self {
         Self {
-            version: CURRENT_VERSION,
+            version: VERSION,
             data: IpPacketResponseData::Health(HealthResponse {
                 request_id,
                 reply_to,

--- a/common/ip-packet-requests/src/v7/response.rs
+++ b/common/ip-packet-requests/src/v7/response.rs
@@ -277,6 +277,8 @@ pub enum StaticConnectFailureReason {
     RequestedIpAlreadyInUse,
     #[error("requested nym-address is already in use")]
     RequestedNymAddressAlreadyInUse,
+    #[error("request timestamp is out of date")]
+    OutOfDateTimestamp,
     #[error("{0}")]
     Other(String),
 }

--- a/common/ip-packet-requests/src/v7/signature.rs
+++ b/common/ip-packet-requests/src/v7/signature.rs
@@ -1,0 +1,54 @@
+use nym_crypto::asymmetric::{ed25519::Ed25519RecoveryError, identity};
+
+#[derive(thiserror::Error, Debug)]
+pub enum SignatureError {
+    #[error("signature is missing")]
+    MissingSignature,
+
+    #[error("failed to parse signature: {error}")]
+    SignatureParseError {
+        message: String,
+        error: Ed25519RecoveryError,
+    },
+
+    #[error("failed to serialize request to binary: {message}")]
+    RequestSerializationError {
+        message: String,
+        error: Box<bincode::ErrorKind>,
+    },
+
+    #[error("signature verification failed")]
+    VerificationFailed {
+        message: String,
+        error: identity::SignatureError,
+    },
+}
+
+pub trait SignedRequest {
+    fn identity(&self) -> &identity::PublicKey;
+
+    fn request(&self) -> Result<Vec<u8>, SignatureError>;
+
+    fn signature(&self) -> Option<&Vec<u8>>;
+
+    fn verify(&self) -> Result<(), SignatureError> {
+        if let Some(signature) = self.signature() {
+            let request_as_bytes = self.request()?;
+            let signature = identity::Signature::from_bytes(signature).map_err(|error| {
+                SignatureError::SignatureParseError {
+                    message: "failed to parse signature".to_string(),
+                    error,
+                }
+            })?;
+
+            self.identity()
+                .verify(request_as_bytes, &signature)
+                .map_err(|error| SignatureError::VerificationFailed {
+                    message: "signature verification failed".to_string(),
+                    error,
+                })
+        } else {
+            Err(SignatureError::MissingSignature)
+        }
+    }
+}

--- a/common/ip-packet-requests/src/v7/signature.rs
+++ b/common/ip-packet-requests/src/v7/signature.rs
@@ -1,17 +1,14 @@
 use std::time::Duration;
 
-use nym_crypto::asymmetric::{ed25519::Ed25519RecoveryError, identity};
+use nym_crypto::asymmetric::identity;
+
+// For reply protection, if a request is older than this, it will be rejected
+const MAX_REQUEST_AGE: Duration = Duration::from_secs(10);
 
 #[derive(thiserror::Error, Debug)]
 pub enum SignatureError {
     #[error("signature is missing")]
     MissingSignature,
-
-    #[error("failed to parse signature: {error}")]
-    SignatureParseError {
-        message: String,
-        error: Ed25519RecoveryError,
-    },
 
     #[error("failed to serialize request to binary: {message}")]
     RequestSerializationError {
@@ -34,27 +31,21 @@ pub trait SignedRequest {
 
     fn request(&self) -> Result<Vec<u8>, SignatureError>;
 
-    fn signature(&self) -> Option<&Vec<u8>>;
+    fn signature(&self) -> Option<&identity::Signature>;
 
     fn timestamp(&self) -> time::OffsetDateTime;
 
     fn verify(&self) -> Result<(), SignatureError> {
         if let Some(signature) = self.signature() {
             // First check that the request is recent enough
-            if time::OffsetDateTime::now_utc() - self.timestamp() > Duration::from_secs(10) {
+            if time::OffsetDateTime::now_utc() - self.timestamp() > MAX_REQUEST_AGE {
                 return Err(SignatureError::RequestOutOfDate);
             }
 
             let request_as_bytes = self.request()?;
-            let signature = identity::Signature::from_bytes(signature).map_err(|error| {
-                SignatureError::SignatureParseError {
-                    message: "failed to parse signature".to_string(),
-                    error,
-                }
-            })?;
 
             self.identity()
-                .verify(request_as_bytes, &signature)
+                .verify(request_as_bytes, signature)
                 .map_err(|error| SignatureError::VerificationFailed {
                     message: "signature verification failed".to_string(),
                     error,

--- a/service-providers/ip-packet-router/Cargo.toml
+++ b/service-providers/ip-packet-router/Cargo.toml
@@ -22,6 +22,7 @@ nym-client-core = { path = "../../common/client-core" }
 nym-config = { path = "../../common/config" }
 nym-crypto = { path = "../../common/crypto" }
 nym-exit-policy = { path = "../../common/exit-policy" }
+nym-id = { path = "../../common/nym-id" }
 nym-ip-packet-requests = { path = "../../common/ip-packet-requests" }
 nym-network-defaults = { path = "../../common/network-defaults" }
 nym-network-requester = { path = "../network-requester" }
@@ -33,13 +34,13 @@ nym-tun = { path = "../../common/tun" }
 nym-types = { path = "../../common/types" }
 nym-wireguard = { path = "../../common/wireguard" }
 nym-wireguard-types = { path = "../../common/wireguard-types" }
-nym-id = { path = "../../common/nym-id" }
 rand = "0.8.5"
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tap.workspace = true
 thiserror = { workspace = true }
+time = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
 tokio-util = { workspace = true, features = ["codec"] }
 url.workspace = true

--- a/service-providers/ip-packet-router/src/connected_client_handler.rs
+++ b/service-providers/ip-packet-router/src/connected_client_handler.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use bytes::Bytes;
-use nym_ip_packet_requests::{codec::MultiIpPacketCodec, response::IpPacketResponse};
+use nym_ip_packet_requests::{codec::MultiIpPacketCodec, v6::response::IpPacketResponse};
 use nym_sdk::mixnet::{MixnetMessageSender, Recipient};
 
 use crate::{

--- a/service-providers/ip-packet-router/src/error.rs
+++ b/service-providers/ip-packet-router/src/error.rs
@@ -91,6 +91,11 @@ pub enum IpPacketRouterError {
 
     #[error("received empty packet")]
     EmptyPacket,
+
+    #[error("failed to verify request: {source}")]
+    FailedToVerifyRequest {
+        source: nym_ip_packet_requests::v7::signature::SignatureError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, IpPacketRouterError>;

--- a/service-providers/ip-packet-router/src/error.rs
+++ b/service-providers/ip-packet-router/src/error.rs
@@ -88,6 +88,9 @@ pub enum IpPacketRouterError {
 
     #[error(transparent)]
     NymIdError(#[from] NymIdError),
+
+    #[error("received empty packet")]
+    EmptyPacket,
 }
 
 pub type Result<T> = std::result::Result<T, IpPacketRouterError>;

--- a/service-providers/ip-packet-router/src/mixnet_listener.rs
+++ b/service-providers/ip-packet-router/src/mixnet_listener.rs
@@ -570,9 +570,6 @@ impl MixnetListener {
             }
         };
 
-        // Once we start to require clients to send v7 requests, we will enfore checking
-        // signatures. Until then, we only check if they are present.
-
         match request.data {
             IpPacketRequestData::StaticConnect(signed_connect_request) => {
                 verify_signed_request(&signed_connect_request)?;
@@ -705,6 +702,8 @@ impl MixnetListener {
 
 fn verify_signed_request(request: &impl SignedRequest) -> Result<()> {
     if let Err(err) = request.verify() {
+        // Once we start to require clients to send v7 requests, we will enfore checking
+        // signatures. Until then, we only check if they are present.
         if !matches!(err, SignatureError::MissingSignature) {
             return Err(IpPacketRouterError::FailedToVerifyRequest { source: err });
         }


### PR DESCRIPTION
Teach the IPR to read both v6 and v7 requests, but always reply with v6. This is to prepare for bumping to v7 and signed connect/disconnect messages.

Follow up PRs will add
- Verify signature
- Send v7 in client with signatures included
