### PR TITLE
Fix cargo warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,8 +526,6 @@ dependencies = [
  "bs58 0.5.1",
  "hmac",
  "k256",
- "once_cell",
- "pbkdf2",
  "rand_core 0.6.4",
  "ripemd",
  "sha2 0.10.8",
@@ -2204,7 +2202,6 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "bitvec",
  "rand_core 0.6.4",
  "subtle 2.5.0",
 ]
@@ -6088,16 +6085,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
 
 [[package]]
 name = "pear"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ members = [
     "tools/nymvisor",
     "tools/ts-rs-cli",
     "wasm/client",
-    #    "wasm/full-nym-wasm",
+    # "wasm/full-nym-wasm",  # If we uncomment this again, remember to also uncomment the profile settings below
     "wasm/mix-fetch",
     "wasm/node-tester",
     "wasm/zknym-lib",
@@ -356,9 +356,12 @@ opt-level = 'z'
 # lto = true
 opt-level = 'z'
 
-[profile.release.package.nym-wasm-sdk]
-# lto = true
-opt-level = 'z'
+# Commented out since the crate is also commented out from the inclusion in the
+# workspace above. We should uncomment this if we re-include it in the
+# workspace
+#[profile.release.package.nym-wasm-sdk]
+## lto = true
+#opt-level = 'z'
 
 [profile.release.package.mix-fetch-wasm]
 # lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,9 +300,9 @@ prometheus = { version = "0.13.0" }
 # coconut/DKG related
 # unfortunately until https://github.com/zkcrypto/bls12_381/issues/10 is resolved, we have to rely on the fork
 # as we need to be able to serialize Gt so that we could create the lookup table for baby-step-giant-step algorithm
-bls12_381 = { git = "https://github.com/jstuczyn/bls12_381", branch = "feature/gt-serialization-0.8.0" }
-group = "0.13.0"
-ff = "0.13.0"
+bls12_381 = { git = "https://github.com/jstuczyn/bls12_381", default-features = false,  branch = "feature/gt-serialization-0.8.0" }
+group = { version = "0.13.0", default-features = false }
+ff = { version = "0.13.0", default-features = false }
 
 # cosmwasm-related
 cosmwasm-derive = "=1.4.3"
@@ -321,14 +321,14 @@ cw4 = { version = "=1.1.2" }
 cw-controllers = { version = "=1.1.0" }
 
 # cosmrs-related
-bip32 = "0.5.1"
+bip32 = { version = "0.5.1", default-features = false }
 
 # temporarily using a fork again (yay.) because we need staking and slashing support
 cosmrs = { git = "https://github.com/jstuczyn/cosmos-rust", branch = "nym-temp/all-validator-features" }
 #cosmrs = {  git = "https://github.com/jstuczyn/cosmos-rust", branch = "nym-temp/all-validator-features" } # unfortuntely we need a fork by yours truly to get the staking support
 tendermint = "0.34"     # same version as used by cosmrs
 tendermint-rpc = "0.34" # same version as used by cosmrs
-prost = "0.12"
+prost = { version = "0.12", default-features = false }
 
 # wasm-related dependencies
 gloo-utils = "0.2.0"


### PR DESCRIPTION
On every cargo command we have the set warnings:

```
warning: /home/jon/src/nym/nym/common/dkg/Cargo.toml: `default-features` is ignored for bls12_381, since `default-features` was not specified for `workspace.dependencies.bls12_381`, this could become a hard error in the future
warning: /home/jon/src/nym/nym/common/dkg/Cargo.toml: `default-features` is ignored for ff, since `default-features` was not specified for `workspace.dependencies.ff`, this could become a hard error in the future
warning: /home/jon/src/nym/nym/common/dkg/Cargo.toml: `default-features` is ignored for group, since `default-features` was not specified for `workspace.dependencies.group`, this could become a hard error in the future
warning: /home/jon/src/nym/nym/common/client-libs/validator-client/Cargo.toml: `default-features` is ignored for bip32, since `default-features` was not specified for `workspace.dependencies.bip32`, this could become a hard error in the future
warning: /home/jon/src/nym/nym/common/client-libs/validator-client/Cargo.toml: `default-features` is ignored for prost, since `default-features` was not specified for `workspace.dependencies.prost`, this could become a hard error in the future
warning: /home/jon/src/nym/nym/common/credentials-interface/Cargo.toml: `default-features` is ignored for bls12_381, since `default-features` was not specified for `workspace.dependencies.bls12_381`, this could become a hard error in the future
warning: /home/jon/src/nym/nym/common/credentials/Cargo.toml: `default-features` is ignored for bls12_381, since `default-features` was not specified for `workspace.dependencies.bls12_381`, this could become a hard error in the future
warning: /home/jon/src/nym/nym/common/nymcoconut/Cargo.toml: `default-features` is ignored for bls12_381, since `default-features` was not specified for `workspace.dependencies.bls12_381`, this could become a hard error in the future
warning: /home/jon/src/nym/nym/common/nymcoconut/Cargo.toml: `default-features` is ignored for ff, since `default-features` was not specified for `workspace.dependencies.ff`, this could become a hard error in the future
warning: /home/jon/src/nym/nym/common/nymcoconut/Cargo.toml: `default-features` is ignored for group, since `default-features` was not specified for `workspace.dependencies.group`, this could become a hard error in the future
```

This PR adds default-features = false to the workspace dependencies to fix these. An alternative way would be to remove `default-features = false` in the crates, but I assume these were put there for a good reason. Also we might have other crates outside of the main workspace that depends on these crates having default features disabled.

We also have the warning

```
warning: profile package spec `nym-wasm-sdk` in profile `release` did not match any packages
```

which we fix by commenting out the profile settings, since the crate is currently commented out in the workspace crate list.
