### PR TITLE
validate nym-node public ips on startup

### DIFF
--- a/nym-node/src/cli/commands/run/args.rs
+++ b/nym-node/src/cli/commands/run/args.rs
@@ -36,6 +36,14 @@ pub(crate) struct Args {
     )]
     pub(crate) init_only: bool,
 
+    /// Flag specifying this node will be running in a local setting.
+    #[clap(
+        long,
+        default_value_t = false,
+        env = NYMNODE_LOCAL_ARG
+    )]
+    local: bool,
+
     /// Specifies the current mode of this nym-node.
     #[clap(
         long,

--- a/nym-node/src/cli/commands/run/args.rs
+++ b/nym-node/src/cli/commands/run/args.rs
@@ -42,7 +42,7 @@ pub(crate) struct Args {
         default_value_t = false,
         env = NYMNODE_LOCAL_ARG
     )]
-    local: bool,
+    pub(crate) local: bool,
 
     /// Specifies the current mode of this nym-node.
     #[clap(

--- a/nym-node/src/cli/commands/run/mod.rs
+++ b/nym-node/src/cli/commands/run/mod.rs
@@ -3,14 +3,40 @@
 
 use crate::node::bonding_information::BondingInformationV1;
 use crate::node::NymNode;
+use nym_config::helpers::SPECIAL_ADDRESSES;
 use nym_node::config::upgrade_helpers::try_load_current_config;
 use nym_node::error::NymNodeError;
 use std::fs;
+use std::net::IpAddr;
+use tracing::log::warn;
 use tracing::{debug, info, trace};
 
 mod args;
 
 pub(crate) use args::Args;
+
+fn check_public_ips(ips: &[IpAddr], local: bool) -> Result<(), NymNodeError> {
+    let mut suspicious_ip = Vec::new();
+    for ip in ips {
+        if SPECIAL_ADDRESSES.contains(ip) {
+            if !local {
+                return Err(NymNodeError::InvalidPublicIp { address: *ip });
+            }
+            suspicious_ip.push(ip);
+        }
+    }
+
+    if !suspicious_ip.is_empty() {
+        warn!("\n##### WARNING #####");
+        for ip in suspicious_ip {
+            warn!("The 'public' IP address you're trying to announce: {ip} may not be accessible to other clients.\
+            Please make sure this is what you intended to announce.\
+            You can ignore this warning if you're running setup on a local network ")
+        }
+        warn!("\n##### WARNING #####\n");
+    }
+    Ok(())
+}
 
 pub(crate) async fn execute(mut args: Args) -> Result<(), NymNodeError> {
     trace!("passed arguments: {args:#?}");
@@ -19,6 +45,7 @@ pub(crate) async fn execute(mut args: Args) -> Result<(), NymNodeError> {
     let output = args.output;
     let bonding_info_path = args.bonding_information_output.clone();
     let init_only = args.init_only;
+    let local = args.local;
 
     let config = if !config_path.exists() {
         debug!("no configuration file found at '{}'", config_path.display());
@@ -46,6 +73,11 @@ pub(crate) async fn execute(mut args: Args) -> Result<(), NymNodeError> {
         }
         config
     };
+
+    if config.host.public_ips.is_empty() {
+        return Err(NymNodeError::NoPublicIps);
+    }
+    check_public_ips(&config.host.public_ips, local);
 
     let nym_node = NymNode::new(config).await?;
 

--- a/nym-node/src/env.rs
+++ b/nym-node/src/env.rs
@@ -9,7 +9,7 @@ pub mod vars {
     pub const NYMNODE_CONFIG_PATH_ARG: &str = "NYMNODE_CONFIG";
 
     pub const NYMNODE_DENY_INIT_ARG: &str = "NYMNODE_DENY_INIT";
-
+    pub const NYMNODE_LOCAL_ARG: &str = "NYMNODE_LOCAL";
     pub const NYMNODE_INIT_ONLY_ARG: &str = "NYMNODE_INIT_ONLY";
 
     pub const NYMMONDE_WRITE_CONFIG_CHANGES_ARG: &str = "NYMNODE_WRITE_CONFIG_CHANGES";


### PR DESCRIPTION
# Description

makes sure nym-node is not run with an empty `public_ips` and that they do not correspond to common misconfigurations like `127.0.0.1` or `0.0.0.0` unless run with `--local` flag

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
