### PR TITLE
impl AsyncRead, AsyncWrite for native MixnetClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5363,6 +5363,7 @@ dependencies = [
 name = "nym-sphinx"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "log",
  "nym-crypto",
  "nym-mixnet-contract-common",
@@ -5379,8 +5380,10 @@ dependencies = [
  "nym-topology",
  "rand 0.8.5",
  "rand_distr",
+ "serde",
  "thiserror",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4180,6 +4180,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
+ "tokio-util",
  "tungstenite",
  "url",
  "wasm-bindgen",
@@ -4956,6 +4957,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "url",
  "zeroize",
 ]
@@ -5300,6 +5302,7 @@ dependencies = [
  "tap",
  "thiserror",
  "tokio",
+ "tokio-util",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,6 +4138,7 @@ version = "1.1.15"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
+ "bincode",
  "bs58 0.5.1",
  "cfg-if",
  "clap 4.5.4",
@@ -5466,6 +5467,7 @@ dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-types",
+ "serde",
  "thiserror",
 ]
 
@@ -5543,6 +5545,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "log",
+ "serde",
  "thiserror",
  "tokio",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4255,6 +4255,7 @@ dependencies = [
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
  "thiserror",
+ "tokio",
  "tsify",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5359,7 +5359,6 @@ dependencies = [
 name = "nym-sphinx"
 version = "0.1.0"
 dependencies = [
- "bincode",
  "log",
  "nym-crypto",
  "nym-mixnet-contract-common",
@@ -5376,7 +5375,6 @@ dependencies = [
  "nym-topology",
  "rand 0.8.5",
  "rand_distr",
- "serde",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5359,6 +5359,7 @@ dependencies = [
 name = "nym-sphinx"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "log",
  "nym-crypto",
  "nym-mixnet-contract-common",
@@ -5375,6 +5376,7 @@ dependencies = [
  "nym-topology",
  "rand 0.8.5",
  "rand_distr",
+ "serde",
  "thiserror",
  "tokio",
 ]

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+bincode = { workspace = true }
 base64 = "0.21.2"
 bs58 = { workspace = true }
 cfg-if = { workspace = true }
@@ -26,7 +27,7 @@ tap = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 tokio = { workspace = true, features = ["macros"] }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }
 time = { workspace = true }
 zeroize = { workspace = true }
 

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -26,6 +26,7 @@ tap = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 tokio = { workspace = true, features = ["macros"] }
+tokio-util = { workspace = true }
 time = { workspace = true }
 zeroize = { workspace = true }
 
@@ -47,7 +48,9 @@ nym-validator-client = { path = "../client-libs/validator-client", default-featu
 nym-task = { path = "../task" }
 nym-credential-storage = { path = "../credential-storage" }
 nym-network-defaults = { path = "../network-defaults" }
-nym-client-core-config-types = { path = "./config-types", features = ["disk-persistence"] }
+nym-client-core-config-types = { path = "./config-types", features = [
+    "disk-persistence",
+] }
 nym-client-core-surb-storage = { path = "./surb-storage" }
 nym-client-core-gateways-storage = { path = "./gateways-storage" }
 

--- a/common/client-core/src/client/inbound_messages.rs
+++ b/common/client-core/src/client/inbound_messages.rs
@@ -1,4 +1,3 @@
-use hyper::body::Buf;
 // Copyright 2020-2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 use nym_sphinx::addressing::clients::Recipient;
@@ -8,6 +7,7 @@ use nym_sphinx::params::PacketType;
 use nym_task::connections::TransmissionLane;
 use serde::{Deserialize, Serialize};
 use tokio_util::{
+    bytes::Buf,
     bytes::BytesMut,
     codec::{Decoder, Encoder},
 };

--- a/common/client-core/src/client/inbound_messages.rs
+++ b/common/client-core/src/client/inbound_messages.rs
@@ -7,7 +7,7 @@ use nym_sphinx::forwarding::packet::MixPacket;
 use nym_sphinx::params::PacketType;
 use nym_task::connections::TransmissionLane;
 
-pub type InputMessageSender = tokio::sync::mpsc::Sender<InputMessage>;
+pub type InputMessageSender = tokio_util::sync::PollSender<InputMessage>;
 pub type InputMessageReceiver = tokio::sync::mpsc::Receiver<InputMessage>;
 
 #[derive(Debug)]

--- a/common/nymsphinx/Cargo.toml
+++ b/common/nymsphinx/Cargo.toml
@@ -12,8 +12,6 @@ log = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 thiserror = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-bincode = { workspace = true }
 
 nym-sphinx-acknowledgements = { path = "acknowledgements" }
 nym-sphinx-addressing = { path = "addressing" }

--- a/common/nymsphinx/Cargo.toml
+++ b/common/nymsphinx/Cargo.toml
@@ -12,6 +12,9 @@ log = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 thiserror = { workspace = true }
+serde = { workspace = true }
+bincode = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }
 
 nym-sphinx-acknowledgements = { path = "acknowledgements" }
 nym-sphinx-addressing = { path = "addressing" }

--- a/common/nymsphinx/Cargo.toml
+++ b/common/nymsphinx/Cargo.toml
@@ -12,6 +12,8 @@ log = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+bincode = { workspace = true }
 
 nym-sphinx-acknowledgements = { path = "acknowledgements" }
 nym-sphinx-addressing = { path = "addressing" }
@@ -30,7 +32,9 @@ nym-topology = { path = "../topology" }
 
 [dev-dependencies]
 nym-mixnet-contract-common = { path = "../cosmwasm-smart-contracts/mixnet-contract" }
-nym-crypto = { path = "../crypto", version = "0.4.0", features = ["asymmetric"] }
+nym-crypto = { path = "../crypto", version = "0.4.0", features = [
+    "asymmetric",
+] }
 
 # do not include this when compiling into wasm as it somehow when combined together with reqwest, it will require
 # net2 via tokio-util -> tokio -> mio -> net2
@@ -43,5 +47,13 @@ features = ["sync"]
 
 [features]
 default = ["sphinx"]
-sphinx = ["nym-crypto/sphinx", "nym-sphinx-params/sphinx", "nym-sphinx-types/sphinx"]
-outfox = ["nym-crypto/outfox", "nym-sphinx-params/outfox", "nym-sphinx-types/outfox"]
+sphinx = [
+    "nym-crypto/sphinx",
+    "nym-sphinx-params/sphinx",
+    "nym-sphinx-types/sphinx",
+]
+outfox = [
+    "nym-crypto/outfox",
+    "nym-sphinx-params/outfox",
+    "nym-sphinx-types/outfox",
+]

--- a/common/nymsphinx/anonymous-replies/src/requests.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests.rs
@@ -4,6 +4,7 @@
 use crate::{ReplySurb, ReplySurbError};
 use nym_sphinx_addressing::clients::{Recipient, RecipientFormattingError};
 use rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::mem;
 use thiserror::Error;
@@ -24,7 +25,7 @@ pub enum InvalidAnonymousSenderTagRepresentation {
     InvalidLength { received: usize, expected: usize },
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub struct AnonymousSenderTag([u8; SENDER_TAG_SIZE]);
 

--- a/common/nymsphinx/anonymous-replies/src/requests.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests.rs
@@ -4,7 +4,6 @@
 use crate::{ReplySurb, ReplySurbError};
 use nym_sphinx_addressing::clients::{Recipient, RecipientFormattingError};
 use rand::{CryptoRng, RngCore};
-use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::mem;
 use thiserror::Error;
@@ -25,7 +24,7 @@ pub enum InvalidAnonymousSenderTagRepresentation {
     InvalidLength { received: usize, expected: usize },
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub struct AnonymousSenderTag([u8; SENDER_TAG_SIZE]);
 

--- a/common/nymsphinx/forwarding/Cargo.toml
+++ b/common/nymsphinx/forwarding/Cargo.toml
@@ -13,3 +13,4 @@ nym-sphinx-params = { path = "../params" }
 nym-sphinx-types = { path = "../types", features = ["sphinx", "outfox"] }
 nym-outfox = { path = "../../../nym-outfox" }
 thiserror = { workspace = true }
+serde = { workspace = true }

--- a/common/nymsphinx/forwarding/src/packet.rs
+++ b/common/nymsphinx/forwarding/src/packet.rs
@@ -4,7 +4,10 @@
 use nym_sphinx_addressing::nodes::{NymNodeRoutingAddress, NymNodeRoutingAddressError};
 use nym_sphinx_params::{PacketSize, PacketType};
 use nym_sphinx_types::{NymPacket, NymPacketError};
-use serde::{de::{self, Visitor}, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 
 use std::fmt::{self, Debug, Formatter};
 use thiserror::Error;
@@ -128,7 +131,7 @@ impl Serialize for MixPacket {
 
 struct MixPacketVisitor;
 
-impl <'de> Visitor<'de> for MixPacketVisitor {
+impl<'de> Visitor<'de> for MixPacketVisitor {
     type Value = MixPacket;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -140,7 +143,7 @@ impl <'de> Visitor<'de> for MixPacketVisitor {
     }
 }
 
-impl <'de> Deserialize <'de> for MixPacket {
+impl<'de> Deserialize<'de> for MixPacket {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         deserializer.deserialize_bytes(MixPacketVisitor)
     }

--- a/common/nymsphinx/src/receiver.rs
+++ b/common/nymsphinx/src/receiver.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::message::{NymMessage, NymMessageError, PaddedMessage, PlainMessage};
+use log::warn;
 use nym_crypto::aes::cipher::{KeyIvInit, StreamCipher};
 use nym_crypto::asymmetric::encryption;
 use nym_crypto::shared_key::recompute_shared_key;
@@ -16,10 +17,11 @@ use nym_sphinx_params::{
     PacketEncryptionAlgorithm, PacketHkdfAlgorithm, ReplySurbEncryptionAlgorithm,
     DEFAULT_NUM_MIX_HOPS,
 };
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 // TODO: should this live in this file?
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ReconstructedMessage {
     /// The actual plaintext message that was received.
     pub message: Vec<u8>,
@@ -27,6 +29,30 @@ pub struct ReconstructedMessage {
     /// Optional ephemeral sender tag indicating pseudo-identity of the party who sent us the message
     /// (alongside any reply SURBs)
     pub sender_tag: Option<AnonymousSenderTag>,
+}
+
+impl From<ReconstructedMessage> for Vec<u8> {
+    fn from(msg: ReconstructedMessage) -> Vec<u8> {
+        match bincode::serialize(&msg) {
+            Ok(serialized) => serialized,
+            Err(err) => {
+                warn!("failed to serialize reconstructed message - {:?}", err);
+                Vec::new()
+            }
+        }
+    }
+}
+
+impl From<&ReconstructedMessage> for Vec<u8> {
+    fn from(msg: &ReconstructedMessage) -> Vec<u8> {
+        match bincode::serialize(msg) {
+            Ok(serialized) => serialized,
+            Err(err) => {
+                warn!("failed to serialize reconstructed message - {:?}", err);
+                Vec::new()
+            }
+        }
+    }
 }
 
 impl From<ReconstructedMessage> for (Vec<u8>, Option<AnonymousSenderTag>) {

--- a/common/nymsphinx/src/receiver.rs
+++ b/common/nymsphinx/src/receiver.rs
@@ -88,7 +88,6 @@ impl Decoder for ReconstructedMessageCodec {
     type Error = MessageRecoveryError;
 
     fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        println!("decoder called with buf: {:?}", buf.to_vec());
         if buf.len() < OFFSET {
             return Ok(None);
         }
@@ -99,20 +98,15 @@ impl Decoder for ReconstructedMessageCodec {
                 .expect("We know that we have at least OFFSET bytes in there"),
         ) as usize;
 
-        println!("len to decode {}", len);
-        println!("buf len {}", buf.len());
-
         if buf.len() < len + OFFSET {
             return Ok(None);
         }
 
         let decoded = match bincode::deserialize(&buf[OFFSET..len + OFFSET]) {
             Ok(decoded) => {
-                println!("decoded: {:?}", decoded);
                 decoded
             }
             Err(e) => {
-                println!("error: {:?}", e);
                 return Ok(None);
             }
         };

--- a/common/nymsphinx/src/receiver.rs
+++ b/common/nymsphinx/src/receiver.rs
@@ -4,6 +4,7 @@
 use std::io;
 
 use crate::message::{NymMessage, NymMessageError, PaddedMessage, PlainMessage};
+use log::debug;
 use nym_crypto::aes::cipher::{KeyIvInit, StreamCipher};
 use nym_crypto::asymmetric::encryption;
 use nym_crypto::shared_key::recompute_shared_key;
@@ -107,6 +108,7 @@ impl Decoder for ReconstructedMessageCodec {
                 decoded
             }
             Err(e) => {
+                debug!("Failed to decode the message - {:?}", e);
                 return Ok(None);
             }
         };

--- a/common/nymsphinx/src/receiver.rs
+++ b/common/nymsphinx/src/receiver.rs
@@ -104,9 +104,7 @@ impl Decoder for ReconstructedMessageCodec {
         }
 
         let decoded = match bincode::deserialize(&buf[OFFSET..len + OFFSET]) {
-            Ok(decoded) => {
-                decoded
-            }
+            Ok(decoded) => decoded,
             Err(e) => {
                 debug!("Failed to decode the message - {:?}", e);
                 return Ok(None);

--- a/common/nymsphinx/src/receiver.rs
+++ b/common/nymsphinx/src/receiver.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::message::{NymMessage, NymMessageError, PaddedMessage, PlainMessage};
-use log::warn;
 use nym_crypto::aes::cipher::{KeyIvInit, StreamCipher};
 use nym_crypto::asymmetric::encryption;
 use nym_crypto::shared_key::recompute_shared_key;
@@ -17,11 +16,10 @@ use nym_sphinx_params::{
     PacketEncryptionAlgorithm, PacketHkdfAlgorithm, ReplySurbEncryptionAlgorithm,
     DEFAULT_NUM_MIX_HOPS,
 };
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 // TODO: should this live in this file?
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 pub struct ReconstructedMessage {
     /// The actual plaintext message that was received.
     pub message: Vec<u8>,
@@ -29,30 +27,6 @@ pub struct ReconstructedMessage {
     /// Optional ephemeral sender tag indicating pseudo-identity of the party who sent us the message
     /// (alongside any reply SURBs)
     pub sender_tag: Option<AnonymousSenderTag>,
-}
-
-impl From<ReconstructedMessage> for Vec<u8> {
-    fn from(msg: ReconstructedMessage) -> Vec<u8> {
-        match bincode::serialize(&msg) {
-            Ok(serialized) => serialized,
-            Err(err) => {
-                warn!("failed to serialize reconstructed message - {:?}", err);
-                Vec::new()
-            }
-        }
-    }
-}
-
-impl From<&ReconstructedMessage> for Vec<u8> {
-    fn from(msg: &ReconstructedMessage) -> Vec<u8> {
-        match bincode::serialize(msg) {
-            Ok(serialized) => serialized,
-            Err(err) => {
-                warn!("failed to serialize reconstructed message - {:?}", err);
-                Vec::new()
-            }
-        }
-    }
 }
 
 impl From<ReconstructedMessage> for (Vec<u8>, Option<AnonymousSenderTag>) {

--- a/common/socks5-client-core/Cargo.toml
+++ b/common/socks5-client-core/Cargo.toml
@@ -19,6 +19,7 @@ serde = { workspace = true, features = ["derive"] } # for config serialization/d
 tap = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "signal"] }
+tokio-util = { workspace = true }
 url = { workspace = true }
 
 nym-bandwidth-controller = { path = "../../common/bandwidth-controller" }

--- a/common/socks5-client-core/src/socks/client.rs
+++ b/common/socks5-client-core/src/socks/client.rs
@@ -7,6 +7,7 @@ use super::{SocksVersion, RESERVED, SOCKS4_VERSION, SOCKS5_VERSION};
 use crate::config;
 use futures::channel::mpsc;
 use futures::task::{Context, Poll};
+use futures::SinkExt;
 use log::*;
 use nym_client_core::client::inbound_messages::{InputMessage, InputMessageSender};
 use nym_service_providers_common::interface::{ProviderInterfaceVersion, RequestVersion};

--- a/common/socks5/proxy-helpers/src/ordered_sender.rs
+++ b/common/socks5/proxy-helpers/src/ordered_sender.rs
@@ -8,7 +8,7 @@ use log::{debug, error};
 use nym_socks5_requests::{ConnectionId, SocketData};
 use std::io;
 
-pub(crate) struct OrderedMessageSender<F, S: Send> {
+pub(crate) struct OrderedMessageSender<F, S: Send + 'static> {
     connection_id: ConnectionId,
     // addresses are provided for better logging
     local_destination_address: String,
@@ -19,7 +19,7 @@ pub(crate) struct OrderedMessageSender<F, S: Send> {
     mix_message_adapter: F,
 }
 
-impl<F, S: Send> OrderedMessageSender<F, S>
+impl<F, S: Send + 'static> OrderedMessageSender<F, S>
 where
     F: Fn(SocketData) -> S,
 {

--- a/common/socks5/proxy-helpers/src/ordered_sender.rs
+++ b/common/socks5/proxy-helpers/src/ordered_sender.rs
@@ -3,6 +3,7 @@
 
 use crate::proxy_runner::MixProxySender;
 use bytes::Bytes;
+use futures::SinkExt;
 use log::{debug, error};
 use nym_socks5_requests::{ConnectionId, SocketData};
 use std::io;
@@ -55,11 +56,9 @@ where
         (self.mix_message_adapter)(data)
     }
 
-    async fn send_message(&self, message: S) {
-        if let Some(sender) = self.mixnet_sender.get_ref() {
-            if sender.send(message).await.is_err() {
-                panic!("BatchRealMessageReceiver has stopped receiving!")
-            }
+    async fn send_message(&mut self, message: S) {
+        if self.mixnet_sender.send(message).await.is_err() {
+            panic!("BatchRealMessageReceiver has stopped receiving!")
         }
     }
 

--- a/common/socks5/proxy-helpers/src/proxy_runner/inbound.rs
+++ b/common/socks5/proxy-helpers/src/proxy_runner/inbound.rs
@@ -74,7 +74,7 @@ async fn wait_for_lane(
     }
 }
 
-pub(super) async fn run_inbound<F, S>(
+pub(super) async fn run_inbound<F, S: Send>(
     mut reader: OwnedReadHalf,
     mut message_sender: OrderedMessageSender<F, S>,
     connection_id: ConnectionId,

--- a/common/socks5/proxy-helpers/src/proxy_runner/mod.rs
+++ b/common/socks5/proxy-helpers/src/proxy_runner/mod.rs
@@ -6,10 +6,10 @@ use crate::ordered_sender::OrderedMessageSender;
 use nym_socks5_requests::{ConnectionId, SocketData};
 use nym_task::connections::LaneQueueLengths;
 use nym_task::TaskClient;
-use tokio_util::sync::PollSender;
 use std::fmt::Debug;
 use std::{sync::Arc, time::Duration};
 use tokio::{net::TcpStream, sync::Notify};
+use tokio_util::sync::PollSender;
 
 mod inbound;
 mod outbound;

--- a/common/socks5/proxy-helpers/src/proxy_runner/mod.rs
+++ b/common/socks5/proxy-helpers/src/proxy_runner/mod.rs
@@ -6,6 +6,7 @@ use crate::ordered_sender::OrderedMessageSender;
 use nym_socks5_requests::{ConnectionId, SocketData};
 use nym_task::connections::LaneQueueLengths;
 use nym_task::TaskClient;
+use tokio_util::sync::PollSender;
 use std::fmt::Debug;
 use std::{sync::Arc, time::Duration};
 use tokio::{net::TcpStream, sync::Notify};
@@ -35,7 +36,7 @@ impl From<(Vec<u8>, bool)> for ProxyMessage {
     }
 }
 
-pub type MixProxySender<S> = tokio::sync::mpsc::Sender<S>;
+pub type MixProxySender<S> = PollSender<S>;
 pub type MixProxyReader<S> = tokio::sync::mpsc::Receiver<S>;
 
 // TODO: when we finally get to implementing graceful shutdown,

--- a/common/statistics/src/collector.rs
+++ b/common/statistics/src/collector.rs
@@ -19,7 +19,7 @@ pub trait StatisticsCollector {
         interval: Duration,
         timestamp: DateTime<Utc>,
     ) -> StatsMessage;
-    async fn send_stats_message(&self, stats_message: StatsMessage) -> Result<(), StatsError>;
+    async fn send_stats_message(&mut self, stats_message: StatsMessage) -> Result<(), StatsError>;
     async fn reset_stats(&mut self);
 }
 

--- a/common/task/Cargo.toml
+++ b/common/task/Cargo.toml
@@ -12,6 +12,7 @@ futures = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "sync"] }
+serde = { workspace = true }
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio]
 workspace = true

--- a/common/task/src/connections.rs
+++ b/common/task/src/connections.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use futures::channel::mpsc;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub type ConnectionId = u64;
 
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TransmissionLane {
     General,
     // we need to treat surb-related requests and responses at higher priority

--- a/gateway/src/node/statistics/collector.rs
+++ b/gateway/src/node/statistics/collector.rs
@@ -52,7 +52,7 @@ impl StatisticsCollector for GatewayStatisticsCollector {
         }
     }
 
-    async fn send_stats_message(&self, stats_message: StatsMessage) -> Result<(), StatsError> {
+    async fn send_stats_message(&mut self, stats_message: StatsMessage) -> Result<(), StatsError> {
         build_and_send_statistics_request(stats_message, self.statistics_service_url.to_string())
             .await
     }

--- a/sdk/rust/nym-sdk/Cargo.toml
+++ b/sdk/rust/nym-sdk/Cargo.toml
@@ -9,7 +9,10 @@ license.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 bip39 = { workspace = true }
-nym-client-core = { path = "../../../common/client-core", features = ["fs-surb-storage", "fs-gateways-storage"] }
+nym-client-core = { path = "../../../common/client-core", features = [
+    "fs-surb-storage",
+    "fs-gateways-storage",
+] }
 nym-crypto = { path = "../../../common/crypto" }
 nym-gateway-requests = { path = "../../../gateway/gateway-requests" }
 nym-bandwidth-controller = { path = "../../../common/bandwidth-controller" }
@@ -21,7 +24,9 @@ nym-sphinx = { path = "../../../common/nymsphinx" }
 nym-task = { path = "../../../common/task" }
 nym-topology = { path = "../../../common/topology" }
 nym-socks5-client-core = { path = "../../../common/socks5-client-core" }
-nym-validator-client = { path = "../../../common/client-libs/validator-client", features = ["http-client"] }
+nym-validator-client = { path = "../../../common/client-libs/validator-client", features = [
+    "http-client",
+] }
 nym-socks5-requests = { path = "../../../common/socks5/requests" }
 nym-ordered-buffer = { path = "../../../common/socks5/ordered-buffer" }
 nym-service-providers-common = { path = "../../../service-providers/common" }

--- a/sdk/rust/nym-sdk/Cargo.toml
+++ b/sdk/rust/nym-sdk/Cargo.toml
@@ -42,6 +42,8 @@ tap = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 toml = "0.5.10"
+tokio = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/sdk/rust/nym-sdk/examples/parallel_sending_and_receiving.rs
+++ b/sdk/rust/nym-sdk/examples/parallel_sending_and_receiving.rs
@@ -16,7 +16,7 @@ async fn main() {
     let our_address = *client.nym_address();
     println!("Our client nym address is: {our_address}");
 
-    let sender = client.split_sender();
+    let mut sender = client.split_sender();
 
     // receiving task
     let receiving_task_handle = tokio::spawn(async move {

--- a/sdk/rust/nym-sdk/src/mixnet/native_client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/native_client.rs
@@ -2,11 +2,11 @@ use crate::mixnet::client::MixnetClientBuilder;
 use crate::mixnet::traits::MixnetMessageSender;
 use crate::{Error, Result};
 use async_trait::async_trait;
-use bytecodec::io::WriteBuf;
 use bytes::{Buf as _, BytesMut};
-use futures::{ready, Sink, SinkExt, Stream, StreamExt};
+use futures::{ready, FutureExt, Sink, SinkExt, Stream, StreamExt};
 use log::error;
 use nym_client_core::client::base_client::GatewayConnection;
+use nym_client_core::client::inbound_messages::InputMessageCodec;
 use nym_client_core::client::{
     base_client::{ClientInput, ClientOutput, ClientState},
     inbound_messages::InputMessage,
@@ -21,11 +21,11 @@ use nym_task::{
     TaskHandle,
 };
 use nym_topology::NymTopology;
-use std::pin::Pin;
+use std::pin::{pin, Pin};
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, ReadBuf};
-use tokio_util::codec::{Encoder, FramedWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio_util::codec::{Encoder, FramedRead};
 
 /// Client connected to the Nym mixnet.
 pub struct MixnetClient {
@@ -288,11 +288,61 @@ impl AsyncRead for MixnetClient {
     }
 }
 
+impl AsyncWrite for MixnetClient {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        let codec = InputMessageCodec {};
+        let mut reader = FramedRead::new(buf, codec);
+        let mut fut = reader.next();
+        let msg = match fut.poll_unpin(cx) {
+            Poll::Ready(Some(Ok(msg))) => msg,
+            Poll::Ready(Some(Err(_))) => {
+                return Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "failed to read message from input",
+                )))
+            }
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(None) => return Poll::Ready(Ok(0)),
+        };
+
+        let msg_size = msg.serialized_size();
+
+        let mut fut = pin!(self.client_input.send(msg));
+        match fut.poll_unpin(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(msg_size as usize)),
+            Poll::Ready(Err(_)) => Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "failed to send message to mixnet",
+            ))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::prelude::v1::Result<(), std::io::Error>> {
+        Sink::poll_flush(self, cx)
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "failed to flush the sink"))
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::prelude::v1::Result<(), std::io::Error>> {
+        AsyncWrite::poll_flush(self, cx)
+    }
+}
+
 impl Sink<InputMessage> for MixnetClient {
     type Error = Error;
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        match self.client_input.input_sender.poll_ready_unpin(cx) {
+        match self.sender().poll_ready_unpin(cx) {
             Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
             Poll::Ready(Err(_)) => Poll::Ready(Err(Error::MessageSendingFailure)),
             Poll::Pending => Poll::Pending,
@@ -300,22 +350,100 @@ impl Sink<InputMessage> for MixnetClient {
     }
 
     fn start_send(mut self: Pin<&mut Self>, item: InputMessage) -> Result<()> {
-        self.client_input
-            .input_sender
+        self.sender()
             .start_send_unpin(item)
             .map_err(|_| Error::MessageSendingFailure)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        self.client_input
-            .input_sender
+        self.sender()
             .poll_flush_unpin(cx)
             .map_err(|_| Error::MessageSendingFailure)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        self.client_input
-            .input_sender
+        self.sender()
+            .poll_close_unpin(cx)
+            .map_err(|_| Error::MessageSendingFailure)
+    }
+}
+
+// TODO: there should be a better way of implementing Sink and AsyncWrite over T: MixnetMessageSender
+impl AsyncWrite for MixnetClientSender {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        let codec = InputMessageCodec {};
+        let mut reader = FramedRead::new(buf, codec);
+        let mut fut = reader.next();
+        let msg = match fut.poll_unpin(cx) {
+            Poll::Ready(Some(Ok(msg))) => msg,
+            Poll::Ready(Some(Err(_))) => {
+                return Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "failed to read message from input",
+                )))
+            }
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(None) => return Poll::Ready(Ok(0)),
+        };
+
+        let msg_size = msg.serialized_size();
+
+        let mut fut = pin!(self.client_input.send(msg));
+        match fut.poll_unpin(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(msg_size as usize)),
+            Poll::Ready(Err(_)) => Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "failed to send message to mixnet",
+            ))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::prelude::v1::Result<(), std::io::Error>> {
+        Sink::poll_flush(self, cx)
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "failed to flush the sink"))
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::prelude::v1::Result<(), std::io::Error>> {
+        AsyncWrite::poll_flush(self, cx)
+    }
+}
+
+impl Sink<InputMessage> for MixnetClientSender {
+    type Error = Error;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        match self.sender().poll_ready_unpin(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(_)) => Poll::Ready(Err(Error::MessageSendingFailure)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: InputMessage) -> Result<()> {
+        self.sender()
+            .start_send_unpin(item)
+            .map_err(|_| Error::MessageSendingFailure)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.sender()
+            .poll_flush_unpin(cx)
+            .map_err(|_| Error::MessageSendingFailure)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.sender()
             .poll_close_unpin(cx)
             .map_err(|_| Error::MessageSendingFailure)
     }
@@ -363,6 +491,10 @@ impl MixnetMessageSender for MixnetClient {
             .await
             .map_err(|_| Error::MessageSendingFailure)
     }
+
+    fn sender(&mut self) -> &mut tokio_util::sync::PollSender<InputMessage> {
+        &mut self.client_input.input_sender
+    }
 }
 
 #[async_trait]
@@ -376,5 +508,9 @@ impl MixnetMessageSender for MixnetClientSender {
             .send(message)
             .await
             .map_err(|_| Error::MessageSendingFailure)
+    }
+
+    fn sender(&mut self) -> &mut tokio_util::sync::PollSender<InputMessage> {
+        &mut self.client_input.input_sender
     }
 }

--- a/sdk/rust/nym-sdk/src/mixnet/native_client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/native_client.rs
@@ -294,7 +294,7 @@ impl MixnetMessageSender for MixnetClient {
         self.packet_type
     }
 
-    async fn send(&self, message: InputMessage) -> Result<()> {
+    async fn send(&mut self, message: InputMessage) -> Result<()> {
         self.client_input
             .send(message)
             .await
@@ -308,7 +308,7 @@ impl MixnetMessageSender for MixnetClientSender {
         self.packet_type
     }
 
-    async fn send(&self, message: InputMessage) -> Result<()> {
+    async fn send(&mut self, message: InputMessage) -> Result<()> {
         self.client_input
             .send(message)
             .await

--- a/sdk/rust/nym-sdk/src/mixnet/traits.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/traits.rs
@@ -18,7 +18,7 @@ pub trait MixnetMessageSender {
 
     /// Sends a [`InputMessage`] to the mixnet. This is the most low-level sending function, for
     /// full customization.
-    async fn send(&self, message: InputMessage) -> Result<()>;
+    async fn send(&mut self, message: InputMessage) -> Result<()>;
 
     /// Sends data to the supplied Nym address with the default surb behaviour.
     ///
@@ -35,7 +35,7 @@ pub trait MixnetMessageSender {
     ///     client.send_plain_message(recipient, "hi").await.unwrap();
     /// }
     /// ```
-    async fn send_plain_message<M>(&self, address: Recipient, message: M) -> Result<()>
+    async fn send_plain_message<M>(&mut self, address: Recipient, message: M) -> Result<()>
     where
         M: AsRef<[u8]> + Send,
     {
@@ -61,7 +61,7 @@ pub trait MixnetMessageSender {
     /// }
     /// ```
     async fn send_message<M>(
-        &self,
+        &mut self,
         address: Recipient,
         message: M,
         surbs: IncludedSurbs,
@@ -103,7 +103,7 @@ pub trait MixnetMessageSender {
     ///     client.send_reply(tag, b"hi").await.unwrap();
     /// }
     /// ```
-    async fn send_reply<M>(&self, recipient_tag: AnonymousSenderTag, message: M) -> Result<()>
+    async fn send_reply<M>(&mut self, recipient_tag: AnonymousSenderTag, message: M) -> Result<()>
     where
         M: AsRef<[u8]> + Send,
     {

--- a/sdk/rust/nym-sdk/src/mixnet/traits.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/traits.rs
@@ -16,6 +16,8 @@ pub trait MixnetMessageSender {
         None
     }
 
+    fn sender(&mut self) -> &mut tokio_util::sync::PollSender<InputMessage>;
+
     /// Sends a [`InputMessage`] to the mixnet. This is the most low-level sending function, for
     /// full customization.
     async fn send(&mut self, message: InputMessage) -> Result<()>;

--- a/service-providers/ip-packet-router/src/mixnet_listener.rs
+++ b/service-providers/ip-packet-router/src/mixnet_listener.rs
@@ -605,7 +605,7 @@ impl MixnetListener {
 
     // When an incoming mixnet message triggers a response that we send back, such as during
     // connect handshake.
-    async fn handle_response(&self, response: IpPacketResponse) -> Result<()> {
+    async fn handle_response(&mut self, response: IpPacketResponse) -> Result<()> {
         let Some(recipient) = response.recipient() else {
             log::error!("No recipient in response packet, this should NOT happen!");
             return Err(IpPacketRouterError::NoRecipientInResponse);
@@ -635,7 +635,7 @@ impl MixnetListener {
 
     // A single incoming request can trigger multiple responses, such as when data requests contain
     // multiple IP packets.
-    async fn handle_responses(&self, responses: Vec<PacketHandleResult>) {
+    async fn handle_responses(&mut self, responses: Vec<PacketHandleResult>) {
         for response in responses {
             match response {
                 Ok(Some(response)) => {

--- a/service-providers/network-requester/Cargo.toml
+++ b/service-providers/network-requester/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { workspace = true }
 addr = { workspace = true }
 async-trait = { workspace = true }
 bs58 = { workspace = true }
-clap = { workspace = true, features = ["cargo", "derive"]}
+clap = { workspace = true, features = ["cargo", "derive"] }
 dirs = "4.0"
 futures = { workspace = true }
 humantime-serde = { workspace = true }
@@ -33,19 +33,26 @@ regex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "chrono"]}
+sqlx = { workspace = true, features = ["runtime-tokio-rustls", "chrono"] }
 tap = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = [ "net", "rt-multi-thread", "macros" ] }
+tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros"] }
 tokio-tungstenite = { workspace = true }
+tokio-util = { workspace = true }
 url = { workspace = true }
 time = { workspace = true }
 zeroize = { workspace = true }
 
 # internal
 nym-async-file-watcher = { path = "../../common/async-file-watcher" }
-nym-bin-common = { path = "../../common/bin-common", features = ["output_format"] }
-nym-client-core = { path = "../../common/client-core", features = ["cli", "fs-gateways-storage", "fs-surb-storage"] }
+nym-bin-common = { path = "../../common/bin-common", features = [
+    "output_format",
+] }
+nym-client-core = { path = "../../common/client-core", features = [
+    "cli",
+    "fs-gateways-storage",
+    "fs-surb-storage",
+] }
 nym-client-websocket-requests = { path = "../../clients/native/websocket-requests" }
 nym-config = { path = "../../common/config" }
 nym-credentials = { path = "../../common/credentials" }

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -39,9 +39,9 @@ use nym_statistics_common::collector::StatisticsSender;
 use nym_task::connections::LaneQueueLengths;
 use nym_task::manager::TaskHandle;
 use nym_task::TaskClient;
-use tokio_util::sync::PollSender;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio_util::sync::PollSender;
 
 // Since it's an atomic, it's safe to be kept static and shared across threads
 static ACTIVE_PROXIES: AtomicUsize = AtomicUsize::new(0);
@@ -404,7 +404,7 @@ impl NRServiceProvider {
     /// Listens for any messages from `mix_reader` that should be written back to the mix network
     /// via the `websocket_writer`.
     async fn mixnet_response_listener(
-        mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
+        mut mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
         mut mix_input_reader: MixProxyReader<MixnetMessage>,
         stats_collector: Option<ServiceStatisticsCollector>,
         packet_type: PacketType,

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -17,7 +17,7 @@ use nym_client_core::client::mix_traffic::transceiver::GatewayTransceiver;
 use nym_client_core::config::disk_persistence::CommonClientPaths;
 use nym_client_core::HardcodedTopologyProvider;
 use nym_network_defaults::NymNetworkDetails;
-use nym_sdk::mixnet::{MixnetMessageSender, TopologyProvider};
+use nym_sdk::mixnet::TopologyProvider;
 use nym_service_providers_common::interface::{
     BinaryInformation, ProviderInterfaceVersion, Request, RequestVersion,
 };
@@ -429,7 +429,7 @@ impl NRServiceProvider {
                         }
 
                         let response_message = msg.into_input_message(packet_type);
-                        mixnet_client_sender.send(response_message).await.unwrap();
+                        nym_sdk::mixnet::MixnetMessageSender::send(&mut mixnet_client_sender, response_message).await.unwrap();
                     } else {
                         log::error!("Exiting: channel closed!");
                         break;

--- a/service-providers/network-requester/src/statistics/collector.rs
+++ b/service-providers/network-requester/src/statistics/collector.rs
@@ -5,6 +5,7 @@ use super::error::StatsError;
 use crate::core::new_legacy_request_version;
 use crate::reply::MixnetMessage;
 use async_trait::async_trait;
+use futures::SinkExt;
 use log::*;
 use nym_service_providers_common::interface::RequestVersion;
 use nym_socks5_proxy_helpers::proxy_runner::MixProxySender;
@@ -165,7 +166,7 @@ impl StatisticsCollector for ServiceStatisticsCollector {
     }
 
     async fn send_stats_message(
-        &self,
+        &mut self,
         stats_message: StatsMessage,
     ) -> Result<(), CommonStatsError> {
         let msg = build_statistics_request_bytes(stats_message)?;

--- a/wasm/client/Cargo.toml
+++ b/wasm/client/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "nym-client-wasm"
-authors = ["Dave Hrycyszyn <futurechimp@users.noreply.github.com>", "Jedrzej Stuczynski <andrew@nymtech.net>"]
+authors = [
+    "Dave Hrycyszyn <futurechimp@users.noreply.github.com>",
+    "Jedrzej Stuczynski <andrew@nymtech.net>",
+]
 version = "1.3.0-rc.0"
 edition = "2021"
 keywords = ["nym", "sphinx", "wasm", "webassembly", "privacy", "client"]
@@ -22,15 +25,16 @@ serde_json = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
-thiserror =  { workspace = true }
+thiserror = { workspace = true }
 tsify = { workspace = true, features = ["js"] }
+tokio = { workspace = true, default-features = false, features = ["sync"] }
 
 nym-bin-common = { path = "../../common/bin-common" }
 wasm-client-core = { path = "../../common/wasm/client-core" }
 wasm-utils = { path = "../../common/wasm/utils" }
 
 nym-node-tester-utils = { path = "../../common/node-tester-utils", optional = true }
-nym-node-tester-wasm = { path = "../node-tester", optional = true}
+nym-node-tester-wasm = { path = "../node-tester", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = { workspace = true }

--- a/wasm/client/src/client.rs
+++ b/wasm/client/src/client.rs
@@ -14,6 +14,7 @@ use crate::response_pusher::ResponsePusher;
 use js_sys::Promise;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tokio::sync::RwLock;
 use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
@@ -50,7 +51,7 @@ pub(crate) const NODE_TESTER_CLIENT_ID: &str = "_nym-node-tester-client";
 #[wasm_bindgen]
 pub struct NymClient {
     self_address: String,
-    client_input: Arc<ClientInput>,
+    client_input: Arc<RwLock<ClientInput>>,
     client_state: Arc<ClientState>,
 
     // keep track of the "old" topology for the purposes of node tester
@@ -196,7 +197,7 @@ impl NymClientBuilder {
 
         Ok(NymClient {
             self_address,
-            client_input: Arc::new(client_input),
+            client_input: Arc::new(RwLock::new(client_input)),
             client_state: Arc::new(started_client.client_state),
             _full_topology: None,
             // this cannot failed as we haven't passed an external task manager

--- a/wasm/mix-fetch/Cargo.toml
+++ b/wasm/mix-fetch/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { workspace = true, features = ["sync"] }
 url = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
-thiserror =  { workspace = true }
+thiserror = { workspace = true }
 tsify = { workspace = true, features = ["js"] }
 
 nym-bin-common = { path = "../../common/bin-common" }


### PR DESCRIPTION
Heavily inspired by what @mfahampshire did for mix-tcp, folds AsyncRead functionality into the MixnetClient.

TODO:

- [x] Sink
- [x] AsyncWrite
- [ ] Add examples


Interesting changes in `wasm`, due to `Sink`, we now need `&mut` for sending, so had to wrap stuff in `RwLock` in `wasm` client and `mixfetch`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/4634)
<!-- Reviewable:end -->
