### PR TITLE
Feature/new node endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3945,6 +3945,7 @@ dependencies = [
  "nym-crypto",
  "nym-mixnet-contract-common",
  "nym-node-requests",
+ "rocket",
  "schemars",
  "serde",
  "serde_json",

--- a/common/client-core/config-types/src/lib.rs
+++ b/common/client-core/config-types/src/lib.rs
@@ -24,6 +24,11 @@ const DEFAULT_MESSAGE_STREAM_AVERAGE_DELAY: Duration = Duration::from_millis(20)
 const DEFAULT_AVERAGE_PACKET_DELAY: Duration = Duration::from_millis(50);
 const DEFAULT_TOPOLOGY_REFRESH_RATE: Duration = Duration::from_secs(5 * 60); // every 5min
 const DEFAULT_TOPOLOGY_RESOLUTION_TIMEOUT: Duration = Duration::from_millis(5_000);
+
+// the same values as our current (10.06.24) blacklist
+const DEFAULT_MIN_MIXNODE_PERFORMANCE: u8 = 50;
+const DEFAULT_MIN_GATEWAY_PERFORMANCE: u8 = 50;
+
 const DEFAULT_MAX_STARTUP_GATEWAY_WAITING_PERIOD: Duration = Duration::from_secs(70 * 60); // 70min -> full epoch (1h) + a bit of overhead
 
 // Set this to a high value for now, so that we don't risk sporadic timeouts that might cause
@@ -558,8 +563,8 @@ impl Default for Topology {
             disable_refreshing: false,
             max_startup_gateway_waiting_period: DEFAULT_MAX_STARTUP_GATEWAY_WAITING_PERIOD,
             topology_structure: TopologyStructure::default(),
-            minimum_mixnode_performance: 50,
-            minimum_gateway_performance: 50,
+            minimum_mixnode_performance: DEFAULT_MIN_MIXNODE_PERFORMANCE,
+            minimum_gateway_performance: DEFAULT_MIN_GATEWAY_PERFORMANCE,
         }
     }
 }

--- a/common/client-core/config-types/src/lib.rs
+++ b/common/client-core/config-types/src/lib.rs
@@ -516,6 +516,14 @@ pub struct Topology {
 
     /// Specifies the mixnode topology to be used for sending packets.
     pub topology_structure: TopologyStructure,
+
+    /// Specifies a minimum performance of a mixnode that is used on route construction.
+    /// This setting is only applicable when `NymApi` topology is used.
+    pub minimum_mixnode_performance: u8,
+
+    /// Specifies a minimum performance of a gateway that is used on route construction.
+    /// This setting is only applicable when `NymApi` topology is used.
+    pub minimum_gateway_performance: u8,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -550,6 +558,8 @@ impl Default for Topology {
             disable_refreshing: false,
             max_startup_gateway_waiting_period: DEFAULT_MAX_STARTUP_GATEWAY_WAITING_PERIOD,
             topology_structure: TopologyStructure::default(),
+            minimum_mixnode_performance: 50,
+            minimum_gateway_performance: 50,
         }
     }
 }

--- a/common/client-core/config-types/src/old/v5.rs
+++ b/common/client-core/config-types/src/old/v5.rs
@@ -146,6 +146,7 @@ impl From<ConfigV5> for Config {
                         .topology
                         .max_startup_gateway_waiting_period,
                     topology_structure: value.debug.topology.topology_structure.into(),
+                    ..Default::default()
                 },
                 reply_surbs: ReplySurbs {
                     minimum_reply_surb_storage_threshold: value

--- a/common/client-core/gateways-storage/fs_gateways_migrations/20240610120000_nullable_gateway_owner.sql
+++ b/common/client-core/gateways-storage/fs_gateways_migrations/20240610120000_nullable_gateway_owner.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+CREATE TABLE remote_gateway_details_temp
+(
+    gateway_id_bs58                          TEXT NOT NULL UNIQUE PRIMARY KEY REFERENCES registered_gateway (gateway_id_bs58),
+    derived_aes128_ctr_blake3_hmac_keys_bs58 TEXT NOT NULL,
+    gateway_owner_address                    TEXT,
+    gateway_listener                         TEXT NOT NULL,
+    wg_tun_address                           TEXT
+);
+
+INSERT INTO remote_gateway_details_temp SELECT * FROM remote_gateway_details;
+
+DROP TABLE remote_gateway_details;
+ALTER TABLE remote_gateway_details_temp RENAME TO remote_gateway_details;

--- a/common/client-core/gateways-storage/src/types.rs
+++ b/common/client-core/gateways-storage/src/types.rs
@@ -199,7 +199,7 @@ impl TryFrom<RawRemoteGatewayDetails> for RemoteGatewayDetails {
             .gateway_owner_address
             .as_ref()
             .map(|raw_owner| {
-                AccountId::from_str(&raw_owner).map_err(|source| {
+                AccountId::from_str(raw_owner).map_err(|source| {
                     BadGateway::MalformedGatewayOwnerAccountAddress {
                         gateway_id: value.gateway_id_bs58.clone(),
                         raw_owner: raw_owner.clone(),

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -388,7 +388,10 @@ where
 
             let cfg = GatewayConfig::new(
                 details.gateway_id,
-                Some(details.gateway_owner_address.to_string()),
+                details
+                    .gateway_owner_address
+                    .as_ref()
+                    .map(|o| o.to_string()),
                 gateway_listener,
             );
             GatewayClient::new(

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -25,7 +25,7 @@ use crate::client::replies::reply_storage::{
 };
 use crate::client::topology_control::nym_api_provider::NymApiTopologyProvider;
 use crate::client::topology_control::{
-    TopologyAccessor, TopologyRefresher, TopologyRefresherConfig,
+    nym_api_provider, TopologyAccessor, TopologyRefresher, TopologyRefresherConfig,
 };
 use crate::config::{Config, DebugConfig};
 use crate::error::ClientCoreError;
@@ -462,12 +462,16 @@ where
 
     fn setup_topology_provider(
         custom_provider: Option<Box<dyn TopologyProvider + Send + Sync>>,
-        provider_from_config: config::TopologyStructure,
+        config_topology: config::Topology,
         nym_api_urls: Vec<Url>,
     ) -> Box<dyn TopologyProvider + Send + Sync> {
         // if no custom provider was ... provided ..., create one using nym-api
-        custom_provider.unwrap_or_else(|| match provider_from_config {
+        custom_provider.unwrap_or_else(|| match config_topology.topology_structure {
             config::TopologyStructure::NymApi => Box::new(NymApiTopologyProvider::new(
+                nym_api_provider::Config {
+                    min_mixnode_performance: config_topology.minimum_mixnode_performance,
+                    min_gateway_performance: config_topology.minimum_gateway_performance,
+                },
                 nym_api_urls,
                 env!("CARGO_PKG_VERSION").to_string(),
             )),
@@ -680,7 +684,7 @@ where
 
         let topology_provider = Self::setup_topology_provider(
             self.custom_topology_provider.take(),
-            self.config.debug.topology.topology_structure,
+            self.config.debug.topology,
             self.config.get_nym_api_endpoints(),
         );
 

--- a/common/client-core/src/client/base_client/storage/migration_helpers.rs
+++ b/common/client-core/src/client/base_client/storage/migration_helpers.rs
@@ -92,11 +92,11 @@ pub mod v1_1_33 {
                     message: format!("the stored gateway id was malformed: {err}"),
                 })?,
             derived_aes128_ctr_blake3_hmac_keys: Arc::new(gateway_shared_key),
-            gateway_owner_address: gateway_owner.parse().map_err(|err| {
+            gateway_owner_address: Some(gateway_owner.parse().map_err(|err| {
                 ClientCoreError::UpgradeFailure {
                     message: format!("the stored gateway owner address was malformed: {err}"),
                 }
-            })?,
+            })?),
             gateway_listener: gateway_listener.parse().map_err(|err| {
                 ClientCoreError::UpgradeFailure {
                     message: format!("the stored gateway listener address was malformed: {err}"),

--- a/common/client-core/src/client/topology_control/nym_api_provider.rs
+++ b/common/client-core/src/client/topology_control/nym_api_provider.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use log::{error, warn};
+use log::{debug, error, warn};
 use nym_topology::provider_trait::TopologyProvider;
-use nym_topology::{nym_topology_from_detailed, NymTopology, NymTopologyError};
+use nym_topology::{NymTopology, NymTopologyError};
 use rand::prelude::SliceRandom;
 use rand::thread_rng;
 use url::Url;
@@ -102,6 +102,12 @@ impl NymApiTopologyProvider {
             }
             Ok(gateways) => gateways,
         };
+
+        debug!(
+            "there are {} mixnodes and {} gateways in total (before performance filtering)",
+            mixnodes.len(),
+            gateways.len()
+        );
 
         let topology = NymTopology::from_unordered(
             mixnodes.iter().filter(|m| {

--- a/common/client-core/src/client/topology_control/nym_api_provider.rs
+++ b/common/client-core/src/client/topology_control/nym_api_provider.rs
@@ -9,17 +9,21 @@ use rand::prelude::SliceRandom;
 use rand::thread_rng;
 use url::Url;
 
+// the same values as our current (10.06.24) blacklist
+pub const DEFAULT_MIN_MIXNODE_PERFORMANCE: u8 = 50;
+pub const DEFAULT_MIN_GATEWAY_PERFORMANCE: u8 = 50;
+
 pub(crate) struct Config {
-    pub min_mixnode_performance: u8,
-    pub min_gateway_performance: u8,
+    pub(crate) min_mixnode_performance: u8,
+    pub(crate) min_gateway_performance: u8,
 }
 
 impl Default for Config {
     fn default() -> Self {
         // old values that decided on blacklist membership
         Config {
-            min_mixnode_performance: 50,
-            min_gateway_performance: 50,
+            min_mixnode_performance: DEFAULT_MIN_MIXNODE_PERFORMANCE,
+            min_gateway_performance: DEFAULT_MIN_GATEWAY_PERFORMANCE,
         }
     }
 }

--- a/common/client-core/src/init/types.rs
+++ b/common/client-core/src/init/types.rs
@@ -88,7 +88,7 @@ impl SelectedGateway {
             .owner
             .as_ref()
             .map(|raw_owner| {
-                AccountId::from_str(&raw_owner).map_err(|source| {
+                AccountId::from_str(raw_owner).map_err(|source| {
                     ClientCoreError::MalformedGatewayOwnerAccountAddress {
                         gateway_id: node.identity_key.to_base58_string(),
                         raw_owner: raw_owner.clone(),

--- a/common/client-core/src/init/types.rs
+++ b/common/client-core/src/init/types.rs
@@ -29,7 +29,7 @@ pub enum SelectedGateway {
     Remote {
         gateway_id: identity::PublicKey,
 
-        gateway_owner_address: AccountId,
+        gateway_owner_address: Option<AccountId>,
 
         gateway_listener: Url,
 
@@ -84,13 +84,19 @@ impl SelectedGateway {
 
         let wg_tun_address = wg_tun_address(wg_tun_ip_address, &node)?;
 
-        let gateway_owner_address = AccountId::from_str(&node.owner).map_err(|source| {
-            ClientCoreError::MalformedGatewayOwnerAccountAddress {
-                gateway_id: node.identity_key.to_base58_string(),
-                raw_owner: node.owner,
-                err: source.to_string(),
-            }
-        })?;
+        let gateway_owner_address = node
+            .owner
+            .as_ref()
+            .map(|raw_owner| {
+                AccountId::from_str(&raw_owner).map_err(|source| {
+                    ClientCoreError::MalformedGatewayOwnerAccountAddress {
+                        gateway_id: node.identity_key.to_base58_string(),
+                        raw_owner: raw_owner.clone(),
+                        err: source.to_string(),
+                    }
+                })
+            })
+            .transpose()?;
 
         let gateway_listener =
             Url::parse(&gateway_listener).map_err(|source| ClientCoreError::MalformedListener {

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -18,6 +18,7 @@ use nym_api_requests::models::{
     GatewayCoreStatusResponse, MixnodeCoreStatusResponse, MixnodeStatusResponse,
     RewardEstimationResponse, StakeSaturationResponse,
 };
+use nym_api_requests::nym_nodes::SkimmedNode;
 use nym_network_defaults::NymNetworkDetails;
 use url::Url;
 
@@ -263,6 +264,28 @@ impl NymApiClient {
 
     pub fn change_nym_api(&mut self, new_endpoint: Url) {
         self.nym_api.change_base_url(new_endpoint);
+    }
+
+    pub async fn get_basic_mixnodes(
+        &self,
+        semver_compatibility: Option<String>,
+    ) -> Result<Vec<SkimmedNode>, ValidatorClientError> {
+        Ok(self
+            .nym_api
+            .get_basic_mixnodes(semver_compatibility)
+            .await?
+            .nodes)
+    }
+
+    pub async fn get_basic_gateways(
+        &self,
+        semver_compatibility: Option<String>,
+    ) -> Result<Vec<SkimmedNode>, ValidatorClientError> {
+        Ok(self
+            .nym_api
+            .get_basic_gateways(semver_compatibility)
+            .await?
+            .nodes)
     }
 
     pub async fn get_cached_active_mixnodes(

--- a/common/client-libs/validator-client/src/nym_api/mod.rs
+++ b/common/client-libs/validator-client/src/nym_api/mod.rs
@@ -33,6 +33,7 @@ pub mod routes;
 
 use nym_api_requests::coconut::models::FreePassNonceResponse;
 use nym_api_requests::coconut::FreePassRequest;
+use nym_api_requests::nym_nodes::{CachedNodesResponse, SkimmedNode};
 pub use nym_http_api_client::Client;
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -93,6 +94,52 @@ pub trait NymApiClientExt: ApiClient {
         self.get_json(
             &[routes::API_VERSION, routes::GATEWAYS, routes::DESCRIBED],
             NO_PARAMS,
+        )
+        .await
+    }
+
+    async fn get_basic_mixnodes(
+        &self,
+        semver_compatibility: Option<String>,
+    ) -> Result<CachedNodesResponse<SkimmedNode>, NymAPIError> {
+        let params = if let Some(semver_compatibility) = &semver_compatibility {
+            vec![("semver_compatibility", semver_compatibility.as_str())]
+        } else {
+            vec![]
+        };
+
+        self.get_json(
+            &[
+                routes::API_VERSION,
+                "unstable",
+                "nym-nodes",
+                "mixnodes",
+                "skimmed",
+            ],
+            &params,
+        )
+        .await
+    }
+
+    async fn get_basic_gateways(
+        &self,
+        semver_compatibility: Option<String>,
+    ) -> Result<CachedNodesResponse<SkimmedNode>, NymAPIError> {
+        let params = if let Some(semver_compatibility) = &semver_compatibility {
+            vec![("semver_compatibility", semver_compatibility.as_str())]
+        } else {
+            vec![]
+        };
+
+        self.get_json(
+            &[
+                routes::API_VERSION,
+                "unstable",
+                "nym-nodes",
+                "gateways",
+                "skimmed",
+            ],
+            &params,
         )
         .await
     }

--- a/common/client-libs/validator-client/src/nyxd/fee/gas_price.rs
+++ b/common/client-libs/validator-client/src/nyxd/fee/gas_price.rs
@@ -140,6 +140,6 @@ mod tests {
 
         let fee = &gas_price * gas_limit;
         // the failing behaviour was result value of 3937
-        assert_eq!(fee.amount, 3938u64.into());
+        assert_eq!(fee.amount, 3938u128);
     }
 }

--- a/common/node-tester-utils/src/node.rs
+++ b/common/node-tester-utils/src/node.rs
@@ -41,7 +41,7 @@ impl<'a> From<&'a mix::Node> for TestableNode {
     fn from(value: &'a mix::Node) -> Self {
         TestableNode {
             encoded_identity: value.identity_key.to_base58_string(),
-            owner: value.owner.clone(),
+            owner: value.owner.as_ref().cloned().unwrap_or_default(),
             typ: NodeType::Mixnode {
                 mix_id: value.mix_id,
             },
@@ -53,7 +53,7 @@ impl<'a> From<&'a gateway::Node> for TestableNode {
     fn from(value: &'a gateway::Node) -> Self {
         TestableNode {
             encoded_identity: value.identity_key.to_base58_string(),
-            owner: value.owner.clone(),
+            owner: value.owner.as_ref().cloned().unwrap_or_default(),
             typ: NodeType::Gateway,
         }
     }

--- a/common/nymsphinx/src/receiver.rs
+++ b/common/nymsphinx/src/receiver.rs
@@ -235,7 +235,7 @@ mod message_receiver {
             1,
             vec![mix::Node {
                 mix_id: 123,
-                owner: "foomp1".to_string(),
+                owner: None,
                 host: "10.20.30.40".parse().unwrap(),
                 mix_host: "10.20.30.40:1789".parse().unwrap(),
                 identity_key: identity::PublicKey::from_base58_string(
@@ -255,7 +255,7 @@ mod message_receiver {
             2,
             vec![mix::Node {
                 mix_id: 234,
-                owner: "foomp2".to_string(),
+                owner: None,
                 host: "11.21.31.41".parse().unwrap(),
                 mix_host: "11.21.31.41:1789".parse().unwrap(),
                 identity_key: identity::PublicKey::from_base58_string(
@@ -275,7 +275,7 @@ mod message_receiver {
             3,
             vec![mix::Node {
                 mix_id: 456,
-                owner: "foomp3".to_string(),
+                owner: None,
                 host: "12.22.32.42".parse().unwrap(),
                 mix_host: "12.22.32.42:1789".parse().unwrap(),
                 identity_key: identity::PublicKey::from_base58_string(
@@ -295,7 +295,7 @@ mod message_receiver {
             // currently coco_nodes don't really exist so this is still to be determined
             mixes,
             vec![gateway::Node {
-                owner: "foomp4".to_string(),
+                owner: None,
                 host: "1.2.3.4".parse().unwrap(),
                 mix_host: "1.2.3.4:1789".parse().unwrap(),
                 clients_ws_port: 9000,

--- a/common/topology/src/gateway.rs
+++ b/common/topology/src/gateway.rs
@@ -9,6 +9,8 @@ use nym_sphinx_addressing::nodes::{NodeIdentity, NymNodeRoutingAddress};
 use nym_sphinx_types::Node as SphinxNode;
 
 use nym_api_requests::nym_nodes::SkimmedNode;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
 use std::fmt;
 use std::fmt::Formatter;
 use std::io;
@@ -48,7 +50,6 @@ pub enum GatewayConversionError {
 
 #[derive(Clone)]
 pub struct Node {
-    pub owner: String,
     pub host: NetworkAddress,
     // we're keeping this as separate resolved field since we do not want to be resolving the potential
     // hostname every time we want to construct a path via this node
@@ -62,6 +63,9 @@ pub struct Node {
 
     pub identity_key: identity::PublicKey,
     pub sphinx_key: encryption::PublicKey, // TODO: or nymsphinx::PublicKey? both are x25519
+
+    // to be removed:
+    pub owner: Option<String>,
     pub version: NodeVersion,
 }
 
@@ -122,7 +126,7 @@ impl fmt::Display for Node {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Node(id: {}, owner: {}, host: {})",
+            "Node(id: {}, owner: {:?}, host: {})",
             self.identity_key, self.owner, self.host,
         )
     }
@@ -156,7 +160,7 @@ impl<'a> TryFrom<&'a GatewayBond> for Node {
         let mix_host = Self::extract_mix_host(&host, bond.gateway.mix_port)?;
 
         Ok(Node {
-            owner: bond.owner.as_str().to_owned(),
+            owner: Some(bond.owner.as_str().to_owned()),
             host,
             mix_host,
             clients_ws_port: bond.gateway.clients_port,
@@ -201,7 +205,7 @@ impl<'a> TryFrom<&'a DescribedGateway> for Node {
         let mix_host = SocketAddr::new(ips[0], value.bond.gateway.mix_port);
 
         Ok(Node {
-            owner: value.bond.owner.as_str().to_owned(),
+            owner: Some(value.bond.owner.as_str().to_owned()),
             host,
             mix_host,
             clients_ws_port: self_described.mixnet_websockets.ws_port,
@@ -225,17 +229,36 @@ impl<'a> TryFrom<&'a SkimmedNode> for Node {
     type Error = GatewayConversionError;
 
     fn try_from(value: &'a SkimmedNode) -> Result<Self, Self::Error> {
-        todo!()
-        // Ok(Node {
-        //     owner: "".to_string(),
-        //     host: (),
-        //     mix_host: (),
-        //     clients_ws_port: 0,
-        //     clients_wss_port: None,
-        //     identity_key: (),
-        //     sphinx_key: (),
-        //     version: Default::default(),
-        // })
+        let Some(entry_details) = &value.entry else {
+            return Err(GatewayConversionError::NotGateway);
+        };
+
+        if value.ip_addresses.is_empty() {
+            return Err(GatewayConversionError::NoIpAddressesProvided {
+                gateway: value.ed25519_identity_pubkey.clone(),
+            });
+        }
+
+        // safety: we just checked the slice is not empty
+        #[allow(clippy::unwrap_used)]
+        let ip = value.ip_addresses.choose(&mut thread_rng()).unwrap();
+
+        let host = if let Some(hostname) = &entry_details.hostname {
+            NetworkAddress::Hostname(hostname.to_string())
+        } else {
+            NetworkAddress::IpAddr(*ip)
+        };
+
+        Ok(Node {
+            host,
+            mix_host: SocketAddr::new(*ip, value.mix_port),
+            clients_ws_port: entry_details.ws_port,
+            clients_wss_port: entry_details.wss_port,
+            identity_key: value.ed25519_identity_pubkey.parse()?,
+            sphinx_key: value.x25519_sphinx_pubkey.parse()?,
+            owner: None,
+            version: NodeVersion::Unknown,
+        })
     }
 }
 

--- a/common/topology/src/gateway.rs
+++ b/common/topology/src/gateway.rs
@@ -8,6 +8,7 @@ use nym_mixnet_contract_common::GatewayBond;
 use nym_sphinx_addressing::nodes::{NodeIdentity, NymNodeRoutingAddress};
 use nym_sphinx_types::Node as SphinxNode;
 
+use nym_api_requests::nym_nodes::SkimmedNode;
 use std::fmt;
 use std::fmt::Formatter;
 use std::io;
@@ -40,6 +41,9 @@ pub enum GatewayConversionError {
         #[source]
         err: AddrParseError,
     },
+
+    #[error("provided node is not an entry gateway in this epoch!")]
+    NotGateway,
 }
 
 #[derive(Clone)]
@@ -214,6 +218,24 @@ impl<'a> TryFrom<&'a DescribedGateway> for Node {
                 .as_str()
                 .into(),
         })
+    }
+}
+
+impl<'a> TryFrom<&'a SkimmedNode> for Node {
+    type Error = GatewayConversionError;
+
+    fn try_from(value: &'a SkimmedNode) -> Result<Self, Self::Error> {
+        todo!()
+        // Ok(Node {
+        //     owner: "".to_string(),
+        //     host: (),
+        //     mix_host: (),
+        //     clients_ws_port: 0,
+        //     clients_wss_port: None,
+        //     identity_key: (),
+        //     sphinx_key: (),
+        //     version: Default::default(),
+        // })
     }
 }
 

--- a/common/topology/src/gateway.rs
+++ b/common/topology/src/gateway.rs
@@ -78,11 +78,9 @@ impl std::fmt::Debug for Node {
 
 impl Node {
     pub fn parse_host(raw: &str) -> Result<NetworkAddress, GatewayConversionError> {
-        raw.parse()
-            .map_err(|err| GatewayConversionError::InvalidAddress {
-                value: raw.to_owned(),
-                source: err,
-            })
+        // safety: this conversion is infallible
+        // (but we retain result return type for legacy reasons)
+        Ok(raw.parse().unwrap())
     }
 
     pub fn extract_mix_host(

--- a/common/topology/src/lib.rs
+++ b/common/topology/src/lib.rs
@@ -14,6 +14,7 @@ use nym_sphinx_types::Node as SphinxNode;
 use rand::prelude::SliceRandom;
 use rand::{CryptoRng, Rng};
 use std::collections::BTreeMap;
+use std::convert::Infallible;
 
 use std::fmt::{self, Display, Formatter};
 use std::io;
@@ -93,7 +94,7 @@ impl NetworkAddress {
 }
 
 impl FromStr for NetworkAddress {
-    type Err = std::io::Error;
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Ok(ip_addr) = s.parse() {

--- a/common/topology/src/lib.rs
+++ b/common/topology/src/lib.rs
@@ -524,7 +524,7 @@ mod converting_mixes_to_vec {
         fn returns_a_vec_with_hashmap_values() {
             let node1 = mix::Node {
                 mix_id: 42,
-                owner: "N/A".to_string(),
+                owner: Some("N/A".to_string()),
                 host: "3.3.3.3".parse().unwrap(),
                 mix_host: "3.3.3.3:1789".parse().unwrap(),
                 identity_key: identity::PublicKey::from_base58_string(
@@ -540,12 +540,12 @@ mod converting_mixes_to_vec {
             };
 
             let node2 = mix::Node {
-                owner: "Alice".to_string(),
+                owner: Some("Alice".to_string()),
                 ..node1.clone()
             };
 
             let node3 = mix::Node {
-                owner: "Bob".to_string(),
+                owner: Some("Bob".to_string()),
                 ..node1.clone()
             };
 
@@ -555,7 +555,9 @@ mod converting_mixes_to_vec {
 
             let topology = NymTopology::new(mixes, vec![]);
             let mixvec = topology.mixes_as_vec();
-            assert!(mixvec.iter().any(|node| node.owner == "N/A"));
+            assert!(mixvec
+                .iter()
+                .any(|node| node.owner.as_ref() == Some(&"N/A".to_string())));
         }
     }
 

--- a/common/topology/src/mix.rs
+++ b/common/topology/src/mix.rs
@@ -8,6 +8,7 @@ use nym_mixnet_contract_common::{MixId, MixNodeBond};
 use nym_sphinx_addressing::nodes::NymNodeRoutingAddress;
 use nym_sphinx_types::Node as SphinxNode;
 
+use nym_api_requests::nym_nodes::SkimmedNode;
 use std::fmt::Formatter;
 use std::io;
 use std::net::SocketAddr;
@@ -27,6 +28,9 @@ pub enum MixnodeConversionError {
         #[source]
         source: io::Error,
     },
+
+    #[error("provided node is not a mixnode in this epoch!")]
+    NotMixnode,
 }
 
 #[derive(Clone)]
@@ -115,6 +119,24 @@ impl<'a> TryFrom<&'a MixNodeBond> for Node {
             layer: bond.layer,
             version: bond.mix_node.version.as_str().into(),
         })
+    }
+}
+
+impl<'a> TryFrom<&'a SkimmedNode> for Node {
+    type Error = MixnodeConversionError;
+
+    fn try_from(value: &'a SkimmedNode) -> Result<Self, Self::Error> {
+        todo!()
+        // Ok(Node {
+        //     owner: "".to_string(),
+        //     host: (),
+        //     mix_host: (),
+        //     clients_ws_port: 0,
+        //     clients_wss_port: None,
+        //     identity_key: (),
+        //     sphinx_key: (),
+        //     version: Default::default(),
+        // })
     }
 }
 

--- a/common/topology/src/mix.rs
+++ b/common/topology/src/mix.rs
@@ -60,11 +60,9 @@ impl std::fmt::Debug for Node {
 
 impl Node {
     pub fn parse_host(raw: &str) -> Result<NetworkAddress, MixnodeConversionError> {
-        raw.parse()
-            .map_err(|err| MixnodeConversionError::InvalidAddress {
-                value: raw.to_owned(),
-                source: err,
-            })
+        // safety: this conversion is infallible
+        // (but we retain result return type for legacy reasons)
+        Ok(raw.parse().unwrap())
     }
 
     pub fn extract_mix_host(

--- a/common/topology/src/serde.rs
+++ b/common/topology/src/serde.rs
@@ -109,7 +109,8 @@ pub struct SerializableMixNode {
     #[serde(alias = "mix_id")]
     pub mix_id: u32,
 
-    pub owner: String,
+    #[cfg_attr(feature = "wasm-serde-types", tsify(optional))]
+    pub owner: Option<String>,
 
     pub host: String,
 
@@ -180,7 +181,8 @@ impl<'a> From<&'a mix::Node> for SerializableMixNode {
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct SerializableGateway {
-    pub owner: String,
+    #[cfg_attr(feature = "wasm-serde-types", tsify(optional))]
+    pub owner: Option<String>,
 
     pub host: String,
 

--- a/common/wasm/client-core/src/config/mod.rs
+++ b/common/wasm/client-core/src/config/mod.rs
@@ -362,6 +362,14 @@ pub struct TopologyWasm {
     /// the first valid instance.
     /// Supersedes `topology_refresh_rate_ms`.
     pub disable_refreshing: bool,
+
+    /// Specifies a minimum performance of a mixnode that is used on route construction.
+    /// This setting is only applicable when `NymApi` topology is used.
+    pub minimum_mixnode_performance: u8,
+
+    /// Specifies a minimum performance of a gateway that is used on route construction.
+    /// This setting is only applicable when `NymApi` topology is used.
+    pub minimum_gateway_performance: u8,
 }
 
 impl Default for TopologyWasm {
@@ -382,6 +390,8 @@ impl From<TopologyWasm> for ConfigTopology {
                 topology.max_startup_gateway_waiting_period_ms as u64,
             ),
             topology_structure: Default::default(),
+            minimum_mixnode_performance: topology.minimum_mixnode_performance,
+            minimum_gateway_performance: topology.minimum_gateway_performance,
         }
     }
 }
@@ -395,6 +405,8 @@ impl From<ConfigTopology> for TopologyWasm {
                 .max_startup_gateway_waiting_period
                 .as_millis() as u32,
             disable_refreshing: topology.disable_refreshing,
+            minimum_mixnode_performance: topology.minimum_mixnode_performance,
+            minimum_gateway_performance: topology.minimum_gateway_performance,
         }
     }
 }

--- a/common/wasm/client-core/src/config/override.rs
+++ b/common/wasm/client-core/src/config/override.rs
@@ -244,6 +244,16 @@ pub struct TopologyWasmOverride {
     /// Supersedes `topology_refresh_rate_ms`.
     #[tsify(optional)]
     pub disable_refreshing: Option<bool>,
+
+    /// Specifies a minimum performance of a mixnode that is used on route construction.
+    /// This setting is only applicable when `NymApi` topology is used.
+    #[tsify(optional)]
+    pub minimum_mixnode_performance: Option<u8>,
+
+    /// Specifies a minimum performance of a gateway that is used on route construction.
+    /// This setting is only applicable when `NymApi` topology is used.
+    #[tsify(optional)]
+    pub minimum_gateway_performance: Option<u8>,
 }
 
 impl From<TopologyWasmOverride> for TopologyWasm {
@@ -261,6 +271,12 @@ impl From<TopologyWasmOverride> for TopologyWasm {
                 .max_startup_gateway_waiting_period_ms
                 .unwrap_or(def.max_startup_gateway_waiting_period_ms),
             disable_refreshing: value.disable_refreshing.unwrap_or(def.disable_refreshing),
+            minimum_mixnode_performance: value
+                .minimum_mixnode_performance
+                .unwrap_or(def.minimum_mixnode_performance),
+            minimum_gateway_performance: value
+                .minimum_gateway_performance
+                .unwrap_or(def.minimum_gateway_performance),
         }
     }
 }

--- a/common/wasm/client-core/src/storage/types.rs
+++ b/common/wasm/client-core/src/storage/types.rs
@@ -16,7 +16,7 @@ pub struct WasmRawRegisteredGateway {
 
     pub derived_aes128_ctr_blake3_hmac_keys_bs58: String,
 
-    pub gateway_owner_address: String,
+    pub gateway_owner_address: Option<String>,
 
     pub gateway_listener: String,
 }
@@ -55,7 +55,10 @@ impl<'a> From<&'a GatewayRegistration> for WasmRawRegisteredGateway {
             derived_aes128_ctr_blake3_hmac_keys_bs58: remote_details
                 .derived_aes128_ctr_blake3_hmac_keys
                 .to_base58_string(),
-            gateway_owner_address: remote_details.gateway_owner_address.to_string(),
+            gateway_owner_address: remote_details
+                .gateway_owner_address
+                .as_ref()
+                .map(|a| a.to_string()),
             gateway_listener: remote_details.gateway_listener.to_string(),
         }
     }

--- a/nym-api/Cargo.toml
+++ b/nym-api/Cargo.toml
@@ -95,7 +95,7 @@ nym-sphinx = { path = "../common/nymsphinx" }
 nym-pemstore = { path = "../common/pemstore" }
 nym-task = { path = "../common/task" }
 nym-topology = { path = "../common/topology" }
-nym-api-requests = { path = "nym-api-requests" }
+nym-api-requests = { path = "nym-api-requests", features = ["request-parsing"] }
 nym-validator-client = { path = "../common/client-libs/validator-client" }
 nym-bin-common = { path = "../common/bin-common", features = ["output_format"] }
 nym-node-tester-utils = { path = "../common/node-tester-utils" }

--- a/nym-api/nym-api-requests/Cargo.toml
+++ b/nym-api/nym-api-requests/Cargo.toml
@@ -16,7 +16,7 @@ serde = { workspace = true, features = ["derive"] }
 ts-rs = { workspace = true, optional = true }
 tendermint = { workspace = true }
 time = { workspace = true, features = ["serde", "parsing", "formatting"] }
-
+rocket = { workspace = true, optional = true }
 
 # for serde on secp256k1 signatures
 ecdsa = { workspace = true, features = ["serde"] }
@@ -33,4 +33,5 @@ serde_json.workspace = true
 
 [features]
 default = []
+request-parsing = ["rocket"]
 generate-ts = ["ts-rs", "nym-mixnet-contract-common/generate-ts"]

--- a/nym-api/nym-api-requests/src/lib.rs
+++ b/nym-api/nym-api-requests/src/lib.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod coconut;
 pub mod models;
+pub mod nym_nodes;
 pub mod pagination;
 
 pub trait Deprecatable {

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -126,6 +126,10 @@ pub struct MixNodeBondAnnotated {
     pub estimated_delegators_apy: Decimal,
     pub family: Option<FamilyHead>,
     pub blacklisted: bool,
+
+    // a rather temporary thing until we query self-described endpoints of mixnodes
+    #[serde(default)]
+    pub ip_addresses: Vec<IpAddr>,
 }
 
 impl MixNodeBondAnnotated {
@@ -157,6 +161,9 @@ pub struct GatewayBondAnnotated {
     pub performance: Performance,
     pub node_performance: NodePerformance,
     pub blacklisted: bool,
+
+    #[serde(default)]
+    pub ip_addresses: Vec<IpAddr>,
 }
 
 impl GatewayBondAnnotated {

--- a/nym-api/nym-api-requests/src/nym_nodes.rs
+++ b/nym-api/nym-api-requests/src/nym_nodes.rs
@@ -5,6 +5,7 @@ use crate::models::{
     GatewayBondAnnotated, MixNodeBondAnnotated, NymNodeDescription, OffsetDateTimeJsonSchemaWrapper,
 };
 use nym_mixnet_contract_common::reward_params::Performance;
+use nym_mixnet_contract_common::MixId;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
@@ -54,11 +55,15 @@ pub struct BasicEntryInformation {
     pub wss_port: Option<u16>,
 }
 
+type NodeId = MixId;
+
 // the bare minimum information needed to construct sphinx packets
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct SkimmedNode {
     // in directory v3 all nodes (mixnodes AND gateways) will have a unique id
-    // pub node_id: NodeId,
+    // but to keep structure consistent, introduce this field now
+    pub node_id: NodeId,
+
     pub ed25519_identity_pubkey: String,
     pub ip_addresses: Vec<IpAddr>,
 
@@ -103,6 +108,7 @@ impl SkimmedNode {
 impl<'a> From<&'a MixNodeBondAnnotated> for SkimmedNode {
     fn from(value: &'a MixNodeBondAnnotated) -> Self {
         SkimmedNode {
+            node_id: value.mix_id(),
             ed25519_identity_pubkey: value.identity_key().to_string(),
             ip_addresses: value.ip_addresses.clone(),
             mix_port: value.mix_node().mix_port,
@@ -119,6 +125,7 @@ impl<'a> From<&'a MixNodeBondAnnotated> for SkimmedNode {
 impl<'a> From<&'a GatewayBondAnnotated> for SkimmedNode {
     fn from(value: &'a GatewayBondAnnotated) -> Self {
         SkimmedNode {
+            node_id: MixId::MAX,
             ip_addresses: value.ip_addresses.clone(),
             ed25519_identity_pubkey: value.gateway_bond.identity().clone(),
             mix_port: value.gateway_bond.gateway.mix_port,

--- a/nym-api/nym-api-requests/src/nym_nodes.rs
+++ b/nym-api/nym-api-requests/src/nym_nodes.rs
@@ -1,0 +1,150 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::models::{
+    GatewayBondAnnotated, MixNodeBondAnnotated, NymNodeDescription, OffsetDateTimeJsonSchemaWrapper,
+};
+use nym_mixnet_contract_common::reward_params::Performance;
+use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CachedNodesResponse<T> {
+    pub refreshed_at: OffsetDateTimeJsonSchemaWrapper,
+    pub nodes: Vec<T>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "request-parsing", derive(rocket::form::FromFormField))]
+pub enum NodeRoleQueryParam {
+    ActiveMixnode,
+
+    #[serde(alias = "entry", alias = "gateway")]
+    EntryGateway,
+
+    #[serde(alias = "exit")]
+    ExitGateway,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub enum NodeRole {
+    // a properly active mixnode
+    Mixnode {
+        layer: u8,
+    },
+
+    #[serde(alias = "entry", alias = "gateway")]
+    EntryGateway,
+
+    #[serde(alias = "exit")]
+    ExitGateway,
+
+    // equivalent of node that's in rewarded set but not in the inactive set
+    Standby,
+
+    Inactive,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct BasicEntryInformation {
+    pub hostname: Option<String>,
+    pub ed25519_identity_pubkey: String,
+
+    pub ws_port: u16,
+    pub wss_port: Option<u16>,
+}
+
+// the bare minimum information needed to construct sphinx packets
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SkimmedNode {
+    // in directory v3 all nodes (mixnodes AND gateways) will have a unique id
+    // pub node_id: NodeId,
+    pub ip_addresses: Vec<IpAddr>,
+
+    // TODO: to be deprecated in favour of well-known hardcoded port for everyone
+    pub mix_port: u16,
+    pub x25519_sphinx_pubkey: String,
+    pub role: NodeRole,
+    pub entry: Option<BasicEntryInformation>,
+
+    /// Average node performance in last 24h period
+    pub performance: Performance,
+}
+
+impl SkimmedNode {
+    pub fn from_described_gateway(
+        annotated: &GatewayBondAnnotated,
+        description: Option<&NymNodeDescription>,
+    ) -> Self {
+        let mut base: SkimmedNode = annotated.into();
+        let Some(description) = description else {
+            return base;
+        };
+
+        // safety: the conversion always set the entry field
+        let entry = base.entry.as_mut().unwrap();
+        entry
+            .hostname
+            .clone_from(&description.host_information.hostname);
+        entry.ws_port = description.mixnet_websockets.ws_port;
+        entry.wss_port = description.mixnet_websockets.wss_port;
+
+        // always prefer self-described data
+        if !description.host_information.ip_address.is_empty() {
+            base.ip_addresses
+                .clone_from(&description.host_information.ip_address)
+        }
+
+        base
+    }
+}
+
+impl<'a> From<&'a MixNodeBondAnnotated> for SkimmedNode {
+    fn from(value: &'a MixNodeBondAnnotated) -> Self {
+        SkimmedNode {
+            ip_addresses: value.ip_addresses.clone(),
+            mix_port: value.mix_node().mix_port,
+            x25519_sphinx_pubkey: value.mix_node().sphinx_key.clone(),
+            role: NodeRole::Mixnode {
+                layer: value.mixnode_details.bond_information.layer.into(),
+            },
+            entry: None,
+            performance: value.node_performance.last_24h,
+        }
+    }
+}
+
+impl<'a> From<&'a GatewayBondAnnotated> for SkimmedNode {
+    fn from(value: &'a GatewayBondAnnotated) -> Self {
+        SkimmedNode {
+            ip_addresses: value.ip_addresses.clone(),
+            mix_port: value.gateway_bond.gateway.mix_port,
+            x25519_sphinx_pubkey: value.gateway_bond.gateway.sphinx_key.clone(),
+            role: NodeRole::EntryGateway,
+            entry: Some(BasicEntryInformation {
+                hostname: None,
+                ed25519_identity_pubkey: value.gateway_bond.identity().clone(),
+                ws_port: value.gateway_bond.gateway.clients_port,
+                wss_port: None,
+            }),
+            performance: value.node_performance.last_24h,
+        }
+    }
+}
+
+// an intermediate variant that exposes additional data such as noise keys but without
+// the full fat of the self-described data
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SemiSkimmedNode {
+    pub basic: SkimmedNode,
+    pub x25519_noise_pubkey: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct FullFatNode {
+    pub expanded: SemiSkimmedNode,
+
+    // kinda temporary for now to make as few changes as possible for now
+    pub self_described: Option<NymNodeDescription>,
+}

--- a/nym-api/nym-api-requests/src/nym_nodes.rs
+++ b/nym-api/nym-api-requests/src/nym_nodes.rs
@@ -49,7 +49,6 @@ pub enum NodeRole {
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct BasicEntryInformation {
     pub hostname: Option<String>,
-    pub ed25519_identity_pubkey: String,
 
     pub ws_port: u16,
     pub wss_port: Option<u16>,
@@ -60,6 +59,7 @@ pub struct BasicEntryInformation {
 pub struct SkimmedNode {
     // in directory v3 all nodes (mixnodes AND gateways) will have a unique id
     // pub node_id: NodeId,
+    pub ed25519_identity_pubkey: String,
     pub ip_addresses: Vec<IpAddr>,
 
     // TODO: to be deprecated in favour of well-known hardcoded port for everyone
@@ -103,6 +103,7 @@ impl SkimmedNode {
 impl<'a> From<&'a MixNodeBondAnnotated> for SkimmedNode {
     fn from(value: &'a MixNodeBondAnnotated) -> Self {
         SkimmedNode {
+            ed25519_identity_pubkey: value.identity_key().to_string(),
             ip_addresses: value.ip_addresses.clone(),
             mix_port: value.mix_node().mix_port,
             x25519_sphinx_pubkey: value.mix_node().sphinx_key.clone(),
@@ -119,12 +120,12 @@ impl<'a> From<&'a GatewayBondAnnotated> for SkimmedNode {
     fn from(value: &'a GatewayBondAnnotated) -> Self {
         SkimmedNode {
             ip_addresses: value.ip_addresses.clone(),
+            ed25519_identity_pubkey: value.gateway_bond.identity().clone(),
             mix_port: value.gateway_bond.gateway.mix_port,
             x25519_sphinx_pubkey: value.gateway_bond.gateway.sphinx_key.clone(),
             role: NodeRole::EntryGateway,
             entry: Some(BasicEntryInformation {
                 hostname: None,
-                ed25519_identity_pubkey: value.gateway_bond.identity().clone(),
                 ws_port: value.gateway_bond.gateway.clients_port,
                 wss_port: None,
             }),
@@ -139,6 +140,7 @@ impl<'a> From<&'a GatewayBondAnnotated> for SkimmedNode {
 pub struct SemiSkimmedNode {
     pub basic: SkimmedNode,
     pub x25519_noise_pubkey: String,
+    // pub location:
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]

--- a/nym-api/src/node_status_api/cache/mod.rs
+++ b/nym-api/src/node_status_api/cache/mod.rs
@@ -103,6 +103,12 @@ impl NodeStatusCache {
         }
     }
 
+    pub(crate) async fn active_mixnodes_cache(
+        &self,
+    ) -> Option<RwLockReadGuard<Cache<Vec<MixNodeBondAnnotated>>>> {
+        self.get(|c| &c.active_set_annotated).await
+    }
+
     pub(crate) async fn mixnodes_annotated_full(&self) -> Option<Vec<MixNodeBondAnnotated>> {
         let mixnodes = self.get(|c| &c.mixnodes_annotated).await?;
 
@@ -128,6 +134,12 @@ impl NodeStatusCache {
     pub(crate) async fn active_set_annotated(&self) -> Option<Cache<Vec<MixNodeBondAnnotated>>> {
         self.get_owned(|c| c.active_set_annotated.clone_cache())
             .await
+    }
+
+    pub(crate) async fn gateways_cache(
+        &self,
+    ) -> Option<RwLockReadGuard<Cache<HashMap<IdentityKey, GatewayBondAnnotated>>>> {
+        self.get(|c| &c.gateways_annotated).await
     }
 
     pub(crate) async fn gateways_annotated_full(&self) -> Option<Vec<GatewayBondAnnotated>> {

--- a/nym-api/src/node_status_api/helpers.rs
+++ b/nym-api/src/node_status_api/helpers.rs
@@ -167,7 +167,7 @@ pub(crate) async fn _get_mixnode_reward_estimation(
             estimation: reward_estimation,
             reward_params,
             epoch: current_interval,
-            as_at,
+            as_at: as_at.unix_timestamp(),
         })
     } else {
         Err(ErrorResponse::new(
@@ -252,7 +252,7 @@ pub(crate) async fn _compute_mixnode_reward_estimation(
             estimation: reward_estimation,
             reward_params,
             epoch: current_interval,
-            as_at,
+            as_at: as_at.unix_timestamp(),
         })
     } else {
         Err(ErrorResponse::new(
@@ -286,7 +286,7 @@ pub(crate) async fn _get_mixnode_stake_saturation(
                 .mixnode_details
                 .rewarding_details
                 .uncapped_bond_saturation(&rewarding_params),
-            as_at,
+            as_at: as_at.unix_timestamp(),
         })
     } else {
         Err(ErrorResponse::new(
@@ -350,7 +350,7 @@ pub(crate) async fn _get_mixnode_inclusion_probabilities(
             elapsed: prob.elapsed,
             delta_max: prob.delta_max,
             delta_l2: prob.delta_l2,
-            as_at,
+            as_at: as_at.unix_timestamp(),
         })
     } else {
         Err(ErrorResponse::new(

--- a/nym-api/src/nym_nodes/mod.rs
+++ b/nym-api/src/nym_nodes/mod.rs
@@ -7,10 +7,26 @@ use rocket_okapi::openapi_get_routes_spec;
 use rocket_okapi::settings::OpenApiSettings;
 
 pub(crate) mod routes;
+mod unstable_routes;
 
 /// Merges the routes with http information and returns it to Rocket for serving
 pub(crate) fn nym_node_routes(settings: &OpenApiSettings) -> (Vec<Route>, OpenApi) {
     openapi_get_routes_spec![
         settings: routes::get_gateways_described
+    ]
+}
+
+pub(crate) fn nym_node_routes_next(settings: &OpenApiSettings) -> (Vec<Route>, OpenApi) {
+    openapi_get_routes_spec![
+        settings:
+        unstable_routes::nodes_basic,
+        unstable_routes::nodes_expanded,
+        unstable_routes::nodes_detailed,
+        unstable_routes::gateways_basic,
+        unstable_routes::gateways_expanded,
+        unstable_routes::gateways_detailed,
+        unstable_routes::mixnodes_basic,
+        unstable_routes::mixnodes_expanded,
+        unstable_routes::mixnodes_detailed,
     ]
 }

--- a/nym-api/src/nym_nodes/unstable_routes.rs
+++ b/nym-api/src/nym_nodes/unstable_routes.rs
@@ -1,0 +1,187 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::node_describe_cache::DescribedNodes;
+use crate::node_status_api::models::ErrorResponse;
+use crate::node_status_api::NodeStatusCache;
+use crate::support::caching::cache::SharedCache;
+use nym_api_requests::nym_nodes::{
+    CachedNodesResponse, FullFatNode, NodeRoleQueryParam, SemiSkimmedNode, SkimmedNode,
+};
+use rocket::http::Status;
+use rocket::serde::json::Json;
+use rocket::State;
+use rocket_okapi::openapi;
+use std::cmp::min;
+use std::ops::Deref;
+
+/*
+   routes:
+
+   // all routes/nodes are split into three tiers:
+   // /skimmed      => [used by clients]            returns the very basic information for routing purposes
+   // /semi-skimmed => [used by other nodes/VPN]    returns more additional information such noise keys
+   // /full-fat     => [used by explorers, et al.]  returns almost everything there is about the nodes
+
+   // there's also additional split based on the role:
+   ?role => filters based on the specific role (mixnode/gateway/(in the future: entry/exit))
+   /mixnodes/<tier> => only returns mixnode role data
+   /gateway/<tier> => only returns (entry) gateway role data
+
+
+*/
+
+#[openapi(tag = "Unstable Nym Nodes")]
+#[get("/skimmed?<role>")]
+pub async fn nodes_basic(
+    status_cache: &State<NodeStatusCache>,
+    describe_cache: &State<SharedCache<DescribedNodes>>,
+    role: Option<NodeRoleQueryParam>,
+) -> Result<Json<CachedNodesResponse<SkimmedNode>>, ErrorResponse> {
+    if let Some(role) = role {
+        match role {
+            NodeRoleQueryParam::ActiveMixnode => return mixnodes_basic(status_cache).await,
+            NodeRoleQueryParam::EntryGateway => {
+                return gateways_basic(status_cache, describe_cache).await
+            }
+            _ => {}
+        }
+    }
+
+    Err(ErrorResponse::new("unimplemented", Status::NotImplemented))
+}
+
+#[openapi(tag = "Unstable Nym Nodes")]
+#[get("/semi-skimmed?<role>")]
+pub async fn nodes_expanded(
+    cache: &State<NodeStatusCache>,
+    role: Option<NodeRoleQueryParam>,
+) -> Result<Json<CachedNodesResponse<SemiSkimmedNode>>, ErrorResponse> {
+    if let Some(role) = role {
+        match role {
+            NodeRoleQueryParam::ActiveMixnode => return mixnodes_expanded(cache).await,
+            NodeRoleQueryParam::EntryGateway => return gateways_expanded(cache).await,
+            _ => {}
+        }
+    }
+
+    Err(ErrorResponse::new("unimplemented", Status::NotImplemented))
+}
+
+#[openapi(tag = "Unstable Nym Nodes")]
+#[get("/full-fat?<role>")]
+pub async fn nodes_detailed(
+    cache: &State<NodeStatusCache>,
+    role: Option<NodeRoleQueryParam>,
+) -> Result<Json<CachedNodesResponse<FullFatNode>>, ErrorResponse> {
+    if let Some(role) = role {
+        match role {
+            NodeRoleQueryParam::ActiveMixnode => return mixnodes_detailed(cache).await,
+            NodeRoleQueryParam::EntryGateway => return gateways_detailed(cache).await,
+            _ => {}
+        }
+    }
+
+    Err(ErrorResponse::new("unimplemented", Status::NotImplemented))
+}
+
+#[openapi(tag = "Unstable Nym Nodes")]
+#[get("/gateways/skimmed")]
+pub async fn gateways_basic(
+    status_cache: &State<NodeStatusCache>,
+    describe_cache: &State<SharedCache<DescribedNodes>>,
+) -> Result<Json<CachedNodesResponse<SkimmedNode>>, ErrorResponse> {
+    let gateways_cache = status_cache
+        .gateways_cache()
+        .await
+        .ok_or(ErrorResponse::new(
+            "could not obtain gateways cache",
+            Status::InternalServerError,
+        ))?;
+
+    if gateways_cache.is_empty() {
+        return Ok(Json(CachedNodesResponse {
+            refreshed_at: gateways_cache.timestamp().into(),
+            nodes: vec![],
+        }));
+    }
+
+    // if the self describe cache is unavailable don't try to use self-describe data
+    let Ok(self_descriptions) = describe_cache.get().await else {
+        return Ok(Json(CachedNodesResponse {
+            refreshed_at: gateways_cache.timestamp().into(),
+            nodes: gateways_cache.values().map(Into::into).collect(),
+        }));
+    };
+
+    let refreshed_at = min(gateways_cache.timestamp(), self_descriptions.timestamp());
+
+    // the same comment holds as with `get_gateways_described`.
+    // this is inefficient and will have to get refactored with directory v3
+    Ok(Json(CachedNodesResponse {
+        refreshed_at: refreshed_at.into(),
+        nodes: gateways_cache
+            .values()
+            .map(|annotated_bond| {
+                SkimmedNode::from_described_gateway(
+                    annotated_bond,
+                    self_descriptions.deref().get(annotated_bond.identity()),
+                )
+            })
+            .collect(),
+    }))
+}
+
+#[openapi(tag = "Unstable Nym Nodes")]
+#[get("/gateways/semi-skimmed")]
+pub async fn gateways_expanded(
+    cache: &State<NodeStatusCache>,
+) -> Result<Json<CachedNodesResponse<SemiSkimmedNode>>, ErrorResponse> {
+    let _ = cache;
+    Err(ErrorResponse::new("unimplemented", Status::NotImplemented))
+}
+
+#[openapi(tag = "Unstable Nym Nodes")]
+#[get("/gateways/full-fat")]
+pub async fn gateways_detailed(
+    cache: &State<NodeStatusCache>,
+) -> Result<Json<CachedNodesResponse<FullFatNode>>, ErrorResponse> {
+    let _ = cache;
+    Err(ErrorResponse::new("unimplemented", Status::NotImplemented))
+}
+
+#[openapi(tag = "Unstable Nym Nodes")]
+#[get("/mixnodes/skimmed")]
+pub async fn mixnodes_basic(
+    cache: &State<NodeStatusCache>,
+) -> Result<Json<CachedNodesResponse<SkimmedNode>>, ErrorResponse> {
+    let mixnodes_cache = cache
+        .active_mixnodes_cache()
+        .await
+        .ok_or(ErrorResponse::new(
+            "could not obtain mixnodes cache",
+            Status::InternalServerError,
+        ))?;
+    Ok(Json(CachedNodesResponse {
+        refreshed_at: mixnodes_cache.timestamp().into(),
+        nodes: mixnodes_cache.iter().map(Into::into).collect(),
+    }))
+}
+
+#[openapi(tag = "Unstable Nym Nodes")]
+#[get("/mixnodes/semi-skimmed")]
+pub async fn mixnodes_expanded(
+    cache: &State<NodeStatusCache>,
+) -> Result<Json<CachedNodesResponse<SemiSkimmedNode>>, ErrorResponse> {
+    let _ = cache;
+    Err(ErrorResponse::new("unimplemented", Status::NotImplemented))
+}
+
+#[openapi(tag = "Unstable Nym Nodes")]
+#[get("/mixnodes/full-fat")]
+pub async fn mixnodes_detailed(
+    cache: &State<NodeStatusCache>,
+) -> Result<Json<CachedNodesResponse<FullFatNode>>, ErrorResponse> {
+    let _ = cache;
+    Err(ErrorResponse::new("unimplemented", Status::NotImplemented))
+}

--- a/nym-api/src/support/http/mod.rs
+++ b/nym-api/src/support/http/mod.rs
@@ -10,6 +10,7 @@ use crate::node_describe_cache::DescribedNodes;
 use crate::node_status_api::routes::unstable;
 use crate::node_status_api::{self, NodeStatusCache};
 use crate::nym_contract_cache::cache::NymContractCache;
+use crate::nym_nodes::nym_node_routes_next;
 use crate::status::{api_status_routes, ApiStatusState, SignerState};
 use crate::support::caching::cache::SharedCache;
 use crate::support::config::Config;
@@ -50,6 +51,10 @@ pub(crate) async fn setup_rocket(
         "/network" => network_routes(&openapi_settings),
         "/api-status" => api_status_routes(&openapi_settings),
         "" => nym_node_routes(&openapi_settings),
+
+        // => when we move those routes, we'll need to add a redirection for backwards compatibility
+        "/unstable/nym-nodes" => nym_node_routes_next(&openapi_settings)
+
     }
 
     let rocket = rocket

--- a/nym-connect/desktop/src-tauri/src/config/mod.rs
+++ b/nym-connect/desktop/src-tauri/src/config/mod.rs
@@ -252,7 +252,9 @@ fn print_saved_config(config: &Config, gateway_details: &RemoteGatewayDetails) {
         config.default_location().display()
     );
     log::info!("Gateway id: {}", gateway_details.gateway_id);
-    log::info!("Gateway owner: {}", gateway_details.gateway_owner_address);
+    if let Some(owner) = gateway_details.gateway_owner_address.as_ref() {
+        log::info!("Gateway owner: {owner}");
+    }
     log::info!("Gateway listener: {}", gateway_details.gateway_listener);
     log::info!(
         "Service provider address: {}",

--- a/sdk/rust/nym-sdk/examples/manually_overwrite_topology.rs
+++ b/sdk/rust/nym-sdk/examples/manually_overwrite_topology.rs
@@ -55,7 +55,7 @@ async fn main() {
         3,
         vec![mix::Node {
             mix_id: 66,
-            owner: "n1ae2pjd7q9p0dea65pqkvcm4x9s264v4fktpyru".to_string(),
+            owner: None,
             host: "139.162.247.97".parse().unwrap(),
             mix_host: "139.162.247.97:1789".parse().unwrap(),
             identity_key: "66UngapebhJRni3Nj52EW1qcNsWYiuonjkWJzHFsmyYY"

--- a/sdk/rust/nym-sdk/examples/manually_overwrite_topology.rs
+++ b/sdk/rust/nym-sdk/examples/manually_overwrite_topology.rs
@@ -21,7 +21,7 @@ async fn main() {
         1,
         vec![mix::Node {
             mix_id: 63,
-            owner: "n1k52k5n45cqt5qpjh8tcwmgqm0wkt355yy0g5vu".to_string(),
+            owner: None,
             host: "172.105.92.48".parse().unwrap(),
             mix_host: "172.105.92.48:1789".parse().unwrap(),
             identity_key: "GLdR2NRVZBiCoCbv4fNqt9wUJZAnNjGXHkx3TjVAUzrK"
@@ -38,7 +38,7 @@ async fn main() {
         2,
         vec![mix::Node {
             mix_id: 23,
-            owner: "n1fzv4jc7fanl9s0qj02ge2ezk3kts545kjtek47".to_string(),
+            owner: None,
             host: "178.79.143.65".parse().unwrap(),
             mix_host: "178.79.143.65:1789".parse().unwrap(),
             identity_key: "4Yr4qmEHd9sgsuQ83191FR2hD88RfsbMmB4tzhhZWriz"

--- a/wasm/node-tester/src/tester.rs
+++ b/wasm/node-tester/src/tester.rs
@@ -197,7 +197,7 @@ impl NymNodeTesterBuilder {
             } else {
                 let cfg = GatewayConfig::new(
                     gateway_info.gateway_id,
-                    Some(gateway_info.gateway_owner_address.to_string()),
+                    gateway_info.gateway_owner_address.map(|a| a.to_string()),
                     gateway_info.gateway_listener.to_string(),
                 );
                 GatewayClient::new(


### PR DESCRIPTION
# Description

This PR introduces new endpoints on nym-api (and creates scaffolding for additional ones) for providing **unfiltered** network topology alongside performance score of all nodes.

`NymApiTopologyProvider` got modified to use those endpoints alongside (configurable) filtering of nodes with score < 50% (like our current blacklist)

Old clients should work as before as no existing endpoint got removed.

# Checklist:

- [ ] added a changelog entry to `CHANGELOG.md`
