### PR TITLE
Add generic wg private network routing

### DIFF
--- a/common/wireguard/src/peer_controller.rs
+++ b/common/wireguard/src/peer_controller.rs
@@ -36,13 +36,13 @@ impl PeerController {
                 msg = self.peer_rx.recv() => {
                     match msg {
                         Some(PeerControlMessage::AddPeer(peer)) => {
-                            if self.wg_api.inner.configure_peer(&peer).is_err() {
-                                log::error!("Could not configure peer {:?}", peer);
+                            if let Err(e) = self.wg_api.inner.configure_peer(&peer) {
+                                log::error!("Could not configure peer: {:?}", e);
                             }
                         }
                         Some(PeerControlMessage::RemovePeer(peer_pubkey)) => {
-                            if self.wg_api.inner.remove_peer(&peer_pubkey).is_err() {
-                                log::error!("Could not remove peer with key {:?}", peer_pubkey);
+                            if let Err(e) = self.wg_api.inner.remove_peer(&peer_pubkey) {
+                                log::error!("Could not remove peer: {:?}", e);
                             }
                         }
                         None => {


### PR DESCRIPTION
As defguard wireguard only allows for peer routing modifications, we will configure the entire wireguard private network to be routed to the wg device.

Configuring per peer is also not desirable, as the interface doesn't allow removing routes, so unused ip routing won't be cleaned until gateway restart (and it would also pollute to routing table with a lot of rules when many peers are added)