### PR TITLE
Add ci check for PR having an assigned milestone

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,25 @@
+name: pr-validation
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - 'release/**'
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+env:
+  LABELS: ${{ join( github.event.pull_request.labels.*.name, ' ' ) }}
+
+jobs:
+  check-milestone:
+    name: Check Milestone
+    runs-on: ubuntu-latest
+    steps:
+      - if: github.event.pull_request.milestone == null && contains( env.LABELS, 'no-milestone' ) == false
+        run: exit 1

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,6 +12,8 @@ on:
       - reopened
       - synchronize
       - edited
+      - milestoned
+      - demilestoned
 
 env:
   LABELS: ${{ join( github.event.pull_request.labels.*.name, ' ' ) }}


### PR DESCRIPTION
Add a CI check for checking that a PR is assigned to a milestone.

You can bypass the check by adding a `no-milestone` label to a PR
