### PR TITLE
Create UserAgent that can be passed from the binary to the nym api client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4623,6 +4623,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "http 1.1.0",
+ "nym-bin-common",
  "reqwest 0.12.4",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5232,6 +5232,7 @@ dependencies = [
  "nym-socks5-client-core",
  "nym-sphinx",
  "nym-topology",
+ "nym-validator-client",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/clients/native/Cargo.toml
+++ b/clients/native/Cargo.toml
@@ -37,7 +37,7 @@ zeroize = { workspace = true }
 
 ## internal
 nym-bandwidth-controller = { path = "../../common/bandwidth-controller" }
-nym-bin-common = { path = "../../common/bin-common", features = ["output_format"] }
+nym-bin-common = { path = "../../common/bin-common", features = ["output_format", "clap"] }
 nym-client-core = { path = "../../common/client-core", features = ["fs-surb-storage", "fs-gateways-storage", "cli"] }
 nym-config = { path = "../../common/config" }
 nym-credential-storage = { path = "../../common/credential-storage" }

--- a/clients/native/src/client/mod.rs
+++ b/clients/native/src/client/mod.rs
@@ -106,8 +106,10 @@ impl SocketClient {
         };
 
         let storage = self.initialise_storage().await?;
+        let user_agent = nym_bin_common::bin_info!().into();
 
-        let mut base_client = BaseClientBuilder::new(&self.config.base, storage, dkg_query_client);
+        let mut base_client = BaseClientBuilder::new(&self.config.base, storage, dkg_query_client)
+            .with_user_agent(user_agent);
 
         if let Some(custom_mixnet) = &self.custom_mixnet {
             base_client = base_client.with_stored_topology(custom_mixnet)?;

--- a/clients/native/src/client/mod.rs
+++ b/clients/native/src/client/mod.rs
@@ -107,6 +107,7 @@ impl SocketClient {
 
         let storage = self.initialise_storage().await?;
         let user_agent = nym_bin_common::bin_info!().into();
+        error!("JON: user_agent: {}", user_agent);
 
         let mut base_client = BaseClientBuilder::new(&self.config.base, storage, dkg_query_client)
             .with_user_agent(user_agent);

--- a/clients/native/src/client/mod.rs
+++ b/clients/native/src/client/mod.rs
@@ -107,7 +107,6 @@ impl SocketClient {
 
         let storage = self.initialise_storage().await?;
         let user_agent = nym_bin_common::bin_info!().into();
-        error!("JON: user_agent: {}", user_agent);
 
         let mut base_client = BaseClientBuilder::new(&self.config.base, storage, dkg_query_client)
             .with_user_agent(user_agent);

--- a/clients/native/src/commands/add_gateway.rs
+++ b/clients/native/src/commands/add_gateway.rs
@@ -5,6 +5,7 @@ use crate::commands::CliNativeClient;
 use crate::error::ClientError;
 use nym_bin_common::output_format::OutputFormat;
 use nym_client_core::cli_helpers::client_add_gateway::{add_gateway, CommonClientAddGatewayArgs};
+use nym_validator_client::UserAgent;
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
@@ -22,8 +23,15 @@ impl AsRef<CommonClientAddGatewayArgs> for Args {
 }
 
 pub(crate) async fn execute(args: Args) -> Result<(), ClientError> {
+    let bin_info = nym_bin_common::bin_info_owned!();
+    let user_agent = UserAgent::new(
+        bin_info.binary_name,
+        bin_info.cargo_triple,
+        bin_info.build_version,
+        bin_info.commit_sha,
+    );
     let output = args.output;
-    let res = add_gateway::<CliNativeClient, _>(args).await?;
+    let res = add_gateway::<CliNativeClient, _>(args, Some(user_agent)).await?;
 
     println!("{}", output.format(&res));
     Ok(())

--- a/clients/native/src/commands/add_gateway.rs
+++ b/clients/native/src/commands/add_gateway.rs
@@ -5,7 +5,6 @@ use crate::commands::CliNativeClient;
 use crate::error::ClientError;
 use nym_bin_common::output_format::OutputFormat;
 use nym_client_core::cli_helpers::client_add_gateway::{add_gateway, CommonClientAddGatewayArgs};
-use nym_validator_client::UserAgent;
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
@@ -23,13 +22,7 @@ impl AsRef<CommonClientAddGatewayArgs> for Args {
 }
 
 pub(crate) async fn execute(args: Args) -> Result<(), ClientError> {
-    let bin_info = nym_bin_common::bin_info_owned!();
-    let user_agent = UserAgent::new(
-        bin_info.binary_name,
-        bin_info.cargo_triple,
-        bin_info.build_version,
-        bin_info.commit_sha,
-    );
+    let user_agent = nym_bin_common::bin_info!().into();
     let output = args.output;
     let res = add_gateway::<CliNativeClient, _>(args, Some(user_agent)).await?;
 

--- a/clients/native/src/commands/init.rs
+++ b/clients/native/src/commands/init.rs
@@ -15,6 +15,7 @@ use nym_bin_common::output_format::OutputFormat;
 use nym_client_core::cli_helpers::client_init::{
     initialise_client, CommonClientInitArgs, InitResultsWithConfig, InitialisableClient,
 };
+use nym_validator_client::UserAgent;
 use serde::Serialize;
 use std::fmt::Display;
 use std::fs;
@@ -114,8 +115,16 @@ impl Display for InitResults {
 pub(crate) async fn execute(args: Init) -> Result<(), ClientError> {
     eprintln!("Initialising client...");
 
+    let bin_info = nym_bin_common::bin_info_owned!();
+    let user_agent = UserAgent::new(
+        bin_info.binary_name,
+        bin_info.cargo_triple,
+        bin_info.build_version,
+        bin_info.commit_sha,
+    );
+
     let output = args.output;
-    let res = initialise_client::<CliNativeClient>(args).await?;
+    let res = initialise_client::<CliNativeClient>(args, Some(user_agent)).await?;
 
     let init_results = InitResults::new(res);
     println!("{}", output.format(&init_results));

--- a/clients/native/src/commands/init.rs
+++ b/clients/native/src/commands/init.rs
@@ -15,7 +15,6 @@ use nym_bin_common::output_format::OutputFormat;
 use nym_client_core::cli_helpers::client_init::{
     initialise_client, CommonClientInitArgs, InitResultsWithConfig, InitialisableClient,
 };
-use nym_validator_client::UserAgent;
 use serde::Serialize;
 use std::fmt::Display;
 use std::fs;
@@ -115,14 +114,7 @@ impl Display for InitResults {
 pub(crate) async fn execute(args: Init) -> Result<(), ClientError> {
     eprintln!("Initialising client...");
 
-    let bin_info = nym_bin_common::bin_info_owned!();
-    let user_agent = UserAgent::new(
-        bin_info.binary_name,
-        bin_info.cargo_triple,
-        bin_info.build_version,
-        bin_info.commit_sha,
-    );
-
+    let user_agent = nym_bin_common::bin_info!().into();
     let output = args.output;
     let res = initialise_client::<CliNativeClient>(args, Some(user_agent)).await?;
 

--- a/clients/socks5/Cargo.toml
+++ b/clients/socks5/Cargo.toml
@@ -25,17 +25,18 @@ zeroize = { workspace = true }
 nym-bin-common = { path = "../../common/bin-common", features = ["output_format"] }
 nym-client-core = { path = "../../common/client-core", features = ["fs-surb-storage", "fs-gateways-storage", "cli"] }
 nym-config = { path = "../../common/config" }
+nym-credential-storage = { path = "../../common/credential-storage" }
 nym-credentials = { path = "../../common/credentials" }
 nym-crypto = { path = "../../common/crypto" }
 nym-gateway-requests = { path = "../../gateway/gateway-requests" }
-nym-credential-storage = { path = "../../common/credential-storage" }
+nym-id = { path = "../../common/nym-id" }
 nym-network-defaults = { path = "../../common/network-defaults" }
-nym-sphinx = { path = "../../common/nymsphinx" }
 nym-ordered-buffer = { path = "../../common/socks5/ordered-buffer" }
 nym-pemstore = { path = "../../common/pemstore" }
-nym-topology = { path = "../../common/topology" }
 nym-socks5-client-core = { path = "../../common/socks5-client-core" }
-nym-id = { path = "../../common/nym-id" }
+nym-sphinx = { path = "../../common/nymsphinx" }
+nym-topology = { path = "../../common/topology" }
+nym-validator-client = { path = "../../common/client-libs/validator-client", features = ["http-client"] }
 
 [features]
 default = []

--- a/clients/socks5/src/commands/add_gateway.rs
+++ b/clients/socks5/src/commands/add_gateway.rs
@@ -5,7 +5,6 @@ use crate::commands::CliSocks5Client;
 use crate::error::Socks5ClientError;
 use nym_bin_common::output_format::OutputFormat;
 use nym_client_core::cli_helpers::client_add_gateway::{add_gateway, CommonClientAddGatewayArgs};
-use nym_validator_client::UserAgent;
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
@@ -23,13 +22,7 @@ impl AsRef<CommonClientAddGatewayArgs> for Args {
 }
 
 pub(crate) async fn execute(args: Args) -> Result<(), Socks5ClientError> {
-    let bin_info = nym_bin_common::bin_info_owned!();
-    let user_agent = UserAgent::new(
-        bin_info.binary_name,
-        bin_info.cargo_triple,
-        bin_info.build_version,
-        bin_info.commit_sha,
-    );
+    let user_agent = nym_bin_common::bin_info!().into();
     let output = args.output;
     let res = add_gateway::<CliSocks5Client, _>(args, Some(user_agent)).await?;
 

--- a/clients/socks5/src/commands/add_gateway.rs
+++ b/clients/socks5/src/commands/add_gateway.rs
@@ -5,6 +5,7 @@ use crate::commands::CliSocks5Client;
 use crate::error::Socks5ClientError;
 use nym_bin_common::output_format::OutputFormat;
 use nym_client_core::cli_helpers::client_add_gateway::{add_gateway, CommonClientAddGatewayArgs};
+use nym_validator_client::UserAgent;
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
@@ -22,8 +23,15 @@ impl AsRef<CommonClientAddGatewayArgs> for Args {
 }
 
 pub(crate) async fn execute(args: Args) -> Result<(), Socks5ClientError> {
+    let bin_info = nym_bin_common::bin_info_owned!();
+    let user_agent = UserAgent::new(
+        bin_info.binary_name,
+        bin_info.cargo_triple,
+        bin_info.build_version,
+        bin_info.commit_sha,
+    );
     let output = args.output;
-    let res = add_gateway::<CliSocks5Client, _>(args).await?;
+    let res = add_gateway::<CliSocks5Client, _>(args, Some(user_agent)).await?;
 
     println!("{}", output.format(&res));
     Ok(())

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -15,7 +15,6 @@ use nym_client_core::cli_helpers::client_init::{
     initialise_client, CommonClientInitArgs, InitResultsWithConfig, InitialisableClient,
 };
 use nym_sphinx::addressing::clients::Recipient;
-use nym_validator_client::UserAgent;
 use serde::Serialize;
 use std::fmt::Display;
 use std::fs;
@@ -130,14 +129,7 @@ impl Display for InitResults {
 pub(crate) async fn execute(args: Init) -> Result<(), Socks5ClientError> {
     eprintln!("Initialising client...");
 
-    let bin_info = nym_bin_common::bin_info_owned!();
-    let user_agent = UserAgent::new(
-        bin_info.binary_name,
-        bin_info.cargo_triple,
-        bin_info.build_version,
-        bin_info.commit_sha,
-    );
-
+    let user_agent = nym_bin_common::bin_info!().into();
     let output = args.output;
     let res = initialise_client::<CliSocks5Client>(args, Some(user_agent)).await?;
 

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -15,6 +15,7 @@ use nym_client_core::cli_helpers::client_init::{
     initialise_client, CommonClientInitArgs, InitResultsWithConfig, InitialisableClient,
 };
 use nym_sphinx::addressing::clients::Recipient;
+use nym_validator_client::UserAgent;
 use serde::Serialize;
 use std::fmt::Display;
 use std::fs;
@@ -129,8 +130,16 @@ impl Display for InitResults {
 pub(crate) async fn execute(args: Init) -> Result<(), Socks5ClientError> {
     eprintln!("Initialising client...");
 
+    let bin_info = nym_bin_common::bin_info_owned!();
+    let user_agent = UserAgent::new(
+        bin_info.binary_name,
+        bin_info.cargo_triple,
+        bin_info.build_version,
+        bin_info.commit_sha,
+    );
+
     let output = args.output;
-    let res = initialise_client::<CliSocks5Client>(args).await?;
+    let res = initialise_client::<CliSocks5Client>(args, Some(user_agent)).await?;
 
     let init_results = InitResults::new(res);
     println!("{}", output.format(&init_results));

--- a/clients/socks5/src/commands/run.rs
+++ b/clients/socks5/src/commands/run.rs
@@ -116,7 +116,13 @@ pub(crate) async fn execute(args: Run) -> Result<(), Box<dyn std::error::Error +
     let storage =
         OnDiskPersistent::from_paths(config.storage_paths.common_paths, &config.core.base.debug)
             .await?;
-    NymClient::new(config.core, storage, args.common_args.custom_mixnet)
-        .run_forever()
-        .await
+    let user_agent = nym_bin_common::bin_info!().into();
+    NymClient::new(
+        config.core,
+        storage,
+        user_agent,
+        args.common_args.custom_mixnet,
+    )
+    .run_forever()
+    .await
 }

--- a/common/bin-common/Cargo.toml
+++ b/common/bin-common/Cargo.toml
@@ -9,9 +9,9 @@ repository = { workspace = true }
 
 [dependencies]
 const-str = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
-clap_complete = { workspace = true }
-clap_complete_fig = { workspace = true }
+clap = { workspace = true, features = ["derive"], optional = true }
+clap_complete = { workspace = true, optional = true }
+clap_complete_fig = { workspace = true, optional = true }
 log = { workspace = true }
 pretty_env_logger = { workspace = true }
 semver = "0.11"
@@ -44,3 +44,4 @@ tracing = [
     "tracing-opentelemetry",
     "opentelemetry",
 ]
+clap = [ "dep:clap", "dep:clap_complete", "dep:clap_complete_fig" ]

--- a/common/bin-common/Cargo.toml
+++ b/common/bin-common/Cargo.toml
@@ -34,7 +34,7 @@ vergen = { workspace = true, features = ["build", "git", "gitcl", "rustc", "carg
 [features]
 default = []
 openapi = ["utoipa"]
-output_format = ["serde_json"]
+output_format = ["serde_json", "dep:clap"]
 bin_info_schema = ["schemars"]
 basic_tracing = ["tracing-subscriber"]
 tracing = [

--- a/common/bin-common/src/build_information/mod.rs
+++ b/common/bin-common/src/build_information/mod.rs
@@ -5,7 +5,6 @@
 // and be used by our smart contracts
 
 use serde::{Deserialize, Serialize};
-use serde_json::de::StrRead;
 use std::fmt::{Display, Formatter};
 
 #[derive(Debug)]

--- a/common/bin-common/src/build_information/mod.rs
+++ b/common/bin-common/src/build_information/mod.rs
@@ -44,6 +44,10 @@ pub struct BinaryBuildInformation {
     /// Provides the cargo debug mode that was used for the build.
     // NOTE: keep the old name cargo_profile instead of cargo_debug for backwards compatibility
     pub cargo_profile: &'static str,
+
+    // VERGEN_CARGO_TARGET_TRIPLE
+    /// Provides the cargo target triple that was used for the build.
+    pub cargo_triple: &'static str,
 }
 
 impl BinaryBuildInformation {
@@ -66,6 +70,7 @@ impl BinaryBuildInformation {
             rustc_version: env!("VERGEN_RUSTC_SEMVER"),
             rustc_channel: env!("VERGEN_RUSTC_CHANNEL"),
             cargo_profile,
+            cargo_triple: env!("VERGEN_CARGO_TARGET_TRIPLE"),
         }
     }
 
@@ -95,6 +100,7 @@ impl BinaryBuildInformation {
             rustc_version: env!("VERGEN_RUSTC_SEMVER"),
             rustc_channel: env!("VERGEN_RUSTC_CHANNEL"),
             cargo_profile,
+            cargo_triple: env!("VERGEN_CARGO_TARGET_TRIPLE"),
         }
     }
 
@@ -109,6 +115,7 @@ impl BinaryBuildInformation {
             rustc_version: self.rustc_version.to_owned(),
             rustc_channel: self.rustc_channel.to_owned(),
             cargo_profile: self.cargo_profile.to_owned(),
+            cargo_triple: self.cargo_triple.to_owned(),
         }
     }
 
@@ -156,6 +163,10 @@ pub struct BinaryBuildInformationOwned {
     /// Provides the cargo debug mode that was used for the build.
     // NOTE: keep the old name cargo_profile instead of cargo_debug for backwards compatibility
     pub cargo_profile: String,
+
+    // VERGEN_CARGO_TARGET_TRIPLE
+    /// Provides the cargo target triple that was used for the build.
+    pub cargo_triple: String,
 }
 
 impl Display for BinaryBuildInformationOwned {

--- a/common/bin-common/src/build_information/mod.rs
+++ b/common/bin-common/src/build_information/mod.rs
@@ -5,6 +5,7 @@
 // and be used by our smart contracts
 
 use serde::{Deserialize, Serialize};
+use serde_json::de::StrRead;
 use std::fmt::{Display, Formatter};
 
 #[derive(Debug)]
@@ -166,7 +167,12 @@ pub struct BinaryBuildInformationOwned {
 
     // VERGEN_CARGO_TARGET_TRIPLE
     /// Provides the cargo target triple that was used for the build.
+    #[serde(default = "unknown")]
     pub cargo_triple: String,
+}
+
+fn unknown() -> String {
+    "unknown".to_string()
 }
 
 impl Display for BinaryBuildInformationOwned {

--- a/common/bin-common/src/lib.rs
+++ b/common/bin-common/src/lib.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod build_information;
-pub mod completions;
 pub mod logging;
 pub mod version_checker;
+
+#[cfg(feature = "clap")]
+pub mod completions;
 
 #[cfg(feature = "output_format")]
 pub mod output_format;

--- a/common/client-core/src/cli_helpers/client_add_gateway.rs
+++ b/common/client-core/src/cli_helpers/client_add_gateway.rs
@@ -16,6 +16,7 @@ use log::info;
 use nym_client_core_gateways_storage::GatewayDetails;
 use nym_crypto::asymmetric::identity;
 use nym_topology::NymTopology;
+use nym_validator_client::UserAgent;
 use std::path::PathBuf;
 
 #[cfg_attr(feature = "cli", derive(clap::Args))]
@@ -60,7 +61,10 @@ pub struct CommonClientAddGatewayArgs {
     pub custom_mixnet: Option<PathBuf>,
 }
 
-pub async fn add_gateway<C, A>(args: A) -> Result<GatewayInfo, C::Error>
+pub async fn add_gateway<C, A>(
+    args: A,
+    user_agent: Option<UserAgent>,
+) -> Result<GatewayInfo, C::Error>
 where
     A: AsRef<CommonClientAddGatewayArgs>,
     C: CliClient,
@@ -111,7 +115,8 @@ where
         hardcoded_topology.get_gateways()
     } else {
         let mut rng = rand::thread_rng();
-        crate::init::helpers::current_gateways(&mut rng, &core.client.nym_api_urls).await?
+        crate::init::helpers::current_gateways(&mut rng, &core.client.nym_api_urls, user_agent)
+            .await?
     };
 
     // since we're registering with a brand new gateway,

--- a/common/client-core/src/cli_helpers/client_init.rs
+++ b/common/client-core/src/cli_helpers/client_init.rs
@@ -16,6 +16,7 @@ use log::info;
 use nym_client_core_gateways_storage::GatewayDetails;
 use nym_crypto::asymmetric::identity;
 use nym_topology::NymTopology;
+use nym_validator_client::UserAgent;
 use rand::rngs::OsRng;
 use std::path::PathBuf;
 
@@ -96,6 +97,7 @@ pub struct InitResultsWithConfig<T> {
 
 pub async fn initialise_client<C>(
     init_args: C::InitArgs,
+    user_agent: Option<UserAgent>,
 ) -> Result<InitResultsWithConfig<C::Config>, C::Error>
 where
     C: InitialisableClient,
@@ -163,7 +165,8 @@ where
         hardcoded_topology.get_gateways()
     } else {
         let mut rng = rand::thread_rng();
-        crate::init::helpers::current_gateways(&mut rng, &core.client.nym_api_urls).await?
+        crate::init::helpers::current_gateways(&mut rng, &core.client.nym_api_urls, user_agent)
+            .await?
     };
 
     let gateway_setup = GatewaySetup::New {

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -54,6 +54,7 @@ use nym_task::{TaskClient, TaskHandle};
 use nym_topology::provider_trait::TopologyProvider;
 use nym_topology::HardcodedTopologyProvider;
 use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
+use nym_validator_client::UserAgent;
 use rand::rngs::OsRng;
 use std::fmt::Debug;
 use std::os::raw::c_int as RawFd;
@@ -185,6 +186,8 @@ pub struct BaseClientBuilder<'a, C, S: MixnetClientStorage> {
     custom_gateway_transceiver: Option<Box<dyn GatewayTransceiver + Send>>,
     shutdown: Option<TaskClient>,
 
+    user_agent: Option<UserAgent>,
+
     setup_method: GatewaySetup,
 }
 
@@ -207,6 +210,7 @@ where
             custom_topology_provider: None,
             custom_gateway_transceiver: None,
             shutdown: None,
+            user_agent: None,
             setup_method: GatewaySetup::MustLoad { gateway_id: None },
         }
     }
@@ -247,6 +251,12 @@ where
     #[must_use]
     pub fn with_shutdown(mut self, shutdown: TaskClient) -> Self {
         self.shutdown = Some(shutdown);
+        self
+    }
+
+    #[must_use]
+    pub fn with_user_agent(mut self, user_agent: Option<UserAgent>) -> Self {
+        self.user_agent = user_agent;
         self
     }
 
@@ -467,6 +477,7 @@ where
         custom_provider: Option<Box<dyn TopologyProvider + Send + Sync>>,
         config_topology: config::Topology,
         nym_api_urls: Vec<Url>,
+        user_agent: UserAgent,
     ) -> Box<dyn TopologyProvider + Send + Sync> {
         // if no custom provider was ... provided ..., create one using nym-api
         custom_provider.unwrap_or_else(|| match config_topology.topology_structure {
@@ -477,6 +488,7 @@ where
                 },
                 nym_api_urls,
                 env!("CARGO_PKG_VERSION").to_string(),
+                user_agent,
             )),
             config::TopologyStructure::GeoAware(group_by) => {
                 Box::new(GeoAwareTopologyProvider::new(
@@ -689,6 +701,14 @@ where
             self.custom_topology_provider.take(),
             self.config.debug.topology,
             self.config.get_nym_api_endpoints(),
+            self.user_agent.clone().unwrap_or_else(|| {
+                UserAgent::new(
+                    "nym-client".to_string(),
+                    "unknown".to_string(),
+                    env!("CARGO_PKG_VERSION").to_string(),
+                    "unknown".to_string(),
+                )
+            }),
         );
 
         // needs to be started as the first thing to block if required waiting for the gateway

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -53,8 +53,7 @@ use nym_task::connections::{ConnectionCommandReceiver, ConnectionCommandSender, 
 use nym_task::{TaskClient, TaskHandle};
 use nym_topology::provider_trait::TopologyProvider;
 use nym_topology::HardcodedTopologyProvider;
-use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
-use nym_validator_client::UserAgent;
+use nym_validator_client::{nyxd::contract_traits::DkgQueryClient, UserAgent};
 use rand::rngs::OsRng;
 use std::fmt::Debug;
 use std::os::raw::c_int as RawFd;
@@ -185,7 +184,6 @@ pub struct BaseClientBuilder<'a, C, S: MixnetClientStorage> {
     custom_topology_provider: Option<Box<dyn TopologyProvider + Send + Sync>>,
     custom_gateway_transceiver: Option<Box<dyn GatewayTransceiver + Send>>,
     shutdown: Option<TaskClient>,
-
     user_agent: Option<UserAgent>,
 
     setup_method: GatewaySetup,
@@ -477,7 +475,7 @@ where
         custom_provider: Option<Box<dyn TopologyProvider + Send + Sync>>,
         config_topology: config::Topology,
         nym_api_urls: Vec<Url>,
-        user_agent: UserAgent,
+        user_agent: Option<UserAgent>,
     ) -> Box<dyn TopologyProvider + Send + Sync> {
         // if no custom provider was ... provided ..., create one using nym-api
         custom_provider.unwrap_or_else(|| match config_topology.topology_structure {
@@ -701,14 +699,7 @@ where
             self.custom_topology_provider.take(),
             self.config.debug.topology,
             self.config.get_nym_api_endpoints(),
-            self.user_agent.clone().unwrap_or_else(|| {
-                UserAgent::new(
-                    "nym-client".to_string(),
-                    "unknown".to_string(),
-                    env!("CARGO_PKG_VERSION").to_string(),
-                    "unknown".to_string(),
-                )
-            }),
+            self.user_agent.clone(),
         );
 
         // needs to be started as the first thing to block if required waiting for the gateway

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -253,8 +253,8 @@ where
     }
 
     #[must_use]
-    pub fn with_user_agent(mut self, user_agent: Option<UserAgent>) -> Self {
-        self.user_agent = user_agent;
+    pub fn with_user_agent(mut self, user_agent: UserAgent) -> Self {
+        self.user_agent = Some(user_agent);
         self
     }
 

--- a/common/client-core/src/client/topology_control/nym_api_provider.rs
+++ b/common/client-core/src/client/topology_control/nym_api_provider.rs
@@ -44,16 +44,22 @@ impl NymApiTopologyProvider {
         config: Config,
         mut nym_api_urls: Vec<Url>,
         client_version: String,
-        user_agent: UserAgent,
+        user_agent: Option<UserAgent>,
     ) -> Self {
         nym_api_urls.shuffle(&mut thread_rng());
 
-        NymApiTopologyProvider {
-            config,
-            validator_client: nym_validator_client::client::NymApiClient::new_with_user_agent(
+        let validator_client = if let Some(user_agent) = user_agent {
+            nym_validator_client::client::NymApiClient::new_with_user_agent(
                 nym_api_urls[0].clone(),
                 user_agent,
-            ),
+            )
+        } else {
+            nym_validator_client::client::NymApiClient::new(nym_api_urls[0].clone())
+        };
+
+        NymApiTopologyProvider {
+            config,
+            validator_client,
             nym_api_urls,
             client_version,
             currently_used_api: 0,

--- a/common/client-core/src/client/topology_control/nym_api_provider.rs
+++ b/common/client-core/src/client/topology_control/nym_api_provider.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use log::{debug, error, warn};
 use nym_topology::provider_trait::TopologyProvider;
 use nym_topology::{NymTopology, NymTopologyError};
+use nym_validator_client::UserAgent;
 use rand::prelude::SliceRandom;
 use rand::thread_rng;
 use url::Url;
@@ -39,13 +40,19 @@ pub(crate) struct NymApiTopologyProvider {
 }
 
 impl NymApiTopologyProvider {
-    pub(crate) fn new(config: Config, mut nym_api_urls: Vec<Url>, client_version: String) -> Self {
+    pub(crate) fn new(
+        config: Config,
+        mut nym_api_urls: Vec<Url>,
+        client_version: String,
+        user_agent: UserAgent,
+    ) -> Self {
         nym_api_urls.shuffle(&mut thread_rng());
 
         NymApiTopologyProvider {
             config,
-            validator_client: nym_validator_client::client::NymApiClient::new(
+            validator_client: nym_validator_client::client::NymApiClient::new_with_user_agent(
                 nym_api_urls[0].clone(),
+                user_agent,
             ),
             nym_api_urls,
             client_version,

--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -71,10 +71,10 @@ pub async fn current_gateways<R: Rng>(
         nym_validator_client::client::NymApiClient::new(nym_api.clone())
     };
 
-    log::debug!("Fetching list of gateways from: {nym_api}");
+    log::info!("Fetching list of gateways from: {nym_api}");
 
     let gateways = client.get_cached_described_gateways().await?;
-    log::debug!("Found {} gateways", gateways.len());
+    log::info!("Found {} gateways", gateways.len());
     log::trace!("Gateways: {:#?}", gateways);
 
     let valid_gateways = gateways

--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -71,10 +71,10 @@ pub async fn current_gateways<R: Rng>(
         nym_validator_client::client::NymApiClient::new(nym_api.clone())
     };
 
-    log::info!("Fetching list of gateways from: {nym_api}");
+    log::debug!("Fetching list of gateways from: {nym_api}");
 
     let gateways = client.get_cached_described_gateways().await?;
-    log::info!("Found {} gateways", gateways.len());
+    log::debug!("Found {} gateways", gateways.len());
     log::trace!("Gateways: {:#?}", gateways);
 
     let valid_gateways = gateways

--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -9,6 +9,7 @@ use nym_crypto::asymmetric::identity;
 use nym_gateway_client::GatewayClient;
 use nym_topology::{filter::VersionFilterable, gateway, mix};
 use nym_validator_client::client::IdentityKeyRef;
+use nym_validator_client::UserAgent;
 use rand::{seq::SliceRandom, Rng};
 use std::{sync::Arc, time::Duration};
 use tungstenite::Message;
@@ -59,11 +60,16 @@ impl<'a> GatewayWithLatency<'a> {
 pub async fn current_gateways<R: Rng>(
     rng: &mut R,
     nym_apis: &[Url],
+    user_agent: Option<UserAgent>,
 ) -> Result<Vec<gateway::Node>, ClientCoreError> {
     let nym_api = nym_apis
         .choose(rng)
         .ok_or(ClientCoreError::ListOfNymApisIsEmpty)?;
-    let client = nym_validator_client::client::NymApiClient::new(nym_api.clone());
+    let client = if let Some(user_agent) = user_agent {
+        nym_validator_client::client::NymApiClient::new_with_user_agent(nym_api.clone(), user_agent)
+    } else {
+        nym_validator_client::client::NymApiClient::new(nym_api.clone())
+    };
 
     log::debug!("Fetching list of gateways from: {nym_api}");
 

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -19,6 +19,7 @@ use nym_api_requests::models::{
     RewardEstimationResponse, StakeSaturationResponse,
 };
 use nym_api_requests::nym_nodes::SkimmedNode;
+use nym_http_api_client::UserAgent;
 use nym_network_defaults::NymNetworkDetails;
 use url::Url;
 
@@ -254,6 +255,16 @@ pub struct NymApiClient {
 impl NymApiClient {
     pub fn new(api_url: Url) -> Self {
         let nym_api = nym_api::Client::new(api_url, None);
+
+        NymApiClient { nym_api }
+    }
+
+    pub fn new_with_user_agent(api_url: Url, user_agent: UserAgent) -> Self {
+        let nym_api = nym_api::Client::builder::<_, ValidatorClientError>(api_url)
+            .expect("invalid api url")
+            .with_user_agent(user_agent)
+            .build::<ValidatorClientError>()
+            .expect("failed to build nym api client");
 
         NymApiClient { nym_api }
     }

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -260,6 +260,7 @@ impl NymApiClient {
     }
 
     pub fn new_with_user_agent(api_url: Url, user_agent: UserAgent) -> Self {
+        dbg!(&user_agent);
         let nym_api = nym_api::Client::builder::<_, ValidatorClientError>(api_url)
             .expect("invalid api url")
             .with_user_agent(user_agent)

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -260,7 +260,6 @@ impl NymApiClient {
     }
 
     pub fn new_with_user_agent(api_url: Url, user_agent: UserAgent) -> Self {
-        dbg!(&user_agent);
         let nym_api = nym_api::Client::builder::<_, ValidatorClientError>(api_url)
             .expect("invalid api url")
             .with_user_agent(user_agent)

--- a/common/client-libs/validator-client/src/lib.rs
+++ b/common/client-libs/validator-client/src/lib.rs
@@ -17,6 +17,7 @@ pub use crate::signing::direct_wallet::DirectSecp256k1HdWallet;
 pub use client::NymApiClient;
 pub use client::{Client, CoconutApiClient, Config};
 pub use nym_api_requests::*;
+pub use nym_http_api_client::UserAgent;
 
 #[cfg(feature = "http-client")]
 pub use cosmrs::rpc::HttpClient as HttpRpcClient;

--- a/common/http-api-client/Cargo.toml
+++ b/common/http-api-client/Cargo.toml
@@ -20,6 +20,8 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
+nym-bin-common = { path = "../bin-common" }
+
 # for request timeout until https://github.com/seanmonstar/reqwest/issues/1135 is fixed
 [target."cfg(target_arch = \"wasm32\")".dependencies.wasmtimer]
 workspace = true

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -519,7 +519,6 @@ where
     E: DeserializeOwned + Display,
 {
     let status = res.status();
-    dbg!(&status);
 
     if !allow_empty {
         if let Some(0) = res.content_length() {

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -287,9 +287,6 @@ impl Client {
         E: Display + DeserializeOwned,
     {
         let res = self.send_get_request(path, params).await?;
-        // dbg!(&res);
-        // dbg!(&res.text().await);
-        // todo!();
         parse_response(res, false).await
     }
 

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -14,6 +14,10 @@ use url::Url;
 
 pub use reqwest::IntoUrl;
 
+pub use user_agent::UserAgent;
+
+mod user_agent;
+
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub type PathSegments<'a> = &'a [&'a str];

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -287,6 +287,9 @@ impl Client {
         E: Display + DeserializeOwned,
     {
         let res = self.send_get_request(path, params).await?;
+        // dbg!(&res);
+        // dbg!(&res.text().await);
+        // todo!();
         parse_response(res, false).await
     }
 
@@ -516,6 +519,7 @@ where
     E: DeserializeOwned + Display,
 {
     let status = res.status();
+    dbg!(&status);
 
     if !allow_empty {
         if let Some(0) = res.content_length() {

--- a/common/http-api-client/src/user_agent.rs
+++ b/common/http-api-client/src/user_agent.rs
@@ -1,0 +1,41 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+
+use http::HeaderValue;
+
+#[derive(Clone, Debug)]
+pub struct UserAgent {
+    application: String,
+    platform: String,
+    version: String,
+    git_commit: String,
+}
+
+impl UserAgent {
+    pub fn new(application: String, platform: String, version: String, git_commit: String) -> Self {
+        UserAgent {
+            application,
+            platform,
+            version,
+            git_commit,
+        }
+    }
+}
+
+impl fmt::Display for UserAgent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}/{}/{}/{}",
+            self.application, self.platform, self.version, self.git_commit
+        )
+    }
+}
+
+impl Into<HeaderValue> for UserAgent {
+    fn into(self) -> HeaderValue {
+        HeaderValue::from_str(&self.to_string()).unwrap()
+    }
+}

--- a/common/http-api-client/src/user_agent.rs
+++ b/common/http-api-client/src/user_agent.rs
@@ -27,10 +27,11 @@ impl UserAgent {
 
 impl fmt::Display for UserAgent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let abbreviated_commit = self.git_commit.chars().take(7).collect::<String>();
         write!(
             f,
             "{}/{}/{}/{}",
-            self.application, self.platform, self.version, self.git_commit
+            self.application, self.platform, self.version, abbreviated_commit
         )
     }
 }

--- a/common/http-api-client/src/user_agent.rs
+++ b/common/http-api-client/src/user_agent.rs
@@ -34,8 +34,10 @@ impl fmt::Display for UserAgent {
     }
 }
 
-impl Into<HeaderValue> for UserAgent {
-    fn into(self) -> HeaderValue {
-        HeaderValue::from_str(&self.to_string()).unwrap()
+impl TryFrom<UserAgent> for HeaderValue {
+    type Error = http::header::InvalidHeaderValue;
+
+    fn try_from(user_agent: UserAgent) -> Result<Self, Self::Error> {
+        HeaderValue::from_str(&user_agent.to_string())
     }
 }

--- a/common/http-api-client/src/user_agent.rs
+++ b/common/http-api-client/src/user_agent.rs
@@ -31,7 +31,7 @@ impl fmt::Display for UserAgent {
         write!(
             f,
             "{}/{}/{}/{}",
-            self.application, self.platform, self.version, abbreviated_commit
+            self.application, self.version, self.platform, abbreviated_commit
         )
     }
 }

--- a/common/http-api-client/src/user_agent.rs
+++ b/common/http-api-client/src/user_agent.rs
@@ -4,6 +4,7 @@
 use std::fmt;
 
 use http::HeaderValue;
+use nym_bin_common::build_information::{BinaryBuildInformation, BinaryBuildInformationOwned};
 
 #[derive(Clone, Debug)]
 pub struct UserAgent {
@@ -39,5 +40,27 @@ impl TryFrom<UserAgent> for HeaderValue {
 
     fn try_from(user_agent: UserAgent) -> Result<Self, Self::Error> {
         HeaderValue::from_str(&user_agent.to_string())
+    }
+}
+
+impl From<BinaryBuildInformation> for UserAgent {
+    fn from(build_info: BinaryBuildInformation) -> Self {
+        UserAgent {
+            application: build_info.binary_name.to_string(),
+            platform: build_info.cargo_triple.to_string(),
+            version: build_info.build_version.to_string(),
+            git_commit: build_info.commit_sha.to_string(),
+        }
+    }
+}
+
+impl From<BinaryBuildInformationOwned> for UserAgent {
+    fn from(build_info: BinaryBuildInformationOwned) -> Self {
+        UserAgent {
+            application: build_info.binary_name,
+            platform: build_info.cargo_triple,
+            version: build_info.build_version,
+            git_commit: build_info.commit_sha,
+        }
     }
 }

--- a/common/wasm/client-core/src/helpers.rs
+++ b/common/wasm/client-core/src/helpers.rs
@@ -122,7 +122,7 @@ pub async fn setup_gateway_from_api(
     nym_apis: &[Url],
 ) -> Result<InitialisationResult, WasmCoreError> {
     let mut rng = thread_rng();
-    let gateways = current_gateways(&mut rng, nym_apis).await?;
+    let gateways = current_gateways(&mut rng, nym_apis, None).await?;
     setup_gateway_wasm(client_store, force_tls, chosen_gateway, &gateways).await
 }
 

--- a/mixnode/Cargo.toml
+++ b/mixnode/Cargo.toml
@@ -56,7 +56,7 @@ nym-task = { path = "../common/task" }
 nym-types = { path = "../common/types" }
 nym-topology = { path = "../common/topology" }
 nym-validator-client = { path = "../common/client-libs/validator-client" }
-nym-bin-common = { path = "../common/bin-common", features = ["output_format"] }
+nym-bin-common = { path = "../common/bin-common", features = ["output_format", "clap"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = [

--- a/sdk/lib/socks5-listener/src/lib.rs
+++ b/sdk/lib/socks5-listener/src/lib.rs
@@ -269,8 +269,9 @@ where
     let nym_apis = config.core.base.client.nym_api_urls.clone();
 
     let storage = MobileClientStorage::new(&config);
-    let socks5_client =
-        Socks5NymClient::new(config.core, storage, None).with_gateway_setup(GatewaySetup::New {
+    let user_agent = nym_bin_common::bin_info!().into();
+    let socks5_client = Socks5NymClient::new(config.core, storage, user_agent, None)
+        .with_gateway_setup(GatewaySetup::New {
             specification: GatewaySelectionSpecification::UniformRemote {
                 must_use_tls: false,
             },

--- a/sdk/lib/socks5-listener/src/lib.rs
+++ b/sdk/lib/socks5-listener/src/lib.rs
@@ -274,7 +274,7 @@ where
             specification: GatewaySelectionSpecification::UniformRemote {
                 must_use_tls: false,
             },
-            available_gateways: current_gateways(&mut rng, &nym_apis).await?,
+            available_gateways: current_gateways(&mut rng, &nym_apis, None).await?,
             wg_tun_address: None,
         });
 

--- a/sdk/rust/nym-sdk/src/lib.rs
+++ b/sdk/rust/nym-sdk/src/lib.rs
@@ -13,6 +13,7 @@ pub use nym_network_defaults::{
     ChainDetails, DenomDetails, DenomDetailsOwned, NymContracts, NymNetworkDetails,
     ValidatorDetails,
 };
+pub use nym_validator_client::UserAgent;
 // we have to re-expose TaskClient since we're allowing custom shutdown in public API
 // (which is quite a shame if you ask me...)
 pub use nym_task::TaskClient;

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -55,7 +55,6 @@ pub struct MixnetClientBuilder<S: MixnetClientStorage = Ephemeral> {
     custom_gateway_transceiver: Option<Box<dyn GatewayTransceiver + Send + Sync>>,
     custom_shutdown: Option<TaskClient>,
     force_tls: bool,
-
     user_agent: Option<UserAgent>,
 
     // TODO: incorporate it properly into `MixnetClientStorage` (I will need it in wasm anyway)
@@ -473,8 +472,10 @@ where
             self.force_tls,
         );
 
+        let user_agent = self.user_agent.clone();
+
         let mut rng = OsRng;
-        let available_gateways = current_gateways(&mut rng, &nym_api_endpoints).await?;
+        let available_gateways = current_gateways(&mut rng, &nym_api_endpoints, user_agent).await?;
 
         Ok(GatewaySetup::New {
             specification: selection_spec,

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -580,54 +580,11 @@ where
         let mut base_builder: BaseClientBuilder<_, _> =
             BaseClientBuilder::new(&base_config, self.storage, self.dkg_query_client)
                 .with_wait_for_gateway(self.wait_for_gateway)
-                .with_wireguard_connection(self.wireguard_mode)
-                .with_user_agent(self.user_agent.clone());
+                .with_wireguard_connection(self.wireguard_mode);
 
-        // let mut base_builder: BaseClientBuilder<_, _> = if !known_gateway {
-        //     // we need to setup a new gateway
-        //     let setup = self.new_gateway_setup().await;
-        //
-        //     BaseClientBuilder::new(&base_config, self.storage, self.dkg_query_client)
-        //         .with_wait_for_gateway(self.wait_for_gateway)
-        //         .with_gateway_setup(setup)
-        // // } else if self.wireguard_mode {
-        // //     // load current active gateway in wireguard mode
-        // //     details_store.set_wireguard_mode(true).await?;
-        // //
-        // //     if let Ok(PersistedGatewayDetails::Default(mut config)) = self
-        // //         .storage
-        // //         .gateway_details_store()
-        // //         .load_gateway_details()
-        // //         .await
-        // //     {
-        // //         config.details.gateway_listener = format!(
-        // //             "ws://{}:{}",
-        // //             WG_TUN_DEVICE_ADDRESS, DEFAULT_CLIENT_LISTENING_PORT
-        // //         );
-        // //         if let Err(e) = self
-        // //             .storage
-        // //             .gateway_details_store()
-        // //             .store_gateway_details(&PersistedGatewayDetails::Default(config))
-        // //             .await
-        // //         {
-        // //             warn!("Could not switch to using wireguard mode - {:?}", e);
-        // //         }
-        // //     } else {
-        // //         warn!("Storage type not supported with wireguard mode");
-        // //     }
-        // //     BaseClientBuilder::new(&base_config, self.storage, self.dkg_query_client)
-        // //         .with_wait_for_gateway(self.wait_for_gateway)
-        // } else {
-        //     // load current active gateway in non-wireguard mode
-        //
-        //     // make sure our current storage mode matches the desired wg mode
-        //     details_store
-        //         .set_wireguard_mode(self.wireguard_mode)
-        //         .await?;
-        //
-        //     BaseClientBuilder::new(&base_config, self.storage, self.dkg_query_client)
-        //         .with_wait_for_gateway(self.wait_for_gateway)
-        // };
+        if let Some(user_agent) = self.user_agent {
+            base_builder = base_builder.with_user_agent(user_agent);
+        }
 
         if let Some(topology_provider) = self.custom_topology_provider {
             base_builder = base_builder.with_topology_provider(topology_provider);

--- a/service-providers/ip-packet-router/Cargo.toml
+++ b/service-providers/ip-packet-router/Cargo.toml
@@ -17,7 +17,7 @@ clap.workspace = true
 etherparse = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
-nym-bin-common = { path = "../../common/bin-common" }
+nym-bin-common = { path = "../../common/bin-common", features = ["clap"] }
 nym-client-core = { path = "../../common/client-core" }
 nym-config = { path = "../../common/config" }
 nym-crypto = { path = "../../common/crypto" }

--- a/service-providers/ip-packet-router/src/cli/add_gateway.rs
+++ b/service-providers/ip-packet-router/src/cli/add_gateway.rs
@@ -23,7 +23,7 @@ impl AsRef<CommonClientAddGatewayArgs> for Args {
 
 pub(crate) async fn execute(args: Args) -> Result<(), IpPacketRouterError> {
     let output = args.output;
-    let res = add_gateway::<CliIpPacketRouterClient, _>(args).await?;
+    let res = add_gateway::<CliIpPacketRouterClient, _>(args, None).await?;
 
     println!("{}", output.format(&res));
     Ok(())

--- a/service-providers/ip-packet-router/src/cli/init.rs
+++ b/service-providers/ip-packet-router/src/cli/init.rs
@@ -88,7 +88,7 @@ pub(crate) async fn execute(args: Init) -> Result<(), IpPacketRouterError> {
     eprintln!("Initialising client...");
 
     let output = args.output;
-    let res = initialise_client::<CliIpPacketRouterClient>(args).await?;
+    let res = initialise_client::<CliIpPacketRouterClient>(args, None).await?;
 
     let init_results = InitResults::new(res);
     println!("{}", output.format(&init_results));

--- a/service-providers/ip-packet-router/src/mixnet_client.rs
+++ b/service-providers/ip-packet-router/src/mixnet_client.rs
@@ -19,14 +19,7 @@ pub(crate) async fn create_mixnet_client(
     let debug_config = config.debug;
 
     let storage_paths = nym_sdk::mixnet::StoragePaths::from(paths.clone());
-
-    let bin_info = nym_bin_common::bin_info_owned!();
-    let user_agent = UserAgent::new(
-        bin_info.binary_name,
-        bin_info.cargo_triple,
-        bin_info.build_version,
-        bin_info.commit_sha,
-    );
+    let user_agent = nym_bin_common::bin_info!().into();
 
     let mut client_builder =
         nym_sdk::mixnet::MixnetClientBuilder::new_with_default_storage(storage_paths)

--- a/service-providers/ip-packet-router/src/mixnet_client.rs
+++ b/service-providers/ip-packet-router/src/mixnet_client.rs
@@ -20,7 +20,6 @@ pub(crate) async fn create_mixnet_client(
 
     let storage_paths = nym_sdk::mixnet::StoragePaths::from(paths.clone());
 
-
     let bin_info = nym_bin_common::bin_info_owned!();
     let user_agent = UserAgent::new(
         bin_info.binary_name,

--- a/service-providers/ip-packet-router/src/mixnet_client.rs
+++ b/service-providers/ip-packet-router/src/mixnet_client.rs
@@ -1,5 +1,5 @@
 use nym_client_core::{config::disk_persistence::CommonClientPaths, TopologyProvider};
-use nym_sdk::{GatewayTransceiver, NymNetworkDetails};
+use nym_sdk::{GatewayTransceiver, NymNetworkDetails, UserAgent};
 use nym_task::TaskClient;
 
 use crate::{config::BaseClientConfig, error::IpPacketRouterError};
@@ -20,6 +20,15 @@ pub(crate) async fn create_mixnet_client(
 
     let storage_paths = nym_sdk::mixnet::StoragePaths::from(paths.clone());
 
+
+    let bin_info = nym_bin_common::bin_info_owned!();
+    let user_agent = UserAgent::new(
+        bin_info.binary_name,
+        bin_info.cargo_triple,
+        bin_info.build_version,
+        bin_info.commit_sha,
+    );
+
     let mut client_builder =
         nym_sdk::mixnet::MixnetClientBuilder::new_with_default_storage(storage_paths)
             .await
@@ -27,6 +36,7 @@ pub(crate) async fn create_mixnet_client(
             .network_details(NymNetworkDetails::new_from_env())
             .debug_config(debug_config)
             .custom_shutdown(shutdown)
+            .with_user_agent(user_agent)
             .with_wait_for_gateway(wait_for_gateway);
     if !config.get_disabled_credentials_mode() {
         client_builder = client_builder.enable_credentials_mode();

--- a/service-providers/ip-packet-router/src/mixnet_client.rs
+++ b/service-providers/ip-packet-router/src/mixnet_client.rs
@@ -1,5 +1,5 @@
 use nym_client_core::{config::disk_persistence::CommonClientPaths, TopologyProvider};
-use nym_sdk::{GatewayTransceiver, NymNetworkDetails, UserAgent};
+use nym_sdk::{GatewayTransceiver, NymNetworkDetails};
 use nym_task::TaskClient;
 
 use crate::{config::BaseClientConfig, error::IpPacketRouterError};

--- a/service-providers/network-requester/src/cli/add_gateway.rs
+++ b/service-providers/network-requester/src/cli/add_gateway.rs
@@ -23,7 +23,7 @@ impl AsRef<CommonClientAddGatewayArgs> for Args {
 
 pub(crate) async fn execute(args: Args) -> Result<(), NetworkRequesterError> {
     let output = args.output;
-    let res = add_gateway::<CliNetworkRequesterClient, _>(args).await?;
+    let res = add_gateway::<CliNetworkRequesterClient, _>(args, None).await?;
 
     println!("{}", output.format(&res));
     Ok(())

--- a/service-providers/network-requester/src/cli/init.rs
+++ b/service-providers/network-requester/src/cli/init.rs
@@ -103,7 +103,7 @@ pub(crate) async fn execute(args: Init) -> Result<(), NetworkRequesterError> {
     eprintln!("Initialising client...");
 
     let output = args.output;
-    let res = initialise_client::<CliNetworkRequesterClient>(args).await?;
+    let res = initialise_client::<CliNetworkRequesterClient>(args, None).await?;
 
     let init_results = InitResults::new(res);
     println!("{}", output.format(&init_results));


### PR DESCRIPTION
- Support setting `UserAgent` for the validator client
- Support setting `UserAgent` in the SDK `MixnetClient`
- Set `UserAgent` when getting the list of gateways and topology in
    - `nym-client`
    - `nym-socks5-client`
    - Standalone `ip-packet-router`

Example of the user agent sent:
`nym-client/1.1.36/x86_64-unknown-linux-gnu/e18bb70`