### PR TITLE
Add mixnodes to self describing api cache

### DIFF
--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -9,7 +9,7 @@ use nym_mixnet_contract_common::mixnode::MixNodeDetails;
 use nym_mixnet_contract_common::reward_params::{Performance, RewardingParams};
 use nym_mixnet_contract_common::rewarding::RewardEstimate;
 use nym_mixnet_contract_common::{
-    GatewayBond, IdentityKey, Interval, MixId, MixNode, Percent, RewardedSetNodeStatus,
+    GatewayBond, IdentityKey, Interval, MixId, MixNode, MixNodeBond, Percent, RewardedSetNodeStatus,
 };
 use nym_node_requests::api::v1::node::models::{AuxiliaryDetails, BinaryBuildInformationOwned};
 use schemars::gen::SchemaGenerator;
@@ -621,6 +621,21 @@ pub struct DescribedGateway {
 impl From<GatewayBond> for DescribedGateway {
     fn from(bond: GatewayBond) -> Self {
         DescribedGateway {
+            bond,
+            self_described: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DescribedMixNode {
+    pub bond: MixNodeBond,
+    pub self_described: Option<NymNodeDescription>,
+}
+
+impl From<MixNodeBond> for DescribedMixNode {
+    fn from(bond: MixNodeBond) -> Self {
+        DescribedMixNode {
             bond,
             self_described: None,
         }

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -607,6 +607,15 @@ pub struct NymNodeDescription {
 
     // for now we only care about their ws/wss situation, nothing more
     pub mixnet_websockets: WebSockets,
+
+    pub role: NymNodeRole,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum NymNodeRole {
+    Mixnode,
+    Gateway,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::nym_nodes::NodeRole;
 use crate::pagination::PaginatedResponse;
 use cosmwasm_std::{Addr, Coin, Decimal};
 use nym_mixnet_contract_common::families::FamilyHead;
@@ -608,14 +609,7 @@ pub struct NymNodeDescription {
     // for now we only care about their ws/wss situation, nothing more
     pub mixnet_websockets: WebSockets,
 
-    pub role: NymNodeRole,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum NymNodeRole {
-    Mixnode,
-    Gateway,
+    pub role: NodeRole,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]

--- a/nym-api/src/main.rs
+++ b/nym-api/src/main.rs
@@ -117,6 +117,7 @@ async fn start_nym_api_tasks(config: Config) -> anyhow::Result<ShutdownHandles> 
     node_describe_cache::new_refresher_with_initial_value(
         &config.topology_cacher,
         nym_contract_cache_state.clone(),
+        node_status_cache_state.clone(),
         described_nodes_state.to_owned(),
     )
     .named("node-self-described-data-refresher")

--- a/nym-api/src/main.rs
+++ b/nym-api/src/main.rs
@@ -116,7 +116,6 @@ async fn start_nym_api_tasks(config: Config) -> anyhow::Result<ShutdownHandles> 
     // let cache = refresher.get_shared_cache();
     node_describe_cache::new_refresher_with_initial_value(
         &config.topology_cacher,
-        nym_contract_cache_state.clone(),
         node_status_cache_state.clone(),
         described_nodes_state.to_owned(),
     )

--- a/nym-api/src/main.rs
+++ b/nym-api/src/main.rs
@@ -116,7 +116,7 @@ async fn start_nym_api_tasks(config: Config) -> anyhow::Result<ShutdownHandles> 
     // let cache = refresher.get_shared_cache();
     node_describe_cache::new_refresher_with_initial_value(
         &config.topology_cacher,
-        node_status_cache_state.clone(),
+        nym_contract_cache_state.clone(),
         described_nodes_state.to_owned(),
     )
     .named("node-self-described-data-refresher")

--- a/nym-api/src/node_describe_cache/mod.rs
+++ b/nym-api/src/node_describe_cache/mod.rs
@@ -242,6 +242,10 @@ impl CacheItemProvider for NodeDescriptionProvider {
     type Item = HashMap<IdentityKey, NymNodeDescription>;
     type Error = NodeDescribeCacheError;
 
+    async fn wait_until_ready(&self) {
+        self.contract_cache.wait_for_initial_values().await
+    }
+
     async fn try_refresh(&self) -> Result<Self::Item, Self::Error> {
         let mut host_id_pairs = self
             .contract_cache

--- a/nym-api/src/nym_nodes/mod.rs
+++ b/nym-api/src/nym_nodes/mod.rs
@@ -12,7 +12,7 @@ mod unstable_routes;
 /// Merges the routes with http information and returns it to Rocket for serving
 pub(crate) fn nym_node_routes(settings: &OpenApiSettings) -> (Vec<Route>, OpenApi) {
     openapi_get_routes_spec![
-        settings: routes::get_gateways_described
+        settings: routes::get_gateways_described, routes::get_mixnodes_described
     ]
 }
 

--- a/nym-api/src/nym_nodes/routes.rs
+++ b/nym-api/src/nym_nodes/routes.rs
@@ -4,7 +4,8 @@
 use crate::node_describe_cache::DescribedNodes;
 use crate::nym_contract_cache::cache::NymContractCache;
 use crate::support::caching::cache::SharedCache;
-use nym_api_requests::models::DescribedGateway;
+use nym_api_requests::models::{DescribedGateway, DescribedMixNode};
+use nym_mixnet_contract_common::MixNodeBond;
 use rocket::serde::json::Json;
 use rocket::State;
 use rocket_okapi::openapi;
@@ -36,6 +37,41 @@ pub async fn get_gateways_described(
         gateways
             .into_iter()
             .map(|bond| DescribedGateway {
+                self_described: self_descriptions.deref().get(bond.identity()).cloned(),
+                bond,
+            })
+            .collect(),
+    )
+}
+
+#[openapi(tag = "Nym Nodes")]
+#[get("/mixnodes/described")]
+pub async fn get_mixnodes_described(
+    contract_cache: &State<NymContractCache>,
+    describe_cache: &State<SharedCache<DescribedNodes>>,
+) -> Json<Vec<DescribedMixNode>> {
+    let mixnodes = contract_cache
+        .mixnodes_filtered()
+        .await
+        .into_iter()
+        .map(|m| m.bond_information)
+        .collect::<Vec<MixNodeBond>>();
+    if mixnodes.is_empty() {
+        return Json(Vec::new());
+    }
+
+    // if the self describe cache is unavailable, well, don't attach describe data
+    let Ok(self_descriptions) = describe_cache.get().await else {
+        return Json(mixnodes.into_iter().map(Into::into).collect());
+    };
+
+    // TODO: this is extremely inefficient, but given we don't have many gateways,
+    // it shouldn't be too much of a problem until we go ahead with directory v3 / the smoosh 2: electric smoosharoo,
+    // but at that point (I hope) the whole caching situation should get refactored
+    Json(
+        mixnodes
+            .into_iter()
+            .map(|bond| DescribedMixNode {
                 self_described: self_descriptions.deref().get(bond.identity()).cloned(),
                 bond,
             })

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -2663,6 +2663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3141,7 +3150,7 @@ dependencies = [
  "ff",
  "getrandom 0.2.10",
  "group",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "nym-dkg",
  "nym-pemstore",
  "rand 0.8.5",
@@ -3390,7 +3399,7 @@ dependencies = [
  "cosmwasm-std",
  "eyre",
  "hmac",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "log",
  "nym-config",
  "nym-crypto",
@@ -3428,7 +3437,7 @@ dependencies = [
  "eyre",
  "flate2",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "nym-api-requests",
  "nym-coconut",


### PR DESCRIPTION
+ abstracts getting the self describing info a bit
+ adds mixnodes to the cache refresher as well
+ adds `role` field to the NodeDescription struct, to be able to distinguish between mixnodes and gateways
+ Switched to using `NodeStatusCache` instead of `ContractCache`