### PR TITLE
Fix NR config compatibility

### DIFF
--- a/service-providers/network-requester/src/config/mod.rs
+++ b/service-providers/network-requester/src/config/mod.rs
@@ -203,7 +203,7 @@ impl Config {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct NetworkRequester {
     /// specifies whether this network requester should run in 'open-proxy' mode
     /// and thus would attempt to resolve **ANY** request it receives.

--- a/service-providers/network-requester/src/config/template.rs
+++ b/service-providers/network-requester/src/config/template.rs
@@ -81,12 +81,6 @@ nr_description = '{{ storage_paths.nr_description }}'
 # and thus would attempt to resolve **ANY** request it receives.
 open_proxy = {{ network_requester.open_proxy }}
 
-# specifies whether this network requester would send anonymized statistics to a statistics aggregator server
-enabled_statistics = {{ network_requester.enabled_statistics }}
-
-# in case of enabled statistics, specifies mixnet client address where a statistics aggregator is running
-statistics_recipient = '{{ network_requester.statistics_recipient }}'
-
 # Disable Poisson sending rate
 # This is equivalent to setting debug.traffic.disable_main_poisson_packet_distribution = true,
 disable_poisson_rate = {{ network_requester.disable_poisson_rate }}


### PR DESCRIPTION
Recently we deleted the old statistics service provider. This fixes some issues where old configs didn't work with the latest changes.

- **Make NR able to read config with old keys in**
- **Remove deleted config keys from NR template**
