### PR TITLE
Send bandwidth status messages when connecting

### DIFF
--- a/common/bandwidth-controller/src/event.rs
+++ b/common/bandwidth-controller/src/event.rs
@@ -1,0 +1,13 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+// See other comments for other TaskStatus message enumds about abusing the Error trait when we
+// should have a new trait for TaskStatus messages
+#[derive(Debug, thiserror::Error)]
+pub enum BandwidthStatusMessage {
+    #[error("remaining bandwidth: {0}")]
+    RemainingBandwidth(i64),
+
+    #[error("no bandwidth left")]
+    NoBandwidth,
+}

--- a/common/bandwidth-controller/src/lib.rs
+++ b/common/bandwidth-controller/src/lib.rs
@@ -14,8 +14,11 @@ use nym_validator_client::coconut::all_coconut_api_clients;
 use nym_validator_client::nym_api::EpochId;
 use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
 
+pub use event::BandwidthStatusMessage;
+
 pub mod acquire;
 pub mod error;
+mod event;
 mod utils;
 
 #[derive(Debug)]

--- a/common/client-libs/gateway-client/src/client.rs
+++ b/common/client-libs/gateway-client/src/client.rs
@@ -11,7 +11,7 @@ use crate::traits::GatewayPacketRouter;
 use crate::{cleanup_socket_message, try_decrypt_binary_message};
 use futures::{SinkExt, StreamExt};
 use log::*;
-use nym_bandwidth_controller::BandwidthController;
+use nym_bandwidth_controller::{BandwidthController, BandwidthStatusMessage};
 use nym_credential_storage::ephemeral_storage::EphemeralStorage as EphemeralCredentialStorage;
 use nym_credential_storage::storage::Storage as CredentialStorage;
 use nym_credentials::CredentialSpendingData;
@@ -76,18 +76,6 @@ impl GatewayConfig {
             gateway_listener,
         }
     }
-}
-
-// See other comments for other TaskStatus message enumds about abusing the Error trait when we
-// should have a new trait for TaskStatus messages
-#[derive(Debug, thiserror::Error)]
-enum BandwidthStatusMessage {
-    #[error("remaining bandwidth: {0}")]
-    RemainingBandwidth(i64),
-
-    #[allow(unused)]
-    #[error("no bandwidth left")]
-    NoBandwidth,
 }
 
 // TODO: this should be refactored into a state machine that keeps track of its authentication state


### PR DESCRIPTION
When connecting to the gateway we get received the available bandwidth left. Emit a status messages for this, for consumption by the application layer.

These messages are handled here https://github.com/nymtech/nym-vpn-client/pull/620

Post merging ecash we should also send these messages when bandwidth runs out, and probably also on a regular basis.