### PR TITLE
Default construct NodeRole for backwards compatibility (apply 4721 on develop)

### DIFF
--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -612,7 +612,13 @@ pub struct NymNodeDescription {
     // for now we only care about their ws/wss situation, nothing more
     pub mixnet_websockets: WebSockets,
 
+    #[serde(default = "default_node_role")]
     pub role: NodeRole,
+}
+
+// For backwards compatibility, set a slightly artificial default
+fn default_node_role() -> NodeRole {
+    NodeRole::Inactive
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]


### PR DESCRIPTION
Same as #4721, applied to develop