### PR TITLE
[DOCs/docs]: Commnet out extra stubs

### DIFF
--- a/documentation/docs/src/SUMMARY.md
+++ b/documentation/docs/src/SUMMARY.md
@@ -15,10 +15,6 @@
 
 # Nodes
 - [Node Types (Previously Setup Guides)](nodes/overview.md)
-    - [Mix Node](nodes/mixnode.md)
-    - [Gateway](nodes/gateway.md)
-    - [Network Requester](nodes/network-requester.md)
-    - [Validator](nodes/validator.md)
 
 # Wallet
 - [Desktop Wallet](wallet/desktop-wallet.md)

--- a/documentation/docs/src/architecture/network-overview.md
+++ b/documentation/docs/src/architecture/network-overview.md
@@ -9,31 +9,31 @@ At a high level, our technologies include:
 * a **mixnet**, which encrypts and mixes Sphinx packet traffic so that it cannot be determined who is communicating with whom. Our mixnet is based on a modified version of the **Loopix** design.
 * a privacy enhancing signature scheme called **Coconut**. Coconut allows a shift in thinking about resource access control, from an identity-based paradigm based on _who you are_ to a privacy-preserving paradigm based on _right to use_.
 * **Sphinx**, a way of transmitting armoured, layer-encrypted information packets which are indistinguishable from each other at a binary level.
-* the **Nyx** blockchain, a general-purpose CosmWasm-enabled smart contract platform, and the home of the smart contracts which keep track of the mixnet. 
+* the **Nyx** blockchain, a general-purpose CosmWasm-enabled smart contract platform, and the home of the smart contracts which keep track of the mixnet.
 
 The most important thing to note is that these technologies ensure privacy at two different levels of the stack: **network data transmission**, and **transactions**.
 
-Here's an overview diagram of the different types of nodes making up the network: 
+Here's an overview diagram of the different types of nodes making up the network:
 
 ![Nym Platform](../images/nym-platform-dark.png)
 
-Developers can think of the network as being comprised of **infrastructure nodes** and **clients** for interacting with this infrastructure via **P**rivacy-**e**nhanced **app**lications (PEApps). 
+Developers can think of the network as being comprised of **infrastructure nodes** and **clients** for interacting with this infrastructure via **P**rivacy-**e**nhanced **app**lications (PEApps).
 
-## Mixnet Infrastructure 
+## Mixnet Infrastructure
 The mixnet - the different pieces of software that your traffic will pass through when using an privacy-enhanced app (PEApp) - is made up of several different types of nodes:
 
-* **Mix Nodes** provide network security for network content _and_ metadata, making it impossible to see who is communicating with who, by performing packet-mixing on traffic travelling through the network. 
+* **Mix Nodes** provide network security for network content _and_ metadata, making it impossible to see who is communicating with who, by performing packet-mixing on traffic travelling through the network.
 
 * **Gateways** act as message storage for clients which may go offline and come back online again, and defend against denial of service attacks. The default gateway implementation included in the Nym platform code holds packets for later retrieval. For many applications (such as simple chat), this is usable out of the box, as it provides a place that potentially offline clients can retrieve packets from. The access token allows clients to pull messages from the gateway node.
 
-* **Services** are applications that communicate with nym clients, listening and sending traffic to the mixnet. This is an umbrella term for a variety of different pieces of code, such as the [network requester](../nodes/network-requester.md) binary.
+* **Services** are applications that communicate with nym clients, listening and sending traffic to the mixnet. This is an umbrella term for a variety of different pieces of code, such as the network requester binary.
 
 * **Nyx Blockchain Validators** secure the network with proof-of-stake Sybil defenses, determine which nodes are included within the network, and work together to create Coconut threshold credentials which provide anonymous access to data and resources. They also produce blocks and secure the Nyx Blockchain. Initially, this chain was used only to house the CosmWasm smart contracts keeping track of Nym's network topology, token vesting contracts, and the `NYM` token itself. In recent months, we've decided to expand the role of Nyx and instead expand its role by making it an open smart contract platform for anyone to upload CosmWasm smart contracts to. Validators also provide privacy-enhanced credentials based on the testimony of a set of decentralized, blockchain-based issuing authorities. Nym validators use the [Coconut](https://arxiv.org/abs/1802.07344) [signature scheme](https://en.wikipedia.org/wiki/Digital_signature) to issue credentials. This allows privacy apps to generate anonymous resource claims through decentralised authorities, then use them with Service Providers.
 
-## Privacy-enhanced applications (PEApps) 
+## Privacy-enhanced applications (PEApps)
 PEApps use a Nym client to connect to the network in order to get the available Network Topology for traffic routing, and send/receive packets to other users and services. Clients, in order to send traffic through the mixnet, connect to gateways. Since applications may go online and offline, a client's gateway provides a sort of mailbox where apps can receive their messages.
 
-Nym clients connect to gateways. Messages are automatically piped to connected clients and deleted from the gateway's disk storage. If a client is offline when a message arrives, it will be stored for later retrieval. When the client connects, all messages will be delivered, and deleted from the gateway's disk. 
+Nym clients connect to gateways. Messages are automatically piped to connected clients and deleted from the gateway's disk storage. If a client is offline when a message arrives, it will be stored for later retrieval. When the client connects, all messages will be delivered, and deleted from the gateway's disk.
 
 When it starts up, a client registers itself with a gateway, and the gateway returns an access token. The access token plus the gateway's IP can then be used as a form of addressing for delivering packets.
 
@@ -46,4 +46,4 @@ Service Providers (SPs) may interact with external systems on behalf of a user. 
 
 There is also a special category of Service Provider, namely SPs that do not visibly interact with any external systems. You might think of these as crypto-utopiapps: they're doing something, but it's not possible from outside to say with any certainty what their function is, or who is interacting with them.
 
-All apps talk with gateways using Sphinx packets and a small set of simple control messages. These messages are sent to gateways over websockets. Each app client has a long-lived relationship with its gateway; Nym defines messages for clients registering and authenticating with gateways, as well as sending encrypted Sphinx packets. 
+All apps talk with gateways using Sphinx packets and a small set of simple control messages. These messages are sent to gateways over websockets. Each app client has a long-lived relationship with its gateway; Nym defines messages for clients registering and authenticating with gateways, as well as sending encrypted Sphinx packets.

--- a/documentation/docs/src/binaries/building-nym.md
+++ b/documentation/docs/src/binaries/building-nym.md
@@ -8,7 +8,7 @@ Nym has two main codebases:
 - the [Nym platform](https://github.com/nymtech/nym), written in Rust. This contains all of our code _except_ for the validators.
 - the [Nym validators](https://github.com/nymtech/nyxd), written in Go.
 
-> This page details how to build the main Nym platform code. **If you want to build and run a validator, [go here](../nodes/validator.md) instead.**
+> This page details how to build the main Nym platform code. **If you want to build and run a validator, [go here](https://nymtech.net/operators/nodes/validator-setup.html) instead.**
 
 ## Prerequisites
 - Debian/Ubuntu: `pkg-config`, `build-essential`, `libssl-dev`, `curl`, `jq`, `git`
@@ -54,18 +54,17 @@ cargo build --release # build your binaries with **mainnet** configuration
 
 Quite a bit of stuff gets built. The key working parts are:
 
-* [mix node](../nodes/mixnode.md): `nym-mixnode`
-* [gateway node](../nodes/gateway.md): `nym-gateway`
-* [websocket client](https://nymtech.net/developers/clients/websocket-client.md): `nym-client`
-* [socks5 client](https://nymtech.net/developers/clients/socks5-client.md): `nym-socks5-client`
-* [network requester](../nodes/network-requester.md): `nym-network-requester`
-* [nym-cli tool](../tools/nym-cli.md): `nym-cli`
+* [Nym Node](https://nymtech.net/operators/nodes/nym-node.html): `nym-node`
+* [Validator](https://nymtech.net/operators/nodes/validator-setup.html)
+* [websocket client](https://nymtech.net/docs/clients/websocket-client.html): `nym-client`
+* [socks5 client](https://nymtech.net/docs/clients/socks5-client.html): `nym-socks5-client`
+* [webassembly client](https://nymtech.net/docs/clients/webassembly-client.html): `webassembly-client`
+* [nym-cli tool](https://nymtech.net/docs/tools/nym-cli.html): `nym-cli`
 * [nym-api](https://nymtech.net/operators/nodes/nym-api.html): `nym-api`
-
-[//]: # (* [nymvisor]&#40;https://nymtech.net/operators/nodes/nymvisor-upgrade.html&#41;: `nymvisor`)
+* [nymvisor](https://nymtech.net/operators/nodes/nymvisor-upgrade.html): `nymvisor`
 
 The repository also contains Typescript applications which aren't built in this process. These can be built by following the instructions on their respective docs pages.
-* [Nym Wallet](../wallet/desktop-wallet.md)
-* [Network Explorer UI](../explorers/mixnet-explorer.md)
+* [Nym Wallet](https://nymtech.net/docs/wallet/desktop-wallet.html)
+* [Network Explorer UI](https://nymtech.net/docs/explorers/mixnet-explorer.html)
 
 > You cannot build from GitHub's .zip or .tar.gz archive files on the releases page - the Nym build scripts automatically include the current git commit hash in the built binary during compilation, so the build will fail if you use the archive code (which isn't a Git repository). Check the code out from github using `git clone` instead.

--- a/documentation/docs/src/nodes/overview.md
+++ b/documentation/docs/src/nodes/overview.md
@@ -1,9 +1,7 @@
 # Node Types
 
-> This section was previously the node setup guides. These have been migrated to their own [**Operator Guides**](https://nymtech.net/operators) book. 
-> 
-> For setup and maintenance guides, go to the Operators book linked above. 
-> 
-> This section is a little spartan for the moment, but we will be adding detailed information about how exactly each node functions, as well as references to any literature and technical specs in the near future. 
+```admonish info
+We are working on a detailed description of how each component of Nym Mixnet and Nyx blockchain functions, as well as references to any literature and technical specs.
 
-This section contains information on the different node types of the mixnet and blockchain.  
+Meanwhile please refer to our [**Operators Guide**](https://nymtech.net/operators) book.
+```

--- a/documentation/operators/src/troubleshooting/vps-isp.md
+++ b/documentation/operators/src/troubleshooting/vps-isp.md
@@ -27,7 +27,7 @@ Begin with the steps listed in [*Connectivity Test and Configuration*](../nodes/
 
 ### Network configuration
 
-On modern Debian based Linux distributions, network is being configure by either [Netplan](www.netplan.io) or [ifup/ifdown](https://manpages.debian.org/testing/ifupdown/ifup.8.en.html) utilities . It is very easy to check which one you have.
+On modern Debian based Linux distributions, the network is configured by either [Netplan](https://netplan.io/) or [ifup/ifdown](https://manpages.debian.org/testing/ifupdown/ifup.8.en.html) utilities . It is very easy to check which one you have.
 
 1. If you have the following folder `/etc/netplan` which has got a YAML file - you are likely to have Netplan.
 2. If you have the following folder `/etc/network` and it is not empty - you are likely to have ifup/down.


### PR DESCRIPTION
This PR clears out pages which refer to old type of binaries without further explanation. 

This is not a final solution, these pages need to be redone and bring more technical understanding to the reader. 

Issue addressed: #4632 

