### PR TITLE
Update peer refresh value

### DIFF
--- a/common/wireguard-types/src/lib.rs
+++ b/common/wireguard-types/src/lib.rs
@@ -6,10 +6,17 @@ pub mod error;
 pub mod public_key;
 pub mod registration;
 
+use std::time::Duration;
+
 pub use config::Config;
 pub use error::Error;
 pub use public_key::PeerPublicKey;
 pub use registration::{ClientMac, ClientMessage, GatewayClient, InitMessage, Nonce};
+
+// To avoid any problems, keep this stale check time bigger (>2x) then the bandwidth cap
+// reset time (currently that one is 24h, at UTC midnight)
+pub const DEFAULT_PEER_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24 * 3); // 3 days
+pub const DEFAULT_PEER_TIMEOUT_CHECK: Duration = Duration::from_secs(5); // 5 seconds
 
 #[cfg(feature = "verify")]
 pub use registration::HmacSha256;

--- a/common/wireguard/src/peer_controller.rs
+++ b/common/wireguard/src/peer_controller.rs
@@ -5,18 +5,14 @@ use chrono::{Timelike, Utc};
 use defguard_wireguard_rs::{host::Peer, key::Key, WireguardInterfaceApi};
 use nym_gateway_storage::Storage;
 use nym_wireguard_types::registration::{RemainingBandwidthData, BANDWIDTH_CAP_PER_DAY};
+use nym_wireguard_types::{DEFAULT_PEER_TIMEOUT, DEFAULT_PEER_TIMEOUT_CHECK};
 use std::time::SystemTime;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc};
 use tokio::sync::mpsc;
 use tokio_stream::{wrappers::IntervalStream, StreamExt};
 
 use crate::error::Error;
 use crate::WgApiWrapper;
-
-// To avoid any problems, keep this stale check time bigger (>2x) then the bandwidth cap
-// reset time (currently that one is 24h, at UTC midnight)
-const DEFAULT_PEER_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24 * 3); // 3 days
-const DEFAULT_PEER_TIMEOUT_CHECK: Duration = Duration::from_secs(5); // 5 seconds
 
 pub enum PeerControlRequest {
     AddPeer(Peer),


### PR DESCRIPTION
Also expose the value by moving it to wireguard types, and separate the refresh time to the database sync time, so that more probable and needed actions happen faster (refresh) and more improbable ones don't overload the system (peer suspended or stale)