### PR TITLE
Avoid race on ip and registration structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6242,7 +6242,6 @@ name = "nym-wireguard-types"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.7",
- "dashmap",
  "hmac",
  "log",
  "nym-config",

--- a/common/wireguard-types/Cargo.toml
+++ b/common/wireguard-types/Cargo.toml
@@ -12,7 +12,6 @@ license.workspace = true
 
 [dependencies]
 base64 = { workspace = true }
-dashmap = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
@@ -35,7 +34,7 @@ x25519-dalek = { workspace = true, features = ["static_secrets"] }
 
 [dev-dependencies]
 rand = "0.8.5"
-nym-crypto = { path = "../crypto", features = ["rand"]}
+nym-crypto = { path = "../crypto", features = ["rand"] }
 
 
 [features]

--- a/common/wireguard-types/src/registration.rs
+++ b/common/wireguard-types/src/registration.rs
@@ -4,8 +4,8 @@
 use crate::error::Error;
 use crate::PeerPublicKey;
 use base64::{engine::general_purpose, Engine};
-use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::net::IpAddr;
 use std::time::SystemTime;
 use std::{fmt, ops::Deref, str::FromStr};
@@ -17,8 +17,8 @@ use nym_crypto::asymmetric::encryption::PrivateKey;
 #[cfg(feature = "verify")]
 use sha2::Sha256;
 
-pub type PendingRegistrations = DashMap<PeerPublicKey, RegistrationData>;
-pub type PrivateIPs = DashMap<IpAddr, Taken>;
+pub type PendingRegistrations = HashMap<PeerPublicKey, RegistrationData>;
+pub type PrivateIPs = HashMap<IpAddr, Taken>;
 
 #[cfg(feature = "verify")]
 pub type HmacSha256 = Hmac<Sha256>;


### PR DESCRIPTION
To avoid a state where the ip is being cleared out before the registration is also cleared out, couple the two structures under the same lock, since they are anyway very inter-dependent.