### PR TITLE
Gateway database modifications for different modes

### DIFF
--- a/common/gateway-storage/migrations/20240910120000_generic_client_id.sql
+++ b/common/gateway-storage/migrations/20240910120000_generic_client_id.sql
@@ -5,11 +5,11 @@
 
 CREATE TABLE clients (
    id              INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-   client_type     TEXT NOT NULL CHECK(client_type IN ('entry mixnet', 'entry wireguard', 'exit wireguard'))
+   client_type     TEXT NOT NULL CHECK(client_type IN ('entry_mixnet', 'exit_mixnet', 'entry_wireguard', 'exit_wireguard'))
 );
 
 INSERT INTO clients (id, client_type)
-SELECT id, 'entry mixnet'
+SELECT id, 'entry_mixnet'
 FROM shared_keys;
 
 CREATE TABLE shared_keys_tmp (

--- a/common/gateway-storage/migrations/20240910120000_generic_client_id.sql
+++ b/common/gateway-storage/migrations/20240910120000_generic_client_id.sql
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+CREATE TABLE clients (
+   id              INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+   client_type     TEXT NOT NULL CHECK(client_type IN ('entry mixnet', 'entry wireguard', 'exit wireguard'))
+);
+
+INSERT INTO clients (id, client_type)
+SELECT id, 'entry mixnet'
+FROM shared_keys;
+
+CREATE TABLE shared_keys_tmp (
+   client_id                                INTEGER NOT NULL PRIMARY KEY REFERENCES clients(id),
+   client_address_bs58                      TEXT NOT NULL UNIQUE,
+   derived_aes128_ctr_blake3_hmac_keys_bs58 TEXT NOT NULL
+);
+
+INSERT INTO shared_keys_tmp (client_id, client_address_bs58, derived_aes128_ctr_blake3_hmac_keys_bs58)
+SELECT id as client_id, client_address_bs58, derived_aes128_ctr_blake3_hmac_keys_bs58 FROM shared_keys;
+
+CREATE TABLE available_bandwidth_tmp (
+   client_id INTEGER NOT NULL PRIMARY KEY REFERENCES clients(id),
+   available INTEGER NOT NULL,
+   expiration TIMESTAMP WITHOUT TIME ZONE
+);
+
+INSERT INTO available_bandwidth_tmp
+SELECT * FROM available_bandwidth;
+
+DROP TABLE available_bandwidth;
+ALTER TABLE available_bandwidth_tmp RENAME TO available_bandwidth;
+
+CREATE TABLE received_ticket_tmp (
+   id                  INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+   client_id           INTEGER NOT NULL REFERENCES clients(id),
+   received_at         TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+   rejected            BOOLEAN
+);
+
+INSERT INTO received_ticket_tmp
+SELECT * FROM received_ticket;
+
+DROP INDEX received_ticket_index;
+CREATE INDEX received_ticket_index ON received_ticket_tmp (received_at);
+
+ -- received tickets that are in the process of verifying
+CREATE TABLE ticket_data_tmp (
+   ticket_id           INTEGER NOT NULL PRIMARY KEY REFERENCES received_ticket_tmp(id),
+
+   -- serial_number, alongside the entire row, will get purged after redemption is complete
+   serial_number       BLOB NOT NULL UNIQUE,
+
+   --    data will get purged after 80% of signers verifies it
+   data                BLOB
+);
+
+INSERT INTO ticket_data_tmp
+SELECT * FROM ticket_data;
+
+DROP TABLE ticket_data;
+ALTER TABLE ticket_data_tmp RENAME TO ticket_data;
+
+-- result of a verification from a single signer (API)
+CREATE TABLE ticket_verification_tmp (
+   ticket_id           INTEGER NOT NULL REFERENCES received_ticket_tmp(id),
+   signer_id           INTEGER NOT NULL,
+   verified_at         TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+   accepted            BOOLEAN NOT NULL,
+   
+   PRIMARY KEY (ticket_id, signer_id)
+);
+
+DROP INDEX ticket_verification_index;
+CREATE INDEX ticket_verification_index ON ticket_verification_tmp (ticket_id);
+
+DROP TABLE ticket_verification;
+ALTER TABLE ticket_verification_tmp RENAME TO ticket_verification;
+
+-- verified tickets that are yet to be redeemed
+CREATE TABLE verified_tickets_tmp (
+   ticket_id           INTEGER NOT NULL PRIMARY KEY REFERENCES received_ticket_tmp(id),
+   proposal_id         INTEGER REFERENCES redemption_proposals(proposal_id)
+);
+
+DROP INDEX verified_tickets_index;
+CREATE INDEX verified_tickets_index ON verified_tickets_tmp (proposal_id);
+
+DROP TABLE verified_tickets;
+ALTER TABLE verified_tickets_tmp RENAME TO verified_tickets;
+
+DROP TABLE received_ticket;
+ALTER TABLE received_ticket_tmp RENAME TO received_ticket;
+
+DROP TABLE shared_keys;
+ALTER TABLE shared_keys_tmp RENAME TO shared_keys;

--- a/common/gateway-storage/src/clients.rs
+++ b/common/gateway-storage/src/clients.rs
@@ -9,6 +9,7 @@ use crate::models::Client;
 #[sqlx(type_name = "TEXT")] // SQLite TEXT type
 pub enum ClientType {
     EntryMixnet,
+    ExitMixnet,
     EntryWireguard,
     ExitWireguard,
 }
@@ -18,9 +19,10 @@ impl FromStr for ClientType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "entry mixnet" => Ok(ClientType::EntryMixnet),
-            "entry wireguard" => Ok(ClientType::EntryWireguard),
-            "exit wireguard" => Ok(ClientType::ExitWireguard),
+            "entry_mixnet" => Ok(ClientType::EntryMixnet),
+            "exit_mixnet" => Ok(ClientType::ExitMixnet),
+            "entry_wireguard" => Ok(ClientType::EntryWireguard),
+            "exit_wireguard" => Ok(ClientType::ExitWireguard),
             _ => Err("Invalid client type"),
         }
     }
@@ -29,9 +31,10 @@ impl FromStr for ClientType {
 impl std::fmt::Display for ClientType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            ClientType::EntryMixnet => "entry mixnet",
-            ClientType::EntryWireguard => "entry wireguard",
-            ClientType::ExitWireguard => "exit wireguard",
+            ClientType::EntryMixnet => "entry_mixnet",
+            ClientType::ExitMixnet => "exit_mixnet",
+            ClientType::EntryWireguard => "entry_wireguard",
+            ClientType::ExitWireguard => "exit_wireguard",
         };
         write!(f, "{}", s)
     }

--- a/common/gateway-storage/src/clients.rs
+++ b/common/gateway-storage/src/clients.rs
@@ -1,0 +1,86 @@
+// Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::str::FromStr;
+
+use crate::models::Client;
+
+#[derive(Debug, PartialEq, sqlx::Type)]
+#[sqlx(type_name = "TEXT")] // SQLite TEXT type
+pub enum ClientType {
+    EntryMixnet,
+    EntryWireguard,
+    ExitWireguard,
+}
+
+impl FromStr for ClientType {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "entry mixnet" => Ok(ClientType::EntryMixnet),
+            "entry wireguard" => Ok(ClientType::EntryWireguard),
+            "exit wireguard" => Ok(ClientType::ExitWireguard),
+            _ => Err("Invalid client type"),
+        }
+    }
+}
+
+impl std::fmt::Display for ClientType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            ClientType::EntryMixnet => "entry mixnet",
+            ClientType::EntryWireguard => "entry wireguard",
+            ClientType::ExitWireguard => "exit wireguard",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ClientManager {
+    connection_pool: sqlx::SqlitePool,
+}
+
+impl ClientManager {
+    /// Creates new instance of the `ClientManager` with the provided sqlite connection pool.
+    ///
+    /// # Arguments
+    ///
+    /// * `connection_pool`: database connection pool to use.
+    pub(crate) fn new(connection_pool: sqlx::SqlitePool) -> Self {
+        ClientManager { connection_pool }
+    }
+
+    /// Inserts new client to the storage, specifying its type.
+    ///
+    /// # Arguments
+    ///
+    /// * `client_type`: Type of the client that gets inserted
+    pub(crate) async fn insert_client(&self, client_type: ClientType) -> Result<i64, sqlx::Error> {
+        let client_id = sqlx::query!("INSERT INTO clients(client_type) VALUES (?)", client_type)
+            .execute(&self.connection_pool)
+            .await?
+            .last_insert_rowid();
+        Ok(client_id)
+    }
+
+    /// Tries to retrieve a particular client.
+    ///
+    /// # Arguments
+    ///
+    /// * `id`: The client id
+    pub(crate) async fn get_client(&self, id: i64) -> Result<Option<Client>, sqlx::Error> {
+        sqlx::query_as!(
+            Client,
+            r#"
+            SELECT id, client_type as "client_type: ClientType"
+            FROM clients
+            WHERE id = ?
+            "#,
+            id
+        )
+        .fetch_optional(&self.connection_pool)
+        .await
+    }
+}

--- a/common/gateway-storage/src/models.rs
+++ b/common/gateway-storage/src/models.rs
@@ -6,9 +6,14 @@ use nym_credentials_interface::{AvailableBandwidth, ClientTicket, CredentialSpen
 use sqlx::FromRow;
 use time::OffsetDateTime;
 
+pub struct Client {
+    pub id: i64,
+    pub client_type: crate::clients::ClientType,
+}
+
 pub struct PersistedSharedKeys {
     #[allow(dead_code)]
-    pub id: i64,
+    pub client_id: i64,
 
     #[allow(dead_code)]
     pub client_address_bs58: String,

--- a/common/gateway-storage/src/shared_keys.rs
+++ b/common/gateway-storage/src/shared_keys.rs
@@ -20,12 +20,12 @@ impl SharedKeysManager {
 
     pub(crate) async fn client_id(&self, client_address_bs58: &str) -> Result<i64, sqlx::Error> {
         let client_id = sqlx::query!(
-            "SELECT id FROM shared_keys WHERE client_address_bs58 = ?",
+            "SELECT client_id FROM shared_keys WHERE client_address_bs58 = ?",
             client_address_bs58
         )
         .fetch_one(&self.connection_pool)
         .await?
-        .id;
+        .client_id;
         Ok(client_id)
     }
 
@@ -34,26 +34,30 @@ impl SharedKeysManager {
     ///
     /// # Arguments
     ///
-    /// * `shared_keys`: shared encryption (AES128CTR) and mac (hmac-blake3) derived shared keys to store.
+    /// * `client_id`: The client id for which the shared keys are stored
+    /// * `client_address_bs58`: base58-encoded address of the client
+    /// * `derived_aes128_ctr_blake3_hmac_keys_bs58`: shared encryption (AES128CTR) and mac (hmac-blake3) derived shared keys to store.
     pub(crate) async fn insert_shared_keys(
         &self,
+        client_id: i64,
         client_address_bs58: String,
         derived_aes128_ctr_blake3_hmac_keys_bs58: String,
-    ) -> Result<i64, sqlx::Error> {
+    ) -> Result<(), sqlx::Error> {
         // https://stackoverflow.com/a/20310838
         // we don't want to be using `INSERT OR REPLACE INTO` due to the foreign key on `available_bandwidth` if the entry already exists
         sqlx::query!(
             r#"
-                INSERT OR IGNORE INTO shared_keys(client_address_bs58, derived_aes128_ctr_blake3_hmac_keys_bs58) VALUES (?, ?);
+                INSERT OR IGNORE INTO shared_keys(client_id, client_address_bs58, derived_aes128_ctr_blake3_hmac_keys_bs58) VALUES (?, ?, ?);
                 UPDATE shared_keys SET derived_aes128_ctr_blake3_hmac_keys_bs58 = ? WHERE client_address_bs58 = ?
             "#,
+            client_id,
             client_address_bs58,
             derived_aes128_ctr_blake3_hmac_keys_bs58,
             derived_aes128_ctr_blake3_hmac_keys_bs58,
             client_address_bs58,
         ).execute(&self.connection_pool).await?;
 
-        self.client_id(&client_address_bs58).await
+        Ok(())
     }
 
     /// Tries to retrieve shared keys stored for the particular client.

--- a/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
@@ -570,7 +570,11 @@ where
             return Ok(InitialAuthResult::new_failed(Some(negotiated_protocol)));
         };
 
-        let client_id = self.shared_state.storage.get_client_id(address).await?;
+        let client_id = self
+            .shared_state
+            .storage
+            .get_mixnet_client_id(address)
+            .await?;
 
         let available_bandwidth: AvailableBandwidth = self
             .shared_state


### PR DESCRIPTION
As gateway clients will not be solely from the mixnet, we need to split the table that handles shared keys from the client ids that are referenced from other tables. That way, the bandwidth table can be shared between different client types (entry mixnet, entry gateway, exit gateway), using the same `client_id` referencing.