### PR TITLE
allow clients to send stateless gateway requests without prior registration

### DIFF
--- a/common/client-libs/gateway-client/src/client/mod.rs
+++ b/common/client-libs/gateway-client/src/client/mod.rs
@@ -293,7 +293,7 @@ impl<C, St> GatewayClient<C, St> {
     // as we need to be able to write the request and read the subsequent response
     async fn send_websocket_message(
         &mut self,
-        msg: Message,
+        msg: impl Into<Message>,
     ) -> Result<ServerResponse, GatewayClientError> {
         let should_restart_mixnet_listener = if self.connection.is_partially_delegated() {
             self.recover_socket_connection().await?;
@@ -307,7 +307,7 @@ impl<C, St> GatewayClient<C, St> {
             SocketState::NotConnected => return Err(GatewayClientError::ConnectionNotEstablished),
             _ => return Err(GatewayClientError::ConnectionInInvalidState),
         };
-        conn.send(msg).await?;
+        conn.send(msg.into()).await?;
         let response = self.read_control_response().await;
 
         if should_restart_mixnet_listener {
@@ -481,8 +481,7 @@ impl<C, St> GatewayClient<C, St> {
             encrypted_address,
             iv,
             self.cfg.bandwidth.require_tickets,
-        )
-        .into();
+        );
 
         match self.send_websocket_message(msg).await? {
             ServerResponse::Authenticate {
@@ -532,6 +531,21 @@ impl<C, St> GatewayClient<C, St> {
         }
     }
 
+    pub async fn get_gateway_protocol(&mut self) -> Result<u8, GatewayClientError> {
+        if !self.connection.is_established() {
+            return Err(GatewayClientError::ConnectionNotEstablished);
+        }
+
+        match self
+            .send_websocket_message(ClientControlRequest::SupportedProtocol {})
+            .await?
+        {
+            ServerResponse::SupportedProtocol { version } => Ok(version),
+            ServerResponse::Error { message } => Err(GatewayClientError::GatewayError(message)),
+            _ => Err(GatewayClientError::UnexpectedResponse),
+        }
+    }
+
     async fn claim_ecash_bandwidth(
         &mut self,
         credential: CredentialSpendingData,
@@ -543,8 +557,7 @@ impl<C, St> GatewayClient<C, St> {
             credential,
             self.shared_key.as_ref().unwrap(),
             iv,
-        )
-        .into();
+        );
         let bandwidth_remaining = match self.send_websocket_message(msg).await? {
             ServerResponse::Bandwidth { available_total } => Ok(available_total),
             ServerResponse::Error { message } => Err(GatewayClientError::GatewayError(message)),
@@ -562,7 +575,7 @@ impl<C, St> GatewayClient<C, St> {
     }
 
     async fn try_claim_testnet_bandwidth(&mut self) -> Result<(), GatewayClientError> {
-        let msg = ClientControlRequest::ClaimFreeTestnetBandwidth.into();
+        let msg = ClientControlRequest::ClaimFreeTestnetBandwidth;
         let bandwidth_remaining = match self.send_websocket_message(msg).await? {
             ServerResponse::Bandwidth { available_total } => Ok(available_total),
             ServerResponse::Error { message } => Err(GatewayClientError::GatewayError(message)),

--- a/common/gateway-requests/src/types.rs
+++ b/common/gateway-requests/src/types.rs
@@ -190,6 +190,7 @@ pub enum ClientControlRequest {
         iv: Vec<u8>,
     },
     ClaimFreeTestnetBandwidth,
+    SupportedProtocol {},
 }
 
 impl ClientControlRequest {
@@ -229,6 +230,7 @@ impl ClientControlRequest {
             ClientControlRequest::ClaimFreeTestnetBandwidth => {
                 "ClaimFreeTestnetBandwidth".to_string()
             }
+            ClientControlRequest::SupportedProtocol { .. } => "SupportedProtocol".to_string(),
         }
     }
 
@@ -272,7 +274,15 @@ impl TryFrom<String> for ClientControlRequest {
     type Error = serde_json::Error;
 
     fn try_from(msg: String) -> Result<Self, Self::Error> {
-        serde_json::from_str(&msg)
+        msg.parse()
+    }
+}
+
+impl FromStr for ClientControlRequest {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
     }
 }
 
@@ -304,6 +314,9 @@ pub enum ServerResponse {
     Send {
         remaining_bandwidth: i64,
     },
+    SupportedProtocol {
+        version: u8,
+    },
     // Generic error
     Error {
         message: String,
@@ -324,6 +337,7 @@ impl ServerResponse {
             ServerResponse::Send { .. } => "Send".to_string(),
             ServerResponse::Error { .. } => "Error".to_string(),
             ServerResponse::TypedError { .. } => "TypedError".to_string(),
+            ServerResponse::SupportedProtocol { .. } => "SupportedProtocol".to_string(),
         }
     }
     pub fn new_error<S: Into<String>>(msg: S) -> Self {

--- a/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/fresh.rs
@@ -1,7 +1,6 @@
 // Copyright 2021-2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::error::RequestHandlingError;
 use crate::node::client_handling::websocket::common_state::CommonHandlerState;
 use crate::node::client_handling::websocket::connection_handler::INITIAL_MESSAGE_TIMEOUT;
 use crate::node::client_handling::{


### PR DESCRIPTION
in order to make changes to the registration/authentication procedure I needed a way of extracting protocol information before undergoing the handshake. 

I figured I might as well put it in separate PR for ease of review