### PR TITLE
Remove clippy github PR annotations

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -90,14 +90,6 @@ jobs:
           command: test
           args: --workspace -- --ignored
 
-      - name: Annotate with clippy checks
-        if: contains(matrix.os, 'ubuntu')
-        uses: actions-rs/clippy-check@v1
-        continue-on-error: true
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace
-
       - name: Clippy
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
It eats up CI resources and time to run the clippy annotation checks that likely no one uses anyway. We keep the clippy checks of course.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/4896)
<!-- Reviewable:end -->
