### PR TITLE
Update cargo deny

### DIFF
--- a/.github/workflows/ci-cargo-deny.yml
+++ b/.github/workflows/ci-cargo-deny.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         log-level: warn
         command: check ${{ matrix.checks }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,10 +232,12 @@ hex-literal = "0.3.3"
 hkdf = "0.12.3"
 hmac = "0.12.1"
 http = "1"
+http-body-util = "0.1"
 httpcodec = "0.2.3"
 humantime = "2.1.0"
 humantime-serde = "1.1.1"
 hyper = "1.4.1"
+hyper-util = "0.1"
 indicatif = "0.17.8"
 inquire = "0.6.2"
 ip_network = "0.4.1"
@@ -300,6 +302,7 @@ time = "0.3.30"
 tokio = "1.39"
 tokio-stream = "0.1.16"
 tokio-test = "0.4.4"
+tokio-tun = "0.11.5"
 tokio-tungstenite = { version = "0.20.1" }
 tokio-util = "0.7.12"
 toml = "0.8.14"
@@ -313,7 +316,6 @@ ts-rs = "7.0.0"
 tungstenite = { version = "0.20.1", default-features = false }
 url = "2.5"
 utoipa = "4.2"
-utoipa-rapidoc = "4.0"
 utoipa-swagger-ui = "7.1"
 utoipauto = "0.1"
 uuid = "*"
@@ -334,7 +336,6 @@ group = { version = "0.13.0", default-features = false }
 ff = { version = "0.13.0", default-features = false }
 
 # cosmwasm-related
-cosmwasm-derive = "=1.4.3"
 cosmwasm-schema = "=1.4.3"
 cosmwasm-std = "=1.4.3"
 # use 0.5.0 as that's the version used by cosmwasm-std 1.4.3

--- a/common/bin-common/Cargo.toml
+++ b/common/bin-common/Cargo.toml
@@ -8,14 +8,14 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-const-str = { workspace = true }
 clap = { workspace = true, features = ["derive"], optional = true }
 clap_complete = { workspace = true, optional = true }
 clap_complete_fig = { workspace = true, optional = true }
+const-str = { workspace = true }
 log = { workspace = true }
 pretty_env_logger = { workspace = true }
-semver = "1.0"
 schemars = { workspace = true, features = ["preserve_order"], optional = true }
+semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -14,7 +14,7 @@ base64 = { workspace = true }
 bs58 = { workspace = true }
 cfg-if = { workspace = true }
 clap = { workspace = true, optional = true }
-comfy-table = { version = "7.1.1", optional = true }
+comfy-table = { workspace = true, optional = true }
 futures = { workspace = true }
 humantime-serde = { workspace = true }
 log = { workspace = true }
@@ -59,19 +59,19 @@ nym-ecash-time = { path = "../ecash-time" }
 
 ### For serving prometheus metrics
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.hyper]
-version = "1"
+workspace = true
 features = ["server", "http1"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.http-body-util]
-version = "0.1"
+workspace = true
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.hyper-util]
-version = "0.1"
+workspace = true
 features = ["tokio"]
 ###
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio-stream]
-version = "0.1.16"
+workspace = true
 features = ["time"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio]
@@ -110,7 +110,7 @@ path = "../wasm/utils"
 features = ["websocket"]
 
 [target."cfg(target_arch = \"wasm32\")".dependencies.time]
-version = "0.3.17"
+workspace = true
 features = ["wasm-bindgen"]
 
 [dev-dependencies]

--- a/common/client-libs/gateway-client/Cargo.toml
+++ b/common/client-libs/gateway-client/Cargo.toml
@@ -43,7 +43,7 @@ workspace = true
 features = ["macros", "rt", "net", "sync", "time"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio-stream]
-version = "0.1.16"
+workspace = true
 features = ["net", "sync", "time"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio-tungstenite]

--- a/common/config/Cargo.toml
+++ b/common/config/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dirs = { version = "5.0.1", optional = true }
+dirs = { workspace = true, optional = true }
 handlebars = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/common/nonexhaustive-delayqueue/Cargo.toml
+++ b/common/nonexhaustive-delayqueue/Cargo.toml
@@ -14,7 +14,7 @@ tokio-stream = { workspace = true } # this one seems to be a thing until `Stream
 workspace = true
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio-util]
-version = "0.7.12"
+workspace = true
 features = ["time"]
 
 [target."cfg(target_arch = \"wasm32\")".dependencies.wasmtimer]

--- a/common/nymsphinx/Cargo.toml
+++ b/common/nymsphinx/Cargo.toml
@@ -42,7 +42,7 @@ nym-crypto = { path = "../crypto", version = "0.4.0", features = [
 path = "framing"
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio]
-version = "1.39.3"
+workspace = true
 features = ["sync"]
 
 [features]

--- a/common/topology/Cargo.toml
+++ b/common/topology/Cargo.toml
@@ -11,13 +11,13 @@ documentation = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = { workspace = true, optional = true }
 bs58 = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
+semver = { workspace = true }
 thiserror = { workspace = true }
-async-trait = { workspace = true, optional = true }
-semver = { version = "1.0" }
 
 # 'serializable' feature
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/common/tun/Cargo.toml
+++ b/common/tun/Cargo.toml
@@ -18,4 +18,4 @@ log.workspace = true
 nym-wireguard-types = { path = "../wireguard-types", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tokio-tun = "0.11.5"
+tokio-tun.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -113,6 +113,12 @@ exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
     #{ allow = ["Zlib"], crate = "adler32" },
+    { allow = ["GPL-3.0"], crate = "nym-api" },
+    { allow = ["GPL-3.0"], crate = "nym-gateway" },
+    { allow = ["GPL-3.0"], crate = "nym-mixnode" },
+    { allow = ["GPL-3.0"], crate = "nym-network-requester" },
+    { allow = ["GPL-3.0"], crate = "nym-node" },
+    { allow = ["GPL-3.0"], crate = "nym-validator-rewarder" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/deny.toml
+++ b/deny.toml
@@ -89,9 +89,18 @@ ignore = [
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    #"MIT",
-    #"Apache-2.0",
-    #"Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "0BSD",
+    "MPL-2.0",
+    "CC0-1.0",
+    "Unicode-DFS-2016",
+    "OpenSSL",
+    "Zlib",
+    "Unicode-3.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -171,6 +180,7 @@ deny = [
     # Wrapper crates can optionally be specified to allow the crate when it
     # is a direct dependency of the otherwise banned crate
     #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+    { name = "openssl" },
 ]
 
 # List of features to allow/deny
@@ -209,6 +219,11 @@ skip-tree = [
     #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
     #{ crate = "ansi_term@0.11.0", depth = 20 },
 ]
+
+[bans.workspace-dependencies]
+duplicates = "deny"
+include-path-dependencies = false
+unused = "deny"
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:

--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,8 @@ targets = [
     # particular target. target_features are currently not validated against
     # the actual valid features supported by the target architecture.
     #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+    "x86_64-unknown-linux-gnu",
+    "wasm32-unknown-unknown",
 ]
 # When creating the dependency graph used as the source of truth when checks are
 # executed, this field can be used to prune crates from the graph, removing them
@@ -100,7 +102,6 @@ allow = [
     "Unicode-DFS-2016",
     "OpenSSL",
     "Zlib",
-    "Unicode-3.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -124,20 +125,20 @@ exceptions = [
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the
 # licensing information
-#[[licenses.clarify]]
+[[licenses.clarify]]
 # The package spec the clarification applies to
-#crate = "ring"
+crate = "ring"
 # The SPDX expression for the license requirements of the crate
-#expression = "MIT AND ISC AND OpenSSL"
+expression = "MIT AND ISC AND OpenSSL"
 # One or more files in the crate's source used as the "source of truth" for
 # the license expression. If the contents match, the clarification will be used
 # when running the license check, otherwise the clarification will be ignored
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
-#license-files = [
-# Each entry is a crate relative path, and the (opaque) hash of its contents
-#{ path = "LICENSE", hash = 0xbd0eed23 }
-#]
+license-files = [
+    # Each entry is a crate relative path, and the (opaque) hash of its contents
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
@@ -226,10 +227,12 @@ skip-tree = [
     #{ crate = "ansi_term@0.11.0", depth = 20 },
 ]
 
-[bans.workspace-dependencies]
-duplicates = "deny"
-include-path-dependencies = false
-unused = "deny"
+# NOTE: re-enable once we remove the last duplicates (only digest and sha2 at
+# the time of this writing).
+#[bans.workspace-dependencies]
+#duplicates = "deny"
+#include-path-dependencies = false
+#unused = "deny"
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,9 @@
 
 # Root options
 
+# The graph table configures how the dependency graph is constructed and thus
+# which crates the checks are performed against
+[graph]
 # If 1 or more target triples (and optionally, target_features) are specified,
 # only the specified targets will be checked when running `cargo deny check`.
 # This means, if a particular package is only ever used as a target specific
@@ -22,7 +25,7 @@
 targets = [
     # The triple can be any string, but only the target triples built in to
     # rustc (as of 1.40) can be checked against actual config expressions
-    #{ triple = "x86_64-unknown-linux-musl" },
+    #"x86_64-unknown-linux-musl",
     # You can also specify which target_features you promise are enabled for a
     # particular target. target_features are currently not validated against
     # the actual valid features supported by the target architecture.
@@ -46,6 +49,9 @@ no-default-features = false
 # If set, these feature will be enabled when collecting metadata. If `--features`
 # is specified on the cmd line they will take precedence over this option.
 #features = []
+
+# The output table provides options for how/if diagnostics are outputted
+[output]
 # When outputting inclusion graphs in diagnostics that include features, this
 # option can be used to specify the depth at which feature edges will be added.
 # This option is included since the graphs can be quite large and the addition
@@ -57,37 +63,18 @@ feature-depth = 1
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-# The path where the advisory database is cloned/fetched into
-db-path = "~/.cargo/advisory-db"
+# The path where the advisory databases are cloned/fetched into
+#db-path = "$CARGO_HOME/advisory-dbs"
 # The url(s) of the advisory databases to use
-db-urls = ["https://github.com/rustsec/advisory-db"]
-# The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "allow"
-# The lint level for crates that have been yanked from their source registry
-yanked = "warn"
-# The lint level for crates with security notices. Note that as of
-# 2019-12-17 there are no security notice advisories in
-# https://github.com/rustsec/advisory-db
-notice = "warn"
+#db-urls = ["https://github.com/rustsec/advisory-db"]
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    "RUSTSEC-2020-0159",
-    "RUSTSEC-2020-0071",
-    "RUSTSEC-2021-0145",
+    #"RUSTSEC-0000-0000",
+    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
+    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
+    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
 ]
-# Threshold for security vulnerabilities, any vulnerability with a CVSS score
-# lower than the range specified will be ignored. Note that ignored advisories
-# will still output a note when they are encountered.
-# * None - CVSS Score 0.0
-# * Low - CVSS Score 0.1 - 3.9
-# * Medium - CVSS Score 4.0 - 6.9
-# * High - CVSS Score 7.0 - 8.9
-# * Critical - CVSS Score 9.0 - 10.0
-#severity-threshold =
-
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
 # Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
@@ -98,45 +85,14 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "MIT",
-    "Apache-2.0",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "ISC",
-    "0BSD",
-    "MPL-2.0",
-    "CC0-1.0",
-    "Unicode-DFS-2016",
-    "OpenSSL",
-    "Zlib",
-    "Unicode-3.0",
+    #"MIT",
+    #"Apache-2.0",
+    #"Apache-2.0 WITH LLVM-exception",
 ]
-# List of explicitly disallowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-deny = [
-    #"Nokia",
-]
-# Lint level for licenses considered copyleft
-copyleft = "warn"
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# * both - The license will be approved if it is both OSI-approved *AND* FSF
-# * either - The license will be approved if it is either OSI-approved *OR* FSF
-# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
-# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
-# * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
-# Lint level used when no other predicates are matched
-# 1. License isn't in the allow or deny lists
-# 2. License isn't copyleft
-# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
@@ -147,28 +103,26 @@ confidence-threshold = 0.8
 exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
-    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+    #{ allow = ["Zlib"], crate = "adler32" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the
 # licensing information
-[[licenses.clarify]]
-# The name of the crate the clarification applies to
-name = "ring"
-# The optional version constraint for the crate
-version = "*"
+#[[licenses.clarify]]
+# The package spec the clarification applies to
+#crate = "ring"
 # The SPDX expression for the license requirements of the crate
-expression = "MIT AND ISC AND OpenSSL"
+#expression = "MIT AND ISC AND OpenSSL"
 # One or more files in the crate's source used as the "source of truth" for
 # the license expression. If the contents match, the clarification will be used
 # when running the license check, otherwise the clarification will be ignored
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
-license-files = [
-    # Each entry is a crate relative path, and the (opaque) hash of its contents
-    { path = "LICENSE", hash = 0xbd0eed23 }
-]
+#license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
@@ -198,34 +152,32 @@ wildcards = "allow"
 # * all - Both lowest-version and simplest-path are used
 highlight = "all"
 # The default lint level for `default` features for crates that are members of
-# the workspace that is being checked. This can be overriden by allowing/denying
+# the workspace that is being checked. This can be overridden by allowing/denying
 # `default` on a crate-by-crate basis if desired.
 workspace-default-features = "allow"
 # The default lint level for `default` features for external crates that are not
-# members of the workspace. This can be overriden by allowing/denying `default`
+# members of the workspace. This can be overridden by allowing/denying `default`
 # on a crate-by-crate basis if desired.
 external-default-features = "allow"
 # List of crates that are allowed. Use with care!
 allow = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
 ]
 # List of crates to deny
 deny = [
-    # Each entry the name of a crate and a version range. If version is
-    # not specified, all versions will be matched.
-    #{ name = "ansi_term", version = "=0.11.0" },
-    #
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
     # Wrapper crates can optionally be specified to allow the crate when it
     # is a direct dependency of the otherwise banned crate
-    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
-    { name = "openssl" },
+    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
 ]
 
 # List of features to allow/deny
 # Each entry the name of a crate and a version range. If version is
 # not specified, all versions will be matched.
 #[[bans.features]]
-#name = "reqwest"
+#crate = "reqwest"
 # Features to not allow
 #deny = ["json"]
 # Features to allow
@@ -246,14 +198,16 @@ deny = [
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite.
 skip-tree = [
-    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+    #{ crate = "ansi_term@0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/nym-api/nym-api-requests/Cargo.toml
+++ b/nym-api/nym-api-requests/Cargo.toml
@@ -11,16 +11,15 @@ bs58 = { workspace = true }
 cosmrs = { workspace = true }
 cosmwasm-std = { workspace = true }
 getset = { workspace = true }
+rocket = { workspace = true, optional = true }
 schemars = { workspace = true, features = ["preserve_order"] }
 serde = { workspace = true, features = ["derive"] }
-ts-rs = { workspace = true, optional = true }
+sha2.workspace = true
 tendermint = { workspace = true }
-time = { workspace = true, features = ["serde", "parsing", "formatting"] }
 thiserror.workspace = true
-rocket = { workspace = true, optional = true }
+time = { workspace = true, features = ["serde", "parsing", "formatting"] }
+ts-rs = { workspace = true, optional = true }
 utoipa.workspace = true
-
-sha2 = "0.10.8"
 
 # for serde on secp256k1 signatures
 ecdsa = { workspace = true, features = ["serde"] }

--- a/service-providers/ip-packet-router/Cargo.toml
+++ b/service-providers/ip-packet-router/Cargo.toml
@@ -46,4 +46,4 @@ tokio-util = { workspace = true, features = ["codec"] }
 url.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tokio-tun = "0.11.5"
+tokio-tun.workspace = true


### PR DESCRIPTION
Update to use latest cargo-deny.

- Regenerate deny.toml
- Backport old settings to deny.toml
- Explicitly allow GPL-3 only on our own specific crates
- Update deny.toml for latest changes
- Fix cargo-deny warnings for duplicate crates
- Update cargo-deny-action to v2

The security related changes about denying vulnerabilities and explicit ignores was not backported, since we don't run it anyway. Currently we're relying on dependabot for this

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/4901)
<!-- Reviewable:end -->
