### PR TITLE
Fix nymvpn.com url in mainnet defaults

### DIFF
--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -32,7 +32,7 @@ pub const NYXD_URL: &str = "https://rpc.nymtech.net";
 pub const NYM_API: &str = "https://validator.nymtech.net/api/";
 pub const NYXD_WS: &str = "wss://rpc.nymtech.net/websocket";
 pub const EXPLORER_API: &str = "https://explorer.nymtech.net/api/";
-pub const NYM_VPN_API: &str = "https://nymvpn.net/api/";
+pub const NYM_VPN_API: &str = "https://nymvpn.com/api/";
 
 // I'm making clippy mad on purpose, because that url HAS TO be updated and deployed before merging
 pub const EXIT_POLICY_URL: &str =


### PR DESCRIPTION
The old URL (nympvn.net) works since it is redirected to nymvpn.com, but the extra roundtrip adds latency to all the API calls the vpn client does. So this PR should help speed things up, in particular when these API calls happen across the mixnet.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/4920)
<!-- Reviewable:end -->
