### PR TITLE
Switch over the last set of jobs to arc runners

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04
+    runs-on: arc-ubuntu-20.04-dind
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies (Linux)

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04-dind
+    runs-on: arc-ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies (Linux)
@@ -99,24 +99,3 @@ jobs:
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
         working-directory: dist/docs
         continue-on-error: false
-
-      - name: Matrix - Node Install
-        run: npm install
-        working-directory: .github/workflows/support-files
-      - name: Matrix - Send Notification
-        env:
-          NYM_NOTIFICATION_KIND: cd-docs
-          NYM_PROJECT_NAME: "Docs CD"
-          NYM_CI_WWW_BASE: "${{ secrets.NYM_CD_WWW_BASE }}"
-          NYM_CI_WWW_LOCATION: "${{ env.GITHUB_REF_SLUG }}"
-          GIT_COMMIT_MESSAGE: "${{ github.event.head_commit.message }}"
-          GIT_BRANCH: "${GITHUB_REF##*/}"
-          MATRIX_SERVER: "${{ secrets.MATRIX_SERVER }}"
-          MATRIX_ROOM: "${{ secrets.MATRIX_ROOM_DOCS }}"
-          MATRIX_USER_ID: "${{ secrets.MATRIX_USER_ID }}"
-          MATRIX_TOKEN: "${{ secrets.MATRIX_TOKEN }}"
-          MATRIX_DEVICE_ID: "${{ secrets.MATRIX_DEVICE_ID }}"
-          IS_SUCCESS: "${{ job.status == 'success' }}"
-        uses: docker://keybaseio/client:stable-node
-        with:
-          args: .github/workflows/support-files/notifications/entry_point.sh

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04-16-core
+    runs-on: arc-ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies (Linux)

--- a/.github/workflows/ci-build-ts.yml
+++ b/.github/workflows/ci-build-ts.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04-dind
+    runs-on: arc-ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
     - name: Install rsync
@@ -45,23 +45,3 @@ jobs:
         REMOTE_USER: ${{ secrets.CI_WWW_REMOTE_USER }}
         TARGET: ${{ secrets.CI_WWW_REMOTE_TARGET }}/ts-${{ env.GITHUB_REF_SLUG }}-example
         EXCLUDE: "/dist/, /node_modules/"
-    - name: Matrix - Node Install
-      run: npm install
-      working-directory: .github/workflows/support-files
-    - name: Matrix - Send Notification
-      env:
-        NYM_NOTIFICATION_KIND: ts-packages
-        NYM_PROJECT_NAME: "ts-packages"
-        NYM_CI_WWW_BASE: "${{ secrets.NYM_CI_WWW_BASE }}"
-        NYM_CI_WWW_LOCATION: "ts-${{ env.GITHUB_REF_SLUG }}"
-        GIT_COMMIT_MESSAGE: "${{ github.event.head_commit.message }}"
-        GIT_BRANCH: "${GITHUB_REF##*/}"
-        IS_SUCCESS: "${{ job.status == 'success' }}"
-        MATRIX_SERVER: "${{ secrets.MATRIX_SERVER }}"
-        MATRIX_ROOM: "${{ secrets.MATRIX_ROOM }}"
-        MATRIX_USER_ID: "${{ secrets.MATRIX_USER_ID }}"
-        MATRIX_TOKEN: "${{ secrets.MATRIX_TOKEN }}"
-        MATRIX_DEVICE_ID: "${{ secrets.MATRIX_DEVICE_ID }}"
-      uses: docker://keybaseio/client:stable-node
-      with:
-        args: .github/workflows/support-files/notifications/entry_point.sh

--- a/.github/workflows/ci-build-ts.yml
+++ b/.github/workflows/ci-build-ts.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04-16-core
+    runs-on: arc-ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
     - name: Install rsync

--- a/.github/workflows/ci-build-ts.yml
+++ b/.github/workflows/ci-build-ts.yml
@@ -1,6 +1,7 @@
 name: ci-build-ts
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "ts-packages/**"

--- a/.github/workflows/ci-build-ts.yml
+++ b/.github/workflows/ci-build-ts.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04
+    runs-on: arc-ubuntu-20.04-dind
     steps:
     - uses: actions/checkout@v4
     - name: Install rsync

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04
+    runs-on: arc-ubuntu-20.04-dind
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies (Linux)

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04-16-core
+    runs-on: arc-ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies (Linux)

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04-dind
+    runs-on: arc-ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies (Linux)
@@ -70,24 +70,3 @@ jobs:
           REMOTE_USER: ${{ secrets.CI_WWW_REMOTE_USER }}
           TARGET: ${{ secrets.CI_WWW_REMOTE_TARGET }}/docs-${{ env.GITHUB_REF_SLUG }}
           EXCLUDE: "/node_modules/"
-
-      - name: Matrix - Node Install
-        run: npm install
-        working-directory: .github/workflows/support-files
-      - name: Matrix - Send Notification
-        env:
-          NYM_NOTIFICATION_KIND: ci-docs
-          NYM_PROJECT_NAME: "Docs CI"
-          NYM_CI_WWW_BASE: "${{ secrets.NYM_CI_WWW_BASE }}"
-          NYM_CI_WWW_LOCATION: "docs-${{ env.GITHUB_REF_SLUG }}"
-          GIT_COMMIT_MESSAGE: "${{ github.event.head_commit.message }}"
-          GIT_BRANCH: "${GITHUB_REF##*/}"
-          MATRIX_SERVER: "${{ secrets.MATRIX_SERVER }}"
-          MATRIX_ROOM: "${{ secrets.MATRIX_ROOM_DOCS }}"
-          MATRIX_USER_ID: "${{ secrets.MATRIX_USER_ID }}"
-          MATRIX_TOKEN: "${{ secrets.MATRIX_TOKEN }}"
-          MATRIX_DEVICE_ID: "${{ secrets.MATRIX_DEVICE_ID }}"
-          IS_SUCCESS: "${{ job.status == 'success' }}"
-        uses: docker://keybaseio/client:stable-node
-        with:
-          args: .github/workflows/support-files/notifications/entry_point.sh

--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04
+    runs-on: arc-ubuntu-20.04-dind
     steps:
       - uses: actions/checkout@v4
       - uses: rlespinasse/github-slug-action@v3.x

--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04
+    runs-on: ubuntu-20.04-16-core
     steps:
       - uses: actions/checkout@v4
       - uses: rlespinasse/github-slug-action@v3.x

--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04-dind
+    runs-on: arc-ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: rlespinasse/github-slug-action@v3.x
@@ -53,24 +53,3 @@ jobs:
         run: yarn lint
       - name: Typecheck with tsc
         run: yarn tsc
-
-      - name: Matrix - Node Install
-        run: npm install
-        working-directory: .github/workflows/support-files
-      - name: Matrix - Send Notification
-        env:
-          NYM_NOTIFICATION_KIND: ts-packages
-          NYM_PROJECT_NAME: "ts-packages"
-          NYM_CI_WWW_BASE: "${{ secrets.NYM_CI_WWW_BASE }}"
-          NYM_CI_WWW_LOCATION: "ts-${{ env.GITHUB_REF_SLUG }}"
-          GIT_COMMIT_MESSAGE: "${{ github.event.head_commit.message }}"
-          GIT_BRANCH: "${GITHUB_REF##*/}"
-          IS_SUCCESS: "${{ job.status == 'success' }}"
-          MATRIX_SERVER: "${{ secrets.MATRIX_SERVER }}"
-          MATRIX_ROOM: "${{ secrets.MATRIX_ROOM }}"
-          MATRIX_USER_ID: "${{ secrets.MATRIX_USER_ID }}"
-          MATRIX_TOKEN: "${{ secrets.MATRIX_TOKEN }}"
-          MATRIX_DEVICE_ID: "${{ secrets.MATRIX_DEVICE_ID }}"
-        uses: docker://keybaseio/client:stable-node
-        with:
-          args: .github/workflows/support-files/notifications/entry_point.sh

--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -1,6 +1,7 @@
 name: ci-lint-typescript
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "ts-packages/**"

--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04-16-core
+    runs-on: arc-ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: rlespinasse/github-slug-action@v3.x

--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04-16-core
+    runs-on: arc-ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: rlespinasse/github-slug-action@v3.x

--- a/.github/workflows/publish-sdk-npm.yml
+++ b/.github/workflows/publish-sdk-npm.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04-16-core
+    runs-on: arc-ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Switch over the remaining GH jobs using 16-core runners to self-hosted arc runners.

Since we can't currently use Docker on the ubuntu-20.04 runners, remove the matrix notification steps

Confirm that the deployment workflows work through manual testing
- [x] cd-docs
- [x] publish-sdk-npm

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/4938)
<!-- Reviewable:end -->
