### PR TITLE
Add "utoipa" feature to nym-node

### DIFF
--- a/nym-node/nym-node-http-api/Cargo.toml
+++ b/nym-node/nym-node-http-api/Cargo.toml
@@ -29,7 +29,7 @@ rand = { workspace = true }
 fastrand = { workspace = true }
 
 nym-crypto = { path = "../../common/crypto", features = ["asymmetric", "rand"] }
-nym-http-api-common = { path = "../../common/http-api-common" }
+nym-http-api-common = { path = "../../common/http-api-common", features = ["utoipa"] }
 nym-node-requests = { path = "../nym-node-requests", default-features = false, features = [
     "openapi",
 ] }


### PR DESCRIPTION
`cargo build -p nym-node` was failing, since its depending on `QueryParams` having `utoipa` traits derived

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/4945)
<!-- Reviewable:end -->
