### PR TITLE
expose authenticator address along other address in node-details

### DIFF
--- a/nym-node/src/node/helpers.rs
+++ b/nym-node/src/node/helpers.rs
@@ -38,6 +38,7 @@ pub(crate) struct DisplayDetails {
 
     pub(crate) exit_network_requester_address: String,
     pub(crate) exit_ip_packet_router_address: String,
+    pub(crate) exit_authenticator_address: String,
 }
 
 impl Display for DisplayDetails {
@@ -63,6 +64,11 @@ impl Display for DisplayDetails {
             f,
             "exit ip packet router address: {}",
             self.exit_ip_packet_router_address
+        )?;
+        writeln!(
+            f,
+            "exit authenticator address: {}",
+            self.exit_authenticator_address
         )?;
         Ok(())
     }

--- a/nym-node/src/node/mod.rs
+++ b/nym-node/src/node/mod.rs
@@ -522,6 +522,7 @@ impl NymNode {
             x25519_wireguard_key: self.x25519_wireguard_key().to_base58_string(),
             exit_network_requester_address: self.exit_network_requester_address().to_string(),
             exit_ip_packet_router_address: self.exit_ip_packet_router_address().to_string(),
+            exit_authenticator_address: self.exit_authenticator_address().to_string(),
         }
     }
 


### PR DESCRIPTION
Expose authenticator address along ip packet router and network requester for easier parsing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/4953)
<!-- Reviewable:end -->
