### PR TITLE
[Product Data] Add session type based on ecash ticket received

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6290,6 +6290,7 @@ name = "nym-statistics-common"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "nym-credentials-interface",
  "nym-sphinx",
  "time",
 ]

--- a/common/statistics/Cargo.toml
+++ b/common/statistics/Cargo.toml
@@ -14,3 +14,4 @@ futures = { workspace = true }
 time = { workspace = true }
 
 nym-sphinx = { path = "../nymsphinx" }
+nym-credentials-interface = { path = "../credentials-interface" }

--- a/common/statistics/src/events.rs
+++ b/common/statistics/src/events.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use futures::channel::mpsc;
+use nym_credentials_interface::TicketType;
 use nym_sphinx::DestinationAddressBytes;
 use time::OffsetDateTime;
 
@@ -25,6 +26,16 @@ impl StatsEvent {
             client,
         })
     }
+
+    pub fn new_ecash_ticket(
+        client: DestinationAddressBytes,
+        ticket_type: TicketType,
+    ) -> StatsEvent {
+        StatsEvent::SessionStatsEvent(SessionEvent::EcashTicket {
+            ticket_type,
+            client,
+        })
+    }
 }
 
 pub enum SessionEvent {
@@ -34,6 +45,10 @@ pub enum SessionEvent {
     },
     SessionStop {
         stop_time: OffsetDateTime,
+        client: DestinationAddressBytes,
+    },
+    EcashTicket {
+        ticket_type: TicketType,
         client: DestinationAddressBytes,
     },
 }

--- a/gateway/src/node/client_handling/websocket/common_state.rs
+++ b/gateway/src/node/client_handling/websocket/common_state.rs
@@ -3,6 +3,7 @@
 
 use nym_credential_verification::{ecash::EcashManager, BandwidthFlushingBehaviourConfig};
 use nym_crypto::asymmetric::identity;
+use nym_statistics_common::events::StatsEventSender;
 use std::sync::Arc;
 
 // I can see this being possible expanded with say storage or client store
@@ -13,4 +14,5 @@ pub(crate) struct CommonHandlerState<S> {
     pub(crate) local_identity: Arc<identity::KeyPair>,
     pub(crate) only_coconut_credentials: bool,
     pub(crate) bandwidth_cfg: BandwidthFlushingBehaviourConfig,
+    pub(crate) stats_event_sender: StatsEventSender,
 }

--- a/gateway/src/node/statistics/sessions.rs
+++ b/gateway/src/node/statistics/sessions.rs
@@ -9,6 +9,7 @@ use time::{Date, OffsetDateTime};
 
 use nym_statistics_common::events::SessionEvent;
 
+#[derive(PartialEq)]
 enum SessionType {
     Vpn,
     Mixnet,
@@ -134,7 +135,9 @@ impl SessionStatsHandler {
 
     fn handle_ecash_ticket(&mut self, ticket_type: TicketType, client: DestinationAddressBytes) {
         if let Some(active_session) = self.active_sessions.get_mut(&client) {
-            active_session.set_type(ticket_type);
+            if active_session.typ == SessionType::Unknown {
+                active_session.set_type(ticket_type);
+            }
         }
     }
 

--- a/gateway/src/node/statistics/sessions.rs
+++ b/gateway/src/node/statistics/sessions.rs
@@ -9,6 +9,8 @@ use time::{Date, Duration, OffsetDateTime};
 
 use nym_statistics_common::events::SessionEvent;
 
+const FINISHED_SESSIONS_CAP: usize = 1_000_000; //to be on the safe side of memory blowups until persistent storage
+
 #[derive(PartialEq)]
 enum SessionType {
     Vpn,
@@ -132,7 +134,9 @@ impl SessionStatsHandler {
     fn handle_session_stop(&mut self, stop_time: OffsetDateTime, client: DestinationAddressBytes) {
         if let Some(session) = self.active_sessions.remove(&client) {
             if let Some(finished_session) = session.end_at(stop_time) {
-                self.finished_sessions.push(finished_session);
+                if self.finished_sessions.len() < FINISHED_SESSIONS_CAP {
+                    self.finished_sessions.push(finished_session);
+                }
             }
         }
     }

--- a/nym-node/nym-node-http-api/src/state/metrics.rs
+++ b/nym-node/nym-node-http-api/src/state/metrics.rs
@@ -170,7 +170,7 @@ impl SessionStatsState {
             .sessions
             .clone()
             .into_iter()
-            .map(|(duration, typ)| Session { duration, typ })
+            .map(|(duration_ms, typ)| Session { duration_ms, typ })
             .collect();
         SessionStats {
             update_time: self.update_time.with_time(time!(0:00)).assume_utc(),

--- a/nym-node/nym-node-http-api/src/state/metrics.rs
+++ b/nym-node/nym-node-http-api/src/state/metrics.rs
@@ -4,7 +4,7 @@
 use crate::state::AppState;
 use axum::extract::FromRef;
 use nym_node_requests::api::v1::metrics::models::{
-    MixingStats, SessionStats, VerlocResult, VerlocResultData, VerlocStats,
+    MixingStats, Session, SessionStats, VerlocResult, VerlocResultData, VerlocStats,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -154,22 +154,30 @@ impl SharedSessionStats {
     }
 }
 
+type FinishedSessions = Vec<(u64, String)>;
+
 #[derive(Debug, Clone)]
 pub struct SessionStatsState {
     pub update_time: Date,
     pub unique_active_users: u32,
     pub session_started: u32,
-    pub session_durations: Vec<u64>,
+    pub sessions: FinishedSessions,
 }
 
 impl SessionStatsState {
     pub fn as_response(&self) -> SessionStats {
+        let sessions = self
+            .sessions
+            .clone()
+            .into_iter()
+            .map(|(duration, typ)| Session { duration, typ })
+            .collect();
         SessionStats {
             update_time: self.update_time.with_time(time!(0:00)).assume_utc(),
             unique_active_users: self.unique_active_users,
-            session_durations: self.session_durations.clone(),
+            sessions,
             sessions_started: self.session_started,
-            sessions_finished: self.session_durations.len() as u32,
+            sessions_finished: self.sessions.len() as u32,
         }
     }
 }
@@ -180,7 +188,7 @@ impl Default for SessionStatsState {
             update_time: OffsetDateTime::UNIX_EPOCH.date(),
             unique_active_users: 0,
             session_started: 0,
-            session_durations: Default::default(),
+            sessions: Default::default(),
         }
     }
 }

--- a/nym-node/nym-node-requests/src/api/v1/metrics/models.rs
+++ b/nym-node/nym-node-requests/src/api/v1/metrics/models.rs
@@ -38,7 +38,7 @@ pub struct MixingStats {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Session {
-    pub duration: u64,
+    pub duration_ms: u64,
     pub typ: String,
 }
 

--- a/nym-node/nym-node-requests/src/api/v1/metrics/models.rs
+++ b/nym-node/nym-node-requests/src/api/v1/metrics/models.rs
@@ -37,13 +37,20 @@ pub struct MixingStats {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Session {
+    pub duration: u64,
+    pub typ: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionStats {
     #[serde(with = "time::serde::rfc3339")]
     pub update_time: OffsetDateTime,
 
     pub unique_active_users: u32,
 
-    pub session_durations: Vec<u64>,
+    pub sessions: Vec<Session>,
 
     pub sessions_started: u32,
 


### PR DESCRIPTION
## What it does
Fire an `EcashTicket` event for the `GatewayStatisticsCollector`, when an Ecash ticket is being accepted. This allows to mark an active session as being a mixnet session or a vpn session.

It also changes the format of the related self-described data, to accommodate that new session type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/4974)
<!-- Reviewable:end -->
