### PR TITLE
Fix critical issues SI86 and SI87 from Cure53

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4868,6 +4868,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha2 0.9.9",
+ "subtle 2.5.0",
  "thiserror",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -350,6 +350,7 @@ prometheus = { version = "0.13.0" }
 bls12_381 = { git = "https://github.com/jstuczyn/bls12_381", default-features = false, branch = "temp/experimental-serdect" }
 group = { version = "0.13.0", default-features = false }
 ff = { version = "0.13.0", default-features = false }
+subtle = "2.5.0"
 
 # cosmwasm-related
 cosmwasm-schema = "=1.4.3"

--- a/common/nym_offline_compact_ecash/Cargo.toml
+++ b/common/nym_offline_compact_ecash/Cargo.toml
@@ -25,6 +25,7 @@ rayon = { workspace = true, optional = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 ff = { workspace = true }
 group = { workspace = true }
+subtle = { workspace = true }
 
 nym-pemstore = { path = "../pemstore" }
 nym-network-defaults = { path = "../network-defaults", default-features = false }

--- a/common/nym_offline_compact_ecash/src/common_types.rs
+++ b/common/nym_offline_compact_ecash/src/common_types.rs
@@ -6,6 +6,7 @@ use crate::error::Result;
 use crate::helpers::{g1_tuple_to_bytes, recover_g1_tuple};
 use bls12_381::{G1Projective, Scalar};
 use serde::{Deserialize, Serialize};
+use subtle::Choice;
 
 pub type SignerIndex = u64;
 
@@ -57,6 +58,11 @@ impl Signature {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let (h, s) = recover_g1_tuple::<Self>(bytes)?;
         Ok(Signature { h, s })
+    }
+
+    /// Checks whether any of the group elements of the signature is an identity element located at infinity
+    pub fn is_at_infinity(&self) -> Choice {
+        self.s.is_identity() | self.h.is_identity()
     }
 }
 

--- a/common/nymcoconut/src/scheme/aggregation.rs
+++ b/common/nymcoconut/src/scheme/aggregation.rs
@@ -253,7 +253,7 @@ mod tests {
 
         let sigs = sks
             .iter()
-            .map(|sk| sign(&params, sk, &attributes).unwrap())
+            .map(|sk| sign(sk, &attributes).unwrap())
             .collect::<Vec<_>>();
 
         // aggregating (any) threshold works

--- a/common/nymcoconut/src/scheme/issuance.rs
+++ b/common/nymcoconut/src/scheme/issuance.rs
@@ -453,7 +453,6 @@ pub fn verify_partial_blind_signature(
 
 /// Creates a Coconut Signature under a given secret key on a set of public attributes only.
 pub fn sign(
-    params: &Parameters,
     secret_key: &SecretKey,
     public_attributes: &[&Attribute],
 ) -> Result<Signature> {
@@ -464,13 +463,23 @@ pub fn sign(
         });
     }
 
-    // TODO: why in the python implementation this hash onto the curve is present
-    // while it's not used in the paper? the paper uses random exponent instead.
-    // (the python implementation hashes string representation of all attributes onto the curve,
-    // but I think the same can be achieved by just summing the attributes thus avoiding the unnecessary
-    // transformation. If I'm wrong, please correct me.)
-    let attributes_sum = public_attributes.iter().copied().sum::<Scalar>();
-    let h = hash_g1((params.gen1() * attributes_sum).to_bytes());
+    //Serialize the array structure of the public attributes into a byte array
+    let mut serialized_attributes = Vec::new();
+    //Prepend the length of the entire array (in bytes)
+    let array_len = public_attributes.len() as u64;
+    serialized_attributes.extend_from_slice(&array_len.to_le_bytes());
+    //Serialize each attribute with its length
+    for &attribute in public_attributes.iter() {
+        let attr_bytes = attribute.to_bytes();
+        let attr_len = attr_bytes.len() as u64;
+
+        // Prefix the attribute with its length
+        serialized_attributes.extend_from_slice(&attr_len.to_le_bytes());
+        serialized_attributes.extend_from_slice(&attr_bytes);
+    }
+
+    //Hash the resulting byte array to derive the point H
+    let h = hash_g1(serialized_attributes);
 
     // x + m0 * y0 + m1 * y1 + ... mn * yn
     let exponent = secret_key.x

--- a/common/nymcoconut/src/scheme/issuance.rs
+++ b/common/nymcoconut/src/scheme/issuance.rs
@@ -452,10 +452,7 @@ pub fn verify_partial_blind_signature(
 }
 
 /// Creates a Coconut Signature under a given secret key on a set of public attributes only.
-pub fn sign(
-    secret_key: &SecretKey,
-    public_attributes: &[&Attribute],
-) -> Result<Signature> {
+pub fn sign(secret_key: &SecretKey, public_attributes: &[&Attribute]) -> Result<Signature> {
     if public_attributes.len() > secret_key.ys.len() {
         return Err(CoconutError::IssuanceMaxAttributes {
             max: secret_key.ys.len(),

--- a/common/nymcoconut/src/scheme/mod.rs
+++ b/common/nymcoconut/src/scheme/mod.rs
@@ -436,8 +436,8 @@ mod tests {
 
         let keypair1 = keygen(&params);
         let keypair2 = keygen(&params);
-        let sig1 = sign(&params, keypair1.secret_key(), &attributes).unwrap();
-        let sig2 = sign(&params, keypair2.secret_key(), &attributes).unwrap();
+        let sig1 = sign(keypair1.secret_key(), &attributes).unwrap();
+        let sig2 = sign(keypair2.secret_key(), &attributes).unwrap();
 
         assert!(verify(
             &params,

--- a/common/nymcoconut/src/scheme/verification.rs
+++ b/common/nymcoconut/src/scheme/verification.rs
@@ -429,5 +429,4 @@ mod tests {
             &forged_signature_2
         ));
     }
-
 }

--- a/common/nymcoconut/src/scheme/verification.rs
+++ b/common/nymcoconut/src/scheme/verification.rs
@@ -394,7 +394,8 @@ mod tests {
 
         //#3
         let h0 = sig_a_zero.0;
-        let h1 = &scalar_2_inv * &sig_a_zero.1 + &scalar_2_inv * &sig_zero_a.1;
+        // Removed unnecessary references
+        let h1 = scalar_2_inv * sig_a_zero.1 + scalar_2_inv * sig_zero_a.1;
         let forged_signature = Signature(h0, h1);
         let a_half = a * scalar_2_inv;
         let new_plaintext = vec![&a_half, &a_half];
@@ -413,7 +414,8 @@ mod tests {
         let scalar_4_inv = Scalar::invert(&scalar_4).unwrap();
         let scalar_3_over_4 = scalar_3 * scalar_4_inv;
 
-        let h1_2 = &scalar_4_inv * &sig_a_zero.1 + &scalar_3_over_4 * &sig_zero_a.1;
+        // Removed unnecessary references
+        let h1_2 = scalar_4_inv * sig_a_zero.1 + scalar_3_over_4 * sig_zero_a.1;
         let forged_signature_2 = Signature(h0, h1_2);
         let a_quarter = a * scalar_4_inv;
         let a_3_over_4 = a * scalar_3_over_4;
@@ -427,4 +429,5 @@ mod tests {
             &forged_signature_2
         ));
     }
+
 }

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -3156,6 +3156,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
+ "subtle 2.5.0",
  "thiserror",
  "zeroize",
 ]

--- a/wasm/zknym-lib/src/generic_scheme/coconut/mod.rs
+++ b/wasm/zknym-lib/src/generic_scheme/coconut/mod.rs
@@ -96,17 +96,14 @@ pub fn ttp_keygen(
 pub fn sign_simple(
     attributes: Vec<String>,
     keys: &KeyPairWrapper,
-    parameters: Option<ParametersWrapper>,
 ) -> Result<CredentialWrapper, ZkNymError> {
-    let params = get_params(&parameters);
-
     let public_attributes = attributes
         .into_iter()
         .map(hash_to_scalar)
         .collect::<Vec<_>>();
     let attributes_ref = public_attributes.iter().collect::<Vec<_>>();
 
-    nym_coconut::sign(params, keys.secret_key(), &attributes_ref)
+    nym_coconut::sign(keys.secret_key(), &attributes_ref)
         .map(Into::into)
         .map_err(Into::into)
 }


### PR DESCRIPTION
This pull request fixes the following issues:

NYM-01-042 WP5: Faulty aggregation to invalid offline eCash signatures ([link](https://nymtech.atlassian.net/browse/SI-87?atlOrigin=eyJpIjoiYTg1MzE2Y2VjMTZmNGYzNWE0M2VhYmNmODcwOGQxN2IiLCJwIjoiaiJ9))

2024-07-26 - C53 - NYM - NYM-01-033 WP5: Signature forgery of Pointcheval-Sanders schema ([link](https://nymtech.atlassian.net/browse/SI-86?atlOrigin=eyJpIjoiOWRhYmU0ZjhiMDQzNDBlNWE5NmNlZGFmMWE2MjY0ZGIiLCJwIjoiaiJ9))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/4982)
<!-- Reviewable:end -->
