### PR TITLE
[new-docs/operators] : Fix callout syntax

### DIFF
--- a/documentation/docs/pages/operators/binaries/building-nym.mdx
+++ b/documentation/docs/pages/operators/binaries/building-nym.mdx
@@ -43,7 +43,7 @@ If you really don't want to use the shell script installer, the [Rust installati
 
 ## Download and Build Nym Binaries
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 You cannot build from GitHub's .zip or .tar.gz archive files on the releases page - the Nym build scripts automatically include the current git commit hash in the built binary during compilation, so the build will fail if you use the archive code (which isn't a Git repository). Check the code out from github using `git clone` instead.
 </Callout>
 

--- a/documentation/docs/pages/operators/binaries/building-nym.mdx
+++ b/documentation/docs/pages/operators/binaries/building-nym.mdx
@@ -43,7 +43,7 @@ If you really don't want to use the shell script installer, the [Rust installati
 
 ## Download and Build Nym Binaries
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 You cannot build from GitHub's .zip or .tar.gz archive files on the releases page - the Nym build scripts automatically include the current git commit hash in the built binary during compilation, so the build will fail if you use the archive code (which isn't a Git repository). Check the code out from github using `git clone` instead.
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel.mdx
+++ b/documentation/docs/pages/operators/community-counsel.mdx
@@ -6,7 +6,7 @@ import { MyTab } from 'components/generic-tabs.tsx';
 
 # Community Counsel
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 **The entire content of this section is under [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/).**
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel/exit-gateway.mdx
+++ b/documentation/docs/pages/operators/community-counsel/exit-gateway.mdx
@@ -12,7 +12,7 @@ This page is a part of Nym Community Counsel (before Legal Forum) and its conten
 This document presents an initiative to further support Nym’s mission of allowing privacy for everyone everywhere. This would be achieved with the support of Nym node operators operating Gateways and opening these to any online service. Such setup needs a **clear policy**, one which will remain the **same for all operators** running Nym nodes. [**Nym exit policy**](https://nymtech.net/.wellknown/network-requester/exit-policy.txt) is a combination of safeguards like (nowadays deprecated) `Tor Null deny list` and `Tor reduced policy` together with changes decided by Nym operators community through the governance (like in this [vote](https://forum.nymtech.net/t/poll-a-new-nym-exit-policy-for-exit-gateways-and-the-nym-mixnet-is-inbound/464)). This policy aims to find a healthy compromise between protecting the operators and NymVPN users against attacks while allowing for as wide experience when accessing the internet through Nym Network.
 
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 The following part is for informational purposes only. Nym core team cannot provide comprehensive legal advice across all jurisdictions. Knowledge and experience with the legalities are being built up with the help of our counsel and with you, the community of Nym node operators. We encourage Nym node operators to join the [Node Operator](https://matrix.to/#/#operators:nymtech.chat) and [Operators Legal Forum](https://matrix.to/#/!YfoUFsJjsXbWmijbPG:nymtech.chat?via=nymtech.chat&via=matrix.org) channels on Element to share best practices and experiences.
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel/exit-gateway.mdx
+++ b/documentation/docs/pages/operators/community-counsel/exit-gateway.mdx
@@ -12,7 +12,7 @@ This page is a part of Nym Community Counsel (before Legal Forum) and its conten
 This document presents an initiative to further support Nym’s mission of allowing privacy for everyone everywhere. This would be achieved with the support of Nym node operators operating Gateways and opening these to any online service. Such setup needs a **clear policy**, one which will remain the **same for all operators** running Nym nodes. [**Nym exit policy**](https://nymtech.net/.wellknown/network-requester/exit-policy.txt) is a combination of safeguards like (nowadays deprecated) `Tor Null deny list` and `Tor reduced policy` together with changes decided by Nym operators community through the governance (like in this [vote](https://forum.nymtech.net/t/poll-a-new-nym-exit-policy-for-exit-gateways-and-the-nym-mixnet-is-inbound/464)). This policy aims to find a healthy compromise between protecting the operators and NymVPN users against attacks while allowing for as wide experience when accessing the internet through Nym Network.
 
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 The following part is for informational purposes only. Nym core team cannot provide comprehensive legal advice across all jurisdictions. Knowledge and experience with the legalities are being built up with the help of our counsel and with you, the community of Nym node operators. We encourage Nym node operators to join the [Node Operator](https://matrix.to/#/#operators:nymtech.chat) and [Operators Legal Forum](https://matrix.to/#/!YfoUFsJjsXbWmijbPG:nymtech.chat?via=nymtech.chat&via=matrix.org) channels on Element to share best practices and experiences.
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel/isp-list.mdx
+++ b/documentation/docs/pages/operators/community-counsel/isp-list.mdx
@@ -12,7 +12,7 @@ If you came across any legal findings, please share them in our [list of jurisdi
 
 While we trust that Nym node operators are honest, we would like to ask everyone to do your own research.
 
-<Callout color="danger" emoji="">
+<Callout type="danger" emoji="">
 To edit or add information to the ISP list, make changes to the csv file located [here](https://github.com/nymtech/nym/blob/develop/documentation/docs/data/csv/isp-sheet.csv) and submit your edits as a pull request according to [this guide](add-content.mdx).
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel/isp-list.mdx
+++ b/documentation/docs/pages/operators/community-counsel/isp-list.mdx
@@ -12,7 +12,7 @@ If you came across any legal findings, please share them in our [list of jurisdi
 
 While we trust that Nym node operators are honest, we would like to ask everyone to do your own research.
 
-<Callout type="danger" emoji="">
+<Callout type="warning" emoji="">
 To edit or add information to the ISP list, make changes to the csv file located [here](https://github.com/nymtech/nym/blob/develop/documentation/docs/data/csv/isp-sheet.csv) and submit your edits as a pull request according to [this guide](add-content.mdx).
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel/jurisdictions.mdx
+++ b/documentation/docs/pages/operators/community-counsel/jurisdictions.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # Exit Gateway - Jurisdictions
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 The following part is for informational purposes only. Nym core team cannot provide comprehensive legal advice across all jurisdictions. Knowledge and experience with the legalities are being built up with the help of our counsel and with you, the community of Nym node operators. We encourage Nym node operators to join the [Node Operator](https://matrix.to/#/#operators:nymtech.chat) and [Operators Legal Forum](https://matrix.to/#/!YfoUFsJjsXbWmijbPG:nymtech.chat?via=nymtech.chat&via=matrix.org) channels on Element to share best practices and experiences.
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel/jurisdictions.mdx
+++ b/documentation/docs/pages/operators/community-counsel/jurisdictions.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # Exit Gateway - Jurisdictions
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 The following part is for informational purposes only. Nym core team cannot provide comprehensive legal advice across all jurisdictions. Knowledge and experience with the legalities are being built up with the help of our counsel and with you, the community of Nym node operators. We encourage Nym node operators to join the [Node Operator](https://matrix.to/#/#operators:nymtech.chat) and [Operators Legal Forum](https://matrix.to/#/!YfoUFsJjsXbWmijbPG:nymtech.chat?via=nymtech.chat&via=matrix.org) channels on Element to share best practices and experiences.
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel/jurisdictions/swiss.mdx
+++ b/documentation/docs/pages/operators/community-counsel/jurisdictions/swiss.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # Legal environment: Switzerland
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 The following part is for informational purposes only. Nym core team cannot provide comprehensive legal advice across all jurisdictions. Knowledge and experience with the legalities are being built up with the help of our counsel and with you, the community of Nym node operators. We encourage Nym node operators to join the [Node Operator](https://matrix.to/#/#operators:nymtech.chat) and [Operators Legal Forum](https://matrix.to/#/!YfoUFsJjsXbWmijbPG:nymtech.chat?via=nymtech.chat&via=matrix.org) channels on Element to share best practices and experiences.
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel/jurisdictions/swiss.mdx
+++ b/documentation/docs/pages/operators/community-counsel/jurisdictions/swiss.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # Legal environment: Switzerland
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 The following part is for informational purposes only. Nym core team cannot provide comprehensive legal advice across all jurisdictions. Knowledge and experience with the legalities are being built up with the help of our counsel and with you, the community of Nym node operators. We encourage Nym node operators to join the [Node Operator](https://matrix.to/#/#operators:nymtech.chat) and [Operators Legal Forum](https://matrix.to/#/!YfoUFsJjsXbWmijbPG:nymtech.chat?via=nymtech.chat&via=matrix.org) channels on Element to share best practices and experiences.
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel/jurisdictions/united-states.mdx
+++ b/documentation/docs/pages/operators/community-counsel/jurisdictions/united-states.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # Legal environment: United States
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 The following part is for informational purposes only. Nym core team cannot provide comprehensive legal advice across all jurisdictions. Knowledge and experience with the legalities are being built up with the help of our counsel and with you, the community of Nym node operators. We encourage Nym node operators to join the [Node Operator](https://matrix.to/#/#operators:nymtech.chat) and [Operators Legal Forum](https://matrix.to/#/!YfoUFsJjsXbWmijbPG:nymtech.chat?via=nymtech.chat&via=matrix.org) channels on Element to share best practices and experiences.
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel/jurisdictions/united-states.mdx
+++ b/documentation/docs/pages/operators/community-counsel/jurisdictions/united-states.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # Legal environment: United States
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 The following part is for informational purposes only. Nym core team cannot provide comprehensive legal advice across all jurisdictions. Knowledge and experience with the legalities are being built up with the help of our counsel and with you, the community of Nym node operators. We encourage Nym node operators to join the [Node Operator](https://matrix.to/#/#operators:nymtech.chat) and [Operators Legal Forum](https://matrix.to/#/!YfoUFsJjsXbWmijbPG:nymtech.chat?via=nymtech.chat&via=matrix.org) channels on Element to share best practices and experiences.
 </Callout>
 

--- a/documentation/docs/pages/operators/community-counsel/landing-pages.mdx
+++ b/documentation/docs/pages/operators/community-counsel/landing-pages.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 
 # Landing Pages
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 The entire content of this page is under [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/).
 </Callout>
 

--- a/documentation/docs/pages/operators/faq/nym-nodes-faq.mdx
+++ b/documentation/docs/pages/operators/faq/nym-nodes-faq.mdx
@@ -15,6 +15,6 @@ This design ensures the nodes aim to have a same size of stake (reputation) whic
 > ACTIVE_SET_PROBABILITY = NODE_PERFORMANCE ^ 20 * STAKE_SATURATION
 
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 We are working on a new tokenomics and reward pages. Coming out soon.
 </Callout>

--- a/documentation/docs/pages/operators/nodes/maintenance.mdx
+++ b/documentation/docs/pages/operators/nodes/maintenance.mdx
@@ -107,7 +107,7 @@ Anything can happen to the server on which your node is running. To back up your
 Assuming that everyone access their wallets from local machine and does *not* store their seeds on VPS, point 2. should be a given. 
 To backup your `nym-node` keys and configuration in the easiest way possible, copy the entire config directory `.nym` from your VPS to your local desktop, using a special copy command `scp`:
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 Never store your mnemonic seed anywhere online nor do *not* share it with anyone!
 </Callout>
 
@@ -242,7 +242,7 @@ cp -r  ~/.nym/nym-nodes/<ID> ~/.nym/nym-nodes/default-nym-node/
 # check occurences of the <SOURCE_ID>
 grep -ir  "<ID>" ~/.nym/nym-nodes/default-nym-node/*
 ```
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 If your node `<ID>` was too generic (like 'gateway' etc) and it occurs elsewhere than just a custom value, **do not use `sed` command but rewrite the values manually using a text editor!**
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/maintenance.mdx
+++ b/documentation/docs/pages/operators/nodes/maintenance.mdx
@@ -107,7 +107,7 @@ Anything can happen to the server on which your node is running. To back up your
 Assuming that everyone access their wallets from local machine and does *not* store their seeds on VPS, point 2. should be a given. 
 To backup your `nym-node` keys and configuration in the easiest way possible, copy the entire config directory `.nym` from your VPS to your local desktop, using a special copy command `scp`:
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 Never store your mnemonic seed anywhere online nor do *not* share it with anyone!
 </Callout>
 
@@ -242,7 +242,7 @@ cp -r  ~/.nym/nym-nodes/<ID> ~/.nym/nym-nodes/default-nym-node/
 # check occurences of the <SOURCE_ID>
 grep -ir  "<ID>" ~/.nym/nym-nodes/default-nym-node/*
 ```
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 If your node `<ID>` was too generic (like 'gateway' etc) and it occurs elsewhere than just a custom value, **do not use `sed` command but rewrite the values manually using a text editor!**
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/maintenance/manual-upgrade.mdx
+++ b/documentation/docs/pages/operators/nodes/maintenance/manual-upgrade.mdx
@@ -81,7 +81,7 @@ Wait for the upgrade height to be reached and the chain to halt awaiting upgrade
 
 You can also use something like [Cosmovisor](https://github.com/cosmos/cosmos-sdk/tree/main/tools/cosmovisor) - grab the relevant information from the current upgrade proposal [here](https://nym.explorers.guru/proposal/9).
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 Cosmovisor will swap the `nyxd` binary, but you'll need to already have the `libwasmvm.x86_64.so` in place.
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/maintenance/nymvisor-upgrade.mdx
+++ b/documentation/docs/pages/operators/nodes/maintenance/nymvisor-upgrade.mdx
@@ -24,7 +24,7 @@ You can use Nymvisor to automate the upgrades of the following binaries:
 * `nym-client`
 * `nym-socks5-client`
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 Nymvisor is an early and experimental software. Users should use it at their own risk.
 </Callout>
 
@@ -298,7 +298,7 @@ This section outlines what happens under the hood with the following commands:
 - Saves the Nymvisor instance's config file to `$NYMVISOR_CONFIG_PATH` and creates the full directory structure for the file
 - Outputs (to `stdout`) the full configuration used
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 `nymvisor init` is specifically for initializing Nymvisor, and should **not** be confused with a daemon's `init` command - such as `nym-socks5-client init` (e.g. `nymvisor run init`).
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/maintenance/nymvisor-upgrade.mdx
+++ b/documentation/docs/pages/operators/nodes/maintenance/nymvisor-upgrade.mdx
@@ -24,7 +24,7 @@ You can use Nymvisor to automate the upgrades of the following binaries:
 * `nym-client`
 * `nym-socks5-client`
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 Nymvisor is an early and experimental software. Users should use it at their own risk.
 </Callout>
 
@@ -298,7 +298,7 @@ This section outlines what happens under the hood with the following commands:
 - Saves the Nymvisor instance's config file to `$NYMVISOR_CONFIG_PATH` and creates the full directory structure for the file
 - Outputs (to `stdout`) the full configuration used
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 `nymvisor init` is specifically for initializing Nymvisor, and should **not** be confused with a daemon's `init` command - such as `nym-socks5-client init` (e.g. `nymvisor run init`).
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/maintenance/nymvisor-upgrade/nymvisor-configuration.mdx
+++ b/documentation/docs/pages/operators/nodes/maintenance/nymvisor-upgrade/nymvisor-configuration.mdx
@@ -12,7 +12,7 @@ import { Steps } from 'nextra/components';
 
 This section contains guide how to setup `systemd` automation for Nymvisor. If you are looking for other chapters, visit these pages: [VPS setup](../preliminrary-steps/vps-setup.mdx), advanced terminal tools like [tmux and nohup setup](../nym-node/configuration.mdx#vps-setup-and-automation), [`nym-node` automation](../nym-node/configuration.mdx#systemd) or [`validator` automation](../validator-setup/nyx-configuration#automation).
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 Since you're planning to run your node via a Nymvisor instance, as well as creating a Nymvisor `.service` file, you will also want to **stop any previous node automation process you already have running**.
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/nym-node/bak-setup.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/bak-setup.mdx
@@ -13,7 +13,7 @@ import Mixnode from './snippets/mixnode-run-tab-snippet.mdx';
 import { VarInfo } from '../../../../components/variable-info.tsx';
 
 
-<CCallout color="danger">
+<CCallout type="danger">
   You can always use `--help` flag to see the commands or arguments associated with a given command.
 </CCallout>
 

--- a/documentation/docs/pages/operators/nodes/nym-node/bak-setup.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/bak-setup.mdx
@@ -13,7 +13,7 @@ import Mixnode from './snippets/mixnode-run-tab-snippet.mdx';
 import { VarInfo } from '../../../../components/variable-info.tsx';
 
 
-<CCallout type="danger">
+<CCallout type="warning">
   You can always use `--help` flag to see the commands or arguments associated with a given command.
 </CCallout>
 

--- a/documentation/docs/pages/operators/nodes/nym-node/bonding.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/bonding.mdx
@@ -5,7 +5,7 @@ import { Steps } from 'nextra/components'
 
 # Bonding Nym Node
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 To you unbond your Nym Node means you are leaving Nym network and you will lose all your delegations (permanently). You can join again with the same identity key, however, you will start with **no delegations**.
 </Callout>
 
@@ -21,7 +21,7 @@ You are asked to `sign` a transaction and bond your node to Nyx blockchain so th
 4. [Setup & Run](setup.mdx) the node
 5. [Configure your node](configuration.mdx)
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 Do not bond your node to the API if the previous steps weren't finished. Bad connectivity, closed ports, or other poor setup will result in your node getting blacklisted.
 </Callout>
 
@@ -63,7 +63,7 @@ echo "$(curl -4 https://ifconfig.me)"
 
 - Enter the `Amount`, `Operating cost` and `Profit margin` and press `Next`
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 
 If you are part of [Nym Delegation Program](https://delegations.explorenym.net) or Service Grants Program, make sure your values are within the [rules](https://forum.nymtech.net/t/nym-delegations-program-update/466) of the programs. Operators setting up larger OP or PM than defined in the rules will be excluded from the program without prior warning!
 </Callout>

--- a/documentation/docs/pages/operators/nodes/nym-node/bonding.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/bonding.mdx
@@ -5,7 +5,7 @@ import { Steps } from 'nextra/components'
 
 # Bonding Nym Node
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 To you unbond your Nym Node means you are leaving Nym network and you will lose all your delegations (permanently). You can join again with the same identity key, however, you will start with **no delegations**.
 </Callout>
 
@@ -21,7 +21,7 @@ You are asked to `sign` a transaction and bond your node to Nyx blockchain so th
 4. [Setup & Run](setup.mdx) the node
 5. [Configure your node](configuration.mdx)
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 Do not bond your node to the API if the previous steps weren't finished. Bad connectivity, closed ports, or other poor setup will result in your node getting blacklisted.
 </Callout>
 
@@ -63,7 +63,7 @@ echo "$(curl -4 https://ifconfig.me)"
 
 - Enter the `Amount`, `Operating cost` and `Profit margin` and press `Next`
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 
 If you are part of [Nym Delegation Program](https://delegations.explorenym.net) or Service Grants Program, make sure your values are within the [rules](https://forum.nymtech.net/t/nym-delegations-program-update/466) of the programs. Operators setting up larger OP or PM than defined in the rules will be excluded from the program without prior warning!
 </Callout>

--- a/documentation/docs/pages/operators/nodes/nym-node/configuration.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/configuration.mdx
@@ -240,7 +240,7 @@ curl -6 https://ipv6.icanhazip.com
 telnet -6 ipv6.telnetmyip.com
 ```
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 Make sure to keep your IPv4 address enabled while setting up IPv6, as the majority of routing goes through that one!
 </Callout>
 
@@ -272,7 +272,7 @@ chmod +x network_tunnel_manager.sh && \
 
 - **If you setting up a new node and not upgrading an existing one, keep it running and [bond](bonding.mdx) your node now**. Then come back here and follow the rest of the configuration.
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 **Run the following steps as root or with `sudo` prefix!**
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/nym-node/configuration.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/configuration.mdx
@@ -132,7 +132,7 @@ RestartSec=30
 WantedBy=multi-user.target
 ```
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 [Accepting T&Cs](setup.md#terms--conditions) is done via a flag `--accept-operator-terms-and-conditions` added explicitly to `nym-node run` command every time. If you use systemd automation, add the flag to your service file's `ExecStart` line.
 </Callout>
 
@@ -183,7 +183,7 @@ systemctl status nym-node.service
 
 - You can also do `service <NODE> stop` or `service <NODE> restart`.
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 Anytime you make any changes to your `systemd` script after you've enabled it, you will need to run:
 ```sh
 systemctl daemon-reload
@@ -213,7 +213,7 @@ However, most of the time the packets sent through the Mixnet are IPv4 based. Th
 If you preparing to run a `nym-node` with all modes enabled in the future, this setup is required.
 </Callout>
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 For everyone participating in Delegation Program or Service Grant program, this setup is a requirement!
 </Callout>
 
@@ -240,7 +240,7 @@ curl -6 https://ipv6.icanhazip.com
 telnet -6 ipv6.telnetmyip.com
 ```
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 Make sure to keep your IPv4 address enabled while setting up IPv6, as the majority of routing goes through that one!
 </Callout>
 
@@ -272,7 +272,7 @@ chmod +x network_tunnel_manager.sh && \
 
 - **If you setting up a new node and not upgrading an existing one, keep it running and [bond](bonding.mdx) your node now**. Then come back here and follow the rest of the configuration.
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 **Run the following steps as root or with `sudo` prefix!**
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/nym-node/setup.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/setup.mdx
@@ -83,7 +83,7 @@ To list all available flags for each command, run `./nym-node <COMMAND> --help` 
 <!-- cmdrun ../../../../target/release/nym-node run --help  -->
 ```
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 The Wireguard flags currently have limited functionality. From version `1.1.6` ([`v2024.9-topdeck`](https://github.com/nymtech/nym/releases/tag/nym-binaries-v2024.9-topdeck)) wireguard is available and recommended to be switched on for nodes running as Gateways. Keep in mind that this option needs a bit of a special [configuration](configuration.md#wireguard-setup).
 </Callout>
 
@@ -158,7 +158,7 @@ In such case, you can `run` a node to initalise it or try if everything works, b
 
 ### Migrate
 
-<Callout type="danger">
+<Callout type="warning">
 Migration is a must for all deprecated nodes (`nym-mixnode`, `nym-gateway`). For backward compatibility we created an [archive section](../archive/nodes/setup-guides.md) with all the guides for individual binaries. However, the binaries from version 1.1.35 (`nym-gateway`) and 1.1.37 (`nym-mixnode`) onwards will no longer have `init` command.
 
 **Nym cannot promise 100% serialisation for operators migrating from long outdated versions to the newest ones. If you are about to migrate, start with  [`nym-node v1.1.0`](https://github.com/nymtech/nym/releases/tag/nym-binaries-v2024.3-eclipse) and keep upgrading version by version all the way to the latest one.**

--- a/documentation/docs/pages/operators/nodes/nym-node/setup.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/setup.mdx
@@ -67,7 +67,7 @@ https://<HOSTNAME>/api/v1/swagger/#/
 
 There are a few changes from the individual binaries used in the past. For example by default `run` command does `init` function as well, local node `--id` will be set by default unless specified otherwise etcetera.
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 You can always use `--help` flag to see the commands or arguments associated with a given command.
 </Callout>
 
@@ -83,13 +83,13 @@ To list all available flags for each command, run `./nym-node <COMMAND> --help` 
 <!-- cmdrun ../../../../target/release/nym-node run --help  -->
 ```
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 The Wireguard flags currently have limited functionality. From version `1.1.6` ([`v2024.9-topdeck`](https://github.com/nymtech/nym/releases/tag/nym-binaries-v2024.9-topdeck)) wireguard is available and recommended to be switched on for nodes running as Gateways. Keep in mind that this option needs a bit of a special [configuration](configuration.md#wireguard-setup).
 </Callout>
 
 ### Terms & Conditions
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 From `nym-node` version `1.1.3` onward is required to accept [**Operators Terms & Conditions**]({{toc_page}}) in order to be part of the active set. Make sure to read them before you add the flag.
 </Callout>
 
@@ -121,7 +121,7 @@ curl -X 'GET' \
 
 **`nym-node` introduces a default human readible ID (local only) `default-nym-node`, which is used if there is not an explicit custom `--id <ID>` specified. All configuration is stored in `~/.nym/nym-nodes/default-nym-node/config/config.toml` or `~/.nym/nym-nodes/<ID>/config/config.toml` respectively.**
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 All commands with more options listed below include `--accept-operator-terms-and-conditions` flag, read [Terms & Conditions](#terms--conditions) chapter above before executing these commands.
 </Callout>
 
@@ -158,7 +158,7 @@ In such case, you can `run` a node to initalise it or try if everything works, b
 
 ### Migrate
 
-<Callout color="danger">
+<Callout type="danger">
 Migration is a must for all deprecated nodes (`nym-mixnode`, `nym-gateway`). For backward compatibility we created an [archive section](../archive/nodes/setup-guides.md) with all the guides for individual binaries. However, the binaries from version 1.1.35 (`nym-gateway`) and 1.1.37 (`nym-mixnode`) onwards will no longer have `init` command.
 
 **Nym cannot promise 100% serialisation for operators migrating from long outdated versions to the newest ones. If you are about to migrate, start with  [`nym-node v1.1.0`](https://github.com/nymtech/nym/releases/tag/nym-binaries-v2024.3-eclipse) and keep upgrading version by version all the way to the latest one.**

--- a/documentation/docs/pages/operators/nodes/performance-and-testing.mdx
+++ b/documentation/docs/pages/operators/nodes/performance-and-testing.mdx
@@ -28,7 +28,7 @@ For the purpose of the performance testing Nym core developers plan to run insta
 
 ## Testing
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 For the moment we paused Fast and Furious `perf` environment. All load and speed testing is carried on directly Nym Mainnet as this is the only way to collect real performance data.
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/performance-and-testing/prometheus-grafana/explorenym-scripts.mdx
+++ b/documentation/docs/pages/operators/nodes/performance-and-testing/prometheus-grafana/explorenym-scripts.mdx
@@ -5,7 +5,7 @@ import { Steps } from 'nextra/components';
 
 # ExploreNym Monitoring Scripts
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 This setup and the scripts included were not written by Nym developers. As always do your own audit before installing any scripts on your machine and familiarize yourself with the security risks involved when opening ports or allowing http access.
 </Callout>
 
@@ -21,7 +21,7 @@ In collaboration with ExploreNYM we published a [step by step guide](#setup) to 
 
 ExploreNYM also has a network measuring instance called `enym-monitor`. This setup is very simple for users, however it means that their data are all aggregated into one server such design always brings a risk of centralisation of distributed node's data into one computer.
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 Make sure you understand and properly evaluate what degree of control you give permission to before granting access to your data to any tools running on someone else's servers.
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/performance-and-testing/prometheus-grafana/explorenym-scripts.mdx
+++ b/documentation/docs/pages/operators/nodes/performance-and-testing/prometheus-grafana/explorenym-scripts.mdx
@@ -5,7 +5,7 @@ import { Steps } from 'nextra/components';
 
 # ExploreNym Monitoring Scripts
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 This setup and the scripts included were not written by Nym developers. As always do your own audit before installing any scripts on your machine and familiarize yourself with the security risks involved when opening ports or allowing http access.
 </Callout>
 
@@ -21,7 +21,7 @@ In collaboration with ExploreNYM we published a [step by step guide](#setup) to 
 
 ExploreNYM also has a network measuring instance called `enym-monitor`. This setup is very simple for users, however it means that their data are all aggregated into one server such design always brings a risk of centralisation of distributed node's data into one computer.
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 Make sure you understand and properly evaluate what degree of control you give permission to before granting access to your data to any tools running on someone else's servers.
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/preliminary-steps/vps-setup.mdx
+++ b/documentation/docs/pages/operators/nodes/preliminary-steps/vps-setup.mdx
@@ -9,7 +9,7 @@ import PortsValidator from 'components/operators/snippets/ports-validator.mdx'
 
 We aim for Nym Network to be reliable and quality base layer of privacy accross the globe, while growing as distributed as possible. It's essential to have a fine tuned machine as a foundation for the nodes to meet the requirements and be rewarded for their work.
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 A sub-optimally configured VPS often results in a non-functional node. To follow these steps carefully will save you time and money later on.
 </Callout>
 
@@ -65,7 +65,7 @@ To install a full node from scratch, refer to the [validator setup guide](../val
 
 Before node or validator setup, the VPS needs to be configured and tested, to verify your connectivity and make sure that your provider wasn't dishonest with the offered services.
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 The commands listed in this chapter must be executed with a prefix `sudo` or from a root shell.
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/validator-setup.mdx
+++ b/documentation/docs/pages/operators/nodes/validator-setup.mdx
@@ -13,7 +13,7 @@ import {Accordion, AccordionItem} from "@nextui-org/react";
 
 The validator is a Go application which implements it's functionalities using [Cosmos SDK](https://v1.cosmos.network/sdk). The underlying state-replication engine is powered by [CometBFT](https://cometbft.com/), where the consensus mechanism is based on the [Tendermint Consensus Algorithm](https://arxiv.org/abs/1807.04938). Finally, a [CosmWasm](https://cosmwasm.com) smart contract module controls crucial mixnet functionalities like decentralised directory service, node bonding, and delegated mixnet staking.
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 We are currently running mainnet with a closed set of reputable validators. To ensure decentralisation of Nyx chain, we are working on a mechanism to onboard new validators to the network. To join the waitlist, please drop an email to `validators [at] nymtech.net` with details of your setup, experience and any other relevent information
 </Callout>
 
@@ -222,7 +222,7 @@ nyxd init <ID> --chain-id=nyx
 nyxd init <ID> --chain-id=sandbox
 ```
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 `init` generates `priv_validator_key.json` and `node_key.json`.
 
 If you have already set up a validator on a network, **make sure to back up the key located at**
@@ -331,7 +331,7 @@ File at /path/to/genesis.json is a valid genesis file
 
 ### Setting up nyxd as full node (non-signing)
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 Skip this section if you're planning to run a validator node to join network consensus. To ensure security & maximum availability of validators, do not expose additional services to the Internet
 </Callout>
 
@@ -412,7 +412,7 @@ You can then restart `nyxd` - it should start syncing from a block > 2000000.
 
 ### Joining Consensus
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 You can skip this section if you are planning to run a full-node. This step will make your node a signing validator which joins network consensus
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/validator-setup.mdx
+++ b/documentation/docs/pages/operators/nodes/validator-setup.mdx
@@ -222,7 +222,7 @@ nyxd init <ID> --chain-id=nyx
 nyxd init <ID> --chain-id=sandbox
 ```
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 `init` generates `priv_validator_key.json` and `node_key.json`.
 
 If you have already set up a validator on a network, **make sure to back up the key located at**
@@ -331,7 +331,7 @@ File at /path/to/genesis.json is a valid genesis file
 
 ### Setting up nyxd as full node (non-signing)
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 Skip this section if you're planning to run a validator node to join network consensus. To ensure security & maximum availability of validators, do not expose additional services to the Internet
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/validator-setup/nym-api.mdx
+++ b/documentation/docs/pages/operators/nodes/validator-setup/nym-api.mdx
@@ -21,7 +21,7 @@ This is important for both the proper decentralisation of the network uptime cal
 
 The process of enabling these different aspects of the system will take time. At the moment, Nym API operators will only have to run the binary in a minimal 'caching' mode in order to get used to maintaining an additional process running alongside a full node.
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 It is highly recommended to run `nym-api` alongside a full node and NOT a validator node, since you will be exposing HTTP port(s) to the Internet. We also observed degradation in p2p and block signing operations when `nym-api` was run alongside a signing validator.
 </Callout>
 
@@ -151,7 +151,7 @@ Begin by generating a new wallet address specifically for your instance to use i
 nyxd keys add signer
 ```
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 It's critical to securely back up the mnemonic phrase generated during this process. This mnemonic is your key to recovering the wallet in the future, so store it in a secure, offline location.
 </Callout>
 

--- a/documentation/docs/pages/operators/nodes/validator-setup/nym-api.mdx
+++ b/documentation/docs/pages/operators/nodes/validator-setup/nym-api.mdx
@@ -21,7 +21,7 @@ This is important for both the proper decentralisation of the network uptime cal
 
 The process of enabling these different aspects of the system will take time. At the moment, Nym API operators will only have to run the binary in a minimal 'caching' mode in order to get used to maintaining an additional process running alongside a full node.
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 It is highly recommended to run `nym-api` alongside a full node and NOT a validator node, since you will be exposing HTTP port(s) to the Internet. We also observed degradation in p2p and block signing operations when `nym-api` was run alongside a signing validator.
 </Callout>
 
@@ -151,7 +151,7 @@ Begin by generating a new wallet address specifically for your instance to use i
 nyxd keys add signer
 ```
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 It's critical to securely back up the mnemonic phrase generated during this process. This mnemonic is your key to recovering the wallet in the future, so store it in a secure, offline location.
 </Callout>
 
@@ -205,7 +205,7 @@ By default the API will be trying to query your full node running locally on `lo
 ./nym-api run --id <ID> --nyxd-validator https://rpc-nym.yourcorp.tld:443
 ```
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 You can also change the value of `local_validator` in the config file found by default in `$HOME/.nym/nym-api/<ID>/config/config.toml`.
 </Callout>
 

--- a/documentation/docs/pages/operators/troubleshooting/nodes.mdx
+++ b/documentation/docs/pages/operators/troubleshooting/nodes.mdx
@@ -248,7 +248,7 @@ If you are still unable to see your node on the dashboard, or your node is decla
 - You did not configure your router firewall while running the node from your local machine behind NAT, or you are lacking IPv6 support
 - Your Mix Node is not running at all, it has either exited / panicked or you closed the session without making the node persistent. Check out the [instructions](../nodes/nym-node/configuration.mdx#automating-your-node-with-tmux-and-systemd).
 
-<Callout color="danger" emoji="">
+<Callout type="danger" emoji="">
 Your Nym Node **must speak both IPv4 and IPv6** in order to cooperate with other nodes and route traffic. This is a common reason behind many errors we are seeing among node operators, so check with your provider that your VPS is able to do this!
 </Callout>
 
@@ -286,7 +286,7 @@ If your connection doesn't work make sure to follow [VPS IPv6 setup](../nodes/ny
 
 #### Incorrect bonding information
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 All delegated stake will be lost when un-bonding! However the Nym Node must be operational in the first place for the delegation to have any effect.
 </Callout>
 

--- a/documentation/docs/pages/operators/troubleshooting/nodes.mdx
+++ b/documentation/docs/pages/operators/troubleshooting/nodes.mdx
@@ -248,7 +248,7 @@ If you are still unable to see your node on the dashboard, or your node is decla
 - You did not configure your router firewall while running the node from your local machine behind NAT, or you are lacking IPv6 support
 - Your Mix Node is not running at all, it has either exited / panicked or you closed the session without making the node persistent. Check out the [instructions](../nodes/nym-node/configuration.mdx#automating-your-node-with-tmux-and-systemd).
 
-<Callout type="danger" emoji="">
+<Callout type="warning" emoji="">
 Your Nym Node **must speak both IPv4 and IPv6** in order to cooperate with other nodes and route traffic. This is a common reason behind many errors we are seeing among node operators, so check with your provider that your VPS is able to do this!
 </Callout>
 
@@ -286,7 +286,7 @@ If your connection doesn't work make sure to follow [VPS IPv6 setup](../nodes/ny
 
 #### Incorrect bonding information
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 All delegated stake will be lost when un-bonding! However the Nym Node must be operational in the first place for the delegation to have any effect.
 </Callout>
 

--- a/documentation/docs/pages/operators/troubleshooting/vps-isp.mdx
+++ b/documentation/docs/pages/operators/troubleshooting/vps-isp.mdx
@@ -10,7 +10,7 @@ import { MyTab } from 'components/generic-tabs.tsx';
 
 ## IPv6 troubleshooting
 
-<Callout color="info" emoji="ℹ️">
+<Callout type="info" emoji="ℹ️">
 To monitor connectivity of your Exit Gateway, use results of probe testing displayed in [harbourmaster.nymtech.net](https://harbourmaster.nymtech.net).
 </Callout>
 
@@ -72,7 +72,7 @@ post-up /sbin/ip -r route add default via <YOUR_IPV6_GATEWAY>
 ```
 Last two lines are particularly important as they enable IPv6 routing. You can find YOUR_IPV6_GATEWAY using your server's control panel. There is no single way to find the gateway, so please access your control panel to find yours or open a support ticket. Here is an example of how it looks on [OVH](https://help.ovhcloud.com/csm/en-ie-vps-configuring-ipv6?id=kb_article_view&sysparm_article=KB0047567).
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 Be extra careful editing this file since you may lock yourself out of the server. If it happens, you can always access the server via the hoster's VNC panel.
 </Callout>
 
@@ -110,7 +110,7 @@ It's up to you as a node operator to ensure that your public and private IPs mat
 
 Running a `nym-node` as a standalone process or wrapped in a service can produce gigabytes of logs. Eventually your operation can malfunction due to the logs chewing up too much disk space or memory. Below are two scripts that can help you clean this up.
 
-<Callout color="danger" emoji="⚠️">
+<Callout type="danger" emoji="⚠️">
 `rm` is a powerful tool, without an easy way of revoking. If you need to extract or backup anything, do it now. Make sure you understand what you removing before you execute these commands.
 </Callout>
 

--- a/documentation/docs/pages/operators/troubleshooting/vps-isp.mdx
+++ b/documentation/docs/pages/operators/troubleshooting/vps-isp.mdx
@@ -72,7 +72,7 @@ post-up /sbin/ip -r route add default via <YOUR_IPV6_GATEWAY>
 ```
 Last two lines are particularly important as they enable IPv6 routing. You can find YOUR_IPV6_GATEWAY using your server's control panel. There is no single way to find the gateway, so please access your control panel to find yours or open a support ticket. Here is an example of how it looks on [OVH](https://help.ovhcloud.com/csm/en-ie-vps-configuring-ipv6?id=kb_article_view&sysparm_article=KB0047567).
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 Be extra careful editing this file since you may lock yourself out of the server. If it happens, you can always access the server via the hoster's VNC panel.
 </Callout>
 
@@ -110,7 +110,7 @@ It's up to you as a node operator to ensure that your public and private IPs mat
 
 Running a `nym-node` as a standalone process or wrapped in a service can produce gigabytes of logs. Eventually your operation can malfunction due to the logs chewing up too much disk space or memory. Below are two scripts that can help you clean this up.
 
-<Callout type="danger" emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
 `rm` is a powerful tool, without an easy way of revoking. If you need to extract or backup anything, do it now. Make sure you understand what you removing before you execute these commands.
 </Callout>
 


### PR DESCRIPTION
Apply 

- `grep -rl "Callout color=" | xargs sed -i "s/Callout\ color=/Callout\ type=/g"` to correct all `Callout` component syntax

and

- `grep -rl 'Callout type=\"danger\"' | xargs sed -i "s/Callout\ type=\"danger\"/Callout\ type=\"warning\"/g"`

to correct callout component syntax and rendering. 


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5006)
<!-- Reviewable:end -->
