### PR TITLE
bugfix: use old name for 'epoch_role' in SkimmedNode

### DIFF
--- a/common/topology/src/mix.rs
+++ b/common/topology/src/mix.rs
@@ -116,7 +116,7 @@ impl<'a> TryFrom<&'a SkimmedNode> for LegacyNode {
             });
         }
 
-        let layer = match value.epoch_role {
+        let layer = match value.role {
             NodeRole::Mixnode { layer } => layer
                 .try_into()
                 .map_err(|_| MixnodeConversionError::InvalidLayer)?,

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -286,7 +286,7 @@ impl MixNodeBondAnnotated {
                 .sphinx_key
                 .parse()
                 .map_err(|_| MalformedNodeBond::InvalidX25519Key)?,
-            epoch_role: role,
+            role: role,
             supported_roles: DeclaredRoles {
                 mixnode: true,
                 entry: false,
@@ -345,7 +345,7 @@ impl GatewayBondAnnotated {
                 .sphinx_key
                 .parse()
                 .map_err(|_| MalformedNodeBond::InvalidX25519Key)?,
-            epoch_role: role,
+            role: role,
             supported_roles: DeclaredRoles {
                 mixnode: false,
                 entry: true,
@@ -827,7 +827,7 @@ impl NymNodeDescription {
             // we can't use the declared roles, we have to take whatever was provided in the contract.
             // why? say this node COULD operate as an exit, but it might be the case the contract decided
             // to assign it an ENTRY role only. we have to use that one instead.
-            epoch_role: role,
+            role: role,
             supported_roles: self.description.declared_role,
             entry,
             performance,

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -286,7 +286,7 @@ impl MixNodeBondAnnotated {
                 .sphinx_key
                 .parse()
                 .map_err(|_| MalformedNodeBond::InvalidX25519Key)?,
-            role: role,
+            role,
             supported_roles: DeclaredRoles {
                 mixnode: true,
                 entry: false,
@@ -345,7 +345,7 @@ impl GatewayBondAnnotated {
                 .sphinx_key
                 .parse()
                 .map_err(|_| MalformedNodeBond::InvalidX25519Key)?,
-            role: role,
+            role,
             supported_roles: DeclaredRoles {
                 mixnode: false,
                 entry: true,
@@ -827,7 +827,7 @@ impl NymNodeDescription {
             // we can't use the declared roles, we have to take whatever was provided in the contract.
             // why? say this node COULD operate as an exit, but it might be the case the contract decided
             // to assign it an ENTRY role only. we have to use that one instead.
-            role: role,
+            role,
             supported_roles: self.description.declared_role,
             entry,
             performance,

--- a/nym-api/nym-api-requests/src/nym_nodes.rs
+++ b/nym-api/nym-api-requests/src/nym_nodes.rs
@@ -141,8 +141,8 @@ pub struct SkimmedNode {
     #[schemars(with = "String")]
     pub x25519_sphinx_pubkey: x25519::PublicKey,
 
-    #[serde(alias = "role")]
-    pub epoch_role: NodeRole,
+    #[serde(alias = "epoch_role")]
+    pub role: NodeRole,
 
     // needed for the purposes of sending appropriate test packets
     #[serde(default)]
@@ -157,7 +157,7 @@ pub struct SkimmedNode {
 
 impl SkimmedNode {
     pub fn get_mix_layer(&self) -> Option<u8> {
-        match self.epoch_role {
+        match self.role {
             NodeRole::Mixnode { layer } => Some(layer),
             _ => None,
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5034)
<!-- Reviewable:end -->
