### PR TITLE
bugfix: restore default http port for nym-api

### DIFF
--- a/nym-api/src/support/config/mod.rs
+++ b/nym-api/src/support/config/mod.rs
@@ -234,9 +234,9 @@ impl Config {
 fn default_http_socket_addr() -> SocketAddr {
     cfg_if::cfg_if! {
         if #[cfg(debug_assertions)] {
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000)
         } else {
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 8080)
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 8000)
         }
     }
 }


### PR DESCRIPTION
when it was run under 'rocket' server the port used was 8000. let's restore that value

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5045)
<!-- Reviewable:end -->
