### PR TITLE
bugfix: adjust runtime storage migration

### DIFF
--- a/nym-api/src/v3_migration.rs
+++ b/nym-api/src/v3_migration.rs
@@ -30,10 +30,6 @@ pub async fn migrate_v3_database(
     let contract_gateways = nyxd_client.get_gateways().await?;
     let nym_nodes = nyxd_client.get_nymnodes().await?;
 
-    if preassigned_ids.len() != contract_gateways.len() {
-        bail!("CONTRACT DATA CORRUPTION: THE NUMBER OF PREASSIGNED GATEWAY IDS IS DIFFERENT THAN THE NUMBER OF GATEWAYS")
-    }
-
     // assign node_id to every gateway
     let all_known = storage.get_all_known_gateways().await?;
     for gateway in all_known {


### PR DESCRIPTION
remove the panic during migration as the gateway count can actually be different if some of them have already migrated to nym-nodes before the code has been run

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5047)
<!-- Reviewable:end -->
