### PR TITLE
chore: deprecated old nym-api client methods and replaced them when possible

### DIFF
--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -18,7 +18,7 @@ use nym_api_requests::ecash::{
     PartialExpirationDateSignatureResponse, VerificationKeyResponse,
 };
 use nym_api_requests::models::{
-    GatewayCoreStatusResponse, MixnodeCoreStatusResponse, MixnodeStatusResponse,
+    ApiHealthResponse, GatewayCoreStatusResponse, MixnodeCoreStatusResponse, MixnodeStatusResponse,
     NymNodeDescription, RewardEstimationResponse, StakeSaturationResponse,
 };
 use nym_api_requests::models::{LegacyDescribedGateway, MixNodeBondAnnotated};
@@ -192,6 +192,8 @@ impl<C, S> Client<C, S> {
 }
 
 // validator-api wrappers
+// we have to allow the use of deprecated method here as they're calling the deprecated trait methods
+#[allow(deprecated)]
 impl<C, S> Client<C, S> {
     pub fn api_url(&self) -> &Url {
         self.nym_api.current_url()
@@ -201,46 +203,54 @@ impl<C, S> Client<C, S> {
         self.nym_api.change_base_url(new_endpoint)
     }
 
+    #[deprecated]
     pub async fn get_cached_mixnodes(&self) -> Result<Vec<MixNodeDetails>, ValidatorClientError> {
         Ok(self.nym_api.get_mixnodes().await?)
     }
 
+    #[deprecated]
     pub async fn get_cached_mixnodes_detailed(
         &self,
     ) -> Result<Vec<MixNodeBondAnnotated>, ValidatorClientError> {
         Ok(self.nym_api.get_mixnodes_detailed().await?)
     }
 
+    #[deprecated]
     pub async fn get_cached_mixnodes_detailed_unfiltered(
         &self,
     ) -> Result<Vec<MixNodeBondAnnotated>, ValidatorClientError> {
         Ok(self.nym_api.get_mixnodes_detailed_unfiltered().await?)
     }
 
+    #[deprecated]
     pub async fn get_cached_rewarded_mixnodes(
         &self,
     ) -> Result<Vec<MixNodeDetails>, ValidatorClientError> {
         Ok(self.nym_api.get_rewarded_mixnodes().await?)
     }
 
+    #[deprecated]
     pub async fn get_cached_rewarded_mixnodes_detailed(
         &self,
     ) -> Result<Vec<MixNodeBondAnnotated>, ValidatorClientError> {
         Ok(self.nym_api.get_rewarded_mixnodes_detailed().await?)
     }
 
+    #[deprecated]
     pub async fn get_cached_active_mixnodes(
         &self,
     ) -> Result<Vec<MixNodeDetails>, ValidatorClientError> {
         Ok(self.nym_api.get_active_mixnodes().await?)
     }
 
+    #[deprecated]
     pub async fn get_cached_active_mixnodes_detailed(
         &self,
     ) -> Result<Vec<MixNodeBondAnnotated>, ValidatorClientError> {
         Ok(self.nym_api.get_active_mixnodes_detailed().await?)
     }
 
+    #[deprecated]
     pub async fn get_cached_gateways(&self) -> Result<Vec<GatewayBond>, ValidatorClientError> {
         Ok(self.nym_api.get_gateways().await?)
     }
@@ -304,6 +314,8 @@ pub struct NymApiClient {
     // we could re-implement the communication with the REST API on port 1317
 }
 
+// we have to allow the use of deprecated method here as they're calling the deprecated trait methods
+#[allow(deprecated)]
 impl NymApiClient {
     pub fn new(api_url: Url) -> Self {
         let nym_api = nym_api::Client::new(api_url, None);
@@ -417,6 +429,38 @@ impl NymApiClient {
         Ok(nodes)
     }
 
+    /// retrieve basic information for nodes are capable of operating as a mixnode
+    /// this includes legacy mixnodes and nym-nodes
+    pub async fn get_all_basic_mixing_capable_nodes(
+        &self,
+        semver_compatibility: Option<String>,
+    ) -> Result<Vec<SkimmedNode>, ValidatorClientError> {
+        // TODO: deal with paging in macro or some helper function or something, because it's the same pattern everywhere
+        let mut page = 0;
+        let mut nodes = Vec::new();
+
+        loop {
+            let mut res = self
+                .nym_api
+                .get_basic_mixing_capable_nodes(
+                    semver_compatibility.clone(),
+                    false,
+                    Some(page),
+                    None,
+                )
+                .await?;
+
+            nodes.append(&mut res.nodes.data);
+            if nodes.len() < res.nodes.pagination.total {
+                page += 1
+            } else {
+                break;
+            }
+        }
+
+        Ok(nodes)
+    }
+
     /// retrieve basic information for all bonded nodes on the network
     pub async fn get_all_basic_nodes(
         &self,
@@ -443,26 +487,35 @@ impl NymApiClient {
         Ok(nodes)
     }
 
+    pub async fn health(&self) -> Result<ApiHealthResponse, ValidatorClientError> {
+        Ok(self.nym_api.health().await?)
+    }
+
+    #[deprecated]
     pub async fn get_cached_active_mixnodes(
         &self,
     ) -> Result<Vec<MixNodeDetails>, ValidatorClientError> {
         Ok(self.nym_api.get_active_mixnodes().await?)
     }
 
+    #[deprecated]
     pub async fn get_cached_rewarded_mixnodes(
         &self,
     ) -> Result<Vec<MixNodeDetails>, ValidatorClientError> {
         Ok(self.nym_api.get_rewarded_mixnodes().await?)
     }
 
+    #[deprecated]
     pub async fn get_cached_mixnodes(&self) -> Result<Vec<MixNodeDetails>, ValidatorClientError> {
         Ok(self.nym_api.get_mixnodes().await?)
     }
 
+    #[deprecated]
     pub async fn get_cached_gateways(&self) -> Result<Vec<GatewayBond>, ValidatorClientError> {
         Ok(self.nym_api.get_gateways().await?)
     }
 
+    #[deprecated]
     pub async fn get_cached_described_gateways(
         &self,
     ) -> Result<Vec<LegacyDescribedGateway>, ValidatorClientError> {
@@ -511,6 +564,7 @@ impl NymApiClient {
         Ok(bonds)
     }
 
+    #[deprecated]
     pub async fn get_gateway_core_status_count(
         &self,
         identity: IdentityKeyRef<'_>,
@@ -522,6 +576,7 @@ impl NymApiClient {
             .await?)
     }
 
+    #[deprecated]
     pub async fn get_mixnode_core_status_count(
         &self,
         mix_id: NodeId,
@@ -533,6 +588,7 @@ impl NymApiClient {
             .await?)
     }
 
+    #[deprecated]
     pub async fn get_mixnode_status(
         &self,
         mix_id: NodeId,
@@ -540,6 +596,7 @@ impl NymApiClient {
         Ok(self.nym_api.get_mixnode_status(mix_id).await?)
     }
 
+    #[deprecated]
     pub async fn get_mixnode_reward_estimation(
         &self,
         mix_id: NodeId,
@@ -547,6 +604,7 @@ impl NymApiClient {
         Ok(self.nym_api.get_mixnode_reward_estimation(mix_id).await?)
     }
 
+    #[deprecated]
     pub async fn get_mixnode_stake_saturation(
         &self,
         mix_id: NodeId,
@@ -578,6 +636,7 @@ impl NymApiClient {
             .await?)
     }
 
+    #[deprecated]
     pub async fn spent_credentials_filter(
         &self,
     ) -> Result<SpentCredentialsResponse, ValidatorClientError> {

--- a/common/client-libs/validator-client/src/connection_tester.rs
+++ b/common/client-libs/validator-client/src/connection_tester.rs
@@ -164,7 +164,7 @@ async fn test_nym_api_connection(
 ) -> ConnectionResult {
     let result = match timeout(
         Duration::from_secs(CONNECTION_TEST_TIMEOUT_SEC),
-        client.get_cached_mixnodes(),
+        client.health(),
     )
     .await
     {

--- a/common/client-libs/validator-client/src/nym_api/mod.rs
+++ b/common/client-libs/validator-client/src/nym_api/mod.rs
@@ -11,7 +11,8 @@ use nym_api_requests::ecash::models::{
 };
 use nym_api_requests::ecash::VerificationKeyResponse;
 use nym_api_requests::models::{
-    AnnotationResponse, LegacyDescribedMixNode, NodePerformanceResponse, NymNodeDescription,
+    AnnotationResponse, ApiHealthResponse, LegacyDescribedMixNode, NodePerformanceResponse,
+    NymNodeDescription,
 };
 use nym_api_requests::nym_nodes::PaginatedCachedNodesResponse;
 use nym_api_requests::pagination::PaginatedResponse;
@@ -53,11 +54,25 @@ pub fn rfc_3339_date() -> Vec<BorrowedFormatItem<'static>> {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait NymApiClientExt: ApiClient {
+    async fn health(&self) -> Result<ApiHealthResponse, NymAPIError> {
+        self.get_json(
+            &[
+                routes::API_VERSION,
+                routes::API_STATUS_ROUTES,
+                routes::HEALTH,
+            ],
+            NO_PARAMS,
+        )
+        .await
+    }
+
+    #[deprecated]
     async fn get_mixnodes(&self) -> Result<Vec<MixNodeDetails>, NymAPIError> {
         self.get_json(&[routes::API_VERSION, routes::MIXNODES], NO_PARAMS)
             .await
     }
 
+    #[deprecated]
     async fn get_mixnodes_detailed(&self) -> Result<Vec<MixNodeBondAnnotated>, NymAPIError> {
         self.get_json(
             &[
@@ -71,6 +86,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_gateways_detailed(&self) -> Result<Vec<GatewayBondAnnotated>, NymAPIError> {
         self.get_json(
             &[
@@ -84,6 +100,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_mixnodes_detailed_unfiltered(
         &self,
     ) -> Result<Vec<MixNodeBondAnnotated>, NymAPIError> {
@@ -99,11 +116,13 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_gateways(&self) -> Result<Vec<GatewayBond>, NymAPIError> {
         self.get_json(&[routes::API_VERSION, routes::GATEWAYS], NO_PARAMS)
             .await
     }
 
+    #[deprecated]
     async fn get_gateways_described(&self) -> Result<Vec<LegacyDescribedGateway>, NymAPIError> {
         self.get_json(
             &[routes::API_VERSION, routes::GATEWAYS, routes::DESCRIBED],
@@ -112,6 +131,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_mixnodes_described(&self) -> Result<Vec<LegacyDescribedMixNode>, NymAPIError> {
         self.get_json(
             &[routes::API_VERSION, routes::MIXNODES, routes::DESCRIBED],
@@ -158,6 +178,7 @@ pub trait NymApiClientExt: ApiClient {
             .await
     }
 
+    #[deprecated]
     async fn get_basic_mixnodes(
         &self,
         semver_compatibility: Option<String>,
@@ -181,6 +202,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_basic_gateways(
         &self,
         semver_compatibility: Option<String>,
@@ -286,6 +308,47 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    /// retrieve basic information for nodes that got assigned 'mixing' node in this epoch
+    /// this includes legacy mixnodes and nym-nodes
+    async fn get_basic_mixing_capable_nodes(
+        &self,
+        semver_compatibility: Option<String>,
+        no_legacy: bool,
+        page: Option<u32>,
+        per_page: Option<u32>,
+    ) -> Result<PaginatedCachedNodesResponse<SkimmedNode>, NymAPIError> {
+        let mut params = Vec::new();
+
+        if let Some(arg) = &semver_compatibility {
+            params.push(("semver_compatibility", arg.clone()))
+        }
+
+        if no_legacy {
+            params.push(("no_legacy", "true".to_string()))
+        }
+
+        if let Some(page) = page {
+            params.push(("page", page.to_string()))
+        }
+
+        if let Some(per_page) = per_page {
+            params.push(("per_page", per_page.to_string()))
+        }
+
+        self.get_json(
+            &[
+                routes::API_VERSION,
+                "unstable",
+                "nym-nodes",
+                "skimmed",
+                "mixnodes",
+                "all",
+            ],
+            &params,
+        )
+        .await
+    }
+
     async fn get_basic_nodes(
         &self,
         semver_compatibility: Option<String>,
@@ -318,6 +381,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_active_mixnodes(&self) -> Result<Vec<MixNodeDetails>, NymAPIError> {
         self.get_json(
             &[routes::API_VERSION, routes::MIXNODES, routes::ACTIVE],
@@ -326,6 +390,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_active_mixnodes_detailed(&self) -> Result<Vec<MixNodeBondAnnotated>, NymAPIError> {
         self.get_json(
             &[
@@ -340,6 +405,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_rewarded_mixnodes(&self) -> Result<Vec<MixNodeDetails>, NymAPIError> {
         self.get_json(
             &[routes::API_VERSION, routes::MIXNODES, routes::REWARDED],
@@ -348,6 +414,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_mixnode_report(
         &self,
         mix_id: NodeId,
@@ -365,6 +432,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_gateway_report(
         &self,
         identity: IdentityKeyRef<'_>,
@@ -382,6 +450,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_mixnode_history(
         &self,
         mix_id: NodeId,
@@ -399,6 +468,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_gateway_history(
         &self,
         identity: IdentityKeyRef<'_>,
@@ -416,6 +486,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_rewarded_mixnodes_detailed(
         &self,
     ) -> Result<Vec<MixNodeBondAnnotated>, NymAPIError> {
@@ -432,6 +503,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_gateway_core_status_count(
         &self,
         identity: IdentityKeyRef<'_>,
@@ -463,6 +535,7 @@ pub trait NymApiClientExt: ApiClient {
         }
     }
 
+    #[deprecated]
     async fn get_mixnode_core_status_count(
         &self,
         mix_id: NodeId,
@@ -495,6 +568,7 @@ pub trait NymApiClientExt: ApiClient {
         }
     }
 
+    #[deprecated]
     async fn get_mixnode_status(
         &self,
         mix_id: NodeId,
@@ -512,6 +586,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_mixnode_reward_estimation(
         &self,
         mix_id: NodeId,
@@ -529,6 +604,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn compute_mixnode_reward_estimation(
         &self,
         mix_id: NodeId,
@@ -548,6 +624,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_mixnode_stake_saturation(
         &self,
         mix_id: NodeId,
@@ -565,6 +642,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_mixnode_inclusion_probability(
         &self,
         mix_id: NodeId,
@@ -598,6 +676,7 @@ pub trait NymApiClientExt: ApiClient {
             .await
     }
 
+    #[deprecated]
     async fn get_mixnode_avg_uptime(&self, mix_id: NodeId) -> Result<UptimeResponse, NymAPIError> {
         self.get_json(
             &[
@@ -612,6 +691,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_mixnodes_blacklisted(&self) -> Result<Vec<NodeId>, NymAPIError> {
         self.get_json(
             &[routes::API_VERSION, routes::MIXNODES, routes::BLACKLISTED],
@@ -620,6 +700,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn get_gateways_blacklisted(&self) -> Result<Vec<IdentityKey>, NymAPIError> {
         self.get_json(
             &[routes::API_VERSION, routes::GATEWAYS, routes::BLACKLISTED],
@@ -676,6 +757,7 @@ pub trait NymApiClientExt: ApiClient {
         .await
     }
 
+    #[deprecated]
     async fn double_spending_filter_v1(&self) -> Result<SpentCredentialsResponse, NymAPIError> {
         self.get_json(
             &[

--- a/common/client-libs/validator-client/src/nym_api/routes.rs
+++ b/common/client-libs/validator-client/src/nym_api/routes.rs
@@ -36,6 +36,8 @@ pub mod ecash {
 }
 
 pub const STATUS_ROUTES: &str = "status";
+pub const API_STATUS_ROUTES: &str = "api-status";
+pub const HEALTH: &str = "health";
 pub const MIXNODE: &str = "mixnode";
 pub const GATEWAY: &str = "gateway";
 pub const NYM_NODES: &str = "nym-nodes";

--- a/common/commands/src/validator/mixnet/query/query_all_gateways.rs
+++ b/common/commands/src/validator/mixnet/query/query_all_gateways.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::context::QueryClientWithNyxd;
-use crate::utils::{pretty_cosmwasm_coin, show_error};
+use crate::utils::show_error;
 use clap::Parser;
 use comfy_table::Table;
-use nym_validator_client::client::NymApiClientExt;
 
 #[derive(Debug, Parser)]
 pub struct Args {
@@ -15,12 +14,11 @@ pub struct Args {
 }
 
 pub async fn query(args: Args, client: &QueryClientWithNyxd) {
-    match client.nym_api.get_gateways().await {
+    match client.get_all_cached_described_nodes().await {
         Ok(res) => match args.identity_key {
             Some(identity_key) => {
                 let node = res.iter().find(|node| {
-                    node.gateway
-                        .identity_key
+                    node.ed25519_identity_key()
                         .to_string()
                         .eq_ignore_ascii_case(&identity_key)
                 });
@@ -32,14 +30,16 @@ pub async fn query(args: Args, client: &QueryClientWithNyxd) {
             None => {
                 let mut table = Table::new();
 
-                table.set_header(vec!["Identity Key", "Owner", "Host", "Bond", "Version"]);
-                for node in res {
+                table.set_header(vec!["Node Id", "Identity Key", "Version", "Is Legacy"]);
+                for node in res
+                    .into_iter()
+                    .filter(|node| node.description.declared_role.entry)
+                {
                     table.add_row(vec![
-                        node.gateway.identity_key.to_string(),
-                        node.owner.to_string(),
-                        node.gateway.host.to_string(),
-                        pretty_cosmwasm_coin(&node.pledge_amount),
-                        node.gateway.version.clone(),
+                        node.node_id.to_string(),
+                        node.ed25519_identity_key().to_base58_string(),
+                        node.description.build_information.build_version,
+                        (!node.contract_node_type.is_nym_node()).to_string(),
                     ]);
                 }
 

--- a/explorer-api/src/mix_node/econ_stats.rs
+++ b/explorer-api/src/mix_node/econ_stats.rs
@@ -8,6 +8,9 @@ use nym_contracts_common::truncate_decimal;
 use nym_mixnet_contract_common::NodeId;
 use nym_validator_client::client::NymApiClientExt;
 
+// use deprecated method as hopefully this whole API will be sunset soon-enough...
+// and we're only getting info for legacy node so the relevant data should still exist
+#[allow(deprecated)]
 pub(crate) async fn retrieve_mixnode_econ_stats(
     client: &ThreadsafeValidatorClient,
     mix_id: NodeId,

--- a/explorer-api/src/tasks.rs
+++ b/explorer-api/src/tasks.rs
@@ -17,6 +17,8 @@ pub(crate) struct ExplorerApiTasks {
     shutdown: TaskClient,
 }
 
+// allow usage of deprecated methods here as we actually want to be explicitly querying for legacy data
+#[allow(deprecated)]
 impl ExplorerApiTasks {
     pub(crate) fn new(state: ExplorerApiStateContext, shutdown: TaskClient) -> Self {
         ExplorerApiTasks { state, shutdown }

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -622,7 +622,7 @@ impl<St> Gateway<St> {
         // TODO: if anything, this should be getting data directly from the contract
         // as opposed to the validator API
         let validator_client = self.random_api_client()?;
-        let existing_nodes = match validator_client.get_cached_gateways().await {
+        let existing_nodes = match validator_client.get_all_basic_nodes(None).await {
             Ok(nodes) => nodes,
             Err(err) => {
                 error!("failed to grab initial network gateways - {err}\n Please try to startup again in few minutes");
@@ -630,9 +630,9 @@ impl<St> Gateway<St> {
             }
         };
 
-        Ok(existing_nodes.iter().any(|node| {
-            node.gateway.identity_key == self.identity_keypair.public_key().to_base58_string()
-        }))
+        Ok(existing_nodes
+            .iter()
+            .any(|node| &node.ed25519_identity_pubkey == self.identity_keypair.public_key()))
     }
 
     pub async fn run(mut self) -> Result<(), GatewayError>

--- a/mixnode/src/node/mod.rs
+++ b/mixnode/src/node/mod.rs
@@ -234,7 +234,7 @@ impl MixNode {
         // TODO: if anything, this should be getting data directly from the contract
         // as opposed to the validator API
         let validator_client = self.random_api_client();
-        let existing_nodes = match validator_client.get_cached_mixnodes().await {
+        let existing_nodes = match validator_client.get_all_basic_nodes(None).await {
             Ok(nodes) => nodes,
             Err(err) => {
                 error!(
@@ -245,10 +245,9 @@ impl MixNode {
             }
         };
 
-        existing_nodes.iter().any(|node| {
-            node.bond_information.mix_node.identity_key
-                == self.identity_keypair.public_key().to_base58_string()
-        })
+        existing_nodes
+            .iter()
+            .any(|node| &node.ed25519_identity_pubkey == self.identity_keypair.public_key())
     }
 
     async fn wait_for_interrupt(&self, shutdown: TaskHandle) {

--- a/nym-api/nym-api-requests/src/models.rs
+++ b/nym-api/nym-api-requests/src/models.rs
@@ -897,6 +897,12 @@ pub enum DescribedNodeType {
     NymNode,
 }
 
+impl DescribedNodeType {
+    pub fn is_nym_node(&self) -> bool {
+        matches!(self, DescribedNodeType::NymNode)
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, schemars::JsonSchema, ToSchema)]
 #[cfg_attr(feature = "generate-ts", derive(ts_rs::TS))]
 #[cfg_attr(

--- a/nym-credential-proxy/Cargo.lock
+++ b/nym-credential-proxy/Cargo.lock
@@ -215,6 +215,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-client-ip"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eefda7e2b27e1bda4d6fa8a06b50803b8793769045918bc37ad062d48a6efac"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "serde",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1323,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,7 +2342,7 @@ dependencies = [
  "digest 0.9.0",
  "ff",
  "group",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "nym-network-defaults",
  "nym-pemstore",
  "rand",
@@ -2355,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "nym-credential-proxy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2540,6 +2567,7 @@ name = "nym-http-api-common"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "axum-client-ip",
  "bytes",
  "colored",
  "mime",

--- a/nym-wallet/src-tauri/src/operations/mixnet/bond.rs
+++ b/nym-wallet/src-tauri/src/operations/mixnet/bond.rs
@@ -403,6 +403,8 @@ pub async fn update_gateway_config(
     )?)
 }
 
+// TODO: fix later (yeah...)
+#[allow(deprecated)]
 #[tauri::command]
 pub async fn get_mixnode_avg_uptime(
     state: tauri::State<'_, WalletState>,
@@ -605,6 +607,8 @@ pub async fn get_nym_node_description(
     )
 }
 
+// TODO: fix later (yeah...)
+#[allow(deprecated)]
 #[tauri::command]
 pub async fn get_mixnode_uptime(
     mix_id: NodeId,

--- a/nym-wallet/src-tauri/src/operations/mixnet/delegate.rs
+++ b/nym-wallet/src-tauri/src/operations/mixnet/delegate.rs
@@ -141,6 +141,8 @@ pub async fn undelegate_all_from_mixnode(
     Ok(res)
 }
 
+// TODO: fix later (yeah...)
+#[allow(deprecated)]
 #[tauri::command]
 pub async fn get_all_mix_delegations(
     state: tauri::State<'_, WalletState>,

--- a/nym-wallet/src-tauri/src/operations/nym_api/status.rs
+++ b/nym-wallet/src-tauri/src/operations/nym_api/status.rs
@@ -14,6 +14,8 @@ use nym_validator_client::models::{
     MixnodeStatusResponse, RewardEstimationResponse, StakeSaturationResponse,
 };
 
+// TODO: fix later (yeah...)
+#[allow(deprecated)]
 #[tauri::command]
 pub async fn mixnode_core_node_status(
     mix_id: NodeId,
@@ -25,6 +27,8 @@ pub async fn mixnode_core_node_status(
         .await?)
 }
 
+// TODO: fix later (yeah...)
+#[allow(deprecated)]
 #[tauri::command]
 pub async fn gateway_core_node_status(
     identity: IdentityKeyRef<'_>,
@@ -36,6 +40,8 @@ pub async fn gateway_core_node_status(
         .await?)
 }
 
+// TODO: fix later (yeah...)
+#[allow(deprecated)]
 #[tauri::command]
 pub async fn gateway_report(
     identity: IdentityKeyRef<'_>,
@@ -44,6 +50,8 @@ pub async fn gateway_report(
     Ok(api_client!(state).get_gateway_report(identity).await?)
 }
 
+// TODO: fix later (yeah...)
+#[allow(deprecated)]
 #[tauri::command]
 pub async fn mixnode_status(
     mix_id: NodeId,
@@ -52,6 +60,8 @@ pub async fn mixnode_status(
     Ok(api_client!(state).get_mixnode_status(mix_id).await?)
 }
 
+// TODO: fix later (yeah...)
+#[allow(deprecated)]
 #[tauri::command]
 pub async fn mixnode_reward_estimation(
     mix_id: NodeId,
@@ -62,6 +72,8 @@ pub async fn mixnode_reward_estimation(
         .await?)
 }
 
+// TODO: fix later (yeah...)
+#[allow(deprecated)]
 #[tauri::command]
 pub async fn compute_mixnode_reward_estimation(
     mix_id: u32,
@@ -85,6 +97,8 @@ pub async fn compute_mixnode_reward_estimation(
         .await?)
 }
 
+// TODO: fix later (yeah...)
+#[allow(deprecated)]
 #[tauri::command]
 pub async fn mixnode_stake_saturation(
     mix_id: NodeId,
@@ -95,6 +109,8 @@ pub async fn mixnode_stake_saturation(
         .await?)
 }
 
+// TODO: fix later (yeah...)
+#[allow(deprecated)]
 #[tauri::command]
 pub async fn mixnode_inclusion_probability(
     mix_id: NodeId,


### PR DESCRIPTION
this is to that the next time those methods are used outside the monorepo, the relevant calls flag up the CI via clippy

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5069)
<!-- Reviewable:end -->
