### PR TITLE
[Product Data] Better unique user count on gateways

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,14 +431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "autodoc"
-version = "0.1.0"
-dependencies = [
- "env_logger 0.11.5",
- "log",
-]
-
-[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,19 +2353,6 @@ dependencies = [
  "regex",
  "termcolor",
 ]
-
-[[package]]
-name = "env_logger"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime 2.1.0",
- "log",
- ]
 
 [[package]]
 name = "envy"
@@ -5481,6 +5460,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "sha2 0.10.8",
  "si-scale",
  "sqlx",
  "subtle-encoding",
@@ -7488,7 +7468,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "log",
 ]
 

--- a/common/gateway-stats-storage/src/lib.rs
+++ b/common/gateway-stats-storage/src/lib.rs
@@ -104,8 +104,8 @@ impl PersistentStatsStorage {
             .await?)
     }
 
-    pub async fn get_unique_users_count(&self, date: Date) -> Result<i32, StatsStorageError> {
-        Ok(self.session_manager.get_unique_users_count(date).await?)
+    pub async fn get_unique_users(&self, date: Date) -> Result<Vec<String>, StatsStorageError> {
+        Ok(self.session_manager.get_unique_users(date).await?)
     }
 
     pub async fn delete_unique_users(&self, before_date: Date) -> Result<(), StatsStorageError> {

--- a/common/gateway-stats-storage/src/sessions.rs
+++ b/common/gateway-stats-storage/src/sessions.rs
@@ -71,14 +71,13 @@ impl SessionManager {
         Ok(())
     }
 
-    pub(crate) async fn get_unique_users_count(&self, date: Date) -> Result<i32> {
-        Ok(sqlx::query!(
-            "SELECT COUNT(*) as count FROM sessions_unique_users WHERE day = ?",
+    pub(crate) async fn get_unique_users(&self, date: Date) -> Result<Vec<String>> {
+        sqlx::query_scalar!(
+            "SELECT client_address as count FROM sessions_unique_users WHERE day = ?",
             date
         )
-        .fetch_one(&self.connection_pool)
-        .await?
-        .count)
+        .fetch_all(&self.connection_pool)
+        .await
     }
 
     pub(crate) async fn delete_unique_users(&self, before_date: Date) -> Result<()> {

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -40,6 +40,7 @@ once_cell = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 si-scale = { workspace = true }
 subtle-encoding = { workspace = true, features = ["bech32-preview"] }
 thiserror = { workspace = true }

--- a/nym-node/nym-node-http-api/src/state/metrics.rs
+++ b/nym-node/nym-node-http-api/src/state/metrics.rs
@@ -159,7 +159,8 @@ type FinishedSessions = Vec<(u64, String)>;
 #[derive(Debug, Clone)]
 pub struct SessionStatsState {
     pub update_time: Date,
-    pub unique_active_users: u32,
+    pub unique_active_users_count: u32,
+    pub unique_active_users_hashes: Vec<String>,
     pub session_started: u32,
     pub sessions: FinishedSessions,
 }
@@ -174,7 +175,8 @@ impl SessionStatsState {
             .collect();
         SessionStats {
             update_time: self.update_time.with_time(time!(0:00)).assume_utc(),
-            unique_active_users: self.unique_active_users,
+            unique_active_users: self.unique_active_users_count,
+            unique_active_users_hashes: self.unique_active_users_hashes.clone(),
             sessions,
             sessions_started: self.session_started,
             sessions_finished: self.sessions.len() as u32,
@@ -186,7 +188,8 @@ impl Default for SessionStatsState {
     fn default() -> Self {
         SessionStatsState {
             update_time: OffsetDateTime::UNIX_EPOCH.date(),
-            unique_active_users: 0,
+            unique_active_users_count: 0,
+            unique_active_users_hashes: Default::default(),
             session_started: 0,
             sessions: Default::default(),
         }

--- a/nym-node/nym-node-requests/src/api/v1/metrics/models.rs
+++ b/nym-node/nym-node-requests/src/api/v1/metrics/models.rs
@@ -50,6 +50,8 @@ pub struct SessionStats {
 
     pub unique_active_users: u32,
 
+    pub unique_active_users_hashes: Vec<String>,
+
     pub sessions: Vec<Session>,
 
     pub sessions_started: u32,


### PR DESCRIPTION
To avoid double counting clients across gateways, we add a user ID to the gateway session data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5084)
<!-- Reviewable:end -->
