### PR TITLE
Bump NS agent to 1.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6064,7 +6064,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node-status-agent"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap 4.5.20",

--- a/nym-node-status-agent/Cargo.toml
+++ b/nym-node-status-agent/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "nym-node-status-agent"
-version = "0.1.4"
+version = "0.1.5"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-node-status-api/src/http/api/mod.rs
+++ b/nym-node-status-api/src/http/api/mod.rs
@@ -1,10 +1,7 @@
 use anyhow::anyhow;
 use axum::{response::Redirect, Router};
 use tokio::net::ToSocketAddrs;
-use tower_http::{
-    cors::CorsLayer,
-    trace::{DefaultOnResponse, TraceLayer},
-};
+use tower_http::{cors::CorsLayer, trace::TraceLayer};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -61,10 +58,7 @@ impl RouterBuilder {
             // CORS layer needs to wrap other API layers
             .layer(setup_cors())
             // logger should be outermost layer
-            .layer(
-                TraceLayer::new_for_http()
-                    .on_response(DefaultOnResponse::new().level(tracing::Level::DEBUG)),
-            )
+            .layer(TraceLayer::new_for_http())
     }
 }
 

--- a/nym-node-status-api/src/http/api/testruns.rs
+++ b/nym-node-status-api/src/http/api/testruns.rs
@@ -49,7 +49,8 @@ async fn request_testrun(State(state): State<AppState>) -> HttpResult<Json<Testr
                 );
                 Ok(Json(testrun))
             } else {
-                Err(HttpError::no_available_testruns())
+                tracing::debug!("No testruns available for agent");
+                Err(HttpError::no_testruns_available())
             }
         }
         Err(err) => Err(HttpError::internal_with_logging(err)),

--- a/nym-node-status-api/src/http/error.rs
+++ b/nym-node-status-api/src/http/error.rs
@@ -27,9 +27,9 @@ impl HttpError {
         }
     }
 
-    pub(crate) fn no_available_testruns() -> Self {
+    pub(crate) fn no_testruns_available() -> Self {
         Self {
-            message: serde_json::json!({"message": "No available testruns"}).to_string(),
+            message: serde_json::json!({"message": "No testruns available"}).to_string(),
             status: axum::http::StatusCode::SERVICE_UNAVAILABLE,
         }
     }


### PR DESCRIPTION
## API improvements

- agent exits gracefully when no testrun available
- API doesn't log every error (to avoid log spam)
- update network probe within NS agent image: [CI rebuild](https://github.com/nymtech/nym/blob/release/2024.13-magura/nym-node-status-agent/Dockerfile#L9) of NS agent will pick up updated network probe

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5089)
<!-- Reviewable:end -->
