### PR TITLE
bugfix: don't send empty BankMsg in ecash contract

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1219,6 +1219,7 @@ dependencies = [
 name = "nym-ecash"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bs58 0.4.0",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1330,6 +1331,10 @@ dependencies = [
 [[package]]
 name = "nym-network-defaults"
 version = "0.1.0"
+dependencies = [
+ "cargo_metadata",
+ "regex",
+]
 
 [[package]]
 name = "nym-pemstore"
@@ -1570,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1582,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1593,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rfc6979"

--- a/contracts/ecash/Cargo.toml
+++ b/contracts/ecash/Cargo.toml
@@ -36,6 +36,7 @@ nym-multisig-contract-common = { path = "../../common/cosmwasm-smart-contracts/m
 nym-network-defaults = { path = "../../common/network-defaults", default-features = false }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 sylvia = { workspace = true, features = ["mt"] }
 nym-crypto = { path = "../../common/crypto", features = ["rand", "asymmetric"] }
 rand_chacha = "0.3"

--- a/contracts/ecash/src/support/tests.rs
+++ b/contracts/ecash/src/support/tests.rs
@@ -1,10 +1,113 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::contract::NymEcashContract;
+use crate::helpers::Config;
+use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info, MockApi, MockQuerier};
+use cosmwasm_std::{coin, Addr, Deps, Empty, Env, MemoryStorage, MessageInfo, OwnedDeps};
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha20Rng;
+use sylvia::types::{ExecCtx, InstantiateCtx, QueryCtx};
 
 pub fn test_rng() -> ChaCha20Rng {
     let dummy_seed = [42u8; 32];
     ChaCha20Rng::from_seed(dummy_seed)
+}
+
+const CONTRACT: NymEcashContract<'static> = NymEcashContract::new();
+
+const DENOM: &str = "unym";
+
+#[allow(dead_code)]
+pub struct TestSetupSimple {
+    pub deps: OwnedDeps<MemoryStorage, MockApi, MockQuerier<Empty>>,
+    pub env: Env,
+    pub rng: ChaCha20Rng,
+    pub owner: Addr,
+    pub holding_account: Addr,
+    pub multisig_contract: Addr,
+    pub group_contract: Addr,
+}
+
+impl TestSetupSimple {
+    pub fn new() -> Self {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let owner = Addr::unchecked("owner");
+
+        let init_ctx = InstantiateCtx {
+            deps: deps.as_mut(),
+            env: env.clone(),
+            info: mock_info(owner.as_str(), &[]),
+        };
+
+        let rng = test_rng();
+        let holding_account = Addr::unchecked("holding_account");
+        let multisig_contract = Addr::unchecked("multisig_contract");
+        let group_contract = Addr::unchecked("group_contract");
+
+        CONTRACT
+            .instantiate(
+                init_ctx,
+                holding_account.to_string(),
+                multisig_contract.to_string(),
+                group_contract.to_string(),
+                coin(75_000_000, DENOM.to_string()),
+            )
+            .unwrap();
+
+        TestSetupSimple {
+            deps,
+            env,
+            rng,
+            owner,
+            holding_account,
+            multisig_contract,
+            group_contract,
+        }
+    }
+
+    pub fn admin(&self) -> MessageInfo {
+        let admin = CONTRACT
+            .contract_admin
+            .get(self.deps.as_ref())
+            .unwrap()
+            .unwrap();
+        mock_info(admin.as_str(), &[])
+    }
+
+    pub fn execute_ctx(&mut self, sender: MessageInfo) -> ExecCtx {
+        ExecCtx {
+            env: self.env.clone(),
+            deps: self.deps.as_mut(),
+            info: sender,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn query_ctx(&self) -> QueryCtx {
+        QueryCtx {
+            env: self.env.clone(),
+            deps: self.deps.as_ref(),
+        }
+    }
+
+    pub fn contract(&self) -> NymEcashContract {
+        CONTRACT
+    }
+
+    pub fn deps(&self) -> Deps<'_> {
+        self.deps.as_ref()
+    }
+
+    pub fn config(&self) -> Config {
+        CONTRACT.config.load(self.deps().storage).unwrap()
+    }
+
+    pub fn with_deposit_amount(mut self, amount: u128) -> Self {
+        CONTRACT
+            .update_deposit_value(self.execute_ctx(self.admin()), coin(amount, DENOM))
+            .unwrap();
+        self
+    }
 }


### PR DESCRIPTION
if ticketbook prices were to be set so low the resultant redemption would have created `BankMsg` with value of 0, that message is no longer going to be sent

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5121)
<!-- Reviewable:end -->
