### PR TITLE
start session collection for exit gateways

### DIFF
--- a/nym-node/src/node/mod.rs
+++ b/nym-node/src/node/mod.rs
@@ -622,6 +622,7 @@ impl NymNode {
             self.exit_gateway.stats_storage.clone(),
         );
         exit_gateway.set_task_client(task_client);
+        exit_gateway.set_session_stats(self.entry_gateway.sessions_stats.clone()); //Weird naming I'll give you that, but Andrew is gonna rework it anyway
         if self.config.wireguard.enabled {
             exit_gateway.set_wireguard_data(self.wireguard.into());
         }


### PR DESCRIPTION
Apparently, exit gateways are also entry gateways so we need to start session stats for them as well

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5148)
<!-- Reviewable:end -->
