### PR TITLE
bugfix: correctly expose ecash-related data on nym-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4457,7 +4457,6 @@ dependencies = [
  "async-trait",
  "axum 0.7.7",
  "axum-extra",
- "axum-macros",
  "axum-test",
  "bincode",
  "bip39",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4457,6 +4457,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.7",
  "axum-extra",
+ "axum-macros",
  "axum-test",
  "bincode",
  "bip39",

--- a/nym-api/Cargo.toml
+++ b/nym-api/Cargo.toml
@@ -71,9 +71,6 @@ utoipauto = { workspace = true }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 tracing = { workspace = true }
 
-# useful for `#[axum_macros::debug_handler]`
-axum-macros = "0.4.2"
-
 ## ephemera-specific
 #actix-web = "4"
 #array-bytes = "6.0.0"

--- a/nym-api/Cargo.toml
+++ b/nym-api/Cargo.toml
@@ -71,6 +71,9 @@ utoipauto = { workspace = true }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 tracing = { workspace = true }
 
+# useful for `#[axum_macros::debug_handler]`
+axum-macros = "0.4.2"
+
 ## ephemera-specific
 #actix-web = "4"
 #array-bytes = "6.0.0"
@@ -120,7 +123,7 @@ nym-types = { path = "../common/types" }
 nym-http-api-common = { path = "../common/http-api-common", features = ["utoipa"] }
 nym-serde-helpers = { path = "../common/serde-helpers", features = ["date"] }
 nym-ticketbooks-merkle = { path = "../common/ticketbooks-merkle" }
-nym-statistics-common = {path ="../common/statistics" }
+nym-statistics-common = { path = "../common/statistics" }
 
 [features]
 no-reward = []

--- a/nym-api/src/ecash/api_routes/aggregation.rs
+++ b/nym-api/src/ecash/api_routes/aggregation.rs
@@ -6,7 +6,7 @@ use crate::ecash::error::EcashError;
 use crate::ecash::state::EcashState;
 use crate::node_status_api::models::AxumResult;
 use crate::support::http::state::AppState;
-use axum::extract::{Path, State};
+use axum::extract::{Query, State};
 use axum::{Json, Router};
 use nym_api_requests::ecash::models::{
     AggregatedCoinIndicesSignatureResponse, AggregatedExpirationDateSignatureResponse,
@@ -50,7 +50,7 @@ pub(crate) fn aggregation_routes() -> Router<AppState> {
 )]
 async fn master_verification_key(
     State(state): State<Arc<EcashState>>,
-    Path(EpochIdParam { epoch_id }): Path<EpochIdParam>,
+    Query(EpochIdParam { epoch_id }): Query<EpochIdParam>,
 ) -> AxumResult<Json<VerificationKeyResponse>> {
     trace!("aggregated_verification_key request");
 
@@ -63,7 +63,6 @@ async fn master_verification_key(
 }
 
 #[derive(Deserialize, IntoParams)]
-#[into_params(parameter_in = Path)]
 struct ExpirationDateParam {
     expiration_date: Option<String>,
 }
@@ -81,7 +80,7 @@ struct ExpirationDateParam {
 )]
 async fn expiration_date_signatures(
     State(state): State<Arc<EcashState>>,
-    Path(ExpirationDateParam { expiration_date }): Path<ExpirationDateParam>,
+    Query(ExpirationDateParam { expiration_date }): Query<ExpirationDateParam>,
 ) -> AxumResult<Json<AggregatedExpirationDateSignatureResponse>> {
     trace!("aggregated_expiration_date_signatures request");
 
@@ -117,8 +116,8 @@ async fn expiration_date_signatures(
     )
 )]
 async fn coin_indices_signatures(
+    Query(EpochIdParam { epoch_id }): Query<EpochIdParam>,
     State(state): State<Arc<EcashState>>,
-    Path(EpochIdParam { epoch_id }): Path<EpochIdParam>,
 ) -> AxumResult<Json<AggregatedCoinIndicesSignatureResponse>> {
     trace!("aggregated_coin_indices_signatures request");
 

--- a/nym-api/src/ecash/api_routes/aggregation.rs
+++ b/nym-api/src/ecash/api_routes/aggregation.rs
@@ -6,7 +6,7 @@ use crate::ecash::error::EcashError;
 use crate::ecash::state::EcashState;
 use crate::node_status_api::models::AxumResult;
 use crate::support::http::state::AppState;
-use axum::extract::Path;
+use axum::extract::{Path, State};
 use axum::{Json, Router};
 use nym_api_requests::ecash::models::{
     AggregatedCoinIndicesSignatureResponse, AggregatedExpirationDateSignatureResponse,
@@ -21,28 +21,19 @@ use tracing::trace;
 use utoipa::IntoParams;
 
 /// routes with globally aggregated keys, signatures, etc.
-pub(crate) fn aggregation_routes(ecash_state: Arc<EcashState>) -> Router<AppState> {
+pub(crate) fn aggregation_routes() -> Router<AppState> {
     Router::new()
         .route(
             "/master-verification-key",
-            axum::routing::get({
-                let ecash_state = Arc::clone(&ecash_state);
-                |epoch_id| master_verification_key(epoch_id, ecash_state)
-            }),
+            axum::routing::get(master_verification_key),
         )
         .route(
             "/aggregated-expiration-date-signatures",
-            axum::routing::get({
-                let ecash_state = Arc::clone(&ecash_state);
-                |expiration_date| expiration_date_signatures(expiration_date, ecash_state)
-            }),
+            axum::routing::get(expiration_date_signatures),
         )
         .route(
             "/aggregated-coin-indices-signatures",
-            axum::routing::get({
-                let ecash_state = Arc::clone(&ecash_state);
-                |epoch_id| coin_indices_signatures(epoch_id, ecash_state)
-            }),
+            axum::routing::get(coin_indices_signatures),
         )
 }
 
@@ -58,8 +49,8 @@ pub(crate) fn aggregation_routes(ecash_state: Arc<EcashState>) -> Router<AppStat
     )
 )]
 async fn master_verification_key(
+    State(state): State<Arc<EcashState>>,
     Path(EpochIdParam { epoch_id }): Path<EpochIdParam>,
-    state: Arc<EcashState>,
 ) -> AxumResult<Json<VerificationKeyResponse>> {
     trace!("aggregated_verification_key request");
 
@@ -89,8 +80,8 @@ struct ExpirationDateParam {
     )
 )]
 async fn expiration_date_signatures(
+    State(state): State<Arc<EcashState>>,
     Path(ExpirationDateParam { expiration_date }): Path<ExpirationDateParam>,
-    state: Arc<EcashState>,
 ) -> AxumResult<Json<AggregatedExpirationDateSignatureResponse>> {
     trace!("aggregated_expiration_date_signatures request");
 
@@ -126,8 +117,8 @@ async fn expiration_date_signatures(
     )
 )]
 async fn coin_indices_signatures(
+    State(state): State<Arc<EcashState>>,
     Path(EpochIdParam { epoch_id }): Path<EpochIdParam>,
-    state: Arc<EcashState>,
 ) -> AxumResult<Json<AggregatedCoinIndicesSignatureResponse>> {
     trace!("aggregated_coin_indices_signatures request");
 

--- a/nym-api/src/ecash/api_routes/handlers.rs
+++ b/nym-api/src/ecash/api_routes/handlers.rs
@@ -5,15 +5,13 @@ use crate::ecash::api_routes::aggregation::aggregation_routes;
 use crate::ecash::api_routes::issued::issued_routes;
 use crate::ecash::api_routes::partial_signing::partial_signing_routes;
 use crate::ecash::api_routes::spending::spending_routes;
-use crate::ecash::state::EcashState;
 use crate::support::http::state::AppState;
 use axum::Router;
-use std::sync::Arc;
 
-pub(crate) fn ecash_routes(ecash_state: Arc<EcashState>) -> Router<AppState> {
+pub(crate) fn ecash_routes() -> Router<AppState> {
     Router::new()
-        .merge(aggregation_routes(Arc::clone(&ecash_state)))
-        .merge(issued_routes(Arc::clone(&ecash_state)))
-        .merge(partial_signing_routes(Arc::clone(&ecash_state)))
-        .merge(spending_routes(Arc::clone(&ecash_state)))
+        .merge(aggregation_routes())
+        .merge(issued_routes())
+        .merge(partial_signing_routes())
+        .merge(spending_routes())
 }

--- a/nym-api/src/ecash/api_routes/helpers.rs
+++ b/nym-api/src/ecash/api_routes/helpers.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #[derive(serde::Deserialize, utoipa::IntoParams)]
-#[into_params(parameter_in = Path)]
 pub(super) struct EpochIdParam {
     pub(super) epoch_id: Option<u64>,
 }

--- a/nym-api/src/ecash/api_routes/partial_signing.rs
+++ b/nym-api/src/ecash/api_routes/partial_signing.rs
@@ -7,7 +7,7 @@ use crate::ecash::helpers::blind_sign;
 use crate::ecash::state::EcashState;
 use crate::node_status_api::models::AxumResult;
 use crate::support::http::state::AppState;
-use axum::extract::Query;
+use axum::extract::{Query, State};
 use axum::{Json, Router};
 use nym_api_requests::ecash::{
     BlindSignRequestBody, BlindedSignatureResponse, PartialCoinIndicesSignatureResponse,
@@ -22,28 +22,16 @@ use time::Date;
 use tracing::{debug, trace};
 use utoipa::IntoParams;
 
-pub(crate) fn partial_signing_routes(ecash_state: Arc<EcashState>) -> Router<AppState> {
+pub(crate) fn partial_signing_routes() -> Router<AppState> {
     Router::new()
-        .route(
-            "/blind-sign",
-            axum::routing::post({
-                let ecash_state = Arc::clone(&ecash_state);
-                |body| post_blind_sign(body, ecash_state)
-            }),
-        )
+        .route("/blind-sign", axum::routing::post(post_blind_sign))
         .route(
             "/partial-expiration-date-signatures",
-            axum::routing::get({
-                let ecash_state = Arc::clone(&ecash_state);
-                |expiration_date| partial_expiration_date_signatures(expiration_date, ecash_state)
-            }),
+            axum::routing::get(partial_expiration_date_signatures),
         )
         .route(
             "/partial-coin-indices-signatures",
-            axum::routing::get({
-                let ecash_state = Arc::clone(&ecash_state);
-                |epoch_id| partial_coin_indices_signatures(epoch_id, ecash_state)
-            }),
+            axum::routing::get(partial_coin_indices_signatures),
         )
 }
 
@@ -59,8 +47,8 @@ pub(crate) fn partial_signing_routes(ecash_state: Arc<EcashState>) -> Router<App
     )
 )]
 async fn post_blind_sign(
+    State(state): State<Arc<EcashState>>,
     Json(blind_sign_request_body): Json<BlindSignRequestBody>,
-    state: Arc<EcashState>,
 ) -> AxumResult<Json<BlindedSignatureResponse>> {
     state.ensure_signer().await?;
 
@@ -134,8 +122,8 @@ struct ExpirationDateParam {
     )
 )]
 async fn partial_expiration_date_signatures(
+    State(state): State<Arc<EcashState>>,
     Query(ExpirationDateParam { expiration_date }): Query<ExpirationDateParam>,
-    state: Arc<EcashState>,
 ) -> AxumResult<Json<PartialExpirationDateSignatureResponse>> {
     state.ensure_signer().await?;
 
@@ -172,8 +160,8 @@ async fn partial_expiration_date_signatures(
     )
 )]
 async fn partial_coin_indices_signatures(
+    State(state): State<Arc<EcashState>>,
     Query(EpochIdParam { epoch_id }): Query<EpochIdParam>,
-    state: Arc<EcashState>,
 ) -> AxumResult<Json<PartialCoinIndicesSignatureResponse>> {
     state.ensure_signer().await?;
 

--- a/nym-api/src/ecash/client.rs
+++ b/nym-api/src/ecash/client.rs
@@ -27,7 +27,7 @@ use nym_validator_client::EcashApiClient;
 
 #[async_trait]
 pub trait Client {
-    async fn address(&self) -> AccountId;
+    async fn address(&self) -> Result<AccountId>;
 
     async fn dkg_contract_address(&self) -> Result<AccountId>;
 

--- a/nym-api/src/ecash/dkg/client.rs
+++ b/nym-api/src/ecash/dkg/client.rs
@@ -35,7 +35,7 @@ impl DkgClient {
         }
     }
 
-    pub(crate) async fn get_address(&self) -> AccountId {
+    pub(crate) async fn get_address(&self) -> Result<AccountId, EcashError> {
         self.inner.address().await
     }
 
@@ -53,7 +53,7 @@ impl DkgClient {
 
     pub(crate) async fn group_member(&self) -> Result<MemberResponse, EcashError> {
         self.inner
-            .group_member(self.get_address().await.to_string())
+            .group_member(self.get_address().await?.to_string())
             .await
     }
 
@@ -126,7 +126,7 @@ impl DkgClient {
         &self,
         epoch_id: EpochId,
     ) -> Result<Option<ContractVKShare>, EcashError> {
-        let address = self.inner.address().await;
+        let address = self.inner.address().await?;
         self.get_verification_key_share(epoch_id, address).await
     }
 
@@ -138,7 +138,7 @@ impl DkgClient {
     }
 
     pub(crate) async fn get_vote(&self, proposal_id: u64) -> Result<VoteResponse, EcashError> {
-        let address = self.get_address().await.to_string();
+        let address = self.get_address().await?.to_string();
         self.inner.get_vote(proposal_id, address).await
     }
 

--- a/nym-api/src/ecash/dkg/dealing.rs
+++ b/nym-api/src/ecash/dkg/dealing.rs
@@ -155,7 +155,7 @@ impl<R: RngCore + CryptoRng> DkgController<R> {
         resharing: bool,
     ) -> Result<(), DealingGenerationError> {
         let dealing_state = self.state.dealing_exchange_state(epoch_id)?;
-        let address = self.dkg_client.get_address().await.to_string();
+        let address = self.dkg_client.get_address().await?.to_string();
 
         let status = self
             .dkg_client
@@ -259,7 +259,7 @@ impl<R: RngCore + CryptoRng> DkgController<R> {
             .checked_sub(1)
             .expect("resharing epoch invariant has been broken");
 
-        let address = self.dkg_client.get_address().await;
+        let address = self.dkg_client.get_address().await?;
         Ok(self
             .dkg_client
             .dealer_in_epoch(previous_epoch_id, address.to_string())

--- a/nym-api/src/ecash/dkg/key_derivation.rs
+++ b/nym-api/src/ecash/dkg/key_derivation.rs
@@ -494,7 +494,7 @@ impl<R: RngCore + CryptoRng> DkgController<R> {
         // submitted proposals and find the one with our address
         self.get_validation_proposals()
             .await?
-            .get(self.dkg_client.get_address().await.as_ref())
+            .get(self.dkg_client.get_address().await?.as_ref())
             .copied()
             .ok_or(KeyDerivationError::UnrecoverableProposalId)
     }

--- a/nym-api/src/ecash/dkg/key_validation.rs
+++ b/nym-api/src/ecash/dkg/key_validation.rs
@@ -155,7 +155,7 @@ impl<R: RngCore + CryptoRng> DkgController<R> {
             };
 
             // if this is our share, obviously vote for yes without spending time on verification
-            if owner.as_ref() == self.dkg_client.get_address().await.as_ref() {
+            if owner.as_ref() == self.dkg_client.get_address().await?.as_ref() {
                 votes.insert(*proposal_id, true);
                 continue;
             }

--- a/nym-api/src/ecash/dkg/key_validation.rs
+++ b/nym-api/src/ecash/dkg/key_validation.rs
@@ -313,7 +313,7 @@ mod tests {
         exchange_dealings(&mut controllers, false).await;
         derive_keypairs(&mut controllers, false).await;
 
-        let first_dealer = controllers[0].dkg_client.get_address().await;
+        let first_dealer = controllers[0].dkg_client.get_address().await?;
 
         {
             let mut guard = chain.lock().unwrap();
@@ -365,8 +365,8 @@ mod tests {
         exchange_dealings(&mut controllers, false).await;
         derive_keypairs(&mut controllers, false).await;
 
-        let first_dealer = controllers[0].dkg_client.get_address().await;
-        let second_dealer = controllers[1].dkg_client.get_address().await;
+        let first_dealer = controllers[0].dkg_client.get_address().await?;
+        let second_dealer = controllers[1].dkg_client.get_address().await?;
 
         {
             let mut guard = chain.lock().unwrap();

--- a/nym-api/src/ecash/error.rs
+++ b/nym-api/src/ecash/error.rs
@@ -25,6 +25,9 @@ pub enum EcashError {
     #[error(transparent)]
     IOError(#[from] std::io::Error),
 
+    #[error("this instance is running without on-chain signing capabilities so no transactions can be sent")]
+    ChainSignerNotEnabled,
+
     #[error("this operation couldn't be completed as this nym-api is not an active ecash signer")]
     NotASigner,
 

--- a/nym-api/src/ecash/tests/fixtures.rs
+++ b/nym-api/src/ecash/tests/fixtures.rs
@@ -263,7 +263,7 @@ pub(crate) struct TestingDkgController {
 
 impl TestingDkgController {
     pub async fn address(&self) -> AccountId {
-        self.dkg_client.get_address().await
+        self.dkg_client.get_address().await.unwrap()
     }
 
     pub async fn cw_address(&self) -> Addr {

--- a/nym-api/src/ecash/tests/helpers.rs
+++ b/nym-api/src/ecash/tests/helpers.rs
@@ -51,7 +51,7 @@ pub(crate) async fn initialise_dkg(controllers: &mut [TestingDkgController], res
 
     // add every dealer to group contract
     for controller in controllers.iter() {
-        let address = controller.dkg_client.get_address().await;
+        let address = controller.dkg_client.get_address().await.unwrap();
         let mut chain = controllers[0].chain_state.lock().unwrap();
         chain.add_member(address.as_ref(), 10);
     }

--- a/nym-api/src/ecash/tests/mod.rs
+++ b/nym-api/src/ecash/tests/mod.rs
@@ -11,6 +11,7 @@ use crate::node_describe_cache::DescribedNodes;
 use crate::node_status_api::handlers::unstable;
 use crate::node_status_api::NodeStatusCache;
 use crate::nym_contract_cache::cache::NymContractCache;
+use crate::status::ApiStatusState;
 use crate::support::caching::cache::SharedCache;
 use crate::support::config;
 use crate::support::http::state::AppState;
@@ -524,8 +525,8 @@ impl DummyClient {
 
 #[async_trait]
 impl super::client::Client for DummyClient {
-    async fn address(&self) -> AccountId {
-        self.validator_address.clone()
+    async fn address(&self) -> Result<AccountId> {
+        Ok(self.validator_address.clone())
     }
 
     async fn dkg_contract_address(&self) -> Result<AccountId> {
@@ -1262,7 +1263,7 @@ struct TestFixture {
 }
 
 impl TestFixture {
-    fn build_app_state(storage: NymApiStorage) -> AppState {
+    fn build_app_state(storage: NymApiStorage, ecash_state: EcashState) -> AppState {
         AppState {
             forced_refresh: Default::default(),
             nym_contract_cache: NymContractCache::new(),
@@ -1275,6 +1276,8 @@ impl TestFixture {
                 NymNetworkDetails::new_empty(),
             ),
             node_info_cache: unstable::NodeInfoCache::default(),
+            api_status: ApiStatusState::new(None),
+            ecash_state: Arc::new(ecash_state),
         }
     }
 
@@ -1337,8 +1340,8 @@ impl TestFixture {
         TestFixture {
             axum: TestServer::new(
                 Router::new()
-                    .nest("/v1/ecash", ecash_routes(Arc::new(ecash_state)))
-                    .with_state(Self::build_app_state(storage.clone())),
+                    .nest("/v1/ecash", ecash_routes())
+                    .with_state(Self::build_app_state(storage.clone(), ecash_state)),
             )
             .unwrap(),
             storage,

--- a/nym-api/src/epoch_operations/error.rs
+++ b/nym-api/src/epoch_operations/error.rs
@@ -11,6 +11,9 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum RewardingError {
+    #[error("this instance is running without on-chain signing capabilities so no transactions can be sent")]
+    ChainSignerNotEnabled,
+
     #[error("Our account ({our_address}) is not permitted to update rewarded set and perform rewarding. The allowed address is {allowed_address}")]
     Unauthorised {
         our_address: AccountId,

--- a/nym-api/src/status/mod.rs
+++ b/nym-api/src/status/mod.rs
@@ -4,12 +4,25 @@
 use crate::ecash;
 use nym_bin_common::bin_info;
 use nym_bin_common::build_information::BinaryBuildInformation;
-
+use std::ops::Deref;
+use std::sync::Arc;
 use tokio::time::Instant;
 
 pub(crate) mod handlers;
 
+#[derive(Clone)]
 pub(crate) struct ApiStatusState {
+    inner: Arc<ApiStatusStateInner>,
+}
+
+impl Deref for ApiStatusState {
+    type Target = ApiStatusStateInner;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+pub(crate) struct ApiStatusStateInner {
     startup_time: Instant,
     build_information: BinaryBuildInformation,
     signer_information: Option<SignerState>,
@@ -27,15 +40,13 @@ pub(crate) struct SignerState {
 }
 
 impl ApiStatusState {
-    pub fn new() -> Self {
+    pub fn new(signer_information: Option<SignerState>) -> Self {
         ApiStatusState {
-            startup_time: Instant::now(),
-            build_information: bin_info!(),
-            signer_information: None,
+            inner: Arc::new(ApiStatusStateInner {
+                startup_time: Instant::now(),
+                build_information: bin_info!(),
+                signer_information,
+            }),
         }
-    }
-
-    pub fn add_zk_nym_signer(&mut self, signer_information: SignerState) {
-        self.signer_information = Some(signer_information)
     }
 }

--- a/nym-api/src/support/cli/run.rs
+++ b/nym-api/src/support/cli/run.rs
@@ -157,7 +157,7 @@ async fn start_nym_api_tasks_axum(config: &Config) -> anyhow::Result<ShutdownHan
     // if ecash signer is enabled, there are additional constraints on the nym-api,
     // such as having sufficient token balance
     let signer_information = if config.ecash_signer.enabled {
-        let cosmos_address = nyxd_client.address().await;
+        let cosmos_address = nyxd_client.address().await?;
 
         // make sure we have some tokens to cover multisig fees
         let balance = nyxd_client.balance(&mix_denom).await?;

--- a/nym-api/src/support/http/router.rs
+++ b/nym-api/src/support/http/router.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::circulating_supply_api::handlers::circulating_supply_routes;
+use crate::ecash::api_routes::handlers::ecash_routes;
 use crate::network::handlers::nym_network_routes;
 use crate::node_status_api::handlers::node_status_routes;
 use crate::nym_contract_cache::handlers::nym_contract_cache_routes;
@@ -62,6 +63,7 @@ impl RouterBuilder {
                     .nest("/network", nym_network_routes())
                     .nest("/api-status", status::handlers::api_status_routes())
                     .nest("/nym-nodes", nym_node_routes())
+                    .nest("/ecash", ecash_routes())
                     .nest("/unstable", unstable_routes()), // CORS layer needs to be "outside" of routes
             );
 
@@ -70,6 +72,7 @@ impl RouterBuilder {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn nest(self, path: &str, router: Router<AppState>) -> Self {
         Self {
             unfinished_router: self.unfinished_router.nest(path, router),

--- a/nym-api/src/support/http/state.rs
+++ b/nym-api/src/support/http/state.rs
@@ -2,15 +2,18 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::circulating_supply_api::cache::CirculatingSupplyCache;
+use crate::ecash::state::EcashState;
 use crate::network::models::NetworkDetails;
 use crate::node_describe_cache::DescribedNodes;
 use crate::node_status_api::handlers::unstable;
 use crate::node_status_api::models::AxumErrorResponse;
 use crate::node_status_api::NodeStatusCache;
 use crate::nym_contract_cache::cache::{CachedRewardedSet, NymContractCache};
+use crate::status::ApiStatusState;
 use crate::support::caching::cache::SharedCache;
 use crate::support::caching::Cache;
 use crate::support::storage;
+use axum::extract::FromRef;
 use nym_api_requests::models::{GatewayBondAnnotated, MixNodeBondAnnotated, NodeAnnotation};
 use nym_mixnet_contract_common::NodeId;
 use nym_task::TaskManager;
@@ -80,6 +83,21 @@ pub(crate) struct AppState {
     pub(crate) described_nodes_cache: SharedCache<DescribedNodes>,
     pub(crate) network_details: NetworkDetails,
     pub(crate) node_info_cache: unstable::NodeInfoCache,
+    pub(crate) api_status: ApiStatusState,
+    // todo: refactor it into inner: Arc<EcashStateInner>
+    pub(crate) ecash_state: Arc<EcashState>,
+}
+
+impl FromRef<AppState> for ApiStatusState {
+    fn from_ref(app_state: &AppState) -> Self {
+        app_state.api_status.clone()
+    }
+}
+
+impl FromRef<AppState> for Arc<EcashState> {
+    fn from_ref(app_state: &AppState) -> Self {
+        app_state.ecash_state.clone()
+    }
 }
 
 #[derive(Clone, Default)]


### PR DESCRIPTION
this PR makes fixes to ecash-related endpoints on nym-api:
- global data (such as aggregated signatures and keys) are actually always available by all apis
- signer information is now correctly returned if the api is an ecash signer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5155)
<!-- Reviewable:end -->
