### PR TITLE
Add derive_extended_private_key to DirectSecp256k1HdWallet

### DIFF
--- a/common/client-libs/validator-client/src/signing/direct_wallet.rs
+++ b/common/client-libs/validator-client/src/signing/direct_wallet.rs
@@ -98,6 +98,13 @@ impl DirectSecp256k1HdWallet {
         Ok((private_key, public_key))
     }
 
+    pub fn derive_extended_private_key(
+        &self,
+        hd_path: &DerivationPath,
+    ) -> Result<XPrv, DirectSecp256k1HdWalletError> {
+        Ok(XPrv::derive_from_path(self.seed, hd_path)?)
+    }
+
     pub fn try_derive_accounts(&self) -> Result<Vec<AccountData>, DirectSecp256k1HdWalletError> {
         let mut accounts = Vec::with_capacity(self.accounts.len());
         for derivation_info in &self.accounts {


### PR DESCRIPTION
Add `derive_extended_private_key` to `DirectSectp256k1HdWallet` to support seeding ecash keys

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5167)
<!-- Reviewable:end -->
