### PR TITLE
Move two minor jobs to free tier github hosted runners

### DIFF
--- a/.github/workflows/ci-contracts-schema.yml
+++ b/.github/workflows/ci-contracts-schema.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   check-schema:
     name: Generate and check schema
-    runs-on: arc-ubuntu-20.04
+    runs-on: ubuntu-20.04
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   matrix_prep:
-    runs-on: arc-ubuntu-20.04
+    runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:


### PR DESCRIPTION
In an attempt to easy the load on the self-hosted runners, move two minor workflows over to GH hosted free tier runners.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5169)
<!-- Reviewable:end -->
