### PR TITLE
Script update

### DIFF
--- a/scripts/network_tunnel_manager.sh
+++ b/scripts/network_tunnel_manager.sh
@@ -153,6 +153,23 @@ joke_through_tunnel() {
     fi
 }
 
+configure_dns_and_icmp_wg() {
+    echo "allowing icmp (ping)..."
+    sudo iptables -A INPUT -p icmp --icmp-type echo-request -j ACCEPT
+    sudo iptables -A OUTPUT -p icmp --icmp-type echo-reply -j ACCEPT
+
+    echo "allowing dns over udp (port 53)..."
+    sudo iptables -A INPUT -p udp --dport 53 -j ACCEPT
+
+    echo "allowing dns over tcp (port 53)..."
+    sudo iptables -A INPUT -p tcp --dport 53 -j ACCEPT
+
+    echo "saving iptables rules..."
+    sudo iptables-save > /etc/iptables/rules.v4
+
+    echo "dns and icmp configuration completed."
+}
+
 case "$1" in
 fetch_ipv6_address_nym_tun)
     fetch_ipv6_address "$tunnel_interface"
@@ -187,6 +204,9 @@ joke_through_the_mixnet)
 joke_through_wg_tunnel)
     joke_through_tunnel "$wg_tunnel_interface"
     ;;
+configure_dns_and_icmp_wg)
+    configure_dns_and_icmp_wg
+    ;;
 *)
     echo "Usage: $0 [command]"
     echo "Commands:"
@@ -203,6 +223,7 @@ joke_through_wg_tunnel)
     echo "  perform_pings                   - Test IPv4 and IPv6 connectivity."
     echo "  joke_through_the_mixnet         - Fetch a joke via nymtun0."
     echo "  joke_through_wg_tunnel          - Fetch a joke via nymwg."
+    echo "  configure_dns_and_icmp_wg       - Allows icmp ping tests for probes alongside configuring dns"
     exit 1
     ;;
 esac

--- a/scripts/network_tunnel_manager.sh
+++ b/scripts/network_tunnel_manager.sh
@@ -11,11 +11,12 @@ else
     echo "iptables-persistent is already installed."
 fi
 
-fetch_ipv6_address_nym_tun() {
-    ipv6_global_address=$(ip -6 addr show $tunnel_interface scope global | grep inet6 | awk '{print $2}' | head -n 1)
+fetch_ipv6_address() {
+    local interface=$1
+    ipv6_global_address=$(ip -6 addr show "$interface" scope global | grep inet6 | awk '{print $2}' | head -n 1)
 
     if [[ -z "$ipv6_global_address" ]]; then
-        echo "no globally routable IPv6 address found on $tunnel_interface. please configure IPv6 or check your network settings."
+        echo "no globally routable IPv6 address found on $interface. Please configure IPv6 or check your network settings."
         exit 1
     else
         echo "using IPv6 address: $ipv6_global_address"
@@ -23,88 +24,88 @@ fetch_ipv6_address_nym_tun() {
 }
 
 fetch_and_display_ipv6() {
-    ipv6_address=$(ip -6 addr show ${network_device} scope global | grep inet6 | awk '{print $2}')
+    ipv6_address=$(ip -6 addr show "$network_device" scope global | grep inet6 | awk '{print $2}')
     if [[ -z "$ipv6_address" ]]; then
-        echo "no global IPv6 address found on ${network_device}."
-    else
-        echo "IPv6 address on ${network_device}: $ipv6_address"
+        echo "no global IPv6 address found on $network_device."
+    elsen
+        echo "IPv6 address on $network_device: $ipv6_address"
     fi
 }
 
 adjust_ip_forwarding() {
-    ipv6_forwarding_setting="net.ipv6.conf.all.forwarding=1"
-    ipv4_forwarding_setting="net.ipv4.ip_forward=1"
-    echo "$ipv6_forwarding_setting" | sudo tee -a /etc/sysctl.conf
-    echo "$ipv4_forwarding_setting" | sudo tee -a /etc/sysctl.conf
-    sysctl -p /etc/sysctl.conf
-}
-
-apply_iptables_rules_wg() {
-    echo "applying IPtables rules..."
-    echo "network device: ${network_device}"
-    echo "tunnel_interface: ${wg_tunnel_interface}"
-    sleep 2
-    sudo iptables -A FORWARD -i "$wg_tunnel_interface" -o "$network_device" -j ACCEPT
-    sudo iptables -A FORWARD -i "$network_device" -o "$wg_tunnel_interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
-    sudo ip6tables -A FORWARD -i "$network_device" -o "$wg_tunnel_interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
-    sudo ip6tables -A FORWARD -i "$wg_tunnel_interface" -o "$network_device" -j ACCEPT
-    sudo iptables-save | sudo tee /etc/iptables/rules.v4
-    sudo ip6tables-save | sudo tee /etc/iptables/rules.v6
-}
-
-remove_iptables_rules_wg() {
-    echo "removing IPtables rules..."
-    echo "network device: ${network_device}"
-    echo "tunnel_interface: ${wg_tunnel_interface}"
-    sleep 2
-
-    # IPv4 rules removal wg
-    sudo iptables -D FORWARD -i "$wg_tunnel_interface" -o "$network_device" -j ACCEPT
-    sudo iptables -D FORWARD -i "$network_device" -o "$wg_tunnel_interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
-
-    # IPv6 rules removal wg
-    sudo ip6tables -t nat -D POSTROUTING -o "$network_device" -j MASQUERADE
-    sudo ip6tables -D FORWARD -i "$network_device" -o "$wg_tunnel_interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
-    sudo ip6tables -D FORWARD -i "$wg_tunnel_interface" -o "$network_device" -j ACCEPT
-
-    sudo iptables-save | sudo tee /etc/iptables/rules.v4
-    sudo ip6tables-save | sudo tee /etc/iptables/rules.v6
+    echo "adjusting IP forwarding settings..."
+    sudo sysctl -w net.ipv6.conf.all.forwarding=1
+    sudo sysctl -w net.ipv4.ip_forward=1
 }
 
 apply_iptables_rules() {
-    echo "applying IPtables rules..."
-    echo "network device: ${network_device}"
-    echo "tunnel_interface: ${tunnel_interface}"
+    local interface=$1
+    echo "applying IPtables rules for $interface..."
     sleep 2
+
+    # remove duplicates for IPv4
+    sudo iptables -D FORWARD -i "$interface" -o "$network_device" -j ACCEPT 2>/dev/null || true
+    sudo iptables -D FORWARD -i "$network_device" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || true
+    sudo iptables -t nat -D POSTROUTING -o "$network_device" -j MASQUERADE 2>/dev/null || true
+
+    # remove duplicates for IPv6
+    sudo ip6tables -D FORWARD -i "$interface" -o "$network_device" -j ACCEPT 2>/dev/null || true
+    sudo ip6tables -D FORWARD -i "$network_device" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || true
+    sudo ip6tables -t nat -D POSTROUTING -o "$network_device" -j MASQUERADE 2>/dev/null || true
+
+    # add new rules for IPv4
     sudo iptables -t nat -A POSTROUTING -o "$network_device" -j MASQUERADE
-    sudo iptables -A FORWARD -i "$tunnel_interface" -o "$network_device" -j ACCEPT
-    sudo iptables -A FORWARD -i "$network_device" -o "$tunnel_interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
+    sudo iptables -A FORWARD -i "$interface" -o "$network_device" -j ACCEPT
+    sudo iptables -A FORWARD -i "$network_device" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+    # add new rules for IPv6
     sudo ip6tables -t nat -A POSTROUTING -o "$network_device" -j MASQUERADE
-    sudo ip6tables -A FORWARD -i "$network_device" -o "$tunnel_interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
-    sudo ip6tables -A FORWARD -i "$tunnel_interface" -o "$network_device" -j ACCEPT
-    adjust_ip_forwarding
+    sudo ip6tables -A FORWARD -i "$interface" -o "$network_device" -j ACCEPT
+    sudo ip6tables -A FORWARD -i "$network_device" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
+
     sudo iptables-save | sudo tee /etc/iptables/rules.v4
     sudo ip6tables-save | sudo tee /etc/iptables/rules.v6
 }
 
-remove_iptables_rules() {
-    echo "removing IPtables rules..."
-    echo "network device: ${network_device}"
-    echo "tunnel_interface: ${tunnel_interface}"
+apply_iptables_rules_wg() {
+    local interface=$wg_tunnel_interface
+    echo "applying IPtables rules for WireGuard ($interface)..."
     sleep 2
 
-    # IPv4 rules removal
-    sudo iptables -t nat -D POSTROUTING -o "$network_device" -j MASQUERADE
-    sudo iptables -D FORWARD -i "$tunnel_interface" -o "$network_device" -j ACCEPT
-    sudo iptables -D FORWARD -i "$network_device" -o "$tunnel_interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
+    # remove duplicates for IPv4
+    sudo iptables -D FORWARD -i "$interface" -o "$network_device" -j ACCEPT 2>/dev/null || true
+    sudo iptables -D FORWARD -i "$network_device" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || true
+    sudo iptables -t nat -D POSTROUTING -o "$network_device" -j MASQUERADE 2>/dev/null || true
 
-    # IPv6 rules removal
-    sudo ip6tables -t nat -D POSTROUTING -o "$network_device" -j MASQUERADE
-    sudo ip6tables -D FORWARD -i "$network_device" -o "$tunnel_interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
-    sudo ip6tables -D FORWARD -i "$tunnel_interface" -o "$network_device" -j ACCEPT
+    # remove duplicates for IPv6
+    sudo ip6tables -D FORWARD -i "$interface" -o "$network_device" -j ACCEPT 2>/dev/null || true
+    sudo ip6tables -D FORWARD -i "$network_device" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || true
+    sudo ip6tables -t nat -D POSTROUTING -o "$network_device" -j MASQUERADE 2>/dev/null || true
+
+    # add new rules for IPv4
+    sudo iptables -t nat -A POSTROUTING -o "$network_device" -j MASQUERADE
+    sudo iptables -A FORWARD -i "$interface" -o "$network_device" -j ACCEPT
+    sudo iptables -A FORWARD -i "$network_device" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+    # add new rules for IPv6
+    sudo ip6tables -t nat -A POSTROUTING -o "$network_device" -j MASQUERADE
+    sudo ip6tables -A FORWARD -i "$interface" -o "$network_device" -j ACCEPT
+    sudo ip6tables -A FORWARD -i "$network_device" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
 
     sudo iptables-save | sudo tee /etc/iptables/rules.v4
     sudo ip6tables-save | sudo tee /etc/iptables/rules.v6
+}
+
+
+check_tunnel_iptables() {
+    local interface=$1
+    echo "inspecting IPtables rules for $interface..."
+    echo "---------------------------------------"
+    echo "IPv4 rules:"
+    iptables -L FORWARD -v -n | awk -v dev="$interface" '/^Chain FORWARD/ || $0 ~ dev || $0 ~ "ufw-reject-forward"'
+    echo "---------------------------------------"
+    echo "IPv6 rules:"
+    ip6tables -L FORWARD -v -n | awk -v dev="$interface" '/^Chain FORWARD/ || $0 ~ dev || $0 ~ "ufw6-reject-forward"'
 }
 
 check_ipv6_ipv4_forwarding() {
@@ -114,204 +115,94 @@ check_ipv6_ipv4_forwarding() {
     echo "IPv6 forwarding is $([ "$result_ipv6" == "1" ] && echo "enabled" || echo "not enabled")."
 }
 
-check_nymtun_iptables() {
-    echo "network Device: $network_device"
-    echo "---------------------------------------"
-    echo
-    echo "inspecting IPv4 firewall rules..."
-    iptables -L FORWARD -v -n | awk -v dev="$network_device" '/^Chain FORWARD/ || /nymtun0/ && dev || dev && /nymtun0/ || /ufw-reject-forward/'
-
-    echo "---------------------------------------"
-    echo
-    echo "inspecting IPv6 firewall rules..."
-    ip6tables -L FORWARD -v -n | awk -v dev="$network_device" '/^Chain FORWARD/ || /nymtun0/ && dev || dev && /nymtun0/ || /ufw6-reject-forward/'
-}
-
-joke_through_the_mixnet() {
-    echo "checking Internet and mixnet connectivity (IPv4) via nymtun0..."
-    ipv4_address=$(ip addr show nymtun0 | grep 'inet ' | awk '{print $2}' | cut -d'/' -f1)
-
-    if [ -z "$ipv4_address" ]; then
-        echo
-        echo "no IPv4 address found on nymtun0."
-        echo "please ensure IPv4 is configured correctly on your device."
-        echo "unfortunately, there's no joke for you :( and you might not be able to route IPv4 traffic through your gateway to the internet."
-    else
-        joke=$(curl -s -H "Accept: application/json" --interface "$ipv4_address" https://icanhazdadjoke.com/ | jq -c .joke)
-
-        if [ -z "$joke" ] || [ "$joke" = "null" ]; then
-            echo "failed to fetch a joke. there might be an issue with the Internet connectivity or the joke service."
-        else
-            echo "joke fetched successfully:"
-            echo "$joke"
-        fi
-    fi
-
-    echo "checking Internet and mixnet connectivity (IPv6) via nymtun0..."
-    ipv6_address=$(ip addr show nymtun0 | grep 'inet6 ' | awk '{print $2}' | cut -d'/' -f1 | grep -v '^fe80:')
-
-    if [ -z "$ipv6_address" ]; then
-        echo
-        echo "no globally routable IPv6 address found on nymtun0."
-        echo "please ensure IPv6 is enabled on your VPS or configure your security groups/firewall settings appropriately."
-        echo "unfortunately there's no joke fo you :( and you can't route ipv6 traffic through your gateway to the internet"
-    else
-        joke=$(curl -s -H "Accept: application/json" --interface "$ipv6_address" https://icanhazdadjoke.com/ | jq -c .joke)
-
-        if [ -z "$joke" ] || [ "$joke" = "null" ]; then
-            echo "failed to fetch a joke. there might be an issue with the Internet connectivity or the joke service."
-        else
-            echo "joke fetched successfully:"
-            echo "$joke"
-        fi
-    fi
-}
-
-check_ip6_ipv4_routing() {
-    echo "---------------------------------------"
-    echo "examining IPv4 routing table..."
+check_ip_routing() {
+    echo "IPv4 routing table:"
     ip route
     echo "---------------------------------------"
-    echo
-    echo "examining IPv6 routing table..."
+    echo "IPv6 routing table:"
     ip -6 route
-    echo
 }
 
-perform_ipv4_ipv6_pings() {
-    echo "---------------------------------------"
-    echo "checking IPv4 connectivity (example: google.com)..."
+perform_pings() {
+    echo "performing IPv4 ping to google.com..."
     ping -c 4 google.com
     echo "---------------------------------------"
-    echo
-    echo "checking IPv6 connectivity (example: google.com)..."
+    echo "performing IPv6 ping to google.com..."
     ping6 -c 4 google.com
-    echo
 }
 
-configure_dns_and_icmp_wg() {
-    echo "allowing icmp (ping)..."
-    sudo iptables -A INPUT -p icmp --icmp-type echo-request -j ACCEPT
-    sudo iptables -A OUTPUT -p icmp --icmp-type echo-reply -j ACCEPT
+joke_through_tunnel() {
+    local interface=$1
+    echo "checking tunnel connectivity and fetching a joke for $interface..."
+    ipv4_address=$(ip addr show "$interface" | grep 'inet ' | awk '{print $2}' | cut -d'/' -f1)
+    ipv6_address=$(ip addr show "$interface" | grep 'inet6 ' | awk '{print $2}' | grep -v '^fe80:' | cut -d'/' -f1)
 
-    echo "allowing dns over udp (port 53)..."
-    sudo iptables -A INPUT -p udp --dport 53 -j ACCEPT
-
-    echo "allowing dns over tcp (port 53)..."
-    sudo iptables -A INPUT -p tcp --dport 53 -j ACCEPT
-    
-    echo "saving iptables rules..."
-    sudo iptables-save > /etc/iptables/rules.v4
-
-    echo "dns and icmp configuration completed."
-}
-
-joke_through_wg_tunnel() {
-    echo "checking nymwg tunnel status..."
-
-    tunnel_status=$(ip link show nymwg | grep -o "state [A-Z]*")
-
-    if [[ $tunnel_status == "state UNKNOWN" ]]; then
-        echo "nymwg tunnel is up."
-    else
-        echo "nymwg tunnel is down."
-        echo "please check your nymwg tunnel configuration."
+    if [[ -z "$ipv4_address" && -z "$ipv6_address" ]]; then
+        echo "no IP address found on $interface. Unable to fetch a joke."
         return
     fi
 
-    echo "checking internet and mixnet connectivity (ipv4) via nymwg..."
-    ipv4_address=$(ip addr show nymwg | grep 'inet ' | awk '{print $2}' | cut -d'/' -f1)
-
-    if [ -z "$ipv4_address" ]; then
-        echo
-        echo "no ipv4 address found on nymwg."
-        echo "please ensure ipv4 is configured correctly on your device."
-        echo "unfortunately, there's no joke for you :( and you might not be able to route ipv4 traffic through your gateway to the internet."
-    else
-        joke=$(curl -s -H "accept: application/json" --interface "$ipv4_address" https://icanhazdadjoke.com/ | jq -c .joke)
-
-        if [ -z "$joke" ] || [ "$joke" = "null" ]; then
-            echo "failed to fetch a joke. there might be an issue with the internet connectivity or the joke service."
-        else
-            echo "joke fetched successfully:"
-            echo "$joke"
-        fi
+    if [[ -n "$ipv4_address" ]]; then
+        joke=$(curl -s -H "Accept: application/json" --interface "$ipv4_address" https://icanhazdadjoke.com/ | jq -r .joke)
+        [[ -n "$joke" && "$joke" != "null" ]] && echo "IPv4 joke: $joke" || echo "Failed to fetch a joke via IPv4."
     fi
 
-    echo "checking internet and mixnet connectivity (ipv6) via nymwg..."
-    ipv6_address=$(ip addr show nymwg | grep 'inet6 ' | awk '{print $2}' | cut -d'/' -f1 | grep -v '^fe80:')
-
-    if [ -z "$ipv6_address" ]; then
-        echo
-        echo "no globally routable ipv6 address found on nymwg."
-        echo "please ensure ipv6 is enabled on your vps or configure your security groups/firewall settings appropriately."
-        echo "unfortunately, there's no joke for you :( and you can't route ipv6 traffic through your gateway to the internet."
-    else
-        joke=$(curl -s -H "accept: application/json" --interface "$ipv6_address" https://icanhazdadjoke.com/ | jq -c .joke)
-
-        if [ -z "$joke" ] || [ "$joke" = "null" ]; then
-            echo "failed to fetch a joke. there might be an issue with the internet connectivity or the joke service."
-        else
-            echo "joke fetched successfully:"
-            echo "$joke"
-        fi
+    if [[ -n "$ipv6_address" ]]; then
+        joke=$(curl -s -H "Accept: application/json" --interface "$ipv6_address" https://icanhazdadjoke.com/ | jq -r .joke)
+        [[ -n "$joke" && "$joke" != "null" ]] && echo "IPv6 joke: $joke" || echo "Failed to fetch a joke via IPv6."
     fi
 }
 
 case "$1" in
 fetch_ipv6_address_nym_tun)
-    fetch_ipv6_address_nym_tun
+    fetch_ipv6_address "$tunnel_interface"
     ;;
 fetch_and_display_ipv6)
     fetch_and_display_ipv6
     ;;
-check_nymtun_iptables)
-    check_nymtun_iptables
-    ;;
 apply_iptables_rules)
-    apply_iptables_rules
+    apply_iptables_rules "$tunnel_interface"
     ;;
-remove_iptables_rules)
-    remove_iptables_rules
+apply_iptables_rules_wg)
+    apply_iptables_rules "$wg_tunnel_interface"
+    ;;
+check_nymtun_iptables)
+    check_tunnel_iptables "$tunnel_interface"
+    ;;
+check_nym_wg_tun)
+    check_tunnel_iptables "$wg_tunnel_interface"
     ;;
 check_ipv6_ipv4_forwarding)
     check_ipv6_ipv4_forwarding
     ;;
-check_ip6_ipv4_routing)
-    check_ip6_ipv4_routing
+check_ip_routing)
+    check_ip_routing
     ;;
-perform_ipv4_ipv6_pings)
-    perform_ipv4_ipv6_pings
+perform_pings)
+    perform_pings
     ;;
 joke_through_the_mixnet)
-    joke_through_the_mixnet
-    ;;
-apply_iptables_rules_wg)
-    apply_iptables_rules_wg
+    joke_through_tunnel "$tunnel_interface"
     ;;
 joke_through_wg_tunnel)
-    joke_through_wg_tunnel
-    ;;
-configure_dns_and_icmp_wg)
-    configure_dns_and_icmp_wg
+    joke_through_tunnel "$wg_tunnel_interface"
     ;;
 *)
-    echo "usage: $0 [command]"
-    echo "commands:"
-    echo "  fetch_ipv6_address_nym_tun    - Fetches the IPv6 address assigned to the '$tunnel_interface'."
-    echo "  fetch_and_display_ipv6        - Displays the IPv6 address on the default network device."
-    echo "  apply_iptables_rules          - Applies necessary IPv4 and IPv6 iptables rules."
-    echo "  apply_iptables_rules_wg       - Applies iptable rules for IPv4 and IPv6 for Wireguard."
-    echo "  remove_iptables_rules         - Removes applied IPv4 and IPv6 iptables rules."
-    echo "  remove_iptables_rules_wg      - Removes applied IPv4 and IPv6 iptables rules for Wireguard."
-    echo "  check_ipv6_ipv4_forwarding    - Checks if IPv4 and IPv6 forwarding are enabled."
-    echo "  check_nymtun_iptables         - Check nymtun0 device."
-    echo "  perform_ipv4_ipv6_pings       - Perform IPv4 and IPv6 pings to google."
-    echo "  check_ip6_ipv4_routing        - Check IPv6 and IPv4 routing."
-    echo "  joke_through_the_mixnet       - Run a joke through the mixnet via IPv4 and IPv6."
-    echo "  joke_through_wg_tunnel        - Run a wg test, and get a joke through the wg tunnel."
-    echo "  configure_dns_and_icmp_wg     - Allows icmp ping tests for probes alongside configuring dns"
-    echo "please provide one of the above commands."
+    echo "Usage: $0 [command]"
+    echo "Commands:"
+    echo "  fetch_ipv6_address_nym_tun      - Fetch IPv6 for nymtun0."
+    echo "  fetch_and_display_ipv6          - Show IPv6 on default device."
+    echo "  apply_iptables_rules            - Apply IPtables rules for nymtun0."
+    echo "  apply_iptables_rules_wg         - Apply IPtables rules for nymwg."
+    echo "  remove_iptables_rules           - Remove IPtables rules for nymtun0."
+    echo "  remove_iptables_rules_wg        - Remove IPtables rules for nymwg."
+    echo "  check_nymtun_iptables           - Check IPtables for nymtun0."
+    echo "  check_nym_wg_tun                - Check IPtables for nymwg."
+    echo "  check_ipv6_ipv4_forwarding      - Check IPv4 and IPv6 forwarding."
+    echo "  check_ip_routing                - Display IP routing tables."
+    echo "  perform_pings                   - Test IPv4 and IPv6 connectivity."
+    echo "  joke_through_the_mixnet         - Fetch a joke via nymtun0."
+    echo "  joke_through_wg_tunnel          - Fetch a joke via nymwg."
     exit 1
     ;;
 esac

--- a/scripts/network_tunnel_manager.sh
+++ b/scripts/network_tunnel_manager.sh
@@ -214,8 +214,6 @@ configure_dns_and_icmp_wg)
     echo "  fetch_and_display_ipv6          - Show IPv6 on default device."
     echo "  apply_iptables_rules            - Apply IPtables rules for nymtun0."
     echo "  apply_iptables_rules_wg         - Apply IPtables rules for nymwg."
-    echo "  remove_iptables_rules           - Remove IPtables rules for nymtun0."
-    echo "  remove_iptables_rules_wg        - Remove IPtables rules for nymwg."
     echo "  check_nymtun_iptables           - Check IPtables for nymtun0."
     echo "  check_nym_wg_tun                - Check IPtables for nymwg."
     echo "  check_ipv6_ipv4_forwarding      - Check IPv4 and IPv6 forwarding."


### PR DESCRIPTION
- improved iptables management: apply_iptables_rules and apply_iptables_rules_wg now automatically remove duplicate rules before reapplying them, ensuring a clean setup without disrupting iptables
- consolidated joke feature: unified the "joke through the mixnet" logic into a generic function, allowing it to work seamlessly across any specified interface
- enhanced tunnel checks: added check_nym_wg_tun alongside check_nymtun_iptables, making it easier to verify the state of both tunnels
- reduced error-prone behavior: simplified workflows to avoid issues caused by running commands multiple times

how to use:
1. download the script and make it executable: curl -L -o network_tunnel_manager.sh https://raw.githubusercontent.com/nymtech/nym/refs/heads/develop/scripts/network_tunnel_manager.sh && chmod u+x network_tunnel_manager.sh
 
2. run the following commands as needed:
   - apply_iptables_rules: apply and clean iptables rules for nymtun0
   - apply_iptables_rules_wg: apply and clean iptables rules for nymwg
   - check_ipv6_ipv4_forwarding: verify if ipv4 and ipv6 forwarding are enabled
   - check_ip_routing: display the current ipv4 and ipv6 routing tables

tldr:
- improved iptables handling to avoid duplicates
- unified functionality for better maintainability
- reduced potential errors when rerunning commands

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5176)
<!-- Reviewable:end -->
