### PR TITLE
fix: remove documentation from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,3 @@
 **/node_modules
 **/target
 dist
-documentation


### PR DESCRIPTION
`documentation/autodoc` was added to root `Cargo.toml` modules list recently so it needs to be removed from dockerignore, otherwise docker builds fail

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5264)
<!-- Reviewable:end -->
