### PR TITLE
feat: warn users if node is run in exit mode only

### DIFF
--- a/nym-node/src/cli/commands/run/mod.rs
+++ b/nym-node/src/cli/commands/run/mod.rs
@@ -83,6 +83,10 @@ pub(crate) async fn execute(mut args: Args) -> Result<(), NymNodeError> {
         warn!("this node is going to run without mixnode or gateway support! consider providing `mode` value");
     }
 
+    if config.modes.standalone_exit() {
+        warn!("this node is going to run in EXIT gateway mode only - it will not be able to accept client traffic and thus will NOT be eligible for any rewards. consider running it alongside `entry` (or `full-gateway`) mode")
+    }
+
     if config.host.public_ips.is_empty() {
         return Err(NymNodeError::NoPublicIps);
     }

--- a/nym-node/src/config/mod.rs
+++ b/nym-node/src/config/mod.rs
@@ -77,6 +77,9 @@ pub enum NodeMode {
 
     #[clap(alias = "exit")]
     ExitGateway,
+
+    // entry + exit
+    FullGateway,
 }
 
 impl Display for NodeMode {
@@ -85,6 +88,7 @@ impl Display for NodeMode {
             NodeMode::Mixnode => "mixnode".fmt(f),
             NodeMode::EntryGateway => "entry-gateway".fmt(f),
             NodeMode::ExitGateway => "exit-gateway".fmt(f),
+            NodeMode::FullGateway => "full-gateway".fmt(f),
         }
     }
 }
@@ -122,6 +126,7 @@ impl NodeModes {
             NodeMode::Mixnode => self.with_mixnode(),
             NodeMode::EntryGateway => self.with_entry(),
             NodeMode::ExitGateway => self.with_exit(),
+            NodeMode::FullGateway => self.with_entry().with_exit(),
         }
     }
 

--- a/nym-node/src/config/mod.rs
+++ b/nym-node/src/config/mod.rs
@@ -121,6 +121,10 @@ impl NodeModes {
         self.mixnode || self.entry || self.exit
     }
 
+    pub fn standalone_exit(&self) -> bool {
+        !self.mixnode && !self.entry && self.exit
+    }
+
     pub fn with_mode(&mut self, mode: NodeMode) -> &mut Self {
         match mode {
             NodeMode::Mixnode => self.with_mixnode(),


### PR DESCRIPTION
throws a warning if node is run in "exit" mode only as by default, this will **NOT** enable entry capabilities, i.e. opening the websocket. thus making it ineligible for rewarded set selection (and rewards)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5320)
<!-- Reviewable:end -->
