### PR TITLE
feature: `CancellationToken`-based shutdowns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6494,6 +6494,7 @@ dependencies = [
 name = "nym-task"
 version = "0.1.0"
 dependencies = [
+ "cfg-if",
  "futures",
  "log",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6498,6 +6498,7 @@ dependencies = [
  "log",
  "thiserror",
  "tokio",
+ "tokio-util",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasmtimer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6499,6 +6499,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasmtimer",

--- a/common/task/Cargo.toml
+++ b/common/task/Cargo.toml
@@ -12,6 +12,7 @@ futures = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "sync"] }
+tokio-util = { workspace = true }
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio]
 workspace = true

--- a/common/task/Cargo.toml
+++ b/common/task/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+cfg-if = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }

--- a/common/task/Cargo.toml
+++ b/common/task/Cargo.toml
@@ -13,6 +13,7 @@ log = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "sync"] }
 tokio-util = { workspace = true }
+tracing = { workspace = true }
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio]
 workspace = true

--- a/common/task/Cargo.toml
+++ b/common/task/Cargo.toml
@@ -12,7 +12,7 @@ futures = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "sync"] }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio]

--- a/common/task/src/cancellation.rs
+++ b/common/task/src/cancellation.rs
@@ -50,7 +50,7 @@ impl Deref for ShutdownToken {
 
 impl ShutdownToken {
     const MAX_NAME_LENGTH: usize = 128;
-    const OVERFLOW_NAME: &'static str = "reached maximum TaskClient children name depth";
+    const OVERFLOW_NAME: &'static str = "reached maximum ShutdownToken children name depth";
 
     pub fn new(name: impl Into<String>) -> Self {
         ShutdownToken {
@@ -183,6 +183,14 @@ impl ShutdownManager {
     pub fn with_shutdown_duration(mut self, duration: Duration) -> Self {
         self.max_shutdown_duration = duration;
         self
+    }
+
+    pub fn child_token<S: Into<String>>(&self, child_suffix: S) -> ShutdownToken {
+        self.root_token.child_token(child_suffix)
+    }
+
+    pub fn clone_token<S: Into<String>>(&self, child_suffix: S) -> ShutdownToken {
+        self.root_token.clone_with_suffix(child_suffix)
     }
 
     pub async fn wait_for_shutdown(&self) {

--- a/common/task/src/cancellation.rs
+++ b/common/task/src/cancellation.rs
@@ -23,8 +23,6 @@ pub fn token_name(name: &Option<String>) -> String {
     name.clone().unwrap_or_else(|| "unknown".to_string())
 }
 
-// pending name
-//
 // a wrapper around tokio's CancellationToken that adds optional `name` information to more easily
 // track down sources of shutdown
 #[derive(Debug, Default)]
@@ -104,12 +102,15 @@ impl ShutdownToken {
         child
     }
 
-    // expose the method with the old name for easier migration
+    // exposed method with the old name for easier migration
+    // it will eventually be removed so please try to use `.clone_with_suffix` instead
     #[must_use]
     pub fn fork<S: Into<String>>(&self, child_suffix: S) -> Self {
         self.clone_with_suffix(child_suffix)
     }
 
+    // exposed method with the old name for easier migration
+    // it will eventually be removed so please try to use `.clone().named(name)` instead
     #[must_use]
     pub fn fork_named<S: Into<String>>(&self, name: S) -> Self {
         self.clone().named(name)
@@ -202,9 +203,9 @@ impl Deref for ShutdownManager {
 }
 
 impl ShutdownManager {
-    pub fn new(root_token: impl Into<String>) -> Self {
+    pub fn new(root_token_name: impl Into<String>) -> Self {
         let manager = ShutdownManager {
-            root_token: ShutdownToken::new(root_token),
+            root_token: ShutdownToken::new(root_token_name),
             legacy_task_manager: None,
             shutdown_signals: Default::default(),
             tracker: Default::default(),

--- a/common/task/src/cancellation.rs
+++ b/common/task/src/cancellation.rs
@@ -1,0 +1,144 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::Deref;
+use tokio_util::sync::{CancellationToken, DropGuard};
+
+// pending name
+//
+// a wrapper around tokio's CancellationToken that adds optional `name` information to more easily
+// track down sources of shutdown
+#[derive(Debug)]
+pub struct ShutdownToken {
+    name: Option<String>,
+    inner: CancellationToken,
+}
+
+impl Clone for ShutdownToken {
+    fn clone(&self) -> Self {
+        // make sure to not accidentally overflow the stack if we keep cloning the handle
+        let name = if let Some(name) = &self.name {
+            if name != Self::OVERFLOW_NAME && name.len() < Self::MAX_NAME_LENGTH {
+                Some(format!("{name}-child"))
+            } else {
+                Some(Self::OVERFLOW_NAME.to_string())
+            }
+        } else {
+            None
+        };
+
+        ShutdownToken {
+            name,
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl Deref for ShutdownToken {
+    type Target = CancellationToken;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl ShutdownToken {
+    const MAX_NAME_LENGTH: usize = 128;
+    const OVERFLOW_NAME: &'static str = "reached maximum TaskClient children name depth";
+
+    // Creates a ShutdownToken which will get cancelled whenever the current token gets cancelled.
+    // Unlike a cloned/forked ShutdownToken, cancelling a child token does not cancel the parent token.
+    #[must_use]
+    pub fn child_token<S: Into<String>>(&self, child_suffix: S) -> Self {
+        let suffix = child_suffix.into();
+        let child_name = if let Some(base) = &self.name {
+            format!("{base}-{suffix}")
+        } else {
+            format!("unknown-{suffix}")
+        };
+
+        ShutdownToken {
+            name: Some(child_name),
+            inner: self.inner.child_token(),
+        }
+    }
+
+    // Creates a clone of the ShutdownToken which will get cancelled whenever the current token gets cancelled, and vice versa.
+    #[must_use]
+    pub fn clone_with_suffix<S: Into<String>>(&self, child_suffix: S) -> Self {
+        let mut child = self.clone();
+        let suffix = child_suffix.into();
+        let child_name = if let Some(base) = &self.name {
+            format!("{base}-{suffix}")
+        } else {
+            format!("unknown-{suffix}")
+        };
+
+        child.name = Some(child_name);
+        child
+    }
+
+    // expose the method with the old name for easier migration
+    #[must_use]
+    pub fn fork<S: Into<String>>(&self, child_suffix: S) -> Self {
+        self.clone_with_suffix(child_suffix)
+    }
+
+    #[must_use]
+    pub fn fork_named<S: Into<String>>(&self, name: S) -> Self {
+        self.clone().named(name)
+    }
+
+    #[must_use]
+    pub fn named<S: Into<String>>(mut self, name: S) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_suffix<S: Into<String>>(self, suffix: S) -> Self {
+        let suffix = suffix.into();
+        let name = if let Some(base) = &self.name {
+            format!("{base}-{suffix}")
+        } else {
+            format!("unknown-{suffix}")
+        };
+        self.named(name)
+    }
+
+    // Returned guard will cancel this token (and all its children) on drop unless disarmed.
+    pub fn drop_guard(self) -> ShutdownDropGuard {
+        ShutdownDropGuard {
+            name: self.name,
+            inner: self.inner.drop_guard(),
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn catch_interrupt(&self) {
+        crate::wait_for_signal().await;
+        self.inner.cancel();
+    }
+}
+
+pub struct ShutdownDropGuard {
+    name: Option<String>,
+    inner: DropGuard,
+}
+
+impl Deref for ShutdownDropGuard {
+    type Target = DropGuard;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl ShutdownDropGuard {
+    pub fn disarm(mut self) -> ShutdownToken {
+        ShutdownToken {
+            name: self.name,
+            inner: self.inner.disarm(),
+        }
+    }
+}

--- a/common/task/src/cancellation.rs
+++ b/common/task/src/cancellation.rs
@@ -4,7 +4,6 @@
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use std::future::Future;
-use std::io;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::time::Duration;
@@ -238,7 +237,7 @@ impl ShutdownManager {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn with_default_shutdown_signals(self) -> io::Result<Self> {
+    pub fn with_default_shutdown_signals(self) -> std::io::Result<Self> {
         self.with_interrupt_signal()?
             .with_terminate_signal()?
             .with_quit_signal()
@@ -261,7 +260,7 @@ impl ShutdownManager {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn with_shutdown_signal(self, signal_kind: SignalKind) -> io::Result<Self> {
+    pub fn with_shutdown_signal(self, signal_kind: SignalKind) -> std::io::Result<Self> {
         let mut sig = signal(signal_kind)?;
         Ok(self.with_shutdown(async move {
             sig.recv().await;
@@ -269,17 +268,17 @@ impl ShutdownManager {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn with_interrupt_signal(self) -> io::Result<Self> {
+    pub fn with_interrupt_signal(self) -> std::io::Result<Self> {
         self.with_shutdown_signal(SignalKind::interrupt())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn with_terminate_signal(self) -> io::Result<Self> {
+    pub fn with_terminate_signal(self) -> std::io::Result<Self> {
         self.with_shutdown_signal(SignalKind::terminate())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn with_quit_signal(self) -> io::Result<Self> {
+    pub fn with_quit_signal(self) -> std::io::Result<Self> {
         self.with_shutdown_signal(SignalKind::quit())
     }
 

--- a/common/task/src/lib.rs
+++ b/common/task/src/lib.rs
@@ -9,10 +9,11 @@ pub mod manager;
 pub mod signal;
 pub mod spawn;
 
-pub use cancellation::{ShutdownDropGuard, ShutdownToken};
+pub use cancellation::{ShutdownDropGuard, ShutdownManager, ShutdownToken};
 pub use event::{StatusReceiver, StatusSender, TaskStatus, TaskStatusEvent};
 pub use manager::{TaskClient, TaskHandle, TaskManager};
 pub use spawn::{spawn, spawn_with_report_error};
+pub use tokio_util::task::TaskTracker;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use signal::{wait_for_signal, wait_for_signal_and_error};

--- a/common/task/src/lib.rs
+++ b/common/task/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod cancellation;
 pub mod connections;
 pub mod event;
 pub mod manager;
@@ -8,9 +9,10 @@ pub mod manager;
 pub mod signal;
 pub mod spawn;
 
+pub use cancellation::{ShutdownDropGuard, ShutdownToken};
 pub use event::{StatusReceiver, StatusSender, TaskStatus, TaskStatusEvent};
 pub use manager::{TaskClient, TaskHandle, TaskManager};
-#[cfg(not(target_arch = "wasm32"))]
-pub use signal::wait_for_signal_and_error;
-
 pub use spawn::{spawn, spawn_with_report_error};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use signal::{wait_for_signal, wait_for_signal_and_error};

--- a/nym-node/src/error.rs
+++ b/nym-node/src/error.rs
@@ -50,6 +50,12 @@ pub enum NymNodeError {
     #[error("this binary version no longer supports migration from legacy mixnodes and gateways")]
     UnsupportedMigration,
 
+    #[error("failed to initialise shutdown signals: {source}")]
+    ShutdownSignalFailure {
+        #[source]
+        source: io::Error,
+    },
+
     #[error("could not find an existing config file at '{}' and fresh node initialisation has been disabled", config_path.display())]
     ForbiddenInitialisation { config_path: PathBuf },
 

--- a/nym-node/src/node/http/mod.rs
+++ b/nym-node/src/node/http/mod.rs
@@ -6,9 +6,7 @@ use axum::extract::ConnectInfo;
 use axum::middleware::AddExtension;
 use axum::serve::Serve;
 use axum::Router;
-use nym_task::TaskClient;
 use std::net::SocketAddr;
-use tracing::{debug, error};
 
 pub use router::{api, HttpServerConfig, NymNodeRouter};
 
@@ -19,47 +17,4 @@ pub mod state;
 
 type InnerService = IntoMakeServiceWithConnectInfo<Router, SocketAddr>;
 type ConnectInfoExt = AddExtension<Router, ConnectInfo<SocketAddr>>;
-pub type ServeService = Serve<InnerService, ConnectInfoExt>;
-
-pub struct NymNodeHttpServer {
-    task_client: Option<TaskClient>,
-    inner: ServeService,
-}
-
-impl NymNodeHttpServer {
-    pub(crate) fn new(inner: ServeService) -> Self {
-        NymNodeHttpServer {
-            task_client: None,
-            inner,
-        }
-    }
-
-    #[must_use]
-    pub fn with_task_client(mut self, task_client: TaskClient) -> Self {
-        self.task_client = Some(task_client);
-        self
-    }
-
-    async fn run_server_forever(server: ServeService) {
-        if let Err(err) = server.await {
-            error!("the HTTP server has terminated with the error: {err}");
-        } else {
-            error!("the HTTP server has terminated with producing any errors");
-        }
-    }
-
-    pub async fn run(self) {
-        if let Some(mut task_client) = self.task_client {
-            tokio::select! {
-                _ = task_client.recv_with_delay() => {
-                    debug!("NymNodeHTTPServer: Received shutdown");
-                }
-                _ = Self::run_server_forever(self.inner) => { }
-            }
-        } else {
-            Self::run_server_forever(self.inner).await
-        }
-
-        debug!("NymNodeHTTPServer: Exiting");
-    }
-}
+pub type NymNodeHttpServer = Serve<InnerService, ConnectInfoExt>;

--- a/nym-node/src/node/http/router/mod.rs
+++ b/nym-node/src/node/http/router/mod.rs
@@ -175,12 +175,10 @@ impl NymNodeRouter {
                 source,
             })?;
 
-        let axum_server = axum::serve(
+        Ok(axum::serve(
             listener,
             self.inner
                 .into_make_service_with_connect_info::<SocketAddr>(),
-        );
-
-        Ok(NymNodeHttpServer::new(axum_server))
+        ))
     }
 }

--- a/nym-node/src/node/mod.rs
+++ b/nym-node/src/node/mod.rs
@@ -43,7 +43,7 @@ use nym_node_metrics::NymNodeMetrics;
 use nym_node_requests::api::v1::node::models::{AnnouncePorts, NodeDescription};
 use nym_sphinx_acknowledgements::AckKey;
 use nym_sphinx_addressing::Recipient;
-use nym_task::{ShutdownManager, TaskClient};
+use nym_task::{ShutdownManager, ShutdownToken, TaskClient};
 use nym_validator_client::client::NymApiClientExt;
 use nym_validator_client::models::NodeRefreshBody;
 use nym_validator_client::{NymApiClient, UserAgent};
@@ -859,14 +859,14 @@ impl NymNode {
         &self,
         active_clients_store: ActiveClientsStore,
         active_egress_mixnet_connections: ActiveConnections,
-        shutdown: TaskClient,
+        shutdown: ShutdownToken,
     ) -> MetricEventsSender {
         info!("setting up node metrics...");
 
         // aggregator (to listen for any metrics events)
         let mut metrics_aggregator = MetricsAggregator::new(
             self.config.metrics.debug.aggregator_update_rate,
-            shutdown.fork("aggregator"),
+            shutdown.clone_with_suffix("aggregator"),
         );
 
         // >>>> START: register all relevant handlers for custom events
@@ -928,12 +928,9 @@ impl NymNode {
             ConsoleLogger::new(
                 self.config.metrics.debug.console_logging_update_interval,
                 self.metrics.clone(),
-                shutdown.named("metrics-console-logger"),
+                shutdown.clone_with_suffix("metrics-console-logger"),
             )
             .start();
-        } else {
-            let mut shutdown = shutdown;
-            shutdown.disarm()
         }
 
         let events_sender = metrics_aggregator.sender();
@@ -947,7 +944,7 @@ impl NymNode {
     pub(crate) fn start_mixnet_listener(
         &self,
         active_clients_store: &ActiveClientsStore,
-        shutdown: TaskClient,
+        shutdown: ShutdownToken,
     ) -> (MixForwardingSender, ActiveConnections) {
         let processing_config = ProcessingConfig::new(&self.config);
 
@@ -976,7 +973,7 @@ impl NymNode {
         let mut packet_forwarder = PacketForwarder::new(
             mixnet_client,
             self.metrics.clone(),
-            shutdown.fork("mix-packet-forwarder"),
+            shutdown.clone_with_suffix("mix-packet-forwarder"),
         );
         let mix_packet_sender = packet_forwarder.sender();
         tokio::spawn(async move { packet_forwarder.run().await });
@@ -1011,7 +1008,7 @@ impl NymNode {
 
         let http_server = self.build_http_server().await?;
         let bind_address = self.config.http.bind_address;
-        let server_shutdown = self.shutdown_manager.child_token("http-server");
+        let server_shutdown = self.shutdown_manager.clone_token("http-server");
 
         self.shutdown_manager.spawn(async move {
             {
@@ -1030,13 +1027,13 @@ impl NymNode {
 
         let (mix_packet_sender, active_egress_mixnet_connections) = self.start_mixnet_listener(
             &active_clients_store,
-            self.shutdown_manager.subscribe_legacy("mixnet-traffic"),
+            self.shutdown_manager.clone_token("mixnet-traffic"),
         );
 
         let metrics_sender = self.setup_metrics_backend(
             active_clients_store.clone(),
             active_egress_mixnet_connections,
-            self.shutdown_manager.subscribe_legacy("metrics"),
+            self.shutdown_manager.clone_token("metrics"),
         );
 
         self.start_gateway_tasks(

--- a/nym-node/src/node/mod.rs
+++ b/nym-node/src/node/mod.rs
@@ -448,7 +448,9 @@ impl NymNode {
             wireguard: Some(wireguard_data),
             config,
             accepted_operator_terms_and_conditions: false,
-            shutdown_manager: ShutdownManager::new("NymNode"),
+            shutdown_manager: ShutdownManager::new("NymNode")
+                .with_default_shutdown_signals()
+                .map_err(|source| NymNodeError::ShutdownSignalFailure { source })?,
         })
     }
 
@@ -1048,7 +1050,7 @@ impl NymNode {
         .await?;
 
         self.shutdown_manager.close();
-        self.shutdown_manager.catch_interrupt().await;
+        self.shutdown_manager.catch_shutdown().await;
 
         // send shutdown info to legacy tasks
         info!("attempting to shutdown legacy tasks");

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -3194,6 +3194,7 @@ dependencies = [
  "strum 0.26.3",
  "thiserror",
  "time",
+ "utoipa",
 ]
 
 [[package]]
@@ -3290,6 +3291,7 @@ dependencies = [
  "thiserror",
  "time",
  "ts-rs",
+ "utoipa",
 ]
 
 [[package]]
@@ -3395,6 +3397,7 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "time",
+ "utoipa",
 ]
 
 [[package]]
@@ -3422,6 +3425,7 @@ dependencies = [
  "thiserror",
  "ts-rs",
  "url",
+ "utoipa",
  "x25519-dalek",
 ]
 
@@ -6208,9 +6212,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utoipa"
-version = "4.2.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
 dependencies = [
  "indexmap 2.5.0",
  "serde",
@@ -6220,11 +6224,10 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.3.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf0e16c02bc4bf5322ab65f10ab1149bdbcaa782cba66dc7057370a3f8190be"
+checksum = "a77d306bc75294fd52f3e99b13ece67c02c1a2789190a6f31d32f736624326f7"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.85",


### PR DESCRIPTION
this PR introduces scaffolding for using `CancellationToken` and `TaskTracker` for our graceful shutdowns rather than the existing `TaskClient` and `TaskManager`. 

it focues on creating the new API and migrating **some** of the existing tasks inside `NymNode`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5325)
<!-- Reviewable:end -->
