### PR TITLE
bugfix: make sure refresh data key matches bond info

### DIFF
--- a/nym-api/src/nym_contract_cache/cache/mod.rs
+++ b/nym-api/src/nym_contract_cache/cache/mod.rs
@@ -385,7 +385,7 @@ impl NymContractCache {
             .iter()
             .find(|n| n.bond_information.identity() == encoded_identity)
         {
-            return Some(nym_node.into());
+            return nym_node.try_into().ok();
         }
 
         // 2. check legacy mixnodes
@@ -394,7 +394,7 @@ impl NymContractCache {
             .iter()
             .find(|n| n.bond_information.identity() == encoded_identity)
         {
-            return Some(mixnode.into());
+            return mixnode.try_into().ok();
         }
 
         // 3. check legacy gateways
@@ -403,7 +403,7 @@ impl NymContractCache {
             .iter()
             .find(|n| n.identity() == &encoded_identity)
         {
-            return Some(gateway.into());
+            return gateway.try_into().ok();
         }
 
         None


### PR DESCRIPTION
this is to forbid operators from reusing the same underlying identity key for multiple nodes by overwriting the describe data. the reported key has to always match what the node has bonded with (and the contract enforces uniqueness)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5329)
<!-- Reviewable:end -->
