### PR TITLE
chore: update indexed_db_futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "accessory"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87537f9ae7cfa78d5b8ebd1a1db25959f5e737126be4d8eb44a5452fc4b63cde"
+checksum = "bb3791c4beae5b827e93558ac83a88e63a841aad61759a05d9b577ef16030470"
 dependencies = [
  "macroific",
  "proc-macro2",
@@ -1955,10 +1955,12 @@ dependencies = [
 
 [[package]]
 name = "delegate-display"
-version = "2.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a85201f233142ac819bbf6226e36d0b5e129a47bd325084674261c82d4cd66"
+checksum = "9926686c832494164c33a36bf65118f4bd6e704000b58c94681bf62e9ad67a74"
 dependencies = [
+ "impartial-ord",
+ "itoa",
  "macroific",
  "proc-macro2",
  "quote",
@@ -2006,6 +2008,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2449,9 +2472,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fancy_constructor"
-version = "1.3.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b19d0e43eae2bfbafe4931b5e79c73fb1a849ca15cd41a761a7b8587f9a1a2"
+checksum = "fac0fd7f4636276b4bd7b3148d0ba2c1c3fbede2b5214e47e7fedb70b02cde44"
 dependencies = [
  "macroific",
  "proc-macro2",
@@ -3532,6 +3555,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "impartial-ord"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab604ee7085efba6efc65e4ebca0e9533e3aff6cb501d7d77b211e3a781c6d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "importer-cli"
 version = "0.1.0"
 dependencies = [
@@ -3569,19 +3603,36 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexed_db_futures"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0704b71f13f81b5933d791abf2de26b33c40935143985220299a357721166706"
+checksum = "d56078e9bfed55e1d3c0cebad5be921d32f062be8f1e4bf3750b487bc6e7d13e"
 dependencies = [
  "accessory",
  "cfg-if",
  "delegate-display",
+ "derive_more",
  "fancy_constructor",
+ "indexed_db_futures_macros_internal",
  "js-sys",
- "uuid",
+ "sealed",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "indexed_db_futures_macros_internal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caeba94923b68f254abef921cea7e7698bf4675fdd89d7c58bf1ed885b49a27d"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4030,9 +4081,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "macroific"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05c00ac596022625d01047c421a0d97d7f09a18e429187b341c201cb631b9dd"
+checksum = "89f276537b4b8f981bf1c13d79470980f71134b7bdcc5e6e911e910e556b0285"
 dependencies = [
  "macroific_attr_parse",
  "macroific_core",
@@ -4041,32 +4092,33 @@ dependencies = [
 
 [[package]]
 name = "macroific_attr_parse"
-version = "1.3.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94d5da95b30ae6e10621ad02340909346ad91661f3f8c0f2b62345e46a2f67"
+checksum = "ad4023761b45fcd36abed8fb7ae6a80456b0a38102d55e89a57d9a594a236be9"
 dependencies = [
- "cfg-if",
  "proc-macro2",
  "quote",
+ "sealed",
  "syn 2.0.90",
 ]
 
 [[package]]
 name = "macroific_core"
-version = "1.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13198c120864097a565ccb3ff947672d969932b7975ebd4085732c9f09435e55"
+checksum = "d0a7594d3c14916fa55bef7e9d18c5daa9ed410dd37504251e4b75bbdeec33e3"
 dependencies = [
  "proc-macro2",
  "quote",
+ "sealed",
  "syn 2.0.90",
 ]
 
 [[package]]
 name = "macroific_macro"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c9853143cbed7f1e41dc39fee95f9b361bec65c8dc2a01bf609be01b61f5ae"
+checksum = "4da6f2ed796261b0a74e2b52b42c693bb6dee1effba3a482c49592659f824b3b"
 dependencies = [
  "macroific_attr_parse",
  "macroific_core",
@@ -8632,6 +8684,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10941,7 +11004,6 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -11144,7 +11206,7 @@ name = "wasm-storage"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "futures",
+ "getrandom",
  "indexed_db_futures",
  "js-sys",
  "nym-store-cipher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,8 +398,7 @@ prost = { version = "0.12", default-features = false }
 gloo-utils = "0.2.0"
 gloo-net = "0.6.0"
 
-# TODO: migrate to 0.6+
-indexed_db_futures = "0.4.2"
+indexed_db_futures = "0.6.0"
 js-sys = "0.3.76"
 serde-wasm-bindgen = "0.6.5"
 tsify = "0.4.5"

--- a/common/wasm/client-core/src/lib.rs
+++ b/common/wasm/client-core/src/lib.rs
@@ -1,10 +1,15 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(target_arch = "wasm32")]
 pub mod config;
+#[cfg(target_arch = "wasm32")]
 pub mod error;
+#[cfg(target_arch = "wasm32")]
 pub mod helpers;
+#[cfg(target_arch = "wasm32")]
 pub mod storage;
+#[cfg(target_arch = "wasm32")]
 pub mod topology;
 
 // re-export types for ease of use
@@ -29,4 +34,5 @@ pub use nym_validator_client::{DirectSigningReqwestRpcNyxdClient, QueryReqwestRp
 // TODO: that's a very nasty import path. it should come from contracts instead!
 pub use nym_validator_client::client::IdentityKey;
 
+#[cfg(target_arch = "wasm32")]
 pub use wasm_utils::set_panic_hook;

--- a/common/wasm/client-core/src/lib.rs
+++ b/common/wasm/client-core/src/lib.rs
@@ -1,15 +1,10 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(target_arch = "wasm32")]
 pub mod config;
-#[cfg(target_arch = "wasm32")]
 pub mod error;
-#[cfg(target_arch = "wasm32")]
 pub mod helpers;
-#[cfg(target_arch = "wasm32")]
 pub mod storage;
-#[cfg(target_arch = "wasm32")]
 pub mod topology;
 
 // re-export types for ease of use
@@ -34,5 +29,4 @@ pub use nym_validator_client::{DirectSigningReqwestRpcNyxdClient, QueryReqwestRp
 // TODO: that's a very nasty import path. it should come from contracts instead!
 pub use nym_validator_client::client::IdentityKey;
 
-#[cfg(target_arch = "wasm32")]
 pub use wasm_utils::set_panic_hook;

--- a/common/wasm/client-core/src/storage/mod.rs
+++ b/common/wasm/client-core/src/storage/mod.rs
@@ -4,13 +4,15 @@
 use crate::error::WasmCoreError;
 use crate::storage::wasm_client_traits::{v1, v2, WasmClientStorage};
 use async_trait::async_trait;
-use js_sys::{Array, Promise};
+use js_sys::Promise;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 use wasm_storage::traits::BaseWasmStorage;
-use wasm_storage::{IdbVersionChangeEvent, WasmStorage};
+use wasm_storage::{
+    Build, Database, RawDbResult, TryFromJs, TryToJs, VersionChangeEvent, WasmStorage,
+};
 use wasm_utils::error::{simple_js_error, PromisableResult};
 use zeroize::Zeroizing;
 
@@ -44,28 +46,29 @@ impl ClientStorage {
         // special care must be taken on JS side to ensure it's correctly used there.
         let passphrase = Zeroizing::new(passphrase);
 
-        let migrate_fn = Some(|evt: &IdbVersionChangeEvent| -> Result<(), JsValue> {
+        let migrate_fn = Some(|evt: VersionChangeEvent, db: Database| -> RawDbResult<()> {
             // Even if the web-sys bindings expose the version as a f64, the IndexedDB API
             // works with an unsigned integer.
             // See <https://github.com/rustwasm/wasm-bindgen/issues/1149>
             let old_version = evt.old_version() as u32;
-            let db = evt.db();
 
             if old_version < 1 {
                 // migrating to version 2
 
-                db.create_object_store(v1::KEYS_STORE)?;
-                db.create_object_store(v1::CORE_STORE)?;
+                db.create_object_store(v1::KEYS_STORE).build()?;
+                db.create_object_store(v1::CORE_STORE).build()?;
 
-                db.create_object_store(v2::GATEWAY_REGISTRATIONS_ACTIVE_GATEWAY_STORE)?;
-                db.create_object_store(v2::GATEWAY_REGISTRATIONS_REGISTERED_GATEWAYS_STORE)?;
+                db.create_object_store(v2::GATEWAY_REGISTRATIONS_ACTIVE_GATEWAY_STORE)
+                    .build()?;
+                db.create_object_store(v2::GATEWAY_REGISTRATIONS_REGISTERED_GATEWAYS_STORE)
+                    .build()?;
 
                 return Ok(());
             }
 
             // version 1 -> unimplemented migration
             if old_version < 2 {
-                return Err(simple_js_error("this client is incompatible with existing storage. please initialise it again."));
+                return Err(simple_js_error("this client is incompatible with existing storage. please initialise it again.").into());
             }
 
             Ok(())
@@ -112,7 +115,7 @@ impl BaseWasmStorage for ClientStorage {
     async fn read_value<T, K>(&self, store: &str, key: K) -> Result<Option<T>, Self::StorageError>
     where
         T: DeserializeOwned,
-        K: JsCast,
+        K: TryToJs,
     {
         Ok(self.inner.read_value(store, key).await?)
     }
@@ -125,33 +128,33 @@ impl BaseWasmStorage for ClientStorage {
     ) -> Result<(), Self::StorageError>
     where
         T: Serialize,
-        K: JsCast,
+        K: TryToJs + TryFromJs,
     {
         Ok(self.inner.store_value(store, key, value).await?)
     }
 
     async fn remove_value<K>(&self, store: &str, key: K) -> Result<(), Self::StorageError>
     where
-        K: JsCast,
+        K: TryToJs,
     {
         Ok(self.inner.remove_value(store, key).await?)
     }
 
     async fn has_value<K>(&self, store: &str, key: K) -> Result<bool, Self::StorageError>
     where
-        K: JsCast,
+        K: TryToJs,
     {
         Ok(self.inner.has_value(store, key).await?)
     }
 
     async fn key_count<K>(&self, store: &str, key: K) -> Result<u32, Self::StorageError>
     where
-        K: JsCast,
+        K: TryToJs,
     {
         Ok(self.inner.key_count(store, key).await?)
     }
 
-    async fn get_all_keys(&self, store: &str) -> Result<Array, Self::StorageError> {
+    async fn get_all_keys(&self, store: &str) -> Result<Vec<JsValue>, Self::StorageError> {
         Ok(self.inner.get_all_keys(store).await?)
     }
 }

--- a/common/wasm/client-core/src/storage/wasm_client_traits.rs
+++ b/common/wasm/client-core/src/storage/wasm_client_traits.rs
@@ -286,8 +286,8 @@ pub trait WasmClientStorage: BaseWasmStorage {
             .await
             .map_err(Into::into)
             .map(|arr| {
-                arr.to_vec()
-                    .into_iter()
+                arr.iter()
+                    .cloned()
                     .filter_map(|key| key.as_string())
                     .collect()
             })

--- a/common/wasm/storage/Cargo.toml
+++ b/common/wasm/storage/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
-futures = { workspace = true }
+getrandom = { workspace = true, features = ["js"] }
 js-sys = { workspace = true }
 wasm-bindgen = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/common/wasm/storage/src/traits.rs
+++ b/common/wasm/storage/src/traits.rs
@@ -3,10 +3,11 @@
 
 use crate::WasmStorage;
 use async_trait::async_trait;
-use js_sys::Array;
+use indexed_db_futures::primitive::{TryFromJs, TryToJs};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::error::Error;
+use wasm_bindgen::JsValue;
 
 #[async_trait(?Send)]
 pub trait BaseWasmStorage {
@@ -17,7 +18,7 @@ pub trait BaseWasmStorage {
     async fn read_value<T, K>(&self, store: &str, key: K) -> Result<Option<T>, Self::StorageError>
     where
         T: DeserializeOwned,
-        K: wasm_bindgen::JsCast;
+        K: TryToJs;
 
     async fn store_value<T, K>(
         &self,
@@ -27,21 +28,21 @@ pub trait BaseWasmStorage {
     ) -> Result<(), Self::StorageError>
     where
         T: Serialize,
-        K: wasm_bindgen::JsCast;
+        K: TryToJs + TryFromJs;
 
     async fn remove_value<K>(&self, store: &str, key: K) -> Result<(), Self::StorageError>
     where
-        K: wasm_bindgen::JsCast;
+        K: TryToJs;
 
     async fn has_value<K>(&self, store: &str, key: K) -> Result<bool, Self::StorageError>
     where
-        K: wasm_bindgen::JsCast;
+        K: TryToJs;
 
     async fn key_count<K>(&self, store: &str, key: K) -> Result<u32, Self::StorageError>
     where
-        K: wasm_bindgen::JsCast;
+        K: TryToJs;
 
-    async fn get_all_keys(&self, store: &str) -> Result<js_sys::Array, Self::StorageError>;
+    async fn get_all_keys(&self, store: &str) -> Result<Vec<JsValue>, Self::StorageError>;
 }
 
 #[async_trait(?Send)]
@@ -55,7 +56,7 @@ impl BaseWasmStorage for WasmStorage {
     async fn read_value<T, K>(&self, store: &str, key: K) -> Result<Option<T>, Self::StorageError>
     where
         T: DeserializeOwned,
-        K: wasm_bindgen::JsCast,
+        K: TryToJs,
     {
         self.read_value(store, key).await
     }
@@ -68,33 +69,33 @@ impl BaseWasmStorage for WasmStorage {
     ) -> Result<(), Self::StorageError>
     where
         T: Serialize,
-        K: wasm_bindgen::JsCast,
+        K: TryToJs + TryFromJs,
     {
         self.store_value(store, key, value).await
     }
 
     async fn remove_value<K>(&self, store: &str, key: K) -> Result<(), Self::StorageError>
     where
-        K: wasm_bindgen::JsCast,
+        K: TryToJs,
     {
         self.remove_value(store, key).await
     }
 
     async fn has_value<K>(&self, store: &str, key: K) -> Result<bool, Self::StorageError>
     where
-        K: wasm_bindgen::JsCast,
+        K: TryToJs,
     {
         self.has_value(store, key).await
     }
 
     async fn key_count<K>(&self, store: &str, key: K) -> Result<u32, Self::StorageError>
     where
-        K: wasm_bindgen::JsCast,
+        K: TryToJs,
     {
         self.key_count(store, key).await
     }
 
-    async fn get_all_keys(&self, store: &str) -> Result<Array, Self::StorageError> {
+    async fn get_all_keys(&self, store: &str) -> Result<Vec<JsValue>, Self::StorageError> {
         self.get_all_keys(store).await
     }
 }


### PR DESCRIPTION
updates the `indexed_db_futures` dependency to stop relying on the fork. 

there's been a lot of changes in the API so before it could be merged, I'd need to first create a dummy JS project to double check the behaviour still works, in particular `get_all_keys` since now we're returning `Vec<JsValue>` rather than `js_sys::Array` and I have no idea whether JS itself won't freak out because of it (since the list allocation would be in rust instead of js)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5347)
<!-- Reviewable:end -->
