### PR TITLE
Client gateway selection

### DIFF
--- a/common/client-core/config-types/src/lib.rs
+++ b/common/client-core/config-types/src/lib.rs
@@ -553,7 +553,6 @@ pub struct Topology {
 
     /// Specifies whether this client should attempt to retrieve all available network nodes
     /// as opposed to just active mixnodes/gateways.
-    /// Useless without `ignore_epoch_roles = true`
     pub use_extended_topology: bool,
 
     /// Specifies whether this client should ignore the current epoch role of the target egress node

--- a/common/client-core/src/cli_helpers/client_add_gateway.rs
+++ b/common/client-core/src/cli_helpers/client_add_gateway.rs
@@ -115,7 +115,7 @@ where
         hardcoded_topology.entry_capable_nodes().cloned().collect()
     } else {
         let mut rng = rand::thread_rng();
-        crate::init::helpers::current_gateways(
+        crate::init::helpers::gateways_for_init(
             &mut rng,
             &core.client.nym_api_urls,
             user_agent,

--- a/common/client-core/src/cli_helpers/client_init.rs
+++ b/common/client-core/src/cli_helpers/client_init.rs
@@ -170,7 +170,7 @@ where
         hardcoded_topology.entry_capable_nodes().cloned().collect()
     } else {
         let mut rng = rand::thread_rng();
-        crate::init::helpers::current_gateways(
+        crate::init::helpers::gateways_for_init(
             &mut rng,
             &core.client.nym_api_urls,
             user_agent,

--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -86,7 +86,7 @@ impl<'a, G: ConnectableGateway> GatewayWithLatency<'a, G> {
     }
 }
 
-pub async fn current_gateways<R: Rng>(
+pub async fn gateways_for_init<R: Rng>(
     rng: &mut R,
     nym_apis: &[Url],
     user_agent: Option<UserAgent>,
@@ -108,8 +108,11 @@ pub async fn current_gateways<R: Rng>(
 
     log::trace!("Gateways: {:#?}", gateways);
 
+    // filter out gateways below minimum performance and ones that could operate as a mixnode
+    // (we don't want instability)
     let valid_gateways = gateways
         .iter()
+        .filter(|g| !g.supported_roles.mixnode)
         .filter(|g| g.performance.round_to_integer() >= minimum_performance)
         .filter_map(|gateway| gateway.try_into().ok())
         .collect::<Vec<_>>();

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/nym_node.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/nym_node.rs
@@ -113,6 +113,10 @@ impl Role {
     pub fn is_standby(&self) -> bool {
         matches!(self, Role::Standby)
     }
+
+    pub fn is_mixnode(&self) -> bool {
+        matches!(self, Role::Layer1 | Role::Layer2 | Role::Layer3)
+    }
 }
 
 impl Display for Role {

--- a/common/topology/src/lib.rs
+++ b/common/topology/src/lib.rs
@@ -401,20 +401,17 @@ impl NymTopology {
             });
         };
 
-        // a 'valid' egress is one assigned to either entry role (i.e. entry for another client)
-        // or exit role (as a service provider)
+        // a 'valid' egress is one that is currently **not** acting as a mixnode
         if !ignore_epoch_roles {
-            let Some(role) = self.rewarded_set.role(node.node_id) else {
-                return Err(NymTopologyError::InvalidEgressRole {
-                    node_identity: Box::new(node_identity),
-                });
-            };
-            if !matches!(role, Role::EntryGateway | Role::ExitGateway) {
-                return Err(NymTopologyError::InvalidEgressRole {
-                    node_identity: Box::new(node_identity),
-                });
+            if let Some(role) = self.rewarded_set.role(node.node_id) {
+                if role.is_mixnode() {
+                    return Err(NymTopologyError::InvalidEgressRole {
+                        node_identity: Box::new(node_identity),
+                    });
+                }
             }
         }
+
         Ok(node)
     }
 

--- a/common/wasm/client-core/src/config/mod.rs
+++ b/common/wasm/client-core/src/config/mod.rs
@@ -390,7 +390,6 @@ pub struct TopologyWasm {
 
     /// Specifies whether this client should attempt to retrieve all available network nodes
     /// as opposed to just active mixnodes/gateways.
-    /// Useless without `ignore_epoch_roles = true`
     pub use_extended_topology: bool,
 
     /// Specifies whether this client should ignore the current epoch role of the target egress node

--- a/common/wasm/client-core/src/config/override.rs
+++ b/common/wasm/client-core/src/config/override.rs
@@ -274,7 +274,6 @@ pub struct TopologyWasmOverride {
 
     /// Specifies whether this client should attempt to retrieve all available network nodes
     /// as opposed to just active mixnodes/gateways.
-    /// Useless without `ignore_epoch_roles = true`
     #[tsify(optional)]
     pub use_extended_topology: Option<bool>,
 

--- a/common/wasm/client-core/src/helpers.rs
+++ b/common/wasm/client-core/src/helpers.rs
@@ -10,7 +10,7 @@ use nym_client_core::client::base_client::storage::GatewaysDetailsStore;
 use nym_client_core::client::replies::reply_storage::browser_backend;
 use nym_client_core::config;
 use nym_client_core::error::ClientCoreError;
-use nym_client_core::init::helpers::current_gateways;
+use nym_client_core::init::helpers::gateways_for_init;
 use nym_client_core::init::types::GatewaySelectionSpecification;
 use nym_client_core::init::{
     self, setup_gateway,
@@ -134,7 +134,7 @@ pub async fn setup_gateway_from_api(
     minimum_performance: u8,
 ) -> Result<InitialisationResult, WasmCoreError> {
     let mut rng = thread_rng();
-    let gateways = current_gateways(&mut rng, nym_apis, None, minimum_performance).await?;
+    let gateways = gateways_for_init(&mut rng, nym_apis, None, minimum_performance).await?;
     setup_gateway_wasm(client_store, force_tls, chosen_gateway, gateways).await
 }
 
@@ -144,7 +144,7 @@ pub async fn current_gateways_wasm(
     minimum_performance: u8,
 ) -> Result<Vec<RoutingNode>, ClientCoreError> {
     let mut rng = thread_rng();
-    current_gateways(&mut rng, nym_apis, user_agent, minimum_performance).await
+    gateways_for_init(&mut rng, nym_apis, user_agent, minimum_performance).await
 }
 
 pub async fn setup_from_topology(

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -25,7 +25,7 @@ use nym_client_core::client::{
 };
 use nym_client_core::config::{DebugConfig, StatsReporting};
 use nym_client_core::error::ClientCoreError;
-use nym_client_core::init::helpers::current_gateways;
+use nym_client_core::init::helpers::gateways_for_init;
 use nym_client_core::init::setup_gateway;
 use nym_client_core::init::types::{GatewaySelectionSpecification, GatewaySetup};
 use nym_client_core::ForgetMe;
@@ -513,7 +513,7 @@ where
         let user_agent = self.user_agent.clone();
 
         let mut rng = OsRng;
-        let available_gateways = current_gateways(
+        let available_gateways = gateways_for_init(
             &mut rng,
             &nym_api_endpoints,
             user_agent,


### PR DESCRIPTION
changed how gateway is selected.
- for init the target gateway can't support mixing
- for egress, unless `ignore_epoch_roles` is specified, the gateway can't be currently assigned to a mixing layer. but it can be standby or inactive

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5358)
<!-- Reviewable:end -->
