### PR TITLE
[DOCs/operators]: Bump release version

### DIFF
--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -41,7 +41,7 @@ This page displays a full list of all the changes during our release cycle from 
 ## `v2025.1-reeses`
 
 - [Release Binaries](https://github.com/nymtech/nym/releases/tag/nym-binaries-v2025.1-reeses)
-- [`nym-node`](nodes/nym-node.mdx) version `1.3.0`
+- [`nym-node`](nodes/nym-node.mdx) version `1.3.1`
 
 ```
 nym-node

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -46,10 +46,10 @@ This page displays a full list of all the changes during our release cycle from 
 ```
 nym-node
 Binary Name:        nym-node
-Build Timestamp:    2025-01-15T09:50:54.404428047Z
-Build Version:      1.3.0
-Commit SHA:         c202e2d598fabda5fc16a6c1e110255857a2b1ca
-Commit Date:        2025-01-15T10:27:39.000000000+01:00
+Build Timestamp:    2025-01-16T11:54:17.079662337Z
+Build Version:      1.3.1
+Commit SHA:         5ab164d229f85bd2dd27ec6e38292c281df2f678
+Commit Date:        2025-01-16T12:51:53.000000000+01:00
 Commit Branch:      HEAD
 rustc Version:      1.84.0
 rustc Channel:      stable

--- a/documentation/docs/pages/operators/nodes/nym-node/setup.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/setup.mdx
@@ -20,10 +20,10 @@ This documentation page provides a guide on how to set up and run a [NYM NODE](.
 ```sh
 nym-node
 Binary Name:        nym-node
-Build Timestamp:    2025-01-15T09:50:54.404428047Z
-Build Version:      1.3.0
-Commit SHA:         c202e2d598fabda5fc16a6c1e110255857a2b1ca
-Commit Date:        2025-01-15T10:27:39.000000000+01:00
+Build Timestamp:    2025-01-16T11:54:17.079662337Z
+Build Version:      1.3.1
+Commit SHA:         5ab164d229f85bd2dd27ec6e38292c281df2f678
+Commit Date:        2025-01-16T12:51:53.000000000+01:00
 Commit Branch:      HEAD
 rustc Version:      1.84.0
 rustc Channel:      stable


### PR DESCRIPTION
Get reeses new version to docs

```
nym-node
Binary Name:        nym-node
Build Timestamp:    2025-01-16T11:54:17.079662337Z
Build Version:      1.3.1
Commit SHA:         5ab164d229f85bd2dd27ec6e38292c281df2f678
Commit Date:        2025-01-16T12:51:53.000000000+01:00
Commit Branch:      HEAD
rustc Version:      1.84.0
rustc Channel:      stable
cargo Profile:      release
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5362)
<!-- Reviewable:end -->
