### PR TITLE
Uncouple storage reference for bandwidth client

### DIFF
--- a/common/client-core/gateways-storage/src/backend/fs_backend/mod.rs
+++ b/common/client-core/gateways-storage/src/backend/fs_backend/mod.rs
@@ -15,6 +15,7 @@ pub mod error;
 mod manager;
 mod models;
 
+#[derive(Clone)]
 pub struct OnDiskGatewaysDetails {
     manager: StorageManager,
 }

--- a/common/client-core/gateways-storage/src/backend/mem_backend.rs
+++ b/common/client-core/gateways-storage/src/backend/mem_backend.rs
@@ -20,12 +20,12 @@ pub enum InMemStorageError {
     MalformedGateway(#[from] BadGateway),
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct InMemGatewaysDetails {
     inner: Arc<RwLock<InMemStorageInner>>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct InMemStorageInner {
     active_gateway: Option<String>,
     gateways: HashMap<String, GatewayRegistration>,

--- a/common/client-core/src/client/base_client/storage/mod.rs
+++ b/common/client-core/src/client/base_client/storage/mod.rs
@@ -63,7 +63,7 @@ pub trait MixnetClientStorage {
     fn gateway_details_store(&self) -> &Self::GatewaysDetailsStore;
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Ephemeral {
     key_store: InMemEphemeralKeys,
     reply_store: reply_storage::Empty,
@@ -114,6 +114,7 @@ impl MixnetClientStorage for Ephemeral {
     }
 }
 
+#[derive(Clone)]
 #[cfg(all(
     not(target_arch = "wasm32"),
     feature = "fs-surb-storage",

--- a/common/client-core/src/client/key_manager/persistence.rs
+++ b/common/client-core/src/client/key_manager/persistence.rs
@@ -4,6 +4,7 @@
 use crate::client::key_manager::ClientKeys;
 use async_trait::async_trait;
 use std::error::Error;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -64,6 +65,7 @@ pub enum OnDiskKeysError {
     },
 }
 
+#[derive(Clone)]
 #[cfg(not(target_arch = "wasm32"))]
 pub struct OnDiskKeys {
     paths: ClientKeysPaths,
@@ -193,9 +195,9 @@ impl KeyStore for OnDiskKeys {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct InMemEphemeralKeys {
-    keys: Mutex<Option<ClientKeys>>,
+    keys: Arc<Mutex<Option<ClientKeys>>>,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/common/client-core/surb-storage/src/backend/fs_backend/mod.rs
+++ b/common/client-core/surb-storage/src/backend/fs_backend/mod.rs
@@ -22,7 +22,7 @@ mod error;
 mod manager;
 mod models;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Backend {
     temporary_old_path: Option<PathBuf>,
     database_path: PathBuf,

--- a/common/client-core/surb-storage/src/backend/mod.rs
+++ b/common/client-core/surb-storage/src/backend/mod.rs
@@ -19,7 +19,7 @@ pub mod fs_backend;
 #[error("no information provided")]
 pub struct UndefinedError;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Empty {
     // we need to keep 'basic' metadata here to "load" the CombinedReplyStorage
     pub min_surb_threshold: usize,

--- a/common/credential-storage/src/storage.rs
+++ b/common/credential-storage/src/storage.rs
@@ -19,7 +19,7 @@ use std::error::Error;
 // `SELECT total_tickets, used_tickets FROM ecash_ticketbook WHERE expiration_date >= ?`, today_date
 // then for each calculate the diff total_tickets - used_tickets and multiply the result by the size of the ticket
 #[async_trait]
-pub trait Storage: Send + Sync {
+pub trait Storage: Clone + Send + Sync {
     type StorageError: Error;
 
     async fn close(&self);

--- a/sdk/rust/nym-sdk/examples/manually_handle_storage.rs
+++ b/sdk/rust/nym-sdk/examples/manually_handle_storage.rs
@@ -40,6 +40,7 @@ async fn main() {
     client.disconnect().await;
 }
 
+#[derive(Clone)]
 #[allow(unused)]
 struct MockClientStorage {
     pub key_store: MockKeyStore,
@@ -96,6 +97,7 @@ impl MixnetClientStorage for MockClientStorage {
     }
 }
 
+#[derive(Clone)]
 struct MockKeyStore;
 
 #[async_trait]
@@ -115,6 +117,7 @@ impl KeyStore for MockKeyStore {
     }
 }
 
+#[derive(Clone)]
 struct MockGatewayDetailsStore;
 
 #[async_trait]

--- a/sdk/rust/nym-sdk/src/bandwidth/client.rs
+++ b/sdk/rust/nym-sdk/src/bandwidth/client.rs
@@ -17,22 +17,22 @@ use zeroize::Zeroizing;
 /// The way to create this client is by calling
 /// [`crate::mixnet::DisconnectedMixnetClient::create_bandwidth_client`] on the associated mixnet
 /// client.
-pub struct BandwidthAcquireClient<'a, St: Storage> {
+pub struct BandwidthAcquireClient<St: Storage + Clone> {
     client: DirectSigningHttpRpcNyxdClient,
-    storage: &'a St,
+    storage: St,
     client_id: Zeroizing<Vec<u8>>,
     ticketbook_type: TicketType,
 }
 
-impl<'a, St> BandwidthAcquireClient<'a, St>
+impl<St> BandwidthAcquireClient<St>
 where
-    St: Storage,
+    St: Storage + Clone,
     <St as Storage>::StorageError: Send + Sync + 'static,
 {
     pub(crate) fn new(
         network_details: NymNetworkDetails,
         mnemonic: String,
-        storage: &'a St,
+        storage: St,
         client_id: Vec<u8>,
         ticketbook_type: TicketType,
     ) -> Result<Self> {
@@ -55,7 +55,7 @@ where
     pub async fn acquire(&self) -> Result<()> {
         issue_credential(
             &self.client,
-            self.storage,
+            &self.storage,
             self.client_id.deref(),
             self.ticketbook_type,
         )

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -108,7 +108,7 @@ impl MixnetClientBuilder<OnDiskPersistent> {
 
 impl<S> MixnetClientBuilder<S>
 where
-    S: MixnetClientStorage + 'static,
+    S: MixnetClientStorage + Clone + 'static,
     S::ReplyStore: Send + Sync,
     S::GatewaysDetailsStore: Sync,
     <S::ReplyStore as ReplyStorageBackend>::StorageError: Sync + Send,
@@ -326,7 +326,7 @@ where
 /// client.
 pub struct DisconnectedMixnetClient<S>
 where
-    S: MixnetClientStorage,
+    S: MixnetClientStorage + Clone,
 {
     /// Client configuration
     config: Config,
@@ -371,7 +371,7 @@ where
 
 impl<S> DisconnectedMixnetClient<S>
 where
-    S: MixnetClientStorage + 'static,
+    S: MixnetClientStorage + Clone + 'static,
     S::ReplyStore: Send + Sync,
     S::GatewaysDetailsStore: Sync,
     <S::ReplyStore as ReplyStorageBackend>::StorageError: Sync + Send,
@@ -622,7 +622,7 @@ where
         BandwidthAcquireClient::new(
             self.config.network_details.clone(),
             mnemonic,
-            self.storage.credential_store(),
+            self.storage.credential_store().clone(),
             client_id,
             ticketbook_type,
         )


### PR DESCRIPTION
Because of the `Storage` reference in the bandwidth client, the client can't be separated and used in a different place, as it will be linked to the DisconnectedClient. Cloning it ensures we uncouple this unnecessary dependence.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5372)
<!-- Reviewable:end -->
