### PR TITLE
Handle ecash network errors differently

### DIFF
--- a/common/client-libs/validator-client/src/coconut/mod.rs
+++ b/common/client-libs/validator-client/src/coconut/mod.rs
@@ -65,6 +65,12 @@ pub enum EcashApiError {
         #[from]
         source: cosmrs::ErrorReport,
     },
+
+    #[error("nym api error")]
+    NymApi {
+        #[from]
+        source: crate::ValidatorClientError,
+    },
 }
 
 impl TryFrom<ContractVKShare> for EcashApiClient {

--- a/common/credential-verification/src/ecash/credential_sender.rs
+++ b/common/credential-verification/src/ecash/credential_sender.rs
@@ -13,6 +13,7 @@ use nym_api_requests::constants::MIN_BATCH_REDEMPTION_DELAY;
 use nym_api_requests::ecash::models::{BatchRedeemTicketsBody, VerifyEcashTicketBody};
 use nym_credentials_interface::Bandwidth;
 use nym_credentials_interface::{ClientTicket, TicketType};
+use nym_validator_client::coconut::EcashApiError;
 use nym_validator_client::nym_api::EpochId;
 use nym_validator_client::nyxd::contract_traits::{
     EcashSigningClient, MultisigQueryClient, MultisigSigningClient, PagedMultisigQueryClient,
@@ -352,7 +353,9 @@ impl CredentialHandler {
             }
             Err(err) => {
                 error!("failed to send ticket {ticket_id} for verification to ecash signer '{client}': {err}. if we don't reach quorum, we'll retry later");
-                Ok(false)
+                Err(EcashTicketError::ApiFailure(EcashApiError::NymApi {
+                    source: err,
+                }))
             }
         }
     }


### PR DESCRIPTION
For errors that could be caused by network problems, we should mark the ticket as still pending, not as bad. This won't fix the underlying problem, but should not assume anymore that the client is the culprit and penalise its bandwidth quota.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5378)
<!-- Reviewable:end -->
