### PR TITLE
MixnetClient can send ClientRequests

### DIFF
--- a/common/client-core/src/client/mix_traffic/mod.rs
+++ b/common/client-core/src/client/mix_traffic/mod.rs
@@ -134,8 +134,7 @@ impl MixTrafficController {
                             };
                         },
                         None => {
-                            log::trace!("MixTrafficController: Stopping since channel closed");
-                            break;
+                            log::trace!("MixTrafficController, client request channel closed");
                         }
                     },
                     _ = shutdown.recv_with_delay() => {

--- a/common/client-core/src/client/mix_traffic/transceiver.rs
+++ b/common/client-core/src/client/mix_traffic/transceiver.rs
@@ -86,7 +86,9 @@ impl<G: GatewayTransceiver + ?Sized + Send> GatewayTransceiver for Box<G> {
         &mut self,
         message: ClientRequest,
     ) -> Result<(), GatewayClientError> {
-        (**self).send_client_request(message).await
+        let _ = (**self).send_client_request(message.clone()).await?;
+        log::debug!("Sent client request: {:?}", message);
+        Ok(())
     }
 }
 

--- a/common/client-core/src/client/mix_traffic/transceiver.rs
+++ b/common/client-core/src/client/mix_traffic/transceiver.rs
@@ -36,7 +36,6 @@ pub trait GatewayTransceiver: GatewaySender + GatewayReceiver {
         &mut self,
         message: ClientRequest,
     ) -> Result<(), GatewayClientError>;
-    fn set_pre_shutdown_client_request(&mut self, request: ClientRequest);
 }
 
 /// This trait defines the functionality of sending `MixPacket` into the mixnet,
@@ -88,10 +87,6 @@ impl<G: GatewayTransceiver + ?Sized + Send> GatewayTransceiver for Box<G> {
         message: ClientRequest,
     ) -> Result<(), GatewayClientError> {
         (**self).send_client_request(message).await
-    }
-
-    fn set_pre_shutdown_client_request(&mut self, request: ClientRequest) {
-        (**self).set_pre_shutdown_client_request(request);
     }
 }
 
@@ -149,10 +144,6 @@ where
         message: ClientRequest,
     ) -> Result<(), GatewayClientError> {
         self.gateway_client.send_client_request(message).await
-    }
-
-    fn set_pre_shutdown_client_request(&mut self, request: ClientRequest) {
-        self.gateway_client.set_pre_shutdown_client_request(request);
     }
 }
 
@@ -241,10 +232,6 @@ mod nonwasm_sealed {
         ) -> Result<(), GatewayClientError> {
             Ok(())
         }
-
-        fn set_pre_shutdown_client_request(&mut self, _request: ClientRequest) {
-            // no-op
-        }
     }
 
     #[async_trait]
@@ -326,9 +313,5 @@ impl GatewayTransceiver for MockGateway {
         _message: ClientRequest,
     ) -> Result<(), GatewayClientError> {
         Ok(())
-    }
-
-    fn set_pre_shutdown_client_request(&mut self, _request: ClientRequest) {
-        // no-op
     }
 }

--- a/common/client-libs/gateway-client/src/client/mod.rs
+++ b/common/client-libs/gateway-client/src/client/mod.rs
@@ -107,6 +107,7 @@ pub struct GatewayClient<C, St = EphemeralCredentialStorage> {
 
     /// Listen to shutdown messages and send notifications back to the task manager
     task_client: TaskClient,
+    pre_shutdown_client_request: Option<ClientRequest>,
 }
 
 impl<C, St> GatewayClient<C, St> {
@@ -139,7 +140,20 @@ impl<C, St> GatewayClient<C, St> {
             #[cfg(unix)]
             connection_fd_callback,
             task_client,
+            pre_shutdown_client_request: None,
         }
+    }
+
+    pub fn set_pre_shutdown_client_request(&mut self, request: ClientRequest) {
+        self.pre_shutdown_client_request = Some(request);
+    }
+
+    async fn send_pre_shutdown_client_request(&mut self) -> Result<(), GatewayClientError> {
+        log::debug!("GatewayClient: Sending pre-shutdown request");
+        if let Some(request) = self.pre_shutdown_client_request.take() {
+            self.send_client_request(request).await?;
+        }
+        Ok(())
     }
 
     pub fn gateway_identity(&self) -> identity::PublicKey {
@@ -271,6 +285,19 @@ impl<C, St> GatewayClient<C, St> {
         }
     }
 
+    pub async fn send_client_request(
+        &mut self,
+        message: ClientRequest,
+    ) -> Result<(), GatewayClientError> {
+        if let Some(shared_key) = self.shared_key() {
+            let encrypted = message.encrypt(&*shared_key)?;
+            Box::pin(self.send_websocket_message(encrypted)).await?;
+            Ok(())
+        } else {
+            Err(GatewayClientError::ConnectionInInvalidState)
+        }
+    }
+
     async fn read_control_response(&mut self) -> Result<ServerResponse, GatewayClientError> {
         // we use the fact that all request responses are Message::Text and only pushed
         // sphinx packets are Message::Binary
@@ -288,9 +315,11 @@ impl<C, St> GatewayClient<C, St> {
                 _ = self.task_client.recv() => {
                     log::trace!("GatewayClient control response: Received shutdown");
                     log::debug!("GatewayClient control response: Exiting");
+                    self.send_pre_shutdown_client_request().await?;
                     break Err(GatewayClientError::ConnectionClosedGatewayShutdown);
                 }
                 _ = &mut timeout => {
+                    self.send_pre_shutdown_client_request().await?;
                     break Err(GatewayClientError::Timeout);
                 }
                 msg = conn.next() => {
@@ -1050,6 +1079,7 @@ impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
             #[cfg(unix)]
             connection_fd_callback: None,
             task_client,
+            pre_shutdown_client_request: None,
         }
     }
 
@@ -1082,6 +1112,7 @@ impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
             #[cfg(unix)]
             connection_fd_callback: self.connection_fd_callback,
             task_client,
+            pre_shutdown_client_request: self.pre_shutdown_client_request,
         }
     }
 }

--- a/common/gateway-requests/src/types/text_request.rs
+++ b/common/gateway-requests/src/types/text_request.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 use tungstenite::Message;
 
 // wrapper for all encrypted requests for ease of use
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[non_exhaustive]
 pub enum ClientRequest {
     UpgradeKey {

--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -315,7 +315,7 @@ impl TaskClient {
     const MAX_NAME_LENGTH: usize = 128;
     const OVERFLOW_NAME: &'static str = "reached maximum TaskClient children name depth";
 
-    const SHUTDOWN_TIMEOUT_WAITING_FOR_SIGNAL_ON_EXIT: Duration = Duration::from_secs(5);
+    const SHUTDOWN_TIMEOUT_WAITING_FOR_SIGNAL_ON_EXIT: Duration = Duration::from_secs(10);
 
     fn new(
         notify: watch::Receiver<()>,

--- a/nym-network-monitor/src/main.rs
+++ b/nym-network-monitor/src/main.rs
@@ -219,10 +219,12 @@ async fn main() -> Result<()> {
         TOPOLOGY.get().expect("Topology not set yet!").clone(),
     ));
 
+    let clients_server = clients.clone();
+
     let server_handle = tokio::spawn(async move {
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::from_str(&args.host)?), args.port);
         let server = HttpServer::new(socket, server_cancel_token);
-        server.run(clients).await
+        server.run(clients_server).await
     });
 
     info!("Waiting for message (ctrl-c to exit)");
@@ -254,6 +256,15 @@ async fn main() -> Result<()> {
                 submit_metrics(client).await?;
             }
         };
+    }
+
+    info!("Disconnecting all clients");
+    let mut clients_guard = clients.write().await;
+    while let Some(client) = clients_guard.pop_front() {
+        if let Some(client) = Arc::into_inner(client) {
+            let client_handle = client.into_inner();
+            client_handle.disconnect().await;
+        }
     }
 
     cancel_token.cancel();

--- a/nym-network-monitor/src/main.rs
+++ b/nym-network-monitor/src/main.rs
@@ -59,9 +59,6 @@ async fn make_clients(
                 loop {
                     if Arc::strong_count(&dropped_client) == 1 {
                         if let Some(client) = Arc::into_inner(dropped_client) {
-                            // let forget_me = ClientRequest::ForgetMe {
-                            //     also_from_stats: true,
-                            // };
                             let client_handle = client.into_inner();
                             client_handle.disconnect().await;
                         } else {

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -800,6 +800,8 @@ where
             stats_events_reporter,
             started_client.task_handle,
             None,
+            started_client.client_request_sender,
+            started_client.forget_me,
         ))
     }
 }

--- a/sdk/rust/nym-sdk/src/mixnet/native_client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/native_client.rs
@@ -5,12 +5,15 @@ use async_trait::async_trait;
 use futures::{ready, Stream, StreamExt};
 use log::error;
 use nym_client_core::client::base_client::GatewayConnection;
+use nym_client_core::client::mix_traffic::ClientRequestSender;
 use nym_client_core::client::{
     base_client::{ClientInput, ClientOutput, ClientState},
     inbound_messages::InputMessage,
     received_buffer::ReconstructedMessagesReceiver,
 };
+use nym_client_core::ForgetMe;
 use nym_crypto::asymmetric::identity;
+use nym_gateway_requests::ClientRequest;
 use nym_sphinx::addressing::clients::Recipient;
 use nym_sphinx::{params::PacketType, receiver::ReconstructedMessage};
 use nym_statistics_common::clients::{ClientStatsEvents, ClientStatsSender};
@@ -56,6 +59,8 @@ pub struct MixnetClient {
 
     // internal state used for the `Stream` implementation
     _buffered: Vec<ReconstructedMessage>,
+    pub(crate) client_request_sender: ClientRequestSender,
+    pub(crate) forget_me: ForgetMe,
 }
 
 impl MixnetClient {
@@ -70,6 +75,8 @@ impl MixnetClient {
         stats_events_reporter: ClientStatsSender,
         task_handle: TaskHandle,
         packet_type: Option<PacketType>,
+        client_request_sender: ClientRequestSender,
+        forget_me: ForgetMe,
     ) -> Self {
         Self {
             nym_address,
@@ -82,6 +89,8 @@ impl MixnetClient {
             task_handle,
             packet_type,
             _buffered: Vec::new(),
+            client_request_sender,
+            forget_me,
         }
     }
 
@@ -110,6 +119,10 @@ impl MixnetClient {
     /// client identity, the client encryption key, and the gateway identity.
     pub fn nym_address(&self) -> &Recipient {
         &self.nym_address
+    }
+
+    pub fn client_request_sender(&self) -> ClientRequestSender {
+        self.client_request_sender.clone()
     }
 
     /// Sign a message with the client's private identity key.
@@ -201,6 +214,14 @@ impl MixnetClient {
     /// Disconnect from the mixnet. Currently it is not supported to reconnect a disconnected
     /// client.
     pub async fn disconnect(mut self) {
+        if self.forget_me.any() {
+            log::info!("Sending forget me request: {:?}", self.forget_me);
+            match self.send_forget_me().await {
+                Ok(_) => (),
+                Err(e) => error!("Failed to send forget me request: {}", e),
+            };
+        }
+
         if let TaskHandle::Internal(task_manager) = &mut self.task_handle {
             task_manager.signal_shutdown().ok();
             task_manager.wait_for_shutdown().await;
@@ -208,6 +229,20 @@ impl MixnetClient {
 
         // note: it's important to take ownership of the struct as if the shutdown is `TaskHandle::External`,
         // it must be dropped to finalize the shutdown
+    }
+
+    pub async fn send_forget_me(&self) -> Result<()> {
+        let client_request = ClientRequest::ForgetMe {
+            client: self.forget_me.client(),
+            stats: self.forget_me.stats(),
+        };
+        match self.client_request_sender.send(client_request).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                error!("Failed to send forget me request: {}", e);
+                Err(Error::MessageSendingFailure)
+            }
+        }
     }
 }
 

--- a/sdk/rust/nym-sdk/src/mixnet/native_client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/native_client.rs
@@ -215,11 +215,12 @@ impl MixnetClient {
     /// client.
     pub async fn disconnect(mut self) {
         if self.forget_me.any() {
-            log::info!("Sending forget me request: {:?}", self.forget_me);
+            log::debug!("Sending forget me request: {:?}", self.forget_me);
             match self.send_forget_me().await {
                 Ok(_) => (),
                 Err(e) => error!("Failed to send forget me request: {}", e),
             };
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
         }
 
         if let TaskHandle::Internal(task_manager) = &mut self.task_handle {


### PR DESCRIPTION
Ended up adding another channel to the `MixnetClient`, so that it can signal to the `MixTrafficController` that can send a `ClientRequest` via its `GatewayTransciver`.

Had to add a sleep to the `disconnect` call as the socket would close before the channel message got processed, briefly considered adding an `ack` channel so that we can signal back when the message got sent, but opted for simplicity for now. I've also bumped the default timeout to 10 secs.

Looking at this code, I'm not sure if channels between MixnetClient and MixTrafficController are needed, since messages are processed serially, we might be able to pass an `Arc<Mutex<MixTrafficController>>` to MixnetClient and use it directly, remove a level of indirection from the code, nothing actionable now just shower thoughts... 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5381)
<!-- Reviewable:end -->
