### PR TITLE
Use secure DNS for websocket connection establishment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5746,6 +5746,7 @@ dependencies = [
  "nym-credentials-interface",
  "nym-crypto",
  "nym-gateway-requests",
+ "nym-http-api-client",
  "nym-network-defaults",
  "nym-pemstore",
  "nym-sphinx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5134,6 +5134,7 @@ dependencies = [
  "nym-explorer-client",
  "nym-gateway-client",
  "nym-gateway-requests",
+ "nym-http-api-client",
  "nym-id",
  "nym-metrics",
  "nym-mixnet-client",

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -40,6 +40,7 @@ nym-crypto = { path = "../crypto" }
 nym-explorer-client = { path = "../../explorer-api/explorer-client" }
 nym-gateway-client = { path = "../client-libs/gateway-client" }
 nym-gateway-requests = { path = "../gateway-requests" }
+nym-http-api-client = { path = "../http-api-client" }
 nym-metrics = { path = "../nym-metrics" }
 nym-nonexhaustive-delayqueue = { path = "../nonexhaustive-delayqueue" }
 nym-sphinx = { path = "../nymsphinx" }

--- a/common/client-core/src/error.rs
+++ b/common/client-core/src/error.rs
@@ -36,6 +36,9 @@ pub enum ClientCoreError {
     #[error("no gateway with id: {0}")]
     NoGatewayWithId(String),
 
+    #[error("Invalid URL: {0}")]
+    InvalidURL(String),
+
     #[error("no gateways on network")]
     NoGatewaysOnNetwork,
 

--- a/common/client-core/src/error.rs
+++ b/common/client-core/src/error.rs
@@ -37,7 +37,7 @@ pub enum ClientCoreError {
     NoGatewayWithId(String),
 
     #[error("Invalid URL: {0}")]
-    InvalidURL(String),
+    InvalidUrl(String),
 
     #[error("no gateways on network")]
     NoGatewaysOnNetwork,

--- a/common/client-core/src/error.rs
+++ b/common/client-core/src/error.rs
@@ -39,6 +39,7 @@ pub enum ClientCoreError {
     #[error("Invalid URL: {0}")]
     InvalidUrl(String),
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[error("resolution failed: {0}")]
     ResolutionFailed(#[from] nym_http_api_client::HickoryDnsError),
 

--- a/common/client-core/src/error.rs
+++ b/common/client-core/src/error.rs
@@ -39,6 +39,9 @@ pub enum ClientCoreError {
     #[error("Invalid URL: {0}")]
     InvalidUrl(String),
 
+    #[error("resolution failed: {0}")]
+    ResolutionFailed(#[from] nym_http_api_client::HickoryDnsError),
+
     #[error("no gateways on network")]
     NoGatewaysOnNetwork,
 

--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -3,7 +3,6 @@
 
 use crate::error::ClientCoreError;
 use crate::init::types::RegistrationResult;
-use crate::init::websockets::connect_async;
 use futures::{SinkExt, StreamExt};
 use log::{debug, info, trace, warn};
 use nym_crypto::asymmetric::identity;
@@ -16,6 +15,9 @@ use std::{sync::Arc, time::Duration};
 use tungstenite::Message;
 use url::Url;
 
+#[cfg(not(target_arch = "wasm32"))]
+use crate::init::websockets::connect_async;
+
 use nym_topology::NodeId;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::net::TcpStream;
@@ -23,7 +25,6 @@ use tokio::net::TcpStream;
 use tokio::time::sleep;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::time::Instant;
-#[cfg(not(target_arch = "wasm32"))]
 #[cfg(not(target_arch = "wasm32"))]
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 #[cfg(target_arch = "wasm32")]

--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -3,6 +3,7 @@
 
 use crate::error::ClientCoreError;
 use crate::init::types::RegistrationResult;
+use crate::init::websockets::connect_async;
 use futures::{SinkExt, StreamExt};
 use log::{debug, info, trace, warn};
 use nym_crypto::asymmetric::identity;
@@ -23,7 +24,6 @@ use tokio::time::sleep;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::time::Instant;
 #[cfg(not(target_arch = "wasm32"))]
-use tokio_tungstenite::connect_async;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 #[cfg(target_arch = "wasm32")]

--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -131,7 +131,7 @@ pub async fn gateways_for_init<R: Rng>(
 async fn connect(endpoint: &str) -> Result<WsConn, ClientCoreError> {
     match tokio::time::timeout(CONN_TIMEOUT, connect_async(endpoint)).await {
         Err(_elapsed) => Err(ClientCoreError::GatewayConnectionTimeout),
-        Ok(Err(conn_failure)) => Err(conn_failure.into()),
+        Ok(Err(conn_failure)) => Err(conn_failure),
         Ok(Ok((stream, _))) => Ok(stream),
     }
 }

--- a/common/client-core/src/init/mod.rs
+++ b/common/client-core/src/init/mod.rs
@@ -26,6 +26,7 @@ use serde::Serialize;
 
 pub mod helpers;
 pub mod types;
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod websockets;
 
 // helpers for error wrapping

--- a/common/client-core/src/init/mod.rs
+++ b/common/client-core/src/init/mod.rs
@@ -26,7 +26,7 @@ use serde::Serialize;
 
 pub mod helpers;
 pub mod types;
-pub mod websockets;
+pub(crate) mod websockets;
 
 // helpers for error wrapping
 

--- a/common/client-core/src/init/mod.rs
+++ b/common/client-core/src/init/mod.rs
@@ -26,6 +26,7 @@ use serde::Serialize;
 
 pub mod helpers;
 pub mod types;
+pub mod websockets;
 
 // helpers for error wrapping
 

--- a/common/client-core/src/init/websockets.rs
+++ b/common/client-core/src/init/websockets.rs
@@ -3,7 +3,7 @@ use crate::error::ClientCoreError;
 use nym_http_api_client::HickoryDnsResolver;
 use tokio::net::TcpStream;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
-use tungstenite::{error::UrlError, handshake::client::Response};
+use tungstenite::handshake::client::Response;
 use url::{Host, Url};
 
 use std::net::SocketAddr;
@@ -29,13 +29,7 @@ pub(crate) async fn connect_async(
             // Do a DNS lookup for the domain using our custom DNS resolver
             resolver
                 .resolve_str(domain)
-                .await
-                .map_err(|_| {
-                    // failed to resolve
-                    ClientCoreError::GatewayConnectionFailure {
-                        source: UrlError::NoPathOrQuery.into(),
-                    }
-                })?
+                .await?
                 .into_iter()
                 .map(|a| SocketAddr::new(a, port))
                 .collect()

--- a/common/client-core/src/init/websockets.rs
+++ b/common/client-core/src/init/websockets.rs
@@ -13,12 +13,12 @@ pub(crate) async fn connect_async(
     endpoint: &str,
 ) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response), ClientCoreError> {
     let resolver = HickoryDnsResolver::default();
-    let uri = Url::parse(endpoint).map_err(|_| ClientCoreError::InvalidURL(endpoint.to_owned()))?;
+    let uri = Url::parse(endpoint).map_err(|_| ClientCoreError::InvalidUrl(endpoint.to_owned()))?;
     let port: u16 = uri.port_or_known_default().unwrap_or(443);
 
     let host = uri
         .host()
-        .ok_or(ClientCoreError::InvalidURL(endpoint.to_owned()))?;
+        .ok_or(ClientCoreError::InvalidUrl(endpoint.to_owned()))?;
 
     // Get address for tcp connection, if a domain is provided use our preferred resolver rather than
     // the default std resolve

--- a/common/client-core/src/init/websockets.rs
+++ b/common/client-core/src/init/websockets.rs
@@ -1,0 +1,26 @@
+use nym_http_api_client::dns::HickoryDnsResolver;
+use tokio::net::TcpStream;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+use tungstenite::{
+    error::{Error, UrlError},
+    handshake::client::Response,
+};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) async fn connect_async(
+    endpoint: &str,
+) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response), Error> {
+    use std::net::SocketAddr;
+
+    let resolver = HickoryDnsResolver::default();
+
+    let sock_addrs: Vec<SocketAddr> = resolver
+        .resolve_str(endpoint)
+        .await
+        .map_err(|_| UrlError::NoPathOrQuery)? // failed to resolve
+        .collect();
+
+    let stream = TcpStream::connect(&sock_addrs[..]).await?;
+
+    tokio_tungstenite::client_async_tls(endpoint, stream).await
+}

--- a/common/client-libs/gateway-client/Cargo.toml
+++ b/common/client-libs/gateway-client/Cargo.toml
@@ -27,6 +27,7 @@ nym-credential-storage = { path = "../../credential-storage" }
 nym-credentials-interface = { path = "../../credentials-interface" }
 nym-crypto = { path = "../../crypto" }
 nym-gateway-requests = { path = "../../gateway-requests" }
+nym-http-api-client = { path = "../../http-api-client" }
 nym-network-defaults = { path = "../../network-defaults" }
 nym-sphinx = { path = "../../nymsphinx" }
 nym-statistics-common = { path = "../../statistics" }

--- a/common/client-libs/gateway-client/src/client/websockets.rs
+++ b/common/client-libs/gateway-client/src/client/websockets.rs
@@ -3,7 +3,7 @@ use crate::error::GatewayClientError;
 use nym_http_api_client::HickoryDnsResolver;
 use tokio::net::TcpStream;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
-use tungstenite::{error::UrlError, handshake::client::Response};
+use tungstenite::handshake::client::Response;
 use url::{Host, Url};
 
 use std::net::SocketAddr;
@@ -30,14 +30,7 @@ pub(crate) async fn connect_async(
             // Do a DNS lookup for the domain using our custom DNS resolver
             resolver
                 .resolve_str(domain)
-                .await
-                .map_err(|_| {
-                    // failed to resolve
-                    GatewayClientError::NetworkConnectionFailed {
-                        address: endpoint.to_owned(),
-                        source: UrlError::NoPathOrQuery.into(),
-                    }
-                })?
+                .await?
                 .into_iter()
                 .map(|a| SocketAddr::new(a, port))
                 .collect()

--- a/common/client-libs/gateway-client/src/client/websockets.rs
+++ b/common/client-libs/gateway-client/src/client/websockets.rs
@@ -14,12 +14,12 @@ pub(crate) async fn connect_async(
 ) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response), GatewayClientError> {
     let resolver = HickoryDnsResolver::default();
     let uri =
-        Url::parse(endpoint).map_err(|_| GatewayClientError::InvalidURL(endpoint.to_owned()))?;
+        Url::parse(endpoint).map_err(|_| GatewayClientError::InvalidUrl(endpoint.to_owned()))?;
     let port: u16 = uri.port_or_known_default().unwrap_or(443);
 
     let host = uri
         .host()
-        .ok_or(GatewayClientError::InvalidURL(endpoint.to_owned()))?;
+        .ok_or(GatewayClientError::InvalidUrl(endpoint.to_owned()))?;
 
     // Get address for tcp connection, if a domain is provided use our preferred resolver rather than
     // the default std resolve

--- a/common/client-libs/gateway-client/src/error.rs
+++ b/common/client-libs/gateway-client/src/error.rs
@@ -46,6 +46,7 @@ pub enum GatewayClientError {
     #[error("Invalid URL: {0}")]
     InvalidUrl(String),
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[error("resolution failed: {0}")]
     ResolutionFailed(#[from] nym_http_api_client::HickoryDnsError),
 

--- a/common/client-libs/gateway-client/src/error.rs
+++ b/common/client-libs/gateway-client/src/error.rs
@@ -46,6 +46,9 @@ pub enum GatewayClientError {
     #[error("Invalid URL: {0}")]
     InvalidUrl(String),
 
+    #[error("resolution failed: {0}")]
+    ResolutionFailed(#[from] nym_http_api_client::HickoryDnsError),
+
     #[error("No shared key was provided or obtained")]
     NoSharedKeyAvailable,
 

--- a/common/client-libs/gateway-client/src/error.rs
+++ b/common/client-libs/gateway-client/src/error.rs
@@ -44,7 +44,7 @@ pub enum GatewayClientError {
     NetworkConnectionFailed { address: String, source: WsError },
 
     #[error("Invalid URL: {0}")]
-    InvalidURL(String),
+    InvalidUrl(String),
 
     #[error("No shared key was provided or obtained")]
     NoSharedKeyAvailable,

--- a/common/http-api-client/Cargo.toml
+++ b/common/http-api-client/Cargo.toml
@@ -12,6 +12,8 @@ license.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+once_cell = { workspace = true }
+hickory-resolver = { workspace = true, features = ["dns-over-https-rustls", "webpki-roots"] }
 reqwest = { workspace = true, features = ["json"] }
 http.workspace = true
 url = { workspace = true }

--- a/common/http-api-client/Cargo.toml
+++ b/common/http-api-client/Cargo.toml
@@ -12,8 +12,6 @@ license.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
-once_cell = { workspace = true }
-hickory-resolver = { workspace = true, features = ["dns-over-https-rustls", "webpki-roots"] }
 reqwest = { workspace = true, features = ["json"] }
 http.workspace = true
 url = { workspace = true }

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -40,6 +40,7 @@ struct SocketAddrs {
 
 #[derive(Debug, thiserror::Error)]
 #[error("hickory-dns resolver error: {hickory_error}")]
+/// Error occurring while resolving a hostname into an IP address. 
 pub struct HickoryDnsError {
     #[from]
     hickory_error: ResolveError,

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -40,7 +40,7 @@ struct SocketAddrs {
 
 #[derive(Debug, thiserror::Error)]
 #[error("hickory-dns resolver error: {hickory_error}")]
-/// Error occurring while resolving a hostname into an IP address. 
+/// Error occurring while resolving a hostname into an IP address.
 pub struct HickoryDnsError {
     #[from]
     hickory_error: ResolveError,

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -22,7 +22,7 @@ pub use user_agent::UserAgent;
 #[cfg(not(target_arch = "wasm32"))]
 mod dns;
 #[cfg(not(target_arch = "wasm32"))]
-pub use dns::{HickoryDnsResolver, HickoryDnsError};
+pub use dns::{HickoryDnsError, HickoryDnsResolver};
 
 // The timeout is relatively high as we are often making requests over the mixnet, where latency is
 // high and chatty protocols take a while to complete.

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -3,6 +3,7 @@
 
 use async_trait::async_trait;
 use reqwest::header::HeaderValue;
+use reqwest::IntoUrl;
 use reqwest::{RequestBuilder, Response, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -23,6 +24,9 @@ pub use user_agent::UserAgent;
 mod dns;
 #[cfg(not(target_arch = "wasm32"))]
 pub use dns::HickoryDnsResolver;
+
+pub mod dns;
+use dns::HickoryDnsResolver;
 
 // The timeout is relatively high as we are often making requests over the mixnet, where latency is
 // high and chatty protocols take a while to complete.

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -22,7 +22,7 @@ pub use user_agent::UserAgent;
 #[cfg(not(target_arch = "wasm32"))]
 mod dns;
 #[cfg(not(target_arch = "wasm32"))]
-pub use dns::HickoryDnsResolver;
+pub use dns::{HickoryDnsResolver, HickoryDnsError};
 
 // The timeout is relatively high as we are often making requests over the mixnet, where latency is
 // high and chatty protocols take a while to complete.

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -3,7 +3,6 @@
 
 use async_trait::async_trait;
 use reqwest::header::HeaderValue;
-use reqwest::IntoUrl;
 use reqwest::{RequestBuilder, Response, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -24,9 +23,6 @@ pub use user_agent::UserAgent;
 mod dns;
 #[cfg(not(target_arch = "wasm32"))]
 pub use dns::HickoryDnsResolver;
-
-pub mod dns;
-use dns::HickoryDnsResolver;
 
 // The timeout is relatively high as we are often making requests over the mixnet, where latency is
 // high and chatty protocols take a while to complete.


### PR DESCRIPTION
Adjust the websocket connection establishment (using `tokio_tungstenite`) to use a custom DNS resolver that tries DoH and DoT.

instead of relying on the `tokio_tungstenite` to open the `tokio::net::TcpStream` ([which it does here](https://github.com/snapview/tokio-tungstenite/blob/aafb2f9e036162f7bffa002cfea502376a690724/src/connect.rs#L91)) which would kick in the default network resolver we do the resolution and open the `TcpStream` ourselves before handing off to the websocket libary, 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5386)
<!-- Reviewable:end -->
