### PR TITLE
Send shutdown instead of panic when reaching max fail

### DIFF
--- a/common/client-core/src/client/mix_traffic/mod.rs
+++ b/common/client-core/src/client/mix_traffic/mod.rs
@@ -121,12 +121,12 @@ impl MixTrafficController {
                                 error!("Failed to send sphinx packet(s) to the gateway: {err}");
                                 if self.consecutive_gateway_failure_count == MAX_FAILURE_COUNT {
                                     // Disconnect from the gateway. If we should try to re-connect
-                                    // is handled at the higher layer.
-                                    error!("failed to send sphinx packet to the gateway {MAX_FAILURE_COUNT} times in a row - assuming the gateway is dead");
+                                    // is handled at a higher layer.
+                                    error!("Failed to send sphinx packet to the gateway {MAX_FAILURE_COUNT} times in a row - assuming the gateway is dead");
                                     // WIP(JON): do we need to handle the embedded mixnet client
                                     // case separately?
                                     // WIP(JON): can't we use the CancellationToken here instead?
-                                    shutdown.send_we_stopped(Box::new(ClientCoreError::UnexpectedExit));
+                                    shutdown.send_we_stopped(Box::new(ClientCoreError::GatewayFailedToForwardMessages));
                                     break;
                                 }
                             }

--- a/common/client-core/src/client/mix_traffic/mod.rs
+++ b/common/client-core/src/client/mix_traffic/mod.rs
@@ -123,9 +123,8 @@ impl MixTrafficController {
                                     // Disconnect from the gateway. If we should try to re-connect
                                     // is handled at a higher layer.
                                     error!("Failed to send sphinx packet to the gateway {MAX_FAILURE_COUNT} times in a row - assuming the gateway is dead");
-                                    // WIP(JON): do we need to handle the embedded mixnet client
-                                    // case separately?
-                                    // WIP(JON): can't we use the CancellationToken here instead?
+                                    // Do we need to handle the embedded mixnet client case
+                                    // separately?
                                     shutdown.send_we_stopped(Box::new(ClientCoreError::GatewayFailedToForwardMessages));
                                     break;
                                 }

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -626,9 +626,14 @@ where
         messages: Vec<RealMessage>,
         transmission_lane: TransmissionLane,
     ) {
-        self.real_message_sender
+        if let Err(err) = self
+            .real_message_sender
             .send((messages, transmission_lane))
             .await
-            .expect("real message receiver task (OutQueueControl) has died");
+        {
+            error!(
+                "Failed to forward messages to the real message sender (OutQueueControl): {err}"
+            );
+        }
     }
 }

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -545,7 +545,7 @@ where
             loop {
                 tokio::select! {
                     biased;
-                    _ = shutdown.recv_with_delay() => {
+                    _ = shutdown.recv() => {
                         log::trace!("OutQueueControl: Received shutdown");
                         break;
                     }

--- a/common/client-core/src/error.rs
+++ b/common/client-core/src/error.rs
@@ -96,6 +96,9 @@ pub enum ClientCoreError {
     #[error("timed out while trying to establish gateway connection")]
     GatewayConnectionTimeout,
 
+    #[error("failed to forward mix messages to gateway")]
+    GatewayFailedToForwardMessages,
+
     #[error("no ping measurements for the gateway ({identity}) performed")]
     NoGatewayMeasurements { identity: String },
 


### PR DESCRIPTION
Remove a panic and an unwrap inside client-core that is hit occasionally in the vpn client

This is a change that can have wide ranging impact since it changes the task handling and it's inside client-core, which is used in many components and services, so preventing regressions is important

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5398)
<!-- Reviewable:end -->
