### PR TITLE
Relocate a validator api function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4832,6 +4832,7 @@ dependencies = [
  "ecdsa",
  "getset",
  "nym-compact-ecash",
+ "nym-config",
  "nym-contracts-common",
  "nym-credentials-interface",
  "nym-crypto",

--- a/common/client-libs/validator-client/src/nym_api/mod.rs
+++ b/common/client-libs/validator-client/src/nym_api/mod.rs
@@ -31,6 +31,7 @@ pub use nym_api_requests::{
         StakeSaturationResponse, UptimeResponse,
     },
     nym_nodes::{CachedNodesResponse, SkimmedNode},
+    NymNetworkDetailsResponse
 };
 pub use nym_coconut_dkg_common::types::EpochId;
 use nym_contracts_common::IdentityKey;
@@ -1024,6 +1025,21 @@ pub trait NymApiClientExt: ApiClient {
                 expiration_date,
                 deposits,
             },
+        )
+        .await
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    async fn get_network_details(
+        &self,
+    ) -> Result<NymNetworkDetailsResponse, NymAPIError> {
+        self.get_json(
+            &[
+                routes::API_VERSION,
+                routes::NETWORK,
+                routes::DETAILS,
+            ],
+            NO_PARAMS,
         )
         .await
     }

--- a/common/client-libs/validator-client/src/nym_api/mod.rs
+++ b/common/client-libs/validator-client/src/nym_api/mod.rs
@@ -31,7 +31,7 @@ pub use nym_api_requests::{
         StakeSaturationResponse, UptimeResponse,
     },
     nym_nodes::{CachedNodesResponse, SkimmedNode},
-    NymNetworkDetailsResponse
+    NymNetworkDetailsResponse,
 };
 pub use nym_coconut_dkg_common::types::EpochId;
 use nym_contracts_common::IdentityKey;
@@ -1030,15 +1030,9 @@ pub trait NymApiClientExt: ApiClient {
     }
 
     #[instrument(level = "debug", skip(self))]
-    async fn get_network_details(
-        &self,
-    ) -> Result<NymNetworkDetailsResponse, NymAPIError> {
+    async fn get_network_details(&self) -> Result<NymNetworkDetailsResponse, NymAPIError> {
         self.get_json(
-            &[
-                routes::API_VERSION,
-                routes::NETWORK,
-                routes::DETAILS,
-            ],
+            &[routes::API_VERSION, routes::NETWORK, routes::DETAILS],
             NO_PARAMS,
         )
         .await

--- a/common/client-libs/validator-client/src/nym_api/routes.rs
+++ b/common/client-libs/validator-client/src/nym_api/routes.rs
@@ -67,6 +67,9 @@ pub const STAKE_SATURATION: &str = "stake-saturation";
 pub const INCLUSION_CHANCE: &str = "inclusion-probability";
 pub const SUBMIT_GATEWAY: &str = "submit-gateway-monitoring-results";
 pub const SUBMIT_NODE: &str = "submit-node-monitoring-results";
-pub const PERFORMANCE: &str = "performance";
+
 
 pub const SERVICE_PROVIDERS: &str = "services";
+
+pub const DETAILS: &str = "details";
+pub const NETWORK: &str = "network";

--- a/common/client-libs/validator-client/src/nym_api/routes.rs
+++ b/common/client-libs/validator-client/src/nym_api/routes.rs
@@ -68,7 +68,6 @@ pub const INCLUSION_CHANCE: &str = "inclusion-probability";
 pub const SUBMIT_GATEWAY: &str = "submit-gateway-monitoring-results";
 pub const SUBMIT_NODE: &str = "submit-node-monitoring-results";
 
-
 pub const SERVICE_PROVIDERS: &str = "services";
 
 pub const DETAILS: &str = "details";

--- a/nym-api/nym-api-requests/Cargo.toml
+++ b/nym-api/nym-api-requests/Cargo.toml
@@ -28,6 +28,7 @@ nym-serde-helpers = { path = "../../common/serde-helpers", features = ["bs58", "
 nym-credentials-interface = { path = "../../common/credentials-interface" }
 nym-crypto = { path = "../../common/crypto", features = ["serde", "asymmetric"] }
 
+nym-config = { path = "../../common/config" }
 nym-ecash-time = { path = "../../common/ecash-time" }
 nym-compact-ecash = { path = "../../common/nym_offline_compact_ecash" }
 nym-contracts-common = { path = "../../common/cosmwasm-smart-contracts/contracts-common", features = ["naive_float"] }

--- a/nym-api/nym-api-requests/src/lib.rs
+++ b/nym-api/nym-api-requests/src/lib.rs
@@ -12,6 +12,12 @@ pub mod models;
 pub mod nym_nodes;
 pub mod pagination;
 
+// The response type we fetch from the network details endpoint.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NymNetworkDetailsResponse {
+    pub network: nym_config::defaults::NymNetworkDetails,
+}
+
 pub trait Deprecatable {
     fn deprecate(self) -> Deprecated<Self>
     where


### PR DESCRIPTION
Adds a function to the `nym-validator-client` crate that hits the network details endpont and returns an object parsed from json. This was floating loose in the `nym-vpn-client` repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5401)
<!-- Reviewable:end -->
