### PR TITLE
Dz nym node stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6300,7 +6300,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node-status-api"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6312,6 +6312,7 @@ dependencies = [
  "futures-util",
  "moka",
  "nym-bin-common",
+ "nym-contracts-common",
  "nym-crypto",
  "nym-explorer-client",
  "nym-network-defaults",

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -768,7 +768,7 @@ where
     E: DeserializeOwned + Display,
 {
     let status = res.status();
-    tracing::debug!("Status: {} (success: {})", &status, status.is_success());
+    tracing::trace!("Status: {} (success: {})", &status, status.is_success());
 
     if !allow_empty {
         if let Some(0) = res.content_length() {

--- a/nym-api/nym-api-requests/src/nym_nodes.rs
+++ b/nym-api/nym-api-requests/src/nym_nodes.rs
@@ -72,9 +72,7 @@ pub enum NodeRoleQueryParam {
     ExitGateway,
 }
 
-#[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, schemars::JsonSchema, ToSchema, Default,
-)]
+#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema, ToSchema, Default)]
 pub enum NodeRole {
     // a properly active mixnode
     Mixnode {

--- a/nym-api/nym-api-requests/src/nym_nodes.rs
+++ b/nym-api/nym-api-requests/src/nym_nodes.rs
@@ -72,7 +72,9 @@ pub enum NodeRoleQueryParam {
     ExitGateway,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema, ToSchema, Default)]
+#[derive(
+    Clone, Debug, PartialEq, Serialize, Deserialize, schemars::JsonSchema, ToSchema, Default,
+)]
 pub enum NodeRole {
     // a properly active mixnode
     Mixnode {

--- a/nym-node-status-api/.gitignore
+++ b/nym-node-status-api/.gitignore
@@ -1,6 +1,7 @@
 nym-node-status-agent/nym-gateway-probe
 nym-node-status-agent/keys/
 data/
+settings.sql
 enter_db.sh
 nym-gateway-probe
 *.sqlite

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -22,6 +22,7 @@ cosmwasm-std = { workspace = true }
 envy = { workspace = true }
 futures-util = { workspace = true }
 moka = { workspace = true, features = ["future"] }
+nym-contracts-common = { path = "../../common/cosmwasm-smart-contracts/contracts-common" }
 nym-bin-common = { path = "../../common/bin-common", features = ["models"] }
 nym-node-status-client = { path = "../nym-node-status-client" }
 nym-crypto = { path = "../../common/crypto", features = ["asymmetric", "serde"] }

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -40,7 +40,7 @@ serde_json = { workspace = true }
 serde_json_path = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite", "time", "json"] }
+sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite", "time"] }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
@@ -51,10 +51,6 @@ tracing-log = { workspace = true }
 tower-http = { workspace = true, features = ["cors", "trace"] }
 utoipa = { workspace = true, features = ["axum_extras", "time"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
-# TODO dz `cargo update async-trait`
-# for automatic schema detection, which was merged, but not released yet
-# https://github.com/ProbablyClem/utoipauto/pull/38
-# utoipauto = { git = "https://github.com/ProbablyClem/utoipauto", rev = "eb04cba" }
 utoipauto = { workspace = true }
 
 nym-node-metrics = { path = "../../nym-node/nym-node-metrics" }

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-node-status-api"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -40,7 +40,7 @@ serde_json = { workspace = true }
 serde_json_path = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite", "time"] }
+sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite", "time", "json"] }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/nym-node-status-api/nym-node-status-api/launch_node_status_api.sh
+++ b/nym-node-status-api/nym-node-status-api/launch_node_status_api.sh
@@ -3,15 +3,18 @@
 set -e
 
 user_rust_log_preference=$RUST_LOG
+export ENVIRONMENT=${ENVIRONMENT:-"sandbox"}
 export NYM_API_CLIENT_TIMEOUT=60
 export EXPLORER_CLIENT_TIMEOUT=60
 export NODE_STATUS_API_TESTRUN_REFRESH_INTERVAL=120
 
+if [ "$ENVIRONMENT" = "mainnet" ]; then
+    export NYM_NODE_STATUS_API_HM_URL="https://harbourmaster.nymtech.net"
+fi
+
 # public counterpart of the agent's private key.
 # For TESTING only. NOT used in any other environment
 export NODE_STATUS_API_AGENT_KEY_LIST="H4z8kx5Kkf5JMQHhxaW1MwYndjKCDHC7HsVhHTFfBZ4J"
-
-export ENVIRONMENT=${ENVIRONMENT:-"sandbox"}
 
 script_dir=$(dirname $(realpath "$0"))
 monorepo_root=$(realpath "${script_dir}/../..")

--- a/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
+++ b/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
@@ -5,6 +5,7 @@ CREATE TABLE nym_nodes (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     node_id INTEGER NOT NULL UNIQUE,
     ed25519_identity_pubkey VARCHAR NOT NULL UNIQUE,
+    total_stake INTEGER NOT NULL,
     ip_addresses TEXT NOT NULL,
     mix_port INTEGER NOT NULL,
     x25519_sphinx_pubkey VARCHAR NOT NULL UNIQUE,
@@ -44,6 +45,7 @@ CREATE INDEX idx_nym_nodes_packet_stats_raw_node_id_timestamp_utc ON nym_nodes_p
 CREATE TABLE nym_node_daily_mixing_stats (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     node_id INTEGER NOT NULL,
+    total_stake BIGINT NOT NULL,
     date_utc VARCHAR NOT NULL,
     packets_received INTEGER DEFAULT 0,
     packets_sent INTEGER DEFAULT 0,

--- a/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
+++ b/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
@@ -1,2 +1,19 @@
 ALTER TABLE mixnodes DROP COLUMN blacklisted;
 ALTER TABLE gateways DROP COLUMN blacklisted;
+
+CREATE TABLE nym_nodes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id INTEGER NOT NULL UNIQUE,
+    ed25519_identity_pubkey VARCHAR NOT NULL UNIQUE,
+    ip_addresses VARCHAR,
+    mix_port INTEGER NOT NULL,
+    x25519_sphinx_pubkey VARCHAR NOT NULL UNIQUE,
+    node_role VARCHAR NOT NULL,
+    supported_roles VARCHAR NOT NULL,
+    performance VARCHAR NOT NULL,
+    entry VARCHAR,
+    last_updated_utc INTEGER NOT NULL
+);
+
+CREATE INDEX idx_nym_nodes_mix_id ON mixnodes (mix_id);
+CREATE INDEX idx_nym_nodes_identity_key ON mixnodes (identity_key);

--- a/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
+++ b/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
@@ -2,8 +2,7 @@ ALTER TABLE mixnodes DROP COLUMN blacklisted;
 ALTER TABLE gateways DROP COLUMN blacklisted;
 
 CREATE TABLE nym_nodes (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    node_id INTEGER NOT NULL UNIQUE,
+    node_id INTEGER PRIMARY KEY,
     ed25519_identity_pubkey VARCHAR NOT NULL UNIQUE,
     total_stake INTEGER NOT NULL,
     ip_addresses TEXT NOT NULL,

--- a/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
+++ b/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
@@ -40,3 +40,15 @@ CREATE TABLE nym_nodes_packet_stats_raw (
   );
 
 CREATE INDEX idx_nym_nodes_packet_stats_raw_node_id_timestamp_utc ON nym_nodes_packet_stats_raw (node_id, timestamp_utc);
+
+CREATE TABLE
+  nym_node_daily_mixing_stats (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id INTEGER NOT NULL,
+    date_utc VARCHAR NOT NULL,
+    packets_received INTEGER DEFAULT 0,
+    packets_sent INTEGER DEFAULT 0,
+    packets_dropped INTEGER DEFAULT 0,
+    FOREIGN KEY (node_id) REFERENCES nym_nodes (node_id),
+    UNIQUE (node_id, date_utc) -- This constraint automatically creates an index
+  );

--- a/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
+++ b/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mixnodes DROP COLUMN blacklisted;

--- a/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
+++ b/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
@@ -1,1 +1,2 @@
 ALTER TABLE mixnodes DROP COLUMN blacklisted;
+ALTER TABLE gateways DROP COLUMN blacklisted;

--- a/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
+++ b/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
@@ -5,15 +5,38 @@ CREATE TABLE nym_nodes (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     node_id INTEGER NOT NULL UNIQUE,
     ed25519_identity_pubkey VARCHAR NOT NULL UNIQUE,
-    ip_addresses VARCHAR,
+    ip_addresses TEXT NOT NULL,
     mix_port INTEGER NOT NULL,
     x25519_sphinx_pubkey VARCHAR NOT NULL UNIQUE,
-    node_role VARCHAR NOT NULL,
-    supported_roles VARCHAR NOT NULL,
+    node_role TEXT NOT NULL,
+    supported_roles TEXT NOT NULL,
     performance VARCHAR NOT NULL,
-    entry VARCHAR,
+    entry TEXT,
     last_updated_utc INTEGER NOT NULL
 );
 
 CREATE INDEX idx_nym_nodes_mix_id ON mixnodes (mix_id);
 CREATE INDEX idx_nym_nodes_identity_key ON mixnodes (identity_key);
+
+CREATE TABLE nym_node_descriptions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id INTEGER UNIQUE NOT NULL,
+    moniker VARCHAR,
+    website VARCHAR,
+    security_contact VARCHAR,
+    details VARCHAR,
+    last_updated_utc INTEGER NOT NULL,
+    FOREIGN KEY (node_id) REFERENCES nym_nodes (node_id)
+);
+
+CREATE TABLE nym_nodes_packet_stats_raw (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id INTEGER NOT NULL,
+    timestamp_utc INTEGER NOT NULL,
+    packets_received INTEGER,
+    packets_sent INTEGER,
+    packets_dropped INTEGER,
+    FOREIGN KEY (node_id) REFERENCES nym_nodes (node_id)
+  );
+
+CREATE INDEX idx_nym_nodes_packet_stats_raw_node_id_timestamp_utc ON nym_nodes_packet_stats_raw (node_id, timestamp_utc);

--- a/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
+++ b/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
@@ -37,12 +37,11 @@ CREATE TABLE nym_nodes_packet_stats_raw (
     packets_sent INTEGER,
     packets_dropped INTEGER,
     FOREIGN KEY (node_id) REFERENCES nym_nodes (node_id)
-  );
+);
 
 CREATE INDEX idx_nym_nodes_packet_stats_raw_node_id_timestamp_utc ON nym_nodes_packet_stats_raw (node_id, timestamp_utc);
 
-CREATE TABLE
-  nym_node_daily_mixing_stats (
+CREATE TABLE nym_node_daily_mixing_stats (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     node_id INTEGER NOT NULL,
     date_utc VARCHAR NOT NULL,
@@ -51,4 +50,4 @@ CREATE TABLE
     packets_dropped INTEGER DEFAULT 0,
     FOREIGN KEY (node_id) REFERENCES nym_nodes (node_id),
     UNIQUE (node_id, date_utc) -- This constraint automatically creates an index
-  );
+);

--- a/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
+++ b/nym-node-status-api/nym-node-status-api/migrations/004_obsolete_fields.sql
@@ -16,8 +16,8 @@ CREATE TABLE nym_nodes (
     last_updated_utc INTEGER NOT NULL
 );
 
-CREATE INDEX idx_nym_nodes_mix_id ON mixnodes (mix_id);
-CREATE INDEX idx_nym_nodes_identity_key ON mixnodes (identity_key);
+CREATE INDEX idx_nym_nodes_node_id ON nym_nodes (node_id);
+CREATE INDEX idx_nym_nodes_ed25519_identity_pubkey ON nym_nodes (ed25519_identity_pubkey);
 
 CREATE TABLE nym_node_descriptions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/nym-node-status-api/nym-node-status-api/src/cli/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/cli/mod.rs
@@ -83,6 +83,9 @@ pub(crate) struct Cli {
         env = "NYM_NODE_STATUS_API_MAX_AGENT_COUNT"
     )]
     pub(crate) max_agent_count: i64,
+
+    #[clap(long, default_value = "", env = "NYM_NODE_STATUS_API_HM_URL")]
+    pub(crate) hm_url: String,
 }
 
 fn parse_duration(arg: &str) -> Result<std::time::Duration, std::num::ParseIntError> {

--- a/nym-node-status-api/nym-node-status-api/src/db/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/models.rs
@@ -427,7 +427,7 @@ impl TryFrom<SkimmedNode> for NymNodeInsertRecord {
             mix_port: other.mix_port as i64,
             x25519_sphinx_pubkey: other.x25519_sphinx_pubkey.to_base58_string(),
             node_role: serde_json::to_value(&other.role)?,
-            supported_roles: serde_json::to_value(&other.supported_roles)?,
+            supported_roles: serde_json::to_value(other.supported_roles)?,
             performance: other.performance.value().to_string(),
             entry: match other.entry {
                 Some(entry) => Some(serde_json::to_value(entry)?),
@@ -472,4 +472,11 @@ impl TryFrom<NymNodeDto> for SkimmedNode {
 
         Ok(skimmed_node)
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, sqlx::Decode)]
+pub struct NodeStats {
+    pub packets_received: i64,
+    pub packets_sent: i64,
+    pub packets_dropped: i64,
 }

--- a/nym-node-status-api/nym-node-status-api/src/db/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/models.rs
@@ -109,7 +109,6 @@ pub(crate) struct MixnodeRecord {
     pub(crate) total_stake: i64,
     pub(crate) host: String,
     pub(crate) http_port: u16,
-    pub(crate) blacklisted: bool,
     pub(crate) full_details: String,
     pub(crate) self_described: Option<String>,
     pub(crate) last_updated_utc: i64,
@@ -120,7 +119,6 @@ pub(crate) struct MixnodeRecord {
 pub(crate) struct MixnodeDto {
     pub(crate) mix_id: i64,
     pub(crate) bonded: bool,
-    pub(crate) blacklisted: bool,
     pub(crate) is_dp_delegatee: bool,
     pub(crate) total_stake: i64,
     pub(crate) full_details: String,
@@ -147,7 +145,6 @@ impl TryFrom<MixnodeDto> for http::models::Mixnode {
 
         let last_updated_utc =
             timestamp_as_utc(value.last_updated_utc.cast_checked()?).to_rfc3339();
-        let blacklisted = value.blacklisted;
         let is_dp_delegatee = value.is_dp_delegatee;
         let moniker = value.moniker.clone();
         let website = value.website.clone();
@@ -157,7 +154,6 @@ impl TryFrom<MixnodeDto> for http::models::Mixnode {
         Ok(http::models::Mixnode {
             mix_id,
             bonded: value.bonded,
-            blacklisted,
             is_dp_delegatee,
             total_stake: value.total_stake,
             full_details,
@@ -213,12 +209,6 @@ impl TryFrom<SummaryHistoryDto> for SummaryHistory {
 
 pub(crate) const MIXNODES_BONDED_COUNT: &str = "mixnodes.bonded.count";
 pub(crate) const MIXNODES_BONDED_ACTIVE: &str = "mixnodes.bonded.active";
-pub(crate) const MIXNODES_BONDED_INACTIVE: &str = "mixnodes.bonded.inactive";
-pub(crate) const MIXNODES_BONDED_RESERVE: &str = "mixnodes.bonded.reserve";
-pub(crate) const MIXNODES_BLACKLISTED_COUNT: &str = "mixnodes.blacklisted.count";
-
-pub(crate) const GATEWAYS_BONDED_COUNT: &str = "gateways.bonded.count";
-pub(crate) const GATEWAYS_BLACKLISTED_COUNT: &str = "gateways.blacklisted.count";
 
 pub(crate) const MIXNODES_HISTORICAL_COUNT: &str = "mixnodes.historical.count";
 pub(crate) const GATEWAYS_HISTORICAL_COUNT: &str = "gateways.historical.count";
@@ -240,7 +230,6 @@ pub(crate) mod mixnode {
     #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
     pub(crate) struct MixnodeSummary {
         pub(crate) bonded: MixnodeSummaryBonded,
-        pub(crate) blacklisted: MixnodeSummaryBlacklisted,
         pub(crate) historical: MixnodeSummaryHistorical,
     }
 
@@ -248,14 +237,6 @@ pub(crate) mod mixnode {
     pub(crate) struct MixnodeSummaryBonded {
         pub(crate) count: i32,
         pub(crate) active: i32,
-        pub(crate) inactive: i32,
-        pub(crate) reserve: i32,
-        pub(crate) last_updated_utc: String,
-    }
-
-    #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
-    pub(crate) struct MixnodeSummaryBlacklisted {
-        pub(crate) count: i32,
         pub(crate) last_updated_utc: String,
     }
 
@@ -272,14 +253,7 @@ pub(crate) mod gateway {
     #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
     pub(crate) struct GatewaySummary {
         pub(crate) bonded: GatewaySummaryBonded,
-        pub(crate) blacklisted: GatewaySummaryBlacklisted,
         pub(crate) historical: GatewaySummaryHistorical,
-    }
-
-    #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
-    pub(crate) struct GatewaySummaryExplorer {
-        pub(crate) count: i32,
-        pub(crate) last_updated_utc: String,
     }
 
     #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
@@ -290,12 +264,6 @@ pub(crate) mod gateway {
 
     #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
     pub(crate) struct GatewaySummaryHistorical {
-        pub(crate) count: i32,
-        pub(crate) last_updated_utc: String,
-    }
-
-    #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
-    pub(crate) struct GatewaySummaryBlacklisted {
         pub(crate) count: i32,
         pub(crate) last_updated_utc: String,
     }

--- a/nym-node-status-api/nym-node-status-api/src/db/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/models.rs
@@ -210,22 +210,27 @@ impl TryFrom<SummaryHistoryDto> for SummaryHistory {
     }
 }
 
-pub(crate) const MIXNODES_LEGACY_COUNT: &str = "legacy.mixnodes.count";
+pub(crate) const MIXNODES_LEGACY_COUNT: &str = "mixnodes.legacy.count";
+pub(crate) const NYMNODES_DESCRIBED_COUNT: &str = "nymnode.described.count";
 
-pub(crate) const MIXNODES_BONDED_COUNT: &str = "mixnodes.bonded.count";
-pub(crate) const MIXNODES_BONDED_ACTIVE: &str = "mixnodes.bonded.active";
+pub(crate) const NYMNODE_COUNT: &str = "nymnode.total.count";
+pub(crate) const ASSIGNED_ENTRY_COUNT: &str = "assigned.entry.count";
+pub(crate) const ASSIGNED_EXIT_COUNT: &str = "assigned.exit.count";
+pub(crate) const ASSIGNED_MIXING_COUNT: &str = "assigned.mixing.count";
+
 pub(crate) const GATEWAYS_BONDED_COUNT: &str = "gateways.bonded.count";
 
 pub(crate) const MIXNODES_HISTORICAL_COUNT: &str = "mixnodes.historical.count";
 pub(crate) const GATEWAYS_HISTORICAL_COUNT: &str = "gateways.historical.count";
 
-// `utoipa`` goes crazy if you use module-qualified prefix as field type so we
+// `utoipa` goes crazy if you use module-qualified prefix as field type so we
 //  have to import it
 use gateway::GatewaySummary;
 use mixnode::MixnodeSummary;
 
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub(crate) struct NetworkSummary {
+    pub(crate) total_nodes: i32,
     pub(crate) mixnodes: MixnodeSummary,
     pub(crate) gateways: GatewaySummary,
 }
@@ -235,14 +240,14 @@ pub(crate) mod mixnode {
 
     #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
     pub(crate) struct MixnodeSummary {
-        pub(crate) bonded: MixnodeSummaryBonded,
+        pub(crate) bonded: MixingNodesSummary,
         pub(crate) historical: MixnodeSummaryHistorical,
     }
 
     #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
-    pub(crate) struct MixnodeSummaryBonded {
+    pub(crate) struct MixingNodesSummary {
         pub(crate) count: i32,
-        pub(crate) active: i32,
+        pub(crate) self_described: i32,
         pub(crate) legacy: i32,
         pub(crate) last_updated_utc: String,
     }
@@ -260,12 +265,15 @@ pub(crate) mod gateway {
     #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
     pub(crate) struct GatewaySummary {
         pub(crate) bonded: GatewaySummaryBonded,
+
         pub(crate) historical: GatewaySummaryHistorical,
     }
 
     #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
     pub(crate) struct GatewaySummaryBonded {
         pub(crate) count: i32,
+        pub(crate) entry: i32,
+        pub(crate) exit: i32,
         pub(crate) last_updated_utc: String,
     }
 

--- a/nym-node-status-api/nym-node-status-api/src/db/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/models.rs
@@ -360,14 +360,14 @@ impl TryFrom<GatewaySessionsRecord> for http::models::SessionStats {
     }
 }
 
-pub(crate) enum NodeKind {
+pub(crate) enum MixingNodeKind {
     LegacyMixnode,
     NymNode,
 }
 
 pub(crate) struct ScraperNodeInfo {
     pub node_id: i64,
-    pub node_kind: NodeKind,
+    pub node_kind: MixingNodeKind,
     pub hosts: Vec<String>,
     pub http_api_port: i64,
 }
@@ -409,8 +409,6 @@ pub(crate) struct NymNodeDto {
 
 #[derive(Debug)]
 pub(crate) struct NymNodeInsertRecord {
-    #[allow(dead_code)]
-    pub id: i64,
     pub node_id: i64,
     pub ed25519_identity_pubkey: String,
     pub total_stake: i64,
@@ -429,7 +427,6 @@ impl NymNodeInsertRecord {
         let now = OffsetDateTime::now_utc().to_string();
 
         let record = Self {
-            id: Default::default(),
             node_id: skimmed_node.node_id.into(),
             ed25519_identity_pubkey: skimmed_node.ed25519_identity_pubkey.to_base58_string(),
             total_stake,

--- a/nym-node-status-api/nym-node-status-api/src/db/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/models.rs
@@ -12,7 +12,6 @@ use utoipa::ToSchema;
 pub(crate) struct GatewayRecord {
     pub(crate) identity_key: String,
     pub(crate) bonded: bool,
-    pub(crate) blacklisted: bool,
     pub(crate) self_described: String,
     // TODO dz shouldn't be an option
     pub(crate) explorer_pretty_bond: Option<String>,
@@ -24,7 +23,6 @@ pub(crate) struct GatewayRecord {
 pub(crate) struct GatewayDto {
     pub(crate) gateway_identity_key: String,
     pub(crate) bonded: bool,
-    pub(crate) blacklisted: bool,
     pub(crate) performance: i64,
     pub(crate) self_described: Option<String>,
     pub(crate) explorer_pretty_bond: Option<String>,
@@ -69,7 +67,6 @@ impl TryFrom<GatewayDto> for http::models::Gateway {
         let last_probe_result = serde_json::from_str(&last_probe_result).unwrap_or(None);
 
         let bonded = value.bonded;
-        let blacklisted = value.blacklisted;
         let performance = value.performance as u8;
 
         let description = NodeDescription {
@@ -82,7 +79,6 @@ impl TryFrom<GatewayDto> for http::models::Gateway {
         Ok(http::models::Gateway {
             gateway_identity_key: value.gateway_identity_key.clone(),
             bonded,
-            blacklisted,
             performance,
             self_described,
             explorer_pretty_bond,

--- a/nym-node-status-api/nym-node-status-api/src/db/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/models.rs
@@ -1,9 +1,10 @@
+use std::str::FromStr;
+
 use crate::{
     http::{self, models::SummaryHistory},
     monitor::NumericalCheckedCast,
 };
 use anyhow::Context;
-use cosmwasm_std::Decimal;
 use nym_contracts_common::Percent;
 use nym_crypto::asymmetric::{ed25519, x25519};
 use nym_network_defaults::DEFAULT_NYM_NODE_HTTP_PORT;
@@ -351,8 +352,14 @@ impl TryFrom<GatewaySessionsRecord> for http::models::SessionStats {
     }
 }
 
+pub(crate) enum NodeKind {
+    LegacyMixnode,
+    NymNode,
+}
+
 pub(crate) struct ScraperNodeInfo {
     pub node_id: i64,
+    pub node_kind: NodeKind,
     pub hosts: Vec<String>,
     pub http_api_port: i64,
 }
@@ -381,26 +388,28 @@ impl ScraperNodeInfo {
 pub(crate) struct NymNodeDto {
     pub node_id: i64,
     pub ed25519_identity_pubkey: String,
-    pub ip_addresses: String,
+    pub ip_addresses: serde_json::Value,
     pub mix_port: i64,
     pub x25519_sphinx_pubkey: String,
-    pub node_role: String,
-    pub supported_roles: String,
-    pub entry: Option<String>,
+    pub node_role: serde_json::Value,
+    pub supported_roles: serde_json::Value,
+    pub entry: Option<serde_json::Value>,
     pub performance: String,
 }
 
+#[derive(Debug)]
 pub(crate) struct NymNodeInsertRecord {
     #[allow(dead_code)]
     pub id: i64,
     pub node_id: i64,
     pub ed25519_identity_pubkey: String,
-    pub ip_addresses_serialized: String,
+    pub ip_addresses: serde_json::Value,
     pub mix_port: i64,
     pub x25519_sphinx_pubkey: String,
-    pub node_role: String,
-    pub supported_roles_serialized: String,
+    pub node_role: serde_json::Value,
+    pub supported_roles: serde_json::Value,
     pub performance: String,
+    pub entry: Option<serde_json::Value>,
     pub last_updated_utc: String,
 }
 
@@ -409,16 +418,21 @@ impl TryFrom<SkimmedNode> for NymNodeInsertRecord {
 
     fn try_from(other: SkimmedNode) -> Result<Self, Self::Error> {
         let now = OffsetDateTime::now_utc().to_string();
+
         let record = Self {
             id: Default::default(),
             node_id: other.node_id.into(),
             ed25519_identity_pubkey: other.ed25519_identity_pubkey.to_base58_string(),
-            ip_addresses_serialized: serde_json::to_string(&other.ip_addresses)?,
+            ip_addresses: serde_json::to_value(&other.ip_addresses)?,
             mix_port: other.mix_port as i64,
             x25519_sphinx_pubkey: other.x25519_sphinx_pubkey.to_base58_string(),
-            node_role: serde_json::to_string(&other.role)?,
-            supported_roles_serialized: serde_json::to_string(&other.supported_roles)?,
+            node_role: serde_json::to_value(&other.role)?,
+            supported_roles: serde_json::to_value(&other.supported_roles)?,
             performance: other.performance.value().to_string(),
+            entry: match other.entry {
+                Some(entry) => Some(serde_json::to_value(entry)?),
+                None => None,
+            },
             last_updated_utc: now,
         };
 
@@ -431,11 +445,12 @@ impl TryFrom<NymNodeDto> for SkimmedNode {
 
     fn try_from(other: NymNodeDto) -> Result<Self, Self::Error> {
         let node_id = u32::try_from(other.node_id).context("Invalid node_id in DB")?;
-        let supported_roles = serde_json::from_str(&other.supported_roles)?;
-        let node_role = serde_json::from_str(&other.node_role)?;
-        let ip_addresses = serde_json::from_str(&other.ip_addresses)?;
+        let supported_roles =
+            serde_json::from_value(other.supported_roles).context("supported_roles")?;
+        let node_role = serde_json::from_value(other.node_role).context("node_role")?;
+        let ip_addresses = serde_json::from_value(other.ip_addresses).context("ip_addresses")?;
         let entry = match other.entry {
-            Some(raw) => Some(serde_json::from_str(&raw)?),
+            Some(raw) => Some(serde_json::from_value(raw).context("entry")?),
             None => None,
         };
 
@@ -443,16 +458,16 @@ impl TryFrom<NymNodeDto> for SkimmedNode {
             node_id,
             ed25519_identity_pubkey: ed25519::PublicKey::from_base58_string(
                 other.ed25519_identity_pubkey,
-            )?,
+            )
+            .context("ed25519_identity_pubkey")?,
             ip_addresses,
             mix_port: other.mix_port.try_into()?,
-            x25519_sphinx_pubkey: x25519::PublicKey::from_base58_string(
-                other.x25519_sphinx_pubkey,
-            )?,
+            x25519_sphinx_pubkey: x25519::PublicKey::from_base58_string(other.x25519_sphinx_pubkey)
+                .context("x25519_sphinx_pubkey")?,
             role: node_role,
             supported_roles,
             entry,
-            performance: Percent::new(Decimal::raw(other.performance.parse::<u128>()?))?,
+            performance: Percent::from_str(&other.performance).context("can't parse Percent")?,
         };
 
         Ok(skimmed_node)

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/gateways.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/gateways.rs
@@ -37,20 +37,18 @@ pub(crate) async fn insert_gateways(
     for record in gateways {
         sqlx::query!(
             "INSERT INTO gateways
-                (gateway_identity_key, bonded, blacklisted,
+                (gateway_identity_key, bonded,
                     self_described, explorer_pretty_bond,
                     last_updated_utc, performance)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?)
                 ON CONFLICT(gateway_identity_key) DO UPDATE SET
                 bonded=excluded.bonded,
-                blacklisted=excluded.blacklisted,
                 self_described=excluded.self_described,
                 explorer_pretty_bond=excluded.explorer_pretty_bond,
                 last_updated_utc=excluded.last_updated_utc,
                 performance = excluded.performance;",
             record.identity_key,
             record.bonded,
-            record.blacklisted,
             record.self_described,
             record.explorer_pretty_bond,
             record.last_updated_utc,
@@ -124,7 +122,6 @@ pub(crate) async fn get_all_gateways(pool: &DbPool) -> anyhow::Result<Vec<Gatewa
         r#"SELECT
             gw.gateway_identity_key as "gateway_identity_key!",
             gw.bonded as "bonded: bool",
-            gw.blacklisted as "blacklisted: bool",
             gw.performance as "performance!",
         gw.self_described as "self_described?",
             gw.explorer_pretty_bond as "explorer_pretty_bond?",

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/gateways.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/gateways.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::{
-        models::{BondedStatusDto, GatewayDto, GatewayRecord},
+        models::{GatewayDto, GatewayRecord},
         DbPool,
     },
     http::models::Gateway,
@@ -58,28 +58,6 @@ pub(crate) async fn insert_gateways(
     }
 
     Ok(())
-}
-
-async fn get_all_bonded_gateways_row_ids_by_status(
-    pool: &DbPool,
-    status: bool,
-) -> anyhow::Result<Vec<BondedStatusDto>> {
-    let mut conn = pool.acquire().await?;
-    let items = sqlx::query_as!(
-        BondedStatusDto,
-        r#"SELECT
-            id as "id!",
-            gateway_identity_key as "identity_key!",
-            bonded as "bonded: bool"
-         FROM gateways
-         WHERE bonded = ?"#,
-        status,
-    )
-    .fetch(&mut *conn)
-    .try_collect::<Vec<_>>()
-    .await?;
-
-    Ok(items)
 }
 
 pub(crate) async fn get_all_gateways(pool: &DbPool) -> anyhow::Result<Vec<Gateway>> {

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/gateways.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/gateways.rs
@@ -63,28 +63,6 @@ pub(crate) async fn insert_gateways(
     Ok(())
 }
 
-pub(crate) async fn write_blacklisted_gateways_to_db<'a, I>(
-    pool: &DbPool,
-    gateways: I,
-) -> anyhow::Result<()>
-where
-    I: Iterator<Item = &'a String>,
-{
-    let mut conn = pool.acquire().await?;
-    for gateway_identity_key in gateways {
-        sqlx::query!(
-            "UPDATE gateways
-             SET blacklisted = true
-             WHERE gateway_identity_key = ?;",
-            gateway_identity_key,
-        )
-        .execute(&mut *conn)
-        .await?;
-    }
-
-    Ok(())
-}
-
 /// Ensure all gateways that are set as bonded, are still bonded
 pub(crate) async fn ensure_gateways_still_bonded(
     pool: &DbPool,

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/gateways.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/gateways.rs
@@ -90,7 +90,7 @@ pub(crate) async fn get_all_gateways(pool: &DbPool) -> anyhow::Result<Vec<Gatewa
             gw.gateway_identity_key as "gateway_identity_key!",
             gw.bonded as "bonded: bool",
             gw.performance as "performance!",
-        gw.self_described as "self_described?",
+            gw.self_described as "self_described?",
             gw.explorer_pretty_bond as "explorer_pretty_bond?",
             gw.last_probe_result as "last_probe_result?",
             gw.last_probe_log as "last_probe_log?",

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/misc.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/misc.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 /// `daily_summary`
 pub(crate) async fn insert_summaries(
     pool: &DbPool,
-    summaries: &[(&str, &usize)],
+    summaries: &[(&str, usize)],
     summary: &NetworkSummary,
     last_updated: DateTime<Utc>,
 ) -> anyhow::Result<()> {
@@ -18,7 +18,7 @@ pub(crate) async fn insert_summaries(
 
 async fn insert_summary(
     pool: &DbPool,
-    summaries: &[(&str, &usize)],
+    summaries: &[(&str, usize)],
     last_updated: DateTime<Utc>,
 ) -> anyhow::Result<()> {
     let timestamp = last_updated.timestamp();

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/mixnodes.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/mixnodes.rs
@@ -3,7 +3,7 @@ use tracing::error;
 
 use crate::{
     db::{
-        models::{BondedStatusDto, MixnodeDto, MixnodeRecord},
+        models::{MixnodeDto, MixnodeRecord},
         DbPool,
     },
     http::models::{DailyStats, Mixnode},
@@ -114,28 +114,6 @@ pub(crate) async fn get_daily_stats(pool: &DbPool) -> anyhow::Result<Vec<DailySt
     )
     .fetch(&mut *conn)
     .try_collect::<Vec<DailyStats>>()
-    .await?;
-
-    Ok(items)
-}
-
-async fn get_all_bonded_mixnodes_row_ids_by_status(
-    pool: &DbPool,
-    status: bool,
-) -> anyhow::Result<Vec<BondedStatusDto>> {
-    let mut conn = pool.acquire().await?;
-    let items = sqlx::query_as!(
-        BondedStatusDto,
-        r#"SELECT
-            id as "id!",
-            identity_key as "identity_key!",
-            bonded as "bonded: bool"
-         FROM mixnodes
-         WHERE bonded = ?"#,
-        status,
-    )
-    .fetch(&mut *conn)
-    .try_collect::<Vec<_>>()
     .await?;
 
     Ok(items)

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/mixnodes.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/mixnodes.rs
@@ -91,12 +91,14 @@ pub(crate) async fn get_daily_stats(pool: &DbPool, offset: i64) -> anyhow::Resul
         r#"
         SELECT
             date_utc as "date_utc!",
+            SUM(total_stake) as "total_stake!: i64",
             SUM(packets_received) as "total_packets_received!: i64",
             SUM(packets_sent) as "total_packets_sent!: i64",
             SUM(packets_dropped) as "total_packets_dropped!: i64"
         FROM (
             SELECT
                 date_utc,
+                n.total_stake,
                 n.packets_received,
                 n.packets_sent,
                 n.packets_dropped
@@ -104,6 +106,7 @@ pub(crate) async fn get_daily_stats(pool: &DbPool, offset: i64) -> anyhow::Resul
             UNION ALL
             SELECT
                 m.date_utc,
+                m.total_stake,
                 m.packets_received,
                 m.packets_sent,
                 m.packets_dropped

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/mixnodes.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/mixnodes.rs
@@ -21,13 +21,13 @@ pub(crate) async fn insert_mixnodes(
         sqlx::query!(
             "INSERT INTO mixnodes
                 (mix_id, identity_key, bonded, total_stake,
-                    host, http_api_port, blacklisted, full_details,
+                    host, http_api_port, full_details,
                     self_described, last_updated_utc, is_dp_delegatee)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(mix_id) DO UPDATE SET
                 bonded=excluded.bonded,
                 total_stake=excluded.total_stake, host=excluded.host,
-                http_api_port=excluded.http_api_port,blacklisted=excluded.blacklisted,
+                http_api_port=excluded.http_api_port,
                 full_details=excluded.full_details,self_described=excluded.self_described,
                 last_updated_utc=excluded.last_updated_utc,
                 is_dp_delegatee = excluded.is_dp_delegatee;",
@@ -37,7 +37,6 @@ pub(crate) async fn insert_mixnodes(
             record.total_stake,
             record.host,
             record.http_port,
-            record.blacklisted,
             record.full_details,
             record.self_described,
             record.last_updated_utc,
@@ -57,7 +56,6 @@ pub(crate) async fn get_all_mixnodes(pool: &DbPool) -> anyhow::Result<Vec<Mixnod
         r#"SELECT
             mn.mix_id as "mix_id!",
             mn.bonded as "bonded: bool",
-            mn.blacklisted as "blacklisted: bool",
             mn.is_dp_delegatee as "is_dp_delegatee: bool",
             mn.total_stake as "total_stake!",
             mn.full_details as "full_details!",

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
@@ -11,6 +11,6 @@ pub(crate) use gateways::{get_all_gateways, insert_gateways, select_gateway_iden
 pub(crate) use gateways_stats::{delete_old_records, get_sessions_stats, insert_session_records};
 pub(crate) use misc::insert_summaries;
 pub(crate) use mixnodes::{get_all_mixnodes, get_daily_stats, insert_mixnodes};
-pub(crate) use nym_nodes::insert_nym_nodes;
-pub(crate) use scraper::fetch_active_nodes;
+pub(crate) use nym_nodes::{get_nym_nodes, insert_nym_nodes};
+pub(crate) use scraper::fetch_mixing_nodes;
 pub(crate) use summary::{get_summary, get_summary_history};

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
@@ -13,6 +13,8 @@ pub(crate) use gateways_stats::{delete_old_records, get_sessions_stats, insert_s
 pub(crate) use misc::insert_summaries;
 pub(crate) use mixnodes::{get_all_mixnodes, get_daily_stats, insert_mixnodes};
 pub(crate) use nym_nodes::{get_nym_nodes, insert_nym_nodes};
-pub(crate) use packet_stats::insert_node_packet_stats;
+pub(crate) use packet_stats::{
+    get_raw_node_stats, insert_daily_node_stats, insert_node_packet_stats,
+};
 pub(crate) use scraper::{get_mixing_nodes_for_scraping, insert_scraped_node_description};
 pub(crate) use summary::{get_summary, get_summary_history};

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
@@ -8,7 +8,6 @@ pub(crate) mod testruns;
 
 pub(crate) use gateways::{
     ensure_gateways_still_bonded, get_all_gateways, insert_gateways, select_gateway_identity,
-    write_blacklisted_gateways_to_db,
 };
 pub(crate) use misc::insert_summaries;
 pub(crate) use mixnodes::{

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
@@ -8,9 +8,9 @@ mod summary;
 pub(crate) mod testruns;
 
 pub(crate) use gateways::{get_all_gateways, insert_gateways, select_gateway_identity};
+pub(crate) use gateways_stats::{delete_old_records, get_sessions_stats, insert_session_records};
 pub(crate) use misc::insert_summaries;
 pub(crate) use mixnodes::{get_all_mixnodes, get_daily_stats, insert_mixnodes};
+pub(crate) use nym_nodes::insert_nym_nodes;
 pub(crate) use scraper::fetch_active_nodes;
 pub(crate) use summary::{get_summary, get_summary_history};
-
-pub(crate) use gateways_stats::{delete_old_records, get_sessions_stats, insert_session_records};

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
@@ -3,6 +3,7 @@ mod gateways_stats;
 mod misc;
 mod mixnodes;
 mod nym_nodes;
+mod packet_stats;
 pub(crate) mod scraper;
 mod summary;
 pub(crate) mod testruns;
@@ -12,5 +13,6 @@ pub(crate) use gateways_stats::{delete_old_records, get_sessions_stats, insert_s
 pub(crate) use misc::insert_summaries;
 pub(crate) use mixnodes::{get_all_mixnodes, get_daily_stats, insert_mixnodes};
 pub(crate) use nym_nodes::{get_nym_nodes, insert_nym_nodes};
-pub(crate) use scraper::fetch_mixing_nodes;
+pub(crate) use packet_stats::insert_node_packet_stats;
+pub(crate) use scraper::{get_mixing_nodes_for_scraping, insert_scraped_node_description};
 pub(crate) use summary::{get_summary, get_summary_history};

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/mod.rs
@@ -2,17 +2,14 @@ mod gateways;
 mod gateways_stats;
 mod misc;
 mod mixnodes;
+mod nym_nodes;
 pub(crate) mod scraper;
 mod summary;
 pub(crate) mod testruns;
 
-pub(crate) use gateways::{
-    ensure_gateways_still_bonded, get_all_gateways, insert_gateways, select_gateway_identity,
-};
+pub(crate) use gateways::{get_all_gateways, insert_gateways, select_gateway_identity};
 pub(crate) use misc::insert_summaries;
-pub(crate) use mixnodes::{
-    ensure_mixnodes_still_bonded, get_all_mixnodes, get_daily_stats, insert_mixnodes,
-};
+pub(crate) use mixnodes::{get_all_mixnodes, get_daily_stats, insert_mixnodes};
 pub(crate) use scraper::fetch_active_nodes;
 pub(crate) use summary::{get_summary, get_summary_history};
 

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/packet_stats.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/packet_stats.rs
@@ -1,5 +1,5 @@
 use crate::db::{
-    models::{NodeKind, NodeStats, ScraperNodeInfo},
+    models::{MixingNodeKind, NodeStats, ScraperNodeInfo},
     DbPool,
 };
 use anyhow::Result;
@@ -7,14 +7,14 @@ use anyhow::Result;
 pub(crate) async fn insert_node_packet_stats(
     pool: &DbPool,
     node_id: i64,
-    node_kind: &NodeKind,
+    node_kind: &MixingNodeKind,
     stats: &NodeStats,
     timestamp_utc: i64,
 ) -> Result<()> {
     let mut conn = pool.acquire().await?;
 
     match node_kind {
-        NodeKind::LegacyMixnode => {
+        MixingNodeKind::LegacyMixnode => {
             sqlx::query!(
                 r#"
                 INSERT INTO mixnode_packet_stats_raw (
@@ -30,7 +30,7 @@ pub(crate) async fn insert_node_packet_stats(
             .execute(&mut *conn)
             .await?;
         }
-        NodeKind::NymNode => {
+        MixingNodeKind::NymNode => {
             sqlx::query!(
                 r#"
                 INSERT INTO nym_nodes_packet_stats_raw (
@@ -60,7 +60,7 @@ pub(crate) async fn get_raw_node_stats(
     let packets = match node.node_kind {
         // if no packets are found, it's fine to assume 0 because that's also
         // SQL default value if none provided
-        NodeKind::LegacyMixnode => {
+        MixingNodeKind::LegacyMixnode => {
             sqlx::query_as!(
                 NodeStats,
                 r#"
@@ -78,7 +78,7 @@ pub(crate) async fn get_raw_node_stats(
             .fetch_optional(&mut *conn)
             .await?
         }
-        NodeKind::NymNode => {
+        MixingNodeKind::NymNode => {
             sqlx::query_as!(
                 NodeStats,
                 r#"
@@ -110,7 +110,7 @@ pub(crate) async fn insert_daily_node_stats(
     let mut conn = pool.acquire().await?;
 
     match node.node_kind {
-        NodeKind::LegacyMixnode => {
+        MixingNodeKind::LegacyMixnode => {
             let total_stake = sqlx::query_scalar!(
                 r#"
                     SELECT
@@ -146,7 +146,7 @@ pub(crate) async fn insert_daily_node_stats(
             .execute(&mut *conn)
             .await?;
         }
-        NodeKind::NymNode => {
+        MixingNodeKind::NymNode => {
             let total_stake = sqlx::query_scalar!(
                 r#"
                 SELECT

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/packet_stats.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/packet_stats.rs
@@ -1,0 +1,55 @@
+use crate::{
+    db::{models::NodeKind, DbPool},
+    mixnet_scraper::helpers::NodeStats,
+};
+use anyhow::Result;
+use chrono::Utc;
+
+pub(crate) async fn insert_node_packet_stats(
+    pool: &DbPool,
+    node_id: i64,
+    node_kind: &NodeKind,
+    stats: NodeStats,
+) -> Result<()> {
+    let timestamp = Utc::now();
+    let timestamp_utc = timestamp.timestamp();
+
+    let mut conn = pool.acquire().await?;
+
+    match node_kind {
+        NodeKind::LegacyMixnode => {
+            sqlx::query!(
+                r#"
+                INSERT INTO mixnode_packet_stats_raw (
+                    mix_id, timestamp_utc, packets_received, packets_sent, packets_dropped
+                ) VALUES (?, ?, ?, ?, ?)
+                "#,
+                node_id,
+                timestamp_utc,
+                stats.packets_received,
+                stats.packets_sent,
+                stats.packets_dropped,
+            )
+            .execute(&mut *conn)
+            .await?;
+        }
+        NodeKind::NymNode => {
+            sqlx::query!(
+                r#"
+                INSERT INTO nym_nodes_packet_stats_raw (
+                    node_id, timestamp_utc, packets_received, packets_sent, packets_dropped
+                ) VALUES (?, ?, ?, ?, ?)
+                "#,
+                node_id,
+                timestamp_utc,
+                stats.packets_received,
+                stats.packets_sent,
+                stats.packets_dropped,
+            )
+            .execute(&mut *conn)
+            .await?;
+        }
+    }
+
+    Ok(())
+}

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
@@ -46,14 +46,15 @@ pub(crate) async fn get_mixing_nodes_for_scraping(pool: &DbPool) -> Result<Vec<S
     tracing::debug!("Fetched {} 🦖 mixnodes", nodes_to_scrape.len());
 
     let mut duplicates = 0;
-    let mut legacy_mixnodes = 0;
+    let mut legacy_not_in_nym_node_list = 0;
+    let total_legacy_mixnodes = mixnodes.len();
     for mixnode in mixnodes {
         // TODO dz remove this, only for debugging
         if nodes_to_scrape
             .iter()
             .all(|node| node.node_id != mixnode.node_id)
         {
-            legacy_mixnodes += 1;
+            legacy_not_in_nym_node_list += 1;
         } else {
             duplicates += 1;
         }
@@ -72,8 +73,16 @@ pub(crate) async fn get_mixing_nodes_for_scraping(pool: &DbPool) -> Result<Vec<S
             })
         }
     }
-    tracing::debug!("Ignoring {} duplicates", duplicates);
-    tracing::debug!("Found {} unique legacy mixnodes", legacy_mixnodes);
+    tracing::debug!(
+        "{}/{} legacy mixnodes already included in nym_node list",
+        duplicates,
+        total_legacy_mixnodes
+    );
+    tracing::debug!(
+        "{}/{} legacy mixnodes NOT included in nym_node list",
+        legacy_not_in_nym_node_list,
+        total_legacy_mixnodes
+    );
     tracing::debug!("In total: {} 🌟+🦖 mixing nodes", nodes_to_scrape.len());
 
     Ok(nodes_to_scrape)

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::{
-        models::{NodeKind, ScraperNodeInfo},
+        models::{MixingNodeKind, ScraperNodeInfo},
         queries, DbPool,
     },
     mixnet_scraper::helpers::NodeDescriptionResponse,
@@ -17,7 +17,7 @@ pub(crate) async fn get_mixing_nodes_for_scraping(pool: &DbPool) -> Result<Vec<S
         .for_each(|node| {
             nodes_to_scrape.push(ScraperNodeInfo {
                 node_id: node.node_id.into(),
-                node_kind: NodeKind::NymNode,
+                node_kind: MixingNodeKind::NymNode,
                 hosts: node
                     .ip_addresses
                     .into_iter()
@@ -64,7 +64,7 @@ pub(crate) async fn get_mixing_nodes_for_scraping(pool: &DbPool) -> Result<Vec<S
         {
             nodes_to_scrape.push(ScraperNodeInfo {
                 node_id: mixnode.node_id,
-                node_kind: NodeKind::LegacyMixnode,
+                node_kind: MixingNodeKind::LegacyMixnode,
                 hosts: vec![mixnode.host],
                 http_api_port: mixnode.http_api_port,
             })
@@ -89,7 +89,7 @@ pub(crate) async fn get_mixing_nodes_for_scraping(pool: &DbPool) -> Result<Vec<S
 
 pub(crate) async fn insert_scraped_node_description(
     pool: &DbPool,
-    node_kind: &NodeKind,
+    node_kind: &MixingNodeKind,
     node_id: i64,
     description: &NodeDescriptionResponse,
 ) -> Result<()> {
@@ -97,7 +97,7 @@ pub(crate) async fn insert_scraped_node_description(
     let mut conn = pool.acquire().await?;
 
     match node_kind {
-        NodeKind::LegacyMixnode => {
+        MixingNodeKind::LegacyMixnode => {
             sqlx::query!(
                 r#"
                 INSERT INTO mixnode_description (
@@ -120,7 +120,7 @@ pub(crate) async fn insert_scraped_node_description(
             .execute(&mut *conn)
             .await?;
         }
-        NodeKind::NymNode => {
+        MixingNodeKind::NymNode => {
             sqlx::query!(
                 r#"
                 INSERT INTO nym_node_descriptions (

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
@@ -1,10 +1,26 @@
-use crate::db::{models::ScraperNodeInfo, DbPool};
+use crate::db::{models::ScraperNodeInfo, queries, DbPool};
 use anyhow::Result;
 
-pub(crate) async fn fetch_active_nodes(pool: &DbPool) -> Result<Vec<ScraperNodeInfo>> {
+pub(crate) async fn fetch_mixing_nodes(pool: &DbPool) -> Result<Vec<ScraperNodeInfo>> {
+    let mut nodes_to_scrape = Vec::new();
+
+    queries::get_nym_nodes(pool)
+        .await?
+        .into_iter()
+        .for_each(|node| {
+            nodes_to_scrape.push(ScraperNodeInfo {
+                node_id: node.node_id.into(),
+                hosts: node
+                    .ip_addresses
+                    .into_iter()
+                    .map(|ip| ip.to_string())
+                    .collect::<Vec<_>>(),
+                http_api_port: node.mix_port.into(),
+            })
+        });
+
     let mut conn = pool.acquire().await?;
-    let nodes = sqlx::query_as!(
-        ScraperNodeInfo,
+    let mixnodes = sqlx::query!(
         r#"
             SELECT mix_id as node_id, host, http_api_port
             FROM mixnodes
@@ -13,9 +29,17 @@ pub(crate) async fn fetch_active_nodes(pool: &DbPool) -> Result<Vec<ScraperNodeI
     )
     .fetch_all(&mut *conn)
     .await?;
+    drop(conn);
 
-    // TODO dz join this with nym node info
-    Ok(nodes)
+    for mixnode in mixnodes {
+        nodes_to_scrape.push(ScraperNodeInfo {
+            node_id: mixnode.node_id,
+            hosts: vec![mixnode.host],
+            http_api_port: mixnode.http_api_port,
+        })
+    }
+
+    Ok(nodes_to_scrape)
 }
 
 // TODO: add stuff for gateways

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
@@ -1,7 +1,14 @@
-use crate::db::{models::ScraperNodeInfo, queries, DbPool};
+use crate::{
+    db::{
+        models::{NodeKind, ScraperNodeInfo},
+        queries, DbPool,
+    },
+    mixnet_scraper::helpers::NodeDescriptionResponse,
+};
 use anyhow::Result;
+use chrono::Utc;
 
-pub(crate) async fn fetch_mixing_nodes(pool: &DbPool) -> Result<Vec<ScraperNodeInfo>> {
+pub(crate) async fn get_mixing_nodes_for_scraping(pool: &DbPool) -> Result<Vec<ScraperNodeInfo>> {
     let mut nodes_to_scrape = Vec::new();
 
     queries::get_nym_nodes(pool)
@@ -10,6 +17,7 @@ pub(crate) async fn fetch_mixing_nodes(pool: &DbPool) -> Result<Vec<ScraperNodeI
         .for_each(|node| {
             nodes_to_scrape.push(ScraperNodeInfo {
                 node_id: node.node_id.into(),
+                node_kind: NodeKind::NymNode,
                 hosts: node
                     .ip_addresses
                     .into_iter()
@@ -18,6 +26,9 @@ pub(crate) async fn fetch_mixing_nodes(pool: &DbPool) -> Result<Vec<ScraperNodeI
                 http_api_port: node.mix_port.into(),
             })
         });
+
+    // TODO dz remove log
+    tracing::debug!("Fetched {} 🌟 nym nodes", nodes_to_scrape.len());
 
     let mut conn = pool.acquire().await?;
     let mixnodes = sqlx::query!(
@@ -31,15 +42,102 @@ pub(crate) async fn fetch_mixing_nodes(pool: &DbPool) -> Result<Vec<ScraperNodeI
     .await?;
     drop(conn);
 
+    // TODO dz remove log
+    tracing::debug!("Fetched {} 🦖 mixnodes", nodes_to_scrape.len());
+
+    let mut duplicates = 0;
+    let mut legacy_mixnodes = 0;
     for mixnode in mixnodes {
-        nodes_to_scrape.push(ScraperNodeInfo {
-            node_id: mixnode.node_id,
-            hosts: vec![mixnode.host],
-            http_api_port: mixnode.http_api_port,
-        })
+        // TODO dz remove this, only for debugging
+        if nodes_to_scrape
+            .iter()
+            .all(|node| node.node_id != mixnode.node_id)
+        {
+            legacy_mixnodes += 1;
+        } else {
+            duplicates += 1;
+        }
+
+        // technically, mixnodes shouldn't be in nym_nodes table, but it's
+        // possible due to polyfilling on Nym API
+        if nodes_to_scrape
+            .iter()
+            .all(|node| node.node_id != mixnode.node_id)
+        {
+            nodes_to_scrape.push(ScraperNodeInfo {
+                node_id: mixnode.node_id,
+                node_kind: NodeKind::LegacyMixnode,
+                hosts: vec![mixnode.host],
+                http_api_port: mixnode.http_api_port,
+            })
+        }
     }
+    tracing::debug!("Ignoring {} duplicates", duplicates);
+    tracing::debug!("Found {} unique legacy mixnodes", legacy_mixnodes);
+    tracing::debug!("In total: {} 🌟+🦖 mixing nodes", nodes_to_scrape.len());
 
     Ok(nodes_to_scrape)
 }
 
 // TODO: add stuff for gateways
+
+pub(crate) async fn insert_scraped_node_description(
+    pool: &DbPool,
+    node_kind: &NodeKind,
+    node_id: i64,
+    description: &NodeDescriptionResponse,
+) -> Result<()> {
+    let timestamp = Utc::now().timestamp();
+    let mut conn = pool.acquire().await?;
+
+    match node_kind {
+        NodeKind::LegacyMixnode => {
+            sqlx::query!(
+                r#"
+                INSERT INTO mixnode_description (
+                    mix_id, moniker, website, security_contact, details, last_updated_utc
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT (mix_id) DO UPDATE SET
+                    moniker = excluded.moniker,
+                    website = excluded.website,
+                    security_contact = excluded.security_contact,
+                    details = excluded.details,
+                    last_updated_utc = excluded.last_updated_utc
+                "#,
+                node_id,
+                description.moniker,
+                description.website,
+                description.security_contact,
+                description.details,
+                timestamp,
+            )
+            .execute(&mut *conn)
+            .await?;
+        }
+        NodeKind::NymNode => {
+            sqlx::query!(
+                r#"
+                INSERT INTO nym_node_descriptions (
+                    node_id, moniker, website, security_contact, details, last_updated_utc
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT (node_id) DO UPDATE SET
+                    moniker = excluded.moniker,
+                    website = excluded.website,
+                    security_contact = excluded.security_contact,
+                    details = excluded.details,
+                    last_updated_utc = excluded.last_updated_utc
+                "#,
+                node_id,
+                description.moniker,
+                description.website,
+                description.security_contact,
+                description.details,
+                timestamp,
+            )
+            .execute(&mut *conn)
+            .await?;
+        }
+    }
+
+    Ok(())
+}

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
@@ -6,14 +6,15 @@ pub(crate) async fn fetch_active_nodes(pool: &DbPool) -> Result<Vec<ScraperNodeI
     let nodes = sqlx::query_as!(
         ScraperNodeInfo,
         r#"
-            SELECT mix_id as node_id, host, http_api_port 
-            FROM mixnodes 
+            SELECT mix_id as node_id, host, http_api_port
+            FROM mixnodes
             WHERE bonded = true
         "#
     )
     .fetch_all(&mut *conn)
     .await?;
 
+    // TODO dz join this with nym node info
     Ok(nodes)
 }
 

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/scraper.rs
@@ -27,7 +27,6 @@ pub(crate) async fn get_mixing_nodes_for_scraping(pool: &DbPool) -> Result<Vec<S
             })
         });
 
-    // TODO dz remove log
     tracing::debug!("Fetched {} 🌟 nym nodes", nodes_to_scrape.len());
 
     let mut conn = pool.acquire().await?;
@@ -42,14 +41,12 @@ pub(crate) async fn get_mixing_nodes_for_scraping(pool: &DbPool) -> Result<Vec<S
     .await?;
     drop(conn);
 
-    // TODO dz remove log
     tracing::debug!("Fetched {} 🦖 mixnodes", nodes_to_scrape.len());
 
     let mut duplicates = 0;
     let mut legacy_not_in_nym_node_list = 0;
     let total_legacy_mixnodes = mixnodes.len();
     for mixnode in mixnodes {
-        // TODO dz remove this, only for debugging
         if nodes_to_scrape
             .iter()
             .all(|node| node.node_id != mixnode.node_id)

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/summary.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/summary.rs
@@ -6,14 +6,8 @@ use tracing::error;
 use crate::{
     db::{
         models::{
-            gateway::{
-                GatewaySummary, GatewaySummaryBlacklisted, GatewaySummaryBonded,
-                GatewaySummaryHistorical,
-            },
-            mixnode::{
-                MixnodeSummary, MixnodeSummaryBlacklisted, MixnodeSummaryBonded,
-                MixnodeSummaryHistorical,
-            },
+            gateway::{GatewaySummary, GatewaySummaryBonded, GatewaySummaryHistorical},
+            mixnode::{MixnodeSummary, MixnodeSummaryBonded, MixnodeSummaryHistorical},
             NetworkSummary, SummaryDto, SummaryHistoryDto,
         },
         DbPool,
@@ -78,11 +72,7 @@ pub(crate) async fn get_summary(pool: &DbPool) -> HttpResult<NetworkSummary> {
 async fn from_summary_dto(items: Vec<SummaryDto>) -> HttpResult<NetworkSummary> {
     const MIXNODES_BONDED_COUNT: &str = "mixnodes.bonded.count";
     const MIXNODES_BONDED_ACTIVE: &str = "mixnodes.bonded.active";
-    const MIXNODES_BONDED_INACTIVE: &str = "mixnodes.bonded.inactive";
-    const MIXNODES_BONDED_RESERVE: &str = "mixnodes.bonded.reserve";
-    const MIXNODES_BLACKLISTED_COUNT: &str = "mixnodes.blacklisted.count";
     const GATEWAYS_BONDED_COUNT: &str = "gateways.bonded.count";
-    const GATEWAYS_BLACKLISTED_COUNT: &str = "gateways.blacklisted.count";
     const MIXNODES_HISTORICAL_COUNT: &str = "mixnodes.historical.count";
     const GATEWAYS_HISTORICAL_COUNT: &str = "gateways.historical.count";
 
@@ -96,12 +86,8 @@ async fn from_summary_dto(items: Vec<SummaryDto>) -> HttpResult<NetworkSummary> 
     let keys = [
         GATEWAYS_BONDED_COUNT,
         GATEWAYS_HISTORICAL_COUNT,
-        GATEWAYS_BLACKLISTED_COUNT,
-        MIXNODES_BLACKLISTED_COUNT,
         MIXNODES_BONDED_ACTIVE,
         MIXNODES_BONDED_COUNT,
-        MIXNODES_BONDED_INACTIVE,
-        MIXNODES_BONDED_RESERVE,
         MIXNODES_HISTORICAL_COUNT,
     ];
 
@@ -123,18 +109,6 @@ async fn from_summary_dto(items: Vec<SummaryDto>) -> HttpResult<NetworkSummary> 
         map.get(MIXNODES_BONDED_COUNT).cloned().unwrap_or_default();
     let mixnodes_bonded_active: SummaryDto =
         map.get(MIXNODES_BONDED_ACTIVE).cloned().unwrap_or_default();
-    let mixnodes_bonded_inactive: SummaryDto = map
-        .get(MIXNODES_BONDED_INACTIVE)
-        .cloned()
-        .unwrap_or_default();
-    let mixnodes_bonded_reserve: SummaryDto = map
-        .get(MIXNODES_BONDED_RESERVE)
-        .cloned()
-        .unwrap_or_default();
-    let mixnodes_blacklisted_count: SummaryDto = map
-        .get(MIXNODES_BLACKLISTED_COUNT)
-        .cloned()
-        .unwrap_or_default();
     let gateways_bonded_count: SummaryDto =
         map.get(GATEWAYS_BONDED_COUNT).cloned().unwrap_or_default();
     let mixnodes_historical_count: SummaryDto = map
@@ -145,23 +119,13 @@ async fn from_summary_dto(items: Vec<SummaryDto>) -> HttpResult<NetworkSummary> 
         .get(GATEWAYS_HISTORICAL_COUNT)
         .cloned()
         .unwrap_or_default();
-    let gateways_blacklisted_count: SummaryDto = map
-        .get(GATEWAYS_BLACKLISTED_COUNT)
-        .cloned()
-        .unwrap_or_default();
 
     Ok(NetworkSummary {
         mixnodes: MixnodeSummary {
             bonded: MixnodeSummaryBonded {
                 count: to_count_i32(&mixnodes_bonded_count),
                 active: to_count_i32(&mixnodes_bonded_active),
-                reserve: to_count_i32(&mixnodes_bonded_reserve),
-                inactive: to_count_i32(&mixnodes_bonded_inactive),
                 last_updated_utc: to_timestamp(&mixnodes_bonded_count),
-            },
-            blacklisted: MixnodeSummaryBlacklisted {
-                count: to_count_i32(&mixnodes_blacklisted_count),
-                last_updated_utc: to_timestamp(&mixnodes_blacklisted_count),
             },
             historical: MixnodeSummaryHistorical {
                 count: to_count_i32(&mixnodes_historical_count),
@@ -172,10 +136,6 @@ async fn from_summary_dto(items: Vec<SummaryDto>) -> HttpResult<NetworkSummary> 
             bonded: GatewaySummaryBonded {
                 count: to_count_i32(&gateways_bonded_count),
                 last_updated_utc: to_timestamp(&gateways_bonded_count),
-            },
-            blacklisted: GatewaySummaryBlacklisted {
-                count: to_count_i32(&gateways_blacklisted_count),
-                last_updated_utc: to_timestamp(&gateways_blacklisted_count),
             },
             historical: GatewaySummaryHistorical {
                 count: to_count_i32(&gateways_historical_count),

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/summary.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/summary.rs
@@ -8,7 +8,9 @@ use crate::{
         models::{
             gateway::{GatewaySummary, GatewaySummaryBonded, GatewaySummaryHistorical},
             mixnode::{MixnodeSummary, MixnodeSummaryBonded, MixnodeSummaryHistorical},
-            NetworkSummary, SummaryDto, SummaryHistoryDto,
+            NetworkSummary, SummaryDto, SummaryHistoryDto, GATEWAYS_BONDED_COUNT,
+            GATEWAYS_HISTORICAL_COUNT, LEGACY_MIXNODES_COUNT, MIXNODES_BONDED_ACTIVE,
+            MIXNODES_BONDED_COUNT, MIXNODES_HISTORICAL_COUNT,
         },
         DbPool,
     },
@@ -70,12 +72,6 @@ pub(crate) async fn get_summary(pool: &DbPool) -> HttpResult<NetworkSummary> {
 }
 
 async fn from_summary_dto(items: Vec<SummaryDto>) -> HttpResult<NetworkSummary> {
-    const MIXNODES_BONDED_COUNT: &str = "mixnodes.bonded.count";
-    const MIXNODES_BONDED_ACTIVE: &str = "mixnodes.bonded.active";
-    const GATEWAYS_BONDED_COUNT: &str = "gateways.bonded.count";
-    const MIXNODES_HISTORICAL_COUNT: &str = "mixnodes.historical.count";
-    const GATEWAYS_HISTORICAL_COUNT: &str = "gateways.historical.count";
-
     // convert database rows into a map by key
     let mut map = HashMap::new();
     for item in items {
@@ -88,6 +84,7 @@ async fn from_summary_dto(items: Vec<SummaryDto>) -> HttpResult<NetworkSummary> 
         GATEWAYS_HISTORICAL_COUNT,
         MIXNODES_BONDED_ACTIVE,
         MIXNODES_BONDED_COUNT,
+        LEGACY_MIXNODES_COUNT,
         MIXNODES_HISTORICAL_COUNT,
     ];
 
@@ -109,6 +106,8 @@ async fn from_summary_dto(items: Vec<SummaryDto>) -> HttpResult<NetworkSummary> 
         map.get(MIXNODES_BONDED_COUNT).cloned().unwrap_or_default();
     let mixnodes_bonded_active: SummaryDto =
         map.get(MIXNODES_BONDED_ACTIVE).cloned().unwrap_or_default();
+    let legacy_mixnodes_count: SummaryDto =
+        map.get(LEGACY_MIXNODES_COUNT).cloned().unwrap_or_default();
     let gateways_bonded_count: SummaryDto =
         map.get(GATEWAYS_BONDED_COUNT).cloned().unwrap_or_default();
     let mixnodes_historical_count: SummaryDto = map
@@ -125,6 +124,7 @@ async fn from_summary_dto(items: Vec<SummaryDto>) -> HttpResult<NetworkSummary> 
             bonded: MixnodeSummaryBonded {
                 count: to_count_i32(&mixnodes_bonded_count),
                 active: to_count_i32(&mixnodes_bonded_active),
+                legacy: to_count_i32(&legacy_mixnodes_count),
                 last_updated_utc: to_timestamp(&mixnodes_bonded_count),
             },
             historical: MixnodeSummaryHistorical {

--- a/nym-node-status-api/nym-node-status-api/src/db/queries/summary.rs
+++ b/nym-node-status-api/nym-node-status-api/src/db/queries/summary.rs
@@ -9,8 +9,8 @@ use crate::{
             gateway::{GatewaySummary, GatewaySummaryBonded, GatewaySummaryHistorical},
             mixnode::{MixnodeSummary, MixnodeSummaryBonded, MixnodeSummaryHistorical},
             NetworkSummary, SummaryDto, SummaryHistoryDto, GATEWAYS_BONDED_COUNT,
-            GATEWAYS_HISTORICAL_COUNT, LEGACY_MIXNODES_COUNT, MIXNODES_BONDED_ACTIVE,
-            MIXNODES_BONDED_COUNT, MIXNODES_HISTORICAL_COUNT,
+            GATEWAYS_HISTORICAL_COUNT, MIXNODES_BONDED_ACTIVE, MIXNODES_BONDED_COUNT,
+            MIXNODES_HISTORICAL_COUNT, MIXNODES_LEGACY_COUNT,
         },
         DbPool,
     },
@@ -84,7 +84,7 @@ async fn from_summary_dto(items: Vec<SummaryDto>) -> HttpResult<NetworkSummary> 
         GATEWAYS_HISTORICAL_COUNT,
         MIXNODES_BONDED_ACTIVE,
         MIXNODES_BONDED_COUNT,
-        LEGACY_MIXNODES_COUNT,
+        MIXNODES_LEGACY_COUNT,
         MIXNODES_HISTORICAL_COUNT,
     ];
 
@@ -107,7 +107,7 @@ async fn from_summary_dto(items: Vec<SummaryDto>) -> HttpResult<NetworkSummary> 
     let mixnodes_bonded_active: SummaryDto =
         map.get(MIXNODES_BONDED_ACTIVE).cloned().unwrap_or_default();
     let legacy_mixnodes_count: SummaryDto =
-        map.get(LEGACY_MIXNODES_COUNT).cloned().unwrap_or_default();
+        map.get(MIXNODES_LEGACY_COUNT).cloned().unwrap_or_default();
     let gateways_bonded_count: SummaryDto =
         map.get(GATEWAYS_BONDED_COUNT).cloned().unwrap_or_default();
     let mixnodes_historical_count: SummaryDto = map

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -8,7 +8,6 @@ pub(crate) use nym_node_status_client::models::TestrunAssignment;
 pub struct Gateway {
     pub gateway_identity_key: String,
     pub bonded: bool,
-    pub blacklisted: bool,
     pub performance: u8,
     pub self_described: Option<serde_json::Value>,
     pub explorer_pretty_bond: Option<serde_json::Value>,

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -51,9 +51,7 @@ pub struct DailyStats {
     pub total_packets_received: i64,
     pub total_packets_sent: i64,
     pub total_packets_dropped: i64,
-    // TODO dz uncomment
-    // pub total_stake: i64,
-}
+    pub total_stake: i64,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -38,7 +38,6 @@ pub struct GatewaySkinny {
 pub struct Mixnode {
     pub mix_id: u32,
     pub bonded: bool,
-    pub blacklisted: bool,
     pub is_dp_delegatee: bool,
     pub total_stake: i64,
     pub full_details: Option<serde_json::Value>,

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -51,7 +51,9 @@ pub struct DailyStats {
     pub total_packets_received: i64,
     pub total_packets_sent: i64,
     pub total_packets_dropped: i64,
-    pub total_stake: i64,
+    // TODO dz uncomment
+    // pub total_stake: i64,
+}
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]

--- a/nym-node-status-api/nym-node-status-api/src/http/server.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/server.rs
@@ -17,13 +17,13 @@ pub(crate) async fn start_http_api(
     nym_http_cache_ttl: u64,
     agent_key_list: Vec<PublicKey>,
     agent_max_count: i64,
+    hm_url: String
 ) -> anyhow::Result<ShutdownHandles> {
     let router_builder = RouterBuilder::with_default_routes();
 
-    let state = AppState::new(db_pool, nym_http_cache_ttl, agent_key_list, agent_max_count);
+    let state = AppState::new(db_pool, nym_http_cache_ttl, agent_key_list, agent_max_count, hm_url).await;
     let router = router_builder.with_state(state);
 
-    // TODO dz do we need this to be configurable?
     let bind_addr = format!("0.0.0.0:{}", http_port);
     tracing::info!("Binding server to {bind_addr}");
     let server = router.build_server(bind_addr).await?;

--- a/nym-node-status-api/nym-node-status-api/src/http/server.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/server.rs
@@ -17,11 +17,18 @@ pub(crate) async fn start_http_api(
     nym_http_cache_ttl: u64,
     agent_key_list: Vec<PublicKey>,
     agent_max_count: i64,
-    hm_url: String
+    hm_url: String,
 ) -> anyhow::Result<ShutdownHandles> {
     let router_builder = RouterBuilder::with_default_routes();
 
-    let state = AppState::new(db_pool, nym_http_cache_ttl, agent_key_list, agent_max_count, hm_url).await;
+    let state = AppState::new(
+        db_pool,
+        nym_http_cache_ttl,
+        agent_key_list,
+        agent_max_count,
+        hm_url,
+    )
+    .await;
     let router = router_builder.with_state(state);
 
     let bind_addr = format!("0.0.0.0:{}", http_port);

--- a/nym-node-status-api/nym-node-status-api/src/http/state.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/state.rs
@@ -114,12 +114,13 @@ impl HttpCache {
     pub async fn get_gateway_list(&self, db: &DbPool) -> Vec<Gateway> {
         match self.gateways.get(GATEWAYS_LIST_KEY).await {
             Some(guard) => {
+                tracing::trace!("Fetching from cache...");
                 let read_lock = guard.read().await;
                 read_lock.clone()
             }
             None => {
                 // the key is missing so populate it
-                tracing::warn!("No gateways in cache, refreshing cache from DB...");
+                tracing::trace!("No gateways in cache, refreshing cache from DB...");
 
                 let gateways = crate::db::queries::get_all_gateways(db)
                     .await
@@ -157,11 +158,12 @@ impl HttpCache {
     pub async fn get_mixnodes_list(&self, db: &DbPool) -> Vec<Mixnode> {
         match self.mixnodes.get(MIXNODES_LIST_KEY).await {
             Some(guard) => {
+                tracing::trace!("Fetching from cache...");
                 let read_lock = guard.read().await;
                 read_lock.clone()
             }
             None => {
-                tracing::warn!("No mixnodes in cache, refreshing cache from DB...");
+                tracing::trace!("No mixnodes in cache, refreshing cache from DB...");
 
                 let mixnodes = crate::db::queries::get_all_mixnodes(db)
                     .await

--- a/nym-node-status-api/nym-node-status-api/src/logging.rs
+++ b/nym-node-status-api/nym-node-status-api/src/logging.rs
@@ -33,6 +33,7 @@ pub(crate) fn setup_tracing_logger() -> anyhow::Result<()> {
         "tendermint_rpc",
         "tower_http",
         "axum",
+        "html5ever",
     ];
     for crate_name in warn_crates {
         filter = filter.add_directive(directive_checked(format!("{}=warn", crate_name))?);

--- a/nym-node-status-api/nym-node-status-api/src/logging.rs
+++ b/nym-node-status-api/nym-node-status-api/src/logging.rs
@@ -40,28 +40,6 @@ pub(crate) fn setup_tracing_logger() -> anyhow::Result<()> {
 
     let log_level_hint = filter.max_level_hint();
 
-    // debug or higher granularity (e.g. trace)
-    let debug_or_higher = std::cmp::max(
-        log_level_hint.unwrap_or(LevelFilter::DEBUG),
-        LevelFilter::DEBUG,
-    );
-    filter = filter.add_directive(directive_checked(format!(
-        "nym_bin_common={}",
-        debug_or_higher
-    ))?);
-    filter = filter.add_directive(directive_checked(format!(
-        "nym_explorer_client={}",
-        debug_or_higher
-    ))?);
-    filter = filter.add_directive(directive_checked(format!(
-        "nym_network_defaults={}",
-        debug_or_higher
-    ))?);
-    filter = filter.add_directive(directive_checked(format!(
-        "nym_validator_client={}",
-        debug_or_higher
-    ))?);
-
     log_builder.with_env_filter(filter).init();
     tracing::info!("Log level: {:?}", log_level_hint);
 

--- a/nym-node-status-api/nym-node-status-api/src/main.rs
+++ b/nym-node-status-api/nym-node-status-api/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async move {
         scraper.start().await;
     });
-    tracing::info!("Started node scraper task");
+
 
     // Start the monitor
     let args_clone = args.clone();

--- a/nym-node-status-api/nym-node-status-api/src/main.rs
+++ b/nym-node-status-api/nym-node-status-api/src/main.rs
@@ -66,6 +66,7 @@ async fn main() -> anyhow::Result<()> {
         args.nym_http_cache_ttl,
         agent_key_list.to_owned(),
         args.max_agent_count,
+        args.hm_url,
     )
     .await
     .expect("Failed to start server");

--- a/nym-node-status-api/nym-node-status-api/src/main.rs
+++ b/nym-node-status-api/nym-node-status-api/src/main.rs
@@ -36,7 +36,6 @@ async fn main() -> anyhow::Result<()> {
         scraper.start().await;
     });
 
-
     // Start the monitor
     let args_clone = args.clone();
 

--- a/nym-node-status-api/nym-node-status-api/src/mixnet_scraper/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/mixnet_scraper/mod.rs
@@ -125,7 +125,7 @@ impl Scraper {
                 let pool = pool.clone();
 
                 tokio::spawn(async move {
-                    match Self::scrape_and_store_description(&pool, &node).await {
+                    match scrape_and_store_description(&pool, &node).await {
                         Ok(_) => debug!(
                             "✅ Description task #{} for node {} complete",
                             task_id, node.node_id
@@ -170,7 +170,7 @@ impl Scraper {
                 let pool = pool.clone();
 
                 tokio::spawn(async move {
-                    match Self::scrape_and_store_packet_stats(&pool, &node).await {
+                    match scrape_and_store_packet_stats(&pool, &node).await {
                         Ok(_) => debug!(
                             "✅ Packet stats task #{} for node {} complete",
                             task_id, node.node_id
@@ -187,16 +187,5 @@ impl Scraper {
             }
         }
         Ok(())
-    }
-
-    async fn scrape_and_store_description(pool: &SqlitePool, node: &ScraperNodeInfo) -> Result<()> {
-        scrape_and_store_description(pool, node).await
-    }
-
-    async fn scrape_and_store_packet_stats(
-        pool: &SqlitePool,
-        node: &ScraperNodeInfo,
-    ) -> Result<()> {
-        scrape_and_store_packet_stats(pool, node).await
     }
 }

--- a/nym-node-status-api/nym-node-status-api/src/mixnet_scraper/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/mixnet_scraper/mod.rs
@@ -69,7 +69,7 @@ impl Scraper {
         });
     }
 
-    #[instrument(level = "debug", name = "description_scraper", skip_all)]
+    #[instrument(level = "info", name = "description_scraper", skip_all)]
     async fn run_description_scraper(
         pool: &SqlitePool,
         queue: Arc<Mutex<Vec<ScraperNodeInfo>>>,
@@ -86,7 +86,7 @@ impl Scraper {
         Ok(())
     }
 
-    #[instrument(level = "debug", name = "packet_scraper", skip_all)]
+    #[instrument(level = "info", name = "packet_scraper", skip_all)]
     async fn run_packet_scraper(
         pool: &SqlitePool,
         queue: Arc<Mutex<Vec<ScraperNodeInfo>>>,

--- a/nym-node-status-api/nym-node-status-api/src/mixnet_scraper/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/mixnet_scraper/mod.rs
@@ -11,9 +11,7 @@ use crate::db::models::ScraperNodeInfo;
 use crate::db::queries::get_mixing_nodes_for_scraping;
 
 const DESCRIPTION_SCRAPE_INTERVAL: Duration = Duration::from_secs(60 * 60 * 4);
-// TODO dz restore to 1 hour
-// const PACKET_SCRAPE_INTERVAL: Duration = Duration::from_secs(60 * 60);
-const PACKET_SCRAPE_INTERVAL: Duration = Duration::from_secs(60 * 1);
+const PACKET_SCRAPE_INTERVAL: Duration = Duration::from_secs(60 * 60);
 const QUEUE_CHECK_INTERVAL: Duration = Duration::from_millis(250);
 const MAX_CONCURRENT_TASKS: usize = 5;
 

--- a/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
@@ -123,7 +123,7 @@ impl MetricsScrapingData {
         }
     }
 
-    #[instrument(level = "debug", name = "metrics_scraper")]
+    #[instrument(level = "debug", name = "metrics_scraper", skip_all)]
     async fn try_scrape_metrics(&self) -> Option<SessionStats> {
         match self.try_get_client().await {
             Ok(client) => {
@@ -137,13 +137,13 @@ impl MetricsScrapingData {
                         }
                     }
                     Err(e) => {
-                        tracing::error!("{e}");
+                        tracing::warn!("{e}");
                         None
                     }
                 }
             }
             Err(e) => {
-                tracing::error!("{e}");
+                tracing::warn!("{e}");
                 None
             }
         }

--- a/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
@@ -123,6 +123,7 @@ impl MetricsScrapingData {
         }
     }
 
+    #[instrument(level = "debug", name = "metrics_scraper")]
     async fn try_scrape_metrics(&self) -> Option<SessionStats> {
         match self.try_get_client().await {
             Ok(client) => {
@@ -136,13 +137,13 @@ impl MetricsScrapingData {
                         }
                     }
                     Err(e) => {
-                        tracing::error!("[metrics scraper]: {e}");
+                        tracing::error!("{e}");
                         None
                     }
                 }
             }
             Err(e) => {
-                tracing::error!("[metrics scraper]: {e}");
+                tracing::error!("{e}");
                 None
             }
         }

--- a/nym-node-status-api/nym-node-status-api/src/testruns/queue.rs
+++ b/nym-node-status-api/nym-node-status-api/src/testruns/queue.rs
@@ -109,7 +109,6 @@ pub(crate) async fn try_queue_testrun(
     })
 }
 
-// TODO dz do we need these?
 pub fn now_utc() -> DateTime<chrono::Utc> {
     SystemTime::now().into()
 }


### PR DESCRIPTION
Removed obsolete fields from stats
- blacklisted mixnodes
- blacklisted gateways
- bonded mixnodes
- bonded gateways

Introduced nym-node scraping, beside just mixnodes

`/mixnodes/stats` now returns data for nym-nodes as well, which results in much more accurate "packets mixed" stats

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5418)
<!-- Reviewable:end -->
