### PR TITLE
Remove all recv_with_delay and add shutdown condition to loops in client-core

### DIFF
--- a/clients/native/src/websocket/handler.rs
+++ b/clients/native/src/websocket/handler.rs
@@ -125,10 +125,17 @@ impl Handler {
         };
 
         // get the number of pending replies waiting for reply surbs
-        let reply_queue_length = self
+        let reply_queue_length = match self
             .reply_controller_sender
             .get_lane_queue_length(connection_id)
-            .await;
+            .await
+        {
+            Ok(length) => length,
+            Err(err) => {
+                error!("Failed to get reply queue length for connection {connection_id}: {err}");
+                0
+            }
+        };
 
         let queue_length = base_length + reply_queue_length;
 

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -646,7 +646,7 @@ where
         user_agent: Option<UserAgent>,
         client_stats_id: String,
         input_sender: Sender<InputMessage>,
-        shutdown: TaskClient,
+        task_client: TaskClient,
     ) -> ClientStatsSender {
         info!("Starting statistics control...");
         StatisticsControl::create_and_start(
@@ -656,7 +656,7 @@ where
                 .unwrap_or("unknown".to_string()),
             client_stats_id,
             input_sender.clone(),
-            shutdown.with_suffix("controller"),
+            task_client,
         )
     }
 

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -310,7 +310,7 @@ where
         topology_accessor: TopologyAccessor,
         mix_tx: BatchMixMessageSender,
         stats_tx: ClientStatsSender,
-        shutdown: TaskClient,
+        task_client: TaskClient,
     ) {
         info!("Starting loop cover traffic stream...");
 
@@ -323,9 +323,10 @@ where
             debug_config.traffic,
             debug_config.cover_traffic,
             stats_tx,
+            task_client,
         );
 
-        stream.start_with_shutdown(shutdown);
+        stream.start();
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -340,7 +341,7 @@ where
         reply_controller_receiver: ReplyControllerReceiver,
         lane_queue_lengths: LaneQueueLengths,
         client_connection_rx: ConnectionCommandReceiver,
-        shutdown: TaskClient,
+        task_client: TaskClient,
         packet_type: PacketType,
         stats_tx: ClientStatsSender,
     ) {
@@ -358,8 +359,9 @@ where
             lane_queue_lengths,
             client_connection_rx,
             stats_tx,
+            task_client,
         )
-        .start_with_shutdown(shutdown, packet_type);
+        .start(packet_type);
     }
 
     // buffer controlling all messages fetched from provider

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -384,8 +384,9 @@ where
                 reply_key_storage,
                 reply_controller_sender,
                 metrics_reporter,
+                shutdown,
             );
-        controller.start_with_shutdown(shutdown)
+        controller.start()
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/common/client-core/src/client/cover_traffic_stream.rs
+++ b/common/client-core/src/client/cover_traffic_stream.rs
@@ -175,7 +175,7 @@ impl LoopCoverTrafficStream<OsRng> {
             }
         };
 
-        let cover_message = generate_loop_cover_packet(
+        let cover_message = match generate_loop_cover_packet(
             &mut self.rng,
             topology_ref,
             &self.ack_key,
@@ -184,8 +184,15 @@ impl LoopCoverTrafficStream<OsRng> {
             self.cover_traffic.loop_cover_traffic_average_delay,
             cover_traffic_packet_size,
             self.packet_type,
-        )
-        .expect("Somehow failed to generate a loop cover message with a valid topology");
+        ) {
+            Ok(cover_message) => cover_message,
+            Err(err) => {
+                warn!(
+                    "Somehow failed to generate a loop cover message with a valid topology: {err}"
+                );
+                return;
+            }
+        };
 
         if let Err(err) = self.mix_tx.try_send(vec![cover_message]) {
             match err {

--- a/common/client-core/src/client/mix_traffic/mod.rs
+++ b/common/client-core/src/client/mix_traffic/mod.rs
@@ -113,7 +113,7 @@ impl MixTrafficController {
         spawn_future(async move {
             debug!("Started MixTrafficController with graceful shutdown support");
 
-            loop {
+            while !shutdown.is_shutdown() {
                 tokio::select! {
                     mix_packets = self.mix_rx.recv() => match mix_packets {
                         Some(mix_packets) => {
@@ -146,7 +146,7 @@ impl MixTrafficController {
                             log::trace!("MixTrafficController, client request channel closed");
                         }
                     },
-                    _ = shutdown.recv_with_delay() => {
+                    _ = shutdown.recv() => {
                         log::trace!("MixTrafficController: Received shutdown");
                         break;
                     }

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/acknowledgement_listener.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/acknowledgement_listener.rs
@@ -64,9 +64,12 @@ impl AcknowledgementListener {
         trace!("Received {} from the mix network", frag_id);
         self.stats_tx
             .report(PacketStatisticsEvent::RealAckReceived(ack_content.len()).into());
-        self.action_sender
+        if let Err(err) = self
+            .action_sender
             .unbounded_send(Action::new_remove(frag_id))
-            .unwrap();
+        {
+            error!("Failed to send remove action to action controller: {err}");
+        }
     }
 
     async fn handle_ack_receiver_item(&mut self, item: Vec<Vec<u8>>) {

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/acknowledgement_listener.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/acknowledgement_listener.rs
@@ -88,7 +88,7 @@ impl AcknowledgementListener {
                         break;
                     }
                 },
-                _ = shutdown.recv_with_delay() => {
+                _ = shutdown.recv() => {
                     log::trace!("AcknowledgementListener: Received shutdown");
                 }
             }

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/acknowledgement_listener.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/acknowledgement_listener.rs
@@ -11,6 +11,7 @@ use nym_sphinx::{
     acknowledgements::{identifier::recover_identifier, AckKey},
     chunking::fragment::{FragmentIdentifier, COVER_FRAG_ID},
 };
+use nym_task::TaskClient;
 use std::sync::Arc;
 
 /// Module responsible for listening for any data resembling acknowledgements from the network
@@ -20,6 +21,7 @@ pub(super) struct AcknowledgementListener {
     ack_receiver: AcknowledgementReceiver,
     action_sender: AckActionSender,
     stats_tx: ClientStatsSender,
+    task_client: TaskClient,
 }
 
 impl AcknowledgementListener {
@@ -28,12 +30,14 @@ impl AcknowledgementListener {
         ack_receiver: AcknowledgementReceiver,
         action_sender: AckActionSender,
         stats_tx: ClientStatsSender,
+        task_client: TaskClient,
     ) -> Self {
         AcknowledgementListener {
             ack_key,
             ack_receiver,
             action_sender,
             stats_tx,
+            task_client,
         }
     }
 
@@ -68,7 +72,9 @@ impl AcknowledgementListener {
             .action_sender
             .unbounded_send(Action::new_remove(frag_id))
         {
-            error!("Failed to send remove action to action controller: {err}");
+            if !self.task_client.is_shutdown_poll() {
+                error!("Failed to send remove action to action controller: {err}");
+            }
         }
     }
 
@@ -79,10 +85,10 @@ impl AcknowledgementListener {
         }
     }
 
-    pub(super) async fn run_with_shutdown(&mut self, mut shutdown: nym_task::TaskClient) {
+    pub(super) async fn run(&mut self) {
         debug!("Started AcknowledgementListener with graceful shutdown support");
 
-        while !shutdown.is_shutdown() {
+        while !self.task_client.is_shutdown() {
             tokio::select! {
                 acks = self.ack_receiver.next() => match acks {
                     Some(acks) => self.handle_ack_receiver_item(acks).await,
@@ -91,12 +97,12 @@ impl AcknowledgementListener {
                         break;
                     }
                 },
-                _ = shutdown.recv() => {
+                _ = self.task_client.recv() => {
                     log::trace!("AcknowledgementListener: Received shutdown");
                 }
             }
         }
-        shutdown.recv_timeout().await;
+        self.task_client.recv_timeout().await;
         log::debug!("AcknowledgementListener: Exiting");
     }
 }

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/action_controller.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/action_controller.rs
@@ -268,7 +268,7 @@ impl ActionController {
     pub(super) async fn run_with_shutdown(&mut self, mut shutdown: nym_task::TaskClient) {
         debug!("Started ActionController with graceful shutdown support");
 
-        loop {
+        while !shutdown.is_shutdown() {
             tokio::select! {
                 action = self.incoming_actions.next() => match action {
                     Some(action) => self.process_action(action),
@@ -286,7 +286,7 @@ impl ActionController {
                         break;
                     }
                 },
-                _ = shutdown.recv_with_delay() => {
+                _ = shutdown.recv() => {
                     log::trace!("ActionController: Received shutdown");
                     break;
                 }

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/input_message_listener.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/input_message_listener.rs
@@ -11,6 +11,7 @@ use nym_sphinx::anonymous_replies::requests::AnonymousSenderTag;
 use nym_sphinx::forwarding::packet::MixPacket;
 use nym_sphinx::params::PacketType;
 use nym_task::connections::TransmissionLane;
+use nym_task::TaskClient;
 use rand::{CryptoRng, Rng};
 
 /// Module responsible for dealing with the received messages: splitting them, creating acknowledgements,
@@ -23,6 +24,7 @@ where
     input_receiver: InputMessageReceiver,
     message_handler: MessageHandler<R>,
     reply_controller_sender: ReplyControllerSender,
+    task_client: TaskClient,
 }
 
 impl<R> InputMessageListener<R>
@@ -36,11 +38,13 @@ where
         input_receiver: InputMessageReceiver,
         message_handler: MessageHandler<R>,
         reply_controller_sender: ReplyControllerSender,
+        task_client: TaskClient,
     ) -> Self {
         InputMessageListener {
             input_receiver,
             message_handler,
             reply_controller_sender,
+            task_client,
         }
     }
 
@@ -63,8 +67,14 @@ where
         lane: TransmissionLane,
     ) {
         // offload reply handling to the dedicated task
-        self.reply_controller_sender
+        if let Err(err) = self
+            .reply_controller_sender
             .send_reply(recipient_tag, data, lane)
+        {
+            if !self.task_client.is_shutdown_poll() {
+                error!("failed to send a reply - {err}");
+            }
+        }
     }
 
     async fn handle_plain_message(
@@ -164,10 +174,10 @@ where
         };
     }
 
-    pub(super) async fn run_with_shutdown(&mut self, mut shutdown: nym_task::TaskClient) {
+    pub(super) async fn run(&mut self) {
         debug!("Started InputMessageListener with graceful shutdown support");
 
-        while !shutdown.is_shutdown() {
+        while !self.task_client.is_shutdown() {
             tokio::select! {
                 input_msg = self.input_receiver.recv() => match input_msg {
                     Some(input_msg) => {
@@ -178,12 +188,12 @@ where
                         break;
                     }
                 },
-                _ = shutdown.recv() => {
+                _ = self.task_client.recv() => {
                     log::trace!("InputMessageListener: Received shutdown");
                 }
             }
         }
-        shutdown.recv_timeout().await;
+        self.task_client.recv_timeout().await;
         log::debug!("InputMessageListener: Exiting");
     }
 }

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/input_message_listener.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/input_message_listener.rs
@@ -178,7 +178,7 @@ where
                         break;
                     }
                 },
-                _ = shutdown.recv_with_delay() => {
+                _ = shutdown.recv() => {
                     log::trace!("InputMessageListener: Received shutdown");
                 }
             }

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/mod.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/mod.rs
@@ -262,7 +262,7 @@ where
         let sent_notification_listener = SentNotificationListener::new(
             connectors.sent_notifier,
             connectors.ack_action_sender,
-            task_client.fork("sent_notification_listener"),
+            task_client.with_suffix("sent_notification_listener"),
         );
 
         AcknowledgementController {

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/mod.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/mod.rs
@@ -67,7 +67,7 @@ pub(crate) enum PacketDestination {
 
 /// Structure representing a data `Fragment` that is on-route to the specified `Recipient`
 #[derive(Debug)]
-pub(crate) struct PendingAcknowledgement {
+pub struct PendingAcknowledgement {
     message_chunk: Fragment,
     delay: SphinxDelay,
     destination: PacketDestination,
@@ -204,7 +204,6 @@ where
     retransmission_request_listener: RetransmissionRequestListener<R>,
     sent_notification_listener: SentNotificationListener,
     action_controller: ActionController,
-    task_client: TaskClient,
 }
 
 impl<R> AcknowledgementController<R>
@@ -228,6 +227,7 @@ where
             action_config,
             retransmission_tx,
             connectors.ack_action_receiver,
+            task_client.fork("action_controller"),
         );
 
         // will listen for any acks coming from the network
@@ -236,6 +236,7 @@ where
             connectors.ack_receiver,
             connectors.ack_action_sender.clone(),
             stats_tx,
+            task_client.fork("acknowledgement_listener"),
         );
 
         // will listen for any new messages from the client
@@ -243,6 +244,7 @@ where
             connectors.input_receiver,
             message_handler.clone(),
             reply_controller_sender.clone(),
+            task_client.fork("input_message_listener"),
         );
 
         // will listen for any ack timeouts and trigger retransmission
@@ -252,12 +254,16 @@ where
             message_handler,
             retransmission_rx,
             reply_controller_sender,
+            task_client.fork("retransmission_request_listener"),
         );
 
         // will listen for events indicating the packet was sent through the network so that
         // the retransmission timer should be started.
-        let sent_notification_listener =
-            SentNotificationListener::new(connectors.sent_notifier, connectors.ack_action_sender);
+        let sent_notification_listener = SentNotificationListener::new(
+            connectors.sent_notifier,
+            connectors.ack_action_sender,
+            task_client.fork("sent_notification_listener"),
+        );
 
         AcknowledgementController {
             acknowledgement_listener,
@@ -265,7 +271,6 @@ where
             retransmission_request_listener,
             sent_notification_listener,
             action_controller,
-            task_client,
         }
     }
 
@@ -276,42 +281,28 @@ where
         let mut sent_notification_listener = self.sent_notification_listener;
         let mut action_controller = self.action_controller;
 
-        let shutdown_handle = self.task_client.fork("acknowledgement_listener");
         spawn_future(async move {
-            acknowledgement_listener
-                .run_with_shutdown(shutdown_handle)
-                .await;
+            acknowledgement_listener.run().await;
             debug!("The acknowledgement listener has finished execution!");
         });
 
-        let shutdown_handle = self.task_client.fork("input_message_listener");
         spawn_future(async move {
-            input_message_listener
-                .run_with_shutdown(shutdown_handle)
-                .await;
+            input_message_listener.run().await;
             debug!("The input listener has finished execution!");
         });
 
-        let shutdown_handle = self.task_client.fork("retransmission_request_listener");
         spawn_future(async move {
-            retransmission_request_listener
-                .run_with_shutdown(shutdown_handle, packet_type)
-                .await;
+            retransmission_request_listener.run(packet_type).await;
             debug!("The retransmission request listener has finished execution!");
         });
 
-        let shutdown_handle = self.task_client.fork("sent_notification_listener");
         spawn_future(async move {
-            sent_notification_listener
-                .run_with_shutdown(shutdown_handle)
-                .await;
+            sent_notification_listener.run().await;
             debug!("The sent notification listener has finished execution!");
         });
 
         spawn_future(async move {
-            action_controller
-                .run_with_shutdown(self.task_client.with_suffix("action_controller"))
-                .await;
+            action_controller.run().await;
             debug!("The controller has finished execution!");
         });
     }

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/retransmission_request_listener.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/retransmission_request_listener.rs
@@ -14,7 +14,7 @@ use log::*;
 use nym_sphinx::chunking::fragment::Fragment;
 use nym_sphinx::preparer::PreparedFragment;
 use nym_sphinx::{addressing::clients::Recipient, params::PacketType};
-use nym_task::connections::TransmissionLane;
+use nym_task::{connections::TransmissionLane, TaskClient};
 use rand::{CryptoRng, Rng};
 use std::sync::{Arc, Weak};
 
@@ -25,6 +25,7 @@ pub(super) struct RetransmissionRequestListener<R> {
     message_handler: MessageHandler<R>,
     request_receiver: RetransmissionRequestReceiver,
     reply_controller_sender: ReplyControllerSender,
+    task_client: TaskClient,
 }
 
 impl<R> RetransmissionRequestListener<R>
@@ -37,6 +38,7 @@ where
         message_handler: MessageHandler<R>,
         request_receiver: RetransmissionRequestReceiver,
         reply_controller_sender: ReplyControllerSender,
+        task_client: TaskClient,
     ) -> Self {
         RetransmissionRequestListener {
             maximum_retransmissions,
@@ -44,6 +46,7 @@ where
             message_handler,
             request_receiver,
             reply_controller_sender,
+            task_client,
         }
     }
 
@@ -96,11 +99,16 @@ where
             } => {
                 // if this is retransmission for reply, offload it to the dedicated task
                 // that deals with all the surbs
-                return self.reply_controller_sender.send_retransmission_data(
+                if let Err(err) = self.reply_controller_sender.send_retransmission_data(
                     *recipient_tag,
                     weak_timed_out_ack,
                     *extra_surb_request,
-                );
+                ) {
+                    if !self.task_client.is_shutdown_poll() {
+                        error!("Failed to send retransmission data to the reply controller: {err}");
+                    }
+                }
+                return;
             }
             PacketDestination::KnownRecipient(recipient) => {
                 self.prepare_normal_retransmission_chunk(
@@ -151,7 +159,9 @@ where
             .action_sender
             .unbounded_send(Action::new_update_pending_ack(frag_id, new_delay))
         {
-            error!("Failed to send update pending ack action to the controller: {err}");
+            if !self.task_client.is_shutdown_poll() {
+                error!("Failed to send update pending ack action to the controller: {err}");
+            }
         }
 
         // send to `OutQueueControl` to eventually send to the mix network
@@ -166,14 +176,10 @@ where
             .await
     }
 
-    pub(super) async fn run_with_shutdown(
-        &mut self,
-        mut shutdown: nym_task::TaskClient,
-        packet_type: PacketType,
-    ) {
+    pub(super) async fn run(&mut self, packet_type: PacketType) {
         debug!("Started RetransmissionRequestListener with graceful shutdown support");
 
-        while !shutdown.is_shutdown() {
+        while !self.task_client.is_shutdown() {
             tokio::select! {
                 timed_out_ack = self.request_receiver.next() => match timed_out_ack {
                     Some(timed_out_ack) => self.on_retransmission_request(timed_out_ack, packet_type).await,
@@ -182,12 +188,12 @@ where
                         break;
                     }
                 },
-                _ = shutdown.recv() => {
+                _ = self.task_client.recv() => {
                     log::trace!("RetransmissionRequestListener: Received shutdown");
                 }
             }
         }
-        shutdown.recv_timeout().await;
+        self.task_client.recv_timeout().await;
         log::debug!("RetransmissionRequestListener: Exiting");
     }
 }

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/sent_notification_listener.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/sent_notification_listener.rs
@@ -40,7 +40,7 @@ impl SentNotificationListener {
     pub(super) async fn run_with_shutdown(&mut self, mut shutdown: nym_task::TaskClient) {
         debug!("Started SentNotificationListener with graceful shutdown support");
 
-        loop {
+        while !shutdown.is_shutdown() {
             tokio::select! {
                 frag_id = self.sent_notifier.next() => match frag_id {
                     Some(frag_id) => {
@@ -51,7 +51,7 @@ impl SentNotificationListener {
                         break;
                     }
                 },
-                _ = shutdown.recv_with_delay() => {
+                _ = shutdown.recv() => {
                     log::trace!("SentNotificationListener: Received shutdown");
                     break;
                 }

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/sent_notification_listener.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/sent_notification_listener.rs
@@ -6,6 +6,7 @@ use super::SentPacketNotificationReceiver;
 use futures::StreamExt;
 use log::*;
 use nym_sphinx::chunking::fragment::{FragmentIdentifier, COVER_FRAG_ID};
+use nym_task::TaskClient;
 
 /// Module responsible for starting up retransmission timers.
 /// It is required because when we send our packet to the `real traffic stream` controlled
@@ -14,16 +15,19 @@ use nym_sphinx::chunking::fragment::{FragmentIdentifier, COVER_FRAG_ID};
 pub(super) struct SentNotificationListener {
     sent_notifier: SentPacketNotificationReceiver,
     action_sender: AckActionSender,
+    task_client: TaskClient,
 }
 
 impl SentNotificationListener {
     pub(super) fn new(
         sent_notifier: SentPacketNotificationReceiver,
         action_sender: AckActionSender,
+        task_client: TaskClient,
     ) -> Self {
         SentNotificationListener {
             sent_notifier,
             action_sender,
+            task_client,
         }
     }
 
@@ -36,14 +40,16 @@ impl SentNotificationListener {
             .action_sender
             .unbounded_send(Action::new_start_timer(frag_id))
         {
-            error!("Failed to send start timer action to action controller: {err}");
+            if !self.task_client.is_shutdown_poll() {
+                error!("Failed to send start timer action to action controller: {err}");
+            }
         }
     }
 
-    pub(super) async fn run_with_shutdown(&mut self, mut shutdown: nym_task::TaskClient) {
+    pub(super) async fn run(&mut self) {
         debug!("Started SentNotificationListener with graceful shutdown support");
 
-        while !shutdown.is_shutdown() {
+        while !self.task_client.is_shutdown() {
             tokio::select! {
                 frag_id = self.sent_notifier.next() => match frag_id {
                     Some(frag_id) => {
@@ -54,13 +60,13 @@ impl SentNotificationListener {
                         break;
                     }
                 },
-                _ = shutdown.recv() => {
+                _ = self.task_client.recv() => {
                     log::trace!("SentNotificationListener: Received shutdown");
                     break;
                 }
             }
         }
-        assert!(shutdown.is_shutdown_poll());
+        assert!(self.task_client.is_shutdown_poll());
         log::debug!("SentNotificationListener: Exiting");
     }
 }

--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/sent_notification_listener.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/sent_notification_listener.rs
@@ -32,9 +32,12 @@ impl SentNotificationListener {
             trace!("sent off a cover message - no need to start retransmission timer!");
             return;
         }
-        self.action_sender
+        if let Err(err) = self
+            .action_sender
             .unbounded_send(Action::new_start_timer(frag_id))
-            .unwrap();
+        {
+            error!("Failed to send start timer action to action controller: {err}");
+        }
     }
 
     pub(super) async fn run_with_shutdown(&mut self, mut shutdown: nym_task::TaskClient) {

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -609,15 +609,21 @@ where
     }
 
     pub(crate) fn update_ack_delay(&self, id: FragmentIdentifier, new_delay: Delay) {
-        self.action_sender
+        if let Err(err) = self
+            .action_sender
             .unbounded_send(Action::UpdatePendingAck(id, new_delay))
-            .expect("action control task has died")
+        {
+            error!("Failed to send update action to the controller: {err}");
+        }
     }
 
     pub(crate) fn insert_pending_acks(&self, pending_acks: Vec<PendingAcknowledgement>) {
-        self.action_sender
+        if let Err(err) = self
+            .action_sender
             .unbounded_send(Action::new_insert(pending_acks))
-            .expect("action control task has died")
+        {
+            error!("Failed to send insert action to the controller: {err}");
+        }
     }
 
     // tells real message sender (with the poisson timer) to send this to the mix network

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -618,7 +618,7 @@ where
             .action_sender
             .unbounded_send(Action::UpdatePendingAck(id, new_delay))
         {
-            if !self.task_client.is_shutdown() {
+            if !self.task_client.is_shutdown_poll() {
                 error!("Failed to send update action to the controller: {err}");
             }
         }
@@ -629,7 +629,7 @@ where
             .action_sender
             .unbounded_send(Action::new_insert(pending_acks))
         {
-            if !self.task_client.is_shutdown() {
+            if !self.task_client.is_shutdown_poll() {
                 error!("Failed to send insert action to the controller: {err}");
             }
         }
@@ -646,7 +646,7 @@ where
             .send((messages, transmission_lane))
             .await
         {
-            if !self.task_client.is_shutdown() {
+            if !self.task_client.is_shutdown_poll() {
                 error!("Failed to forward messages to the real message sender: {err}");
             }
         }

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -613,7 +613,7 @@ where
             .action_sender
             .unbounded_send(Action::UpdatePendingAck(id, new_delay))
         {
-            error!("Failed to send update action to the controller: {err}");
+            warn!("Failed to send update action to the controller: {err}");
         }
     }
 
@@ -622,7 +622,7 @@ where
             .action_sender
             .unbounded_send(Action::new_insert(pending_acks))
         {
-            error!("Failed to send insert action to the controller: {err}");
+            warn!("Failed to send insert action to the controller: {err}");
         }
     }
 
@@ -637,9 +637,7 @@ where
             .send((messages, transmission_lane))
             .await
         {
-            error!(
-                "Failed to forward messages to the real message sender (OutQueueControl): {err}"
-            );
+            warn!("Failed to forward messages to the real message sender (OutQueueControl): {err}");
         }
     }
 }

--- a/common/client-core/src/client/real_messages_control/mod.rs
+++ b/common/client-core/src/client/real_messages_control/mod.rs
@@ -179,6 +179,7 @@ impl RealMessagesController<OsRng> {
             topology_access.clone(),
             reply_storage.key_storage(),
             reply_storage.tags_storage(),
+            task_client.fork("message_handler"),
         );
 
         let ack_control = AcknowledgementController::new(

--- a/common/client-core/src/client/real_messages_control/mod.rs
+++ b/common/client-core/src/client/real_messages_control/mod.rs
@@ -31,6 +31,7 @@ use nym_sphinx::addressing::clients::Recipient;
 use nym_sphinx::params::PacketType;
 use nym_statistics_common::clients::ClientStatsSender;
 use nym_task::connections::{ConnectionCommandReceiver, LaneQueueLengths};
+use nym_task::TaskClient;
 use rand::{rngs::OsRng, CryptoRng, Rng};
 use std::sync::Arc;
 
@@ -147,6 +148,7 @@ impl RealMessagesController<OsRng> {
         lane_queue_lengths: LaneQueueLengths,
         client_connection_rx: ConnectionCommandReceiver,
         stats_tx: ClientStatsSender,
+        task_client: TaskClient,
     ) -> Self {
         let rng = OsRng;
 
@@ -186,6 +188,7 @@ impl RealMessagesController<OsRng> {
             message_handler.clone(),
             reply_controller_sender,
             stats_tx.clone(),
+            task_client.fork("ack_control"),
         );
 
         let reply_control = ReplyController::new(
@@ -193,6 +196,7 @@ impl RealMessagesController<OsRng> {
             message_handler,
             reply_storage,
             reply_controller_receiver,
+            task_client.fork("reply_controller"),
         );
 
         let out_queue_control = OutQueueControl::new(
@@ -205,6 +209,7 @@ impl RealMessagesController<OsRng> {
             lane_queue_lengths,
             client_connection_rx,
             stats_tx,
+            task_client.with_suffix("out_queue_control"),
         );
 
         RealMessagesController {
@@ -214,22 +219,20 @@ impl RealMessagesController<OsRng> {
         }
     }
 
-    pub fn start_with_shutdown(self, shutdown: nym_task::TaskClient, packet_type: PacketType) {
+    pub fn start(self, packet_type: PacketType) {
         let mut out_queue_control = self.out_queue_control;
         let ack_control = self.ack_control;
         let mut reply_control = self.reply_control;
 
-        let shutdown_handle = shutdown.fork("out_queue_control");
         spawn_future(async move {
-            out_queue_control.run_with_shutdown(shutdown_handle).await;
+            out_queue_control.run().await;
             debug!("The out queue controller has finished execution!");
         });
-        let shutdown_handle = shutdown.fork("reply_control");
         spawn_future(async move {
-            reply_control.run_with_shutdown(shutdown_handle).await;
+            reply_control.run().await;
             debug!("The reply controller has finished execution!");
         });
 
-        ack_control.start_with_shutdown(shutdown.with_suffix("ack_control"), packet_type);
+        ack_control.start(packet_type);
     }
 }

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -224,10 +224,7 @@ where
         }
     }
 
-    async fn on_message(
-        &mut self,
-        next_message: StreamMessage,
-    ) {
+    async fn on_message(&mut self, next_message: StreamMessage) {
         trace!("created new message");
 
         let (next_message, fragment_id, packet_size) = match next_message {

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -198,7 +198,9 @@ where
         // queues and client load rather than the required delay. So realistically we can treat
         // whatever is about to happen as negligible additional delay.
         trace!("{} is about to get sent to the mixnet", frag_id);
-        self.sent_notifier.unbounded_send(frag_id).unwrap();
+        if let Err(err) = self.sent_notifier.unbounded_send(frag_id) {
+            error!("Failed to notify about sent message: {err}");
+        }
     }
 
     fn loop_cover_message_size(&mut self) -> PacketSize {

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -542,7 +542,7 @@ where
         {
             let mut status_timer = tokio::time::interval(Duration::from_secs(5));
 
-            loop {
+            while !shutdown.is_shutdown() {
                 tokio::select! {
                     biased;
                     _ = shutdown.recv() => {

--- a/common/client-core/src/client/received_buffer.rs
+++ b/common/client-core/src/client/received_buffer.rs
@@ -428,7 +428,7 @@ impl<R: MessageReceiver> RequestReceiver<R> {
         while !shutdown.is_shutdown() {
             tokio::select! {
                 biased;
-                _ = shutdown.recv_with_delay() => {
+                _ = shutdown.recv() => {
                     log::trace!("RequestReceiver: Received shutdown");
                 }
                 request = self.query_receiver.next() => {
@@ -441,7 +441,7 @@ impl<R: MessageReceiver> RequestReceiver<R> {
                 },
             }
         }
-        shutdown.recv_timeout().await;
+        shutdown.recv().await;
         log::debug!("RequestReceiver: Exiting");
     }
 }

--- a/common/client-core/src/client/replies/reply_controller/mod.rs
+++ b/common/client-core/src/client/replies/reply_controller/mod.rs
@@ -860,7 +860,7 @@ where
         while !shutdown.is_shutdown() {
             tokio::select! {
                 biased;
-                _ = shutdown.recv_with_delay() => {
+                _ = shutdown.recv() => {
                     log::trace!("ReplyController: Received shutdown");
                 },
                 req = self.request_receiver.next() => match req {

--- a/common/client-core/src/client/replies/reply_controller/mod.rs
+++ b/common/client-core/src/client/replies/reply_controller/mod.rs
@@ -12,6 +12,7 @@ use nym_sphinx::anonymous_replies::requests::AnonymousSenderTag;
 use nym_sphinx::anonymous_replies::ReplySurb;
 use nym_sphinx::chunking::fragment::{Fragment, FragmentIdentifier};
 use nym_task::connections::{ConnectionId, TransmissionLane};
+use nym_task::TaskClient;
 use rand::{CryptoRng, Rng};
 use std::cmp::{max, min};
 use std::collections::btree_map::Entry;
@@ -68,6 +69,9 @@ pub struct ReplyController<R> {
 
     message_handler: MessageHandler<R>,
     full_reply_storage: CombinedReplyStorage,
+
+    // Listen for shutdown signals
+    task_client: TaskClient,
 }
 
 impl<R> ReplyController<R>
@@ -79,6 +83,7 @@ where
         message_handler: MessageHandler<R>,
         full_reply_storage: CombinedReplyStorage,
         request_receiver: ReplyControllerReceiver,
+        task_client: TaskClient,
     ) -> Self {
         ReplyController {
             config,
@@ -87,6 +92,7 @@ where
             pending_retransmissions: HashMap::new(),
             message_handler,
             full_reply_storage,
+            task_client,
         }
     }
 
@@ -846,8 +852,10 @@ where
     //     todo!()
     // }
 
-    pub(crate) async fn run_with_shutdown(&mut self, mut shutdown: nym_task::TaskClient) {
+    pub(crate) async fn run(&mut self) {
         debug!("Started ReplyController with graceful shutdown support");
+
+        let mut shutdown = self.task_client.fork("select");
 
         let polling_rate = Duration::from_secs(5);
         let mut stale_inspection = new_interval_stream(polling_rate);

--- a/common/client-core/src/client/replies/reply_controller/requests.rs
+++ b/common/client-core/src/client/replies/reply_controller/requests.rs
@@ -15,6 +15,27 @@ pub(crate) fn new_control_channels() -> (ReplyControllerSender, ReplyControllerR
     (tx.into(), rx)
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ReplyControllerSenderError {
+    #[error("failed to send retransmission data to reply controller")]
+    SendRetransmissionData(#[source] mpsc::TrySendError<ReplyControllerMessage>),
+
+    #[error("failed to send reply to reply controller")]
+    SendReply(#[source] mpsc::TrySendError<ReplyControllerMessage>),
+
+    #[error("failed to send additional surbs to reply controller")]
+    AdditionalSurbs(#[source] mpsc::TrySendError<ReplyControllerMessage>),
+
+    #[error("failed to send additional surbs request to reply controller")]
+    AdditionalSurbsRequest(#[source] mpsc::TrySendError<ReplyControllerMessage>),
+
+    #[error("failed to request lane queue length from reply controller")]
+    LaneQueueLength(#[source] mpsc::TrySendError<ReplyControllerMessage>),
+
+    #[error("response channel was dropped before we could receive the response")]
+    ResponseChannelDropped(#[source] oneshot::Canceled),
+}
+
 #[derive(Debug, Clone)]
 pub struct ReplyControllerSender(mpsc::UnboundedSender<ReplyControllerMessage>);
 
@@ -30,17 +51,14 @@ impl ReplyControllerSender {
         recipient: AnonymousSenderTag,
         timed_out_ack: Weak<PendingAcknowledgement>,
         extra_surb_request: bool,
-    ) {
-        if let Err(err) = self
-            .0
+    ) -> Result<(), ReplyControllerSenderError> {
+        self.0
             .unbounded_send(ReplyControllerMessage::RetransmitReply {
                 recipient,
                 timed_out_ack,
                 extra_surb_request,
             })
-        {
-            error!("Failed to send retransmission data to reply controller: {err}",);
-        }
+            .map_err(ReplyControllerSenderError::SendRetransmissionData)
     }
 
     pub(crate) fn send_reply(
@@ -48,14 +66,14 @@ impl ReplyControllerSender {
         recipient: AnonymousSenderTag,
         message: Vec<u8>,
         lane: TransmissionLane,
-    ) {
-        if let Err(err) = self.0.unbounded_send(ReplyControllerMessage::SendReply {
-            recipient,
-            message,
-            lane,
-        }) {
-            error!("Failed to send reply to reply controller: {err}",);
-        }
+    ) -> Result<(), ReplyControllerSenderError> {
+        self.0
+            .unbounded_send(ReplyControllerMessage::SendReply {
+                recipient,
+                message,
+                lane,
+            })
+            .map_err(ReplyControllerSenderError::SendReply)
     }
 
     pub(crate) fn send_additional_surbs(
@@ -63,32 +81,33 @@ impl ReplyControllerSender {
         sender_tag: AnonymousSenderTag,
         reply_surbs: Vec<ReplySurb>,
         from_surb_request: bool,
-    ) {
-        if let Err(err) = self
-            .0
+    ) -> Result<(), ReplyControllerSenderError> {
+        self.0
             .unbounded_send(ReplyControllerMessage::AdditionalSurbs {
                 sender_tag,
                 reply_surbs,
                 from_surb_request,
             })
-        {
-            error!("Failed to send additional surbs to reply controller: {err}",);
-        }
+            .map_err(ReplyControllerSenderError::AdditionalSurbs)
     }
 
-    pub(crate) fn send_additional_surbs_request(&self, recipient: Recipient, amount: u32) {
-        if let Err(err) = self
-            .0
+    pub(crate) fn send_additional_surbs_request(
+        &self,
+        recipient: Recipient,
+        amount: u32,
+    ) -> Result<(), ReplyControllerSenderError> {
+        self.0
             .unbounded_send(ReplyControllerMessage::AdditionalSurbsRequest {
                 recipient: Box::new(recipient),
                 amount,
             })
-        {
-            error!("Failed to send additional surbs request to reply controller: {err}");
-        }
+            .map_err(ReplyControllerSenderError::AdditionalSurbsRequest)
     }
 
-    pub async fn get_lane_queue_length(&self, connection_id: ConnectionId) -> usize {
+    pub async fn get_lane_queue_length(
+        &self,
+        connection_id: ConnectionId,
+    ) -> Result<usize, ReplyControllerSenderError> {
         let (response_tx, response_rx) = oneshot::channel();
         if let Err(err) = self
             .0
@@ -97,17 +116,12 @@ impl ReplyControllerSender {
                 response_channel: response_tx,
             })
         {
-            error!("Failed to send lane queue length request to reply controller: {err}");
+            return Err(ReplyControllerSenderError::LaneQueueLength(err));
         }
 
-        match response_rx.await {
-            Ok(length) => length,
-            Err(_) => {
-                error!("The reply controller has dropped our response channel!");
-                // TODO: should we panic here instead? this message implies something weird and unrecoverable has happened
-                0
-            }
-        }
+        response_rx
+            .await
+            .map_err(ReplyControllerSenderError::ResponseChannelDropped)
     }
 }
 
@@ -122,7 +136,10 @@ impl ReplyQueueLengths {
         }
     }
 
-    pub async fn get_lane_queue_length(&self, connection_id: ConnectionId) -> usize {
+    pub async fn get_lane_queue_length(
+        &self,
+        connection_id: ConnectionId,
+    ) -> Result<usize, ReplyControllerSenderError> {
         self.reply_controller_sender
             .get_lane_queue_length(connection_id)
             .await
@@ -132,7 +149,7 @@ impl ReplyQueueLengths {
 pub(crate) type ReplyControllerReceiver = mpsc::UnboundedReceiver<ReplyControllerMessage>;
 
 #[derive(Debug)]
-pub(crate) enum ReplyControllerMessage {
+pub enum ReplyControllerMessage {
     RetransmitReply {
         recipient: AnonymousSenderTag,
         timed_out_ack: Weak<PendingAcknowledgement>,

--- a/common/client-core/src/client/statistics_control.rs
+++ b/common/client-core/src/client/statistics_control.rs
@@ -121,7 +121,7 @@ impl StatisticsControl {
         let mut snapshot_interval =
             gloo_timers::future::IntervalStream::new(SNAPSHOT_INTERVAL.as_millis() as u32);
 
-        loop {
+        while !task_client.is_shutdown() {
             tokio::select! {
                 biased;
                 _ = task_client.recv() => {

--- a/common/client-core/src/client/statistics_control.rs
+++ b/common/client-core/src/client/statistics_control.rs
@@ -74,7 +74,7 @@ impl StatisticsControl {
                 stats_rx,
                 report_tx,
                 reporting_config,
-                task_client: task_client.fork("statistics-control"),
+                task_client: task_client.fork("statistics_control"),
             },
             ClientStatsSender::new(Some(stats_tx), task_client),
         )

--- a/common/client-core/src/client/statistics_control.rs
+++ b/common/client-core/src/client/statistics_control.rs
@@ -51,6 +51,9 @@ pub(crate) struct StatisticsControl {
 
     /// Config for stats reporting (enabled, address, interval)
     reporting_config: StatsReporting,
+
+    /// Task client for listening for shutdown
+    task_client: nym_task::TaskClient,
 }
 
 impl StatisticsControl {
@@ -59,6 +62,7 @@ impl StatisticsControl {
         client_type: String,
         client_stats_id: String,
         report_tx: InputMessageSender,
+        task_client: nym_task::TaskClient,
     ) -> (Self, ClientStatsSender) {
         let (stats_tx, stats_rx) = tokio::sync::mpsc::unbounded_channel();
 
@@ -70,8 +74,9 @@ impl StatisticsControl {
                 stats_rx,
                 report_tx,
                 reporting_config,
+                task_client: task_client.fork("statistics-control"),
             },
-            ClientStatsSender::new(Some(stats_tx)),
+            ClientStatsSender::new(Some(stats_tx), task_client),
         )
     }
 
@@ -91,7 +96,7 @@ impl StatisticsControl {
         }
     }
 
-    async fn run_with_shutdown(&mut self, mut task_client: nym_task::TaskClient) {
+    async fn run(&mut self) {
         log::debug!("Started StatisticsControl with graceful shutdown support");
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -121,10 +126,10 @@ impl StatisticsControl {
         let mut snapshot_interval =
             gloo_timers::future::IntervalStream::new(SNAPSHOT_INTERVAL.as_millis() as u32);
 
-        while !task_client.is_shutdown() {
+        while !self.task_client.is_shutdown() {
             tokio::select! {
                 biased;
-                _ = task_client.recv() => {
+                _ = self.task_client.recv() => {
                     log::trace!("StatisticsControl: Received shutdown");
                     break;
                 },
@@ -149,16 +154,16 @@ impl StatisticsControl {
                 }
 
                 _ = local_report_interval.next() => {
-                    self.stats.local_report(&mut task_client);
+                    self.stats.local_report(&mut self.task_client);
                 }
             }
         }
         log::debug!("StatisticsControl: Exiting");
     }
 
-    pub(crate) fn start_with_shutdown(mut self, task_client: nym_task::TaskClient) {
+    pub(crate) fn start(mut self) {
         spawn_future(async move {
-            self.run_with_shutdown(task_client).await;
+            self.run().await;
         })
     }
 
@@ -169,9 +174,14 @@ impl StatisticsControl {
         report_tx: InputMessageSender,
         task_client: nym_task::TaskClient,
     ) -> ClientStatsSender {
-        let (controller, sender) =
-            Self::create(reporting_config, client_type, client_stats_id, report_tx);
-        controller.start_with_shutdown(task_client);
+        let (controller, sender) = Self::create(
+            reporting_config,
+            client_type,
+            client_stats_id,
+            report_tx,
+            task_client,
+        );
+        controller.start();
         sender
     }
 }

--- a/common/client-core/src/client/statistics_control.rs
+++ b/common/client-core/src/client/statistics_control.rs
@@ -167,7 +167,7 @@ impl StatisticsControl {
         })
     }
 
-    pub(crate) fn create_and_start_with_shutdown(
+    pub(crate) fn create_and_start(
         reporting_config: StatsReporting,
         client_type: String,
         client_stats_id: String,

--- a/common/client-libs/gateway-client/src/client/mod.rs
+++ b/common/client-libs/gateway-client/src/client/mod.rs
@@ -1053,7 +1053,7 @@ impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
             connection: SocketState::NotConnected,
             packet_router,
             bandwidth_controller: None,
-            stats_reporter: ClientStatsSender::new(None),
+            stats_reporter: ClientStatsSender::new(None, task_client.clone()),
             negotiated_protocol: None,
             #[cfg(unix)]
             connection_fd_callback: None,

--- a/common/statistics/src/clients/mod.rs
+++ b/common/statistics/src/clients/mod.rs
@@ -36,9 +36,9 @@ impl ClientStatsSender {
     /// Report a statistics event using the sender.
     pub fn report(&self, event: ClientStatsEvents) {
         if let Some(tx) = &self.stats_tx {
-            if let Err(err) = tx.send(event) {
-                log::error!("Failed to send stats event: {:?}", err);
-            }
+            tx.send(event)
+                .inspect_err(|err| log::debug!("Failed to send stats event: {err}"))
+                .ok();
         }
     }
 }

--- a/common/task/src/manager.rs
+++ b/common/task/src/manager.rs
@@ -299,6 +299,8 @@ impl Clone for TaskClient {
             None
         };
 
+        log::debug!("Cloned task client: {name:?}");
+
         TaskClient {
             name,
             shutdown: AtomicBool::new(self.shutdown.load(Ordering::Relaxed)),
@@ -344,6 +346,7 @@ impl TaskClient {
             format!("unknown-{suffix}")
         };
 
+        log::debug!("Forked task client: {child_name}");
         child.name = Some(child_name);
         child
     }
@@ -377,6 +380,7 @@ impl TaskClient {
         } else {
             format!("unknown-{suffix}")
         };
+        log::debug!("Renamed task client: {name}");
         self.named(name)
     }
 

--- a/common/wireguard/src/peer_handle.rs
+++ b/common/wireguard/src/peer_handle.rs
@@ -43,7 +43,7 @@ impl PeerHandle {
         let timeout_check_interval = tokio_stream::wrappers::IntervalStream::new(
             tokio::time::interval(DEFAULT_PEER_TIMEOUT_CHECK),
         );
-        let mut task_client = task_client.fork(format!("peer-{public_key}"));
+        let mut task_client = task_client.fork(format!("peer_{public_key}"));
         task_client.disarm();
         PeerHandle {
             public_key,

--- a/gateway/src/node/client_handling/websocket/connection_handler/mod.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/mod.rs
@@ -95,7 +95,7 @@ where
     S: AsyncRead + AsyncWrite + Unpin + Send,
 {
     // don't accept any new requests if we have already received shutdown
-    if handle.shutdown.is_shutdown() {
+    if handle.shutdown.is_shutdown_poll() {
         debug!("stopping the handle as we have received a shutdown");
         return;
     }

--- a/gateway/src/node/client_handling/websocket/listener.rs
+++ b/gateway/src/node/client_handling/websocket/listener.rs
@@ -50,7 +50,7 @@ impl Listener {
                 connection = tcp_listener.accept() => {
                     match connection {
                         Ok((socket, remote_addr)) => {
-                            let shutdown = self.shutdown.fork(format!("websocket-handler-{remote_addr}"));
+                            let shutdown = self.shutdown.fork(format!("websocket_handler_{remote_addr}"));
                             trace!("received a socket connection from {remote_addr}");
                             // TODO: I think we *REALLY* need a mechanism for having a maximum number of connected
                             // clients or spawned tokio tasks -> perhaps a worker system?

--- a/gateway/src/node/mod.rs
+++ b/gateway/src/node/mod.rs
@@ -225,7 +225,7 @@ impl GatewayTasksBuilder {
                 handler_config,
                 nyxd_client,
                 self.identity_keypair.public_key().to_bytes(),
-                self.shutdown.fork("ecash-manager"),
+                self.shutdown.fork("ecash_manager"),
                 self.storage.clone(),
             )
             .await?,
@@ -279,13 +279,13 @@ impl GatewayTasksBuilder {
         let mut message_router_builder = SpMessageRouterBuilder::new(
             *self.identity_keypair.public_key(),
             self.mix_packet_sender.clone(),
-            self.shutdown.fork("network-requester-message-router"),
+            self.shutdown.fork("network_requester_message_router"),
         );
         let transceiver = message_router_builder.gateway_transceiver();
 
         let (on_start_tx, on_start_rx) = oneshot::channel();
         let mut nr_builder = NRServiceProviderBuilder::new(nr_opts.config.clone())
-            .with_shutdown(self.shutdown.fork("network-requester-sp"))
+            .with_shutdown(self.shutdown.fork("network_requester_sp"))
             .with_custom_gateway_transceiver(transceiver)
             .with_wait_for_gateway(true)
             .with_minimum_gateway_performance(0)
@@ -314,13 +314,13 @@ impl GatewayTasksBuilder {
         let mut message_router_builder = SpMessageRouterBuilder::new(
             *self.identity_keypair.public_key(),
             self.mix_packet_sender.clone(),
-            self.shutdown.fork("ipr-message-router"),
+            self.shutdown.fork("ipr_message_router"),
         );
         let transceiver = message_router_builder.gateway_transceiver();
 
         let (on_start_tx, on_start_rx) = oneshot::channel();
         let mut ip_packet_router = IpPacketRouter::new(ip_opts.config.clone())
-            .with_shutdown(self.shutdown.fork("ipr-sp"))
+            .with_shutdown(self.shutdown.fork("ipr_sp"))
             .with_custom_gateway_transceiver(Box::new(transceiver))
             .with_wait_for_gateway(true)
             .with_minimum_gateway_performance(0)
@@ -418,7 +418,7 @@ impl GatewayTasksBuilder {
         let mut message_router_builder = SpMessageRouterBuilder::new(
             *self.identity_keypair.public_key(),
             self.mix_packet_sender.clone(),
-            self.shutdown.fork("authenticator-message-router"),
+            self.shutdown.fork("authenticator_message_router"),
         );
         let transceiver = message_router_builder.gateway_transceiver();
 
@@ -431,7 +431,7 @@ impl GatewayTasksBuilder {
         )
         .with_ecash_verifier(ecash_manager)
         .with_custom_gateway_transceiver(transceiver)
-        .with_shutdown(self.shutdown.fork("authenticator-sp"))
+        .with_shutdown(self.shutdown.fork("authenticator_sp"))
         .with_wait_for_gateway(true)
         .with_minimum_gateway_performance(0)
         .with_custom_topology_provider(topology_provider)
@@ -451,7 +451,7 @@ impl GatewayTasksBuilder {
     pub fn build_stale_messages_cleaner(&self) -> StaleMessagesCleaner {
         StaleMessagesCleaner::new(
             &self.storage,
-            self.shutdown.fork("stale-messages-cleaner"),
+            self.shutdown.fork("stale_messages_cleaner"),
             self.config.debug.stale_messages_max_age,
             self.config.debug.stale_messages_cleaner_run_interval,
         )

--- a/nym-api/src/network_monitor/monitor/sender.rs
+++ b/nym-api/src/network_monitor/monitor/sender.rs
@@ -184,7 +184,10 @@ impl PacketSender {
             shared_keys,
             gateway_packet_router,
             Some(fresh_gateway_client_data.bandwidth_controller.clone()),
-            nym_statistics_common::clients::ClientStatsSender::new(None),
+            nym_statistics_common::clients::ClientStatsSender::new(
+                None,
+                task_client.fork("client-stats-sender"),
+            ),
             #[cfg(unix)]
             None,
             task_client,

--- a/nym-api/src/network_monitor/monitor/sender.rs
+++ b/nym-api/src/network_monitor/monitor/sender.rs
@@ -167,7 +167,7 @@ impl PacketSender {
         let gateway_packet_router = PacketRouter::new(
             ack_sender,
             message_sender,
-            task_client.fork("packet-router"),
+            task_client.fork("packet_router"),
         );
 
         let shared_keys = fresh_gateway_client_data
@@ -186,7 +186,7 @@ impl PacketSender {
             Some(fresh_gateway_client_data.bandwidth_controller.clone()),
             nym_statistics_common::clients::ClientStatsSender::new(
                 None,
-                task_client.fork("client-stats-sender"),
+                task_client.fork("client_stats_sender"),
             ),
             #[cfg(unix)]
             None,

--- a/service-providers/authenticator/src/cli/run.rs
+++ b/service-providers/authenticator/src/cli/run.rs
@@ -41,7 +41,7 @@ pub(crate) async fn execute(args: &Run) -> Result<(), AuthenticatorError> {
         Arc::new(KeyPair::new(&mut OsRng)),
     );
     let task_handler = TaskHandle::default();
-    let handler = DummyHandler::new(peer_rx, task_handler.fork("peer-handler"));
+    let handler = DummyHandler::new(peer_rx, task_handler.fork("peer_handler"));
     tokio::spawn(async move {
         handler.run().await;
     });

--- a/wasm/node-tester/src/tester.rs
+++ b/wasm/node-tester/src/tester.rs
@@ -190,12 +190,15 @@ impl NymNodeTesterBuilder {
 
         let gateway_identity = gateway_info.gateway_id;
 
+        let mut stats_sender_task = task_manager.subscribe().named("stats_sender");
+        stats_sender_task.disarm();
+
         let mut gateway_client =
             if let Some(existing_client) = initialisation_result.authenticated_ephemeral_client {
                 existing_client.upgrade(
                     packet_router,
                     self.bandwidth_controller.take(),
-                    ClientStatsSender::new(None),
+                    ClientStatsSender::new(None, stats_sender_task),
                     gateway_task,
                 )
             } else {
@@ -211,7 +214,7 @@ impl NymNodeTesterBuilder {
                     Some(gateway_info.shared_key),
                     packet_router,
                     self.bandwidth_controller.take(),
-                    ClientStatsSender::new(None),
+                    ClientStatsSender::new(None, stats_sender_task),
                     gateway_task,
                 )
             };


### PR DESCRIPTION
Inside client-core we want to prepare the ground for moving a behaviour
close to what we have in the vpn client.

Remove all the recv_with_delay since we want to just stop

Add shutdown condition to all select loops to guard against the shutdown
listener being polled inside the select blocks.

Remove unwraps when sending on unbounded channels in case the receiver exits before the sender

Move `TaskClient` to be a member field so make it easier to wrap log errors in a shutdown check.

Update all fork names to use underscore consistently, since the task separator is hyphen

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5435)
<!-- Reviewable:end -->
