### PR TITLE
Seedable clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5545,6 +5545,7 @@ dependencies = [
  "rand_chacha",
  "serde",
  "serde_bytes",
+ "sha2 0.10.8",
  "subtle-encoding",
  "thiserror 2.0.11",
  "x25519-dalek",

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -40,6 +40,7 @@ use nym_client_core_config_types::ForgetMe;
 use nym_client_core_gateways_storage::{GatewayDetails, GatewaysDetailsStore};
 use nym_credential_storage::storage::Storage as CredentialStorage;
 use nym_crypto::asymmetric::{encryption, identity};
+use nym_crypto::hkdf::DerivationMaterial;
 use nym_gateway_client::client::config::GatewayClientConfig;
 use nym_gateway_client::{
     AcknowledgementReceiver, GatewayClient, GatewayConfig, MixnetMessageReceiver, PacketRouter,
@@ -192,6 +193,8 @@ pub struct BaseClientBuilder<C, S: MixnetClientStorage> {
 
     #[cfg(unix)]
     connection_fd_callback: Option<Arc<dyn Fn(RawFd) + Send + Sync>>,
+
+    derivation_material: Option<DerivationMaterial>,
 }
 
 impl<C, S> BaseClientBuilder<C, S>
@@ -216,7 +219,17 @@ where
             setup_method: GatewaySetup::MustLoad { gateway_id: None },
             #[cfg(unix)]
             connection_fd_callback: None,
+            derivation_material: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_derivation_material(
+        mut self,
+        derivation_material: Option<DerivationMaterial>,
+    ) -> Self {
+        self.derivation_material = derivation_material;
+        self
     }
 
     #[must_use]
@@ -684,6 +697,7 @@ where
         setup_method: GatewaySetup,
         key_store: &S::KeyStore,
         details_store: &S::GatewaysDetailsStore,
+        derivation_material: Option<DerivationMaterial>,
     ) -> Result<InitialisationResult, ClientCoreError>
     where
         <S::KeyStore as KeyStore>::StorageError: Sync + Send,
@@ -693,7 +707,12 @@ where
         if key_store.load_keys().await.is_err() {
             info!("could not find valid client keys - a new set will be generated");
             let mut rng = OsRng;
-            let keys = ClientKeys::generate_new(&mut rng);
+            let keys = if let Some(derivation_material) = derivation_material {
+                ClientKeys::from_master_key(&mut rng, &derivation_material)
+                    .map_err(|_| ClientCoreError::HkdfDerivationError {})?
+            } else {
+                ClientKeys::generate_new(&mut rng)
+            };
             store_client_keys(keys, key_store).await?;
         }
 
@@ -715,6 +734,7 @@ where
             self.setup_method,
             self.client_store.key_store(),
             self.client_store.gateway_details_store(),
+            self.derivation_material,
         )
         .await?;
 

--- a/common/client-core/src/client/key_manager/mod.rs
+++ b/common/client-core/src/client/key_manager/mod.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use zeroize::ZeroizeOnDrop;
 
 pub mod persistence;
+mod test;
 
 // Note: to support key rotation in the future, all keys will require adding an extra smart pointer,
 // most likely an AtomicCell, or if it doesn't work as I think it does, a Mutex. Although I think

--- a/common/client-core/src/client/key_manager/mod.rs
+++ b/common/client-core/src/client/key_manager/mod.rs
@@ -55,7 +55,10 @@ impl ClientKeys {
     {
         let secret = derivation_material.derive_secret()?;
         Ok(ClientKeys {
-            identity_keypair: Arc::new(identity::KeyPair::from_secret(secret)),
+            identity_keypair: Arc::new(identity::KeyPair::from_secret(
+                secret,
+                derivation_material.index(),
+            )),
             encryption_keypair: Arc::new(encryption::KeyPair::new(rng)),
             ack_key: Arc::new(AckKey::new(rng)),
         })

--- a/common/client-core/src/client/key_manager/test.rs
+++ b/common/client-core/src/client/key_manager/test.rs
@@ -1,0 +1,89 @@
+#[cfg(test)]
+mod tests {
+    use crate::client::key_manager::ClientKeys;
+    use nym_crypto::hkdf::DerivationMaterial;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+
+    #[test]
+    fn test_from_master_key_success() {
+        // Set up a deterministic RNG.
+        let seed = [33u8; 32];
+        let mut rng = ChaCha20Rng::from_seed(seed);
+
+        // Set up the derivation material.
+        let master_key = b"this is a secret master key";
+        let salt = b"unique-salt";
+        let derivation_material = DerivationMaterial::new(master_key, 0, salt);
+
+        // Generate ClientKeys from the master key.
+        let client_keys = ClientKeys::from_master_key(&mut rng, &derivation_material)
+            .expect("Failed to create client keys");
+
+        assert_eq!(
+            client_keys.identity_keypair().public_key().to_string(),
+            String::from("FX4Undr5LPPBA7zThWWpAKXKQTXSbW1C28PnxbCqUkU4")
+        );
+
+        assert_eq!(
+            client_keys.identity_keypair().private_key().to_string(),
+            String::from("6S3uMi2rU5SwyUUYCiMrF5qqdcYnEDMYLggBSvavVzEt")
+        );
+    }
+
+    #[test]
+    fn test_from_master_key_deterministic_identity() {
+        // Using identical derivation material should result in the exactly same identity keypair.
+        let seed = [1u8; 32];
+        let mut rng1 = ChaCha20Rng::from_seed(seed);
+        let mut rng2 = ChaCha20Rng::from_seed(seed);
+
+        let master_key = b"another secret master key";
+        let salt = b"deterministic-salt";
+        let index = 7u32;
+        let derivation_material = DerivationMaterial::new(master_key, index, salt);
+
+        let client_keys1 = ClientKeys::from_master_key(&mut rng1, &derivation_material)
+            .expect("Failed to create client keys (first instance)");
+        let client_keys2 = ClientKeys::from_master_key(&mut rng2, &derivation_material)
+            .expect("Failed to create client keys (second instance)");
+
+        assert_eq!(
+            client_keys1.identity_keypair().public_key().to_string(),
+            client_keys2.identity_keypair().public_key().to_string()
+        );
+
+        assert_eq!(
+            client_keys1.identity_keypair().private_key().to_string(),
+            client_keys2.identity_keypair().private_key().to_string()
+        );
+    }
+
+    #[test]
+    fn test_from_master_key_different_indices() {
+        // Changing the index should yield a different identity key.
+        let seed = [5u8; 32];
+        let mut rng = ChaCha20Rng::from_seed(seed);
+
+        let master_key = b"same secret key";
+        let salt = b"same-salt";
+
+        let derivation_material1 = DerivationMaterial::new(master_key, 1, salt);
+        let derivation_material2 = DerivationMaterial::new(master_key, 2, salt);
+
+        let client_keys1 = ClientKeys::from_master_key(&mut rng, &derivation_material1)
+            .expect("Failed to create client keys for index 1");
+        let client_keys2 = ClientKeys::from_master_key(&mut rng, &derivation_material2)
+            .expect("Failed to create client keys for index 2");
+
+        assert_ne!(
+            client_keys1.identity_keypair().public_key().to_string(),
+            client_keys2.identity_keypair().public_key().to_string()
+        );
+
+        assert_ne!(
+            client_keys1.identity_keypair().private_key().to_string(),
+            client_keys2.identity_keypair().private_key().to_string()
+        );
+    }
+}

--- a/common/client-core/src/error.rs
+++ b/common/client-core/src/error.rs
@@ -222,6 +222,9 @@ pub enum ClientCoreError {
         "fresh registration with gateway {gateway_id} somehow requires an additional key upgrade!"
     )]
     UnexpectedKeyUpgrade { gateway_id: String },
+
+    #[error("failed to derive keys from master key")]
+    HkdfDerivationError {},
 }
 
 /// Set of messages that the client can send to listeners via the task manager

--- a/common/crypto/Cargo.toml
+++ b/common/crypto/Cargo.toml
@@ -24,6 +24,7 @@ ed25519-dalek = { workspace = true, features = ["rand_core"], optional = true }
 rand = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
+sha2 = { workspace = true, optional = true }
 subtle-encoding = { workspace = true, features = ["bech32-preview"] }
 thiserror = { workspace = true }
 zeroize = { workspace = true, optional = true, features = ["zeroize_derive"] }
@@ -40,7 +41,7 @@ default = ["sphinx"]
 aead = ["dep:aead", "aead/std", "aes-gcm-siv", "generic-array"]
 serde = ["dep:serde", "serde_bytes", "ed25519-dalek/serde", "x25519-dalek/serde"]
 asymmetric = ["x25519-dalek", "ed25519-dalek", "zeroize"]
-hashing = ["blake3", "digest", "hkdf", "hmac", "generic-array"]
+hashing = ["blake3", "digest", "hkdf", "hmac", "generic-array", "sha2"]
 stream_cipher = ["aes", "ctr", "cipher", "generic-array"]
 sphinx = ["nym-sphinx-types/sphinx"]
 outfox = ["nym-sphinx-types/outfox"]

--- a/common/crypto/src/asymmetric/identity/mod.rs
+++ b/common/crypto/src/asymmetric/identity/mod.rs
@@ -82,13 +82,13 @@ impl KeyPair {
         }
     }
 
-    pub fn from_secret(secret: SecretKey) -> Self {
+    pub fn from_secret(secret: SecretKey, index: u32) -> Self {
         let ed25519_signing_key = SigningKey::from(secret);
 
         KeyPair {
             private_key: PrivateKey(ed25519_signing_key.to_bytes()),
             public_key: PublicKey(ed25519_signing_key.verifying_key()),
-            index: fake_index(secret.as_slice()),
+            index,
         }
     }
 

--- a/common/crypto/src/asymmetric/identity/mod.rs
+++ b/common/crypto/src/asymmetric/identity/mod.rs
@@ -76,7 +76,7 @@ impl KeyPair {
         KeyPair {
             private_key: PrivateKey(ed25519_signing_key.to_bytes()),
             public_key: PublicKey(ed25519_signing_key.verifying_key()),
-            index: index,
+            index,
         }
     }
 

--- a/common/crypto/src/asymmetric/identity/mod.rs
+++ b/common/crypto/src/asymmetric/identity/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use ed25519_dalek::SignatureError;
-use ed25519_dalek::{Signer, SigningKey};
+use ed25519_dalek::{SecretKey, Signer, SigningKey};
 pub use ed25519_dalek::{Verifier, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, SIGNATURE_LENGTH};
 use nym_pemstore::traits::{PemStorableKey, PemStorableKeyPair};
 use std::fmt::{self, Debug, Display, Formatter};
@@ -18,7 +18,7 @@ pub mod serde_helpers;
 use nym_sphinx_types::{DestinationAddressBytes, DESTINATION_ADDRESS_LENGTH};
 
 #[cfg(feature = "rand")]
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng, RngCore};
 #[cfg(feature = "serde")]
 use serde::de::Error as SerdeError;
 #[cfg(feature = "serde")]
@@ -62,16 +62,31 @@ pub struct KeyPair {
     // nothing secret about public key
     #[zeroize(skip)]
     public_key: PublicKey,
+
+    #[zeroize(skip)]
+    index: u32,
 }
 
 impl KeyPair {
     #[cfg(feature = "rand")]
     pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        let index = rng.gen();
         let ed25519_signing_key = ed25519_dalek::SigningKey::generate(rng);
 
         KeyPair {
             private_key: PrivateKey(ed25519_signing_key.to_bytes()),
             public_key: PublicKey(ed25519_signing_key.verifying_key()),
+            index: index,
+        }
+    }
+
+    pub fn from_secret(secret: SecretKey) -> Self {
+        let ed25519_signing_key = SigningKey::from(secret);
+
+        KeyPair {
+            private_key: PrivateKey(ed25519_signing_key.to_bytes()),
+            public_key: PublicKey(ed25519_signing_key.verifying_key()),
+            index: fake_index(secret.as_slice()),
         }
     }
 
@@ -87,15 +102,31 @@ impl KeyPair {
         Ok(KeyPair {
             private_key: PrivateKey::from_bytes(priv_bytes)?,
             public_key: PublicKey::from_bytes(pub_bytes)?,
+            index: fake_index(pub_bytes),
         })
     }
 }
 
+/// Reduces a byte slice into a u32 value by XOR-ing all its bytes into a 4-byte accumulator.
+/// The process iterates over every byte in the input slice, XOR-ing each one into a slot based on its index modulo 4.
+/// If the input slice contains fewer than 4 bytes, the remaining positions in the accumulator remain zero.
+/// Finally, the accumulator is interpreted in big-endian order to produce the resulting u32.
+/// Index is used to verify deterministic identity key, master key and salt are also requried for verification.
+fn fake_index(input: &[u8]) -> u32 {
+    let mut accumulator = [0u8; 4];
+    for (i, &byte) in input.iter().enumerate() {
+        accumulator[i % 4] ^= byte;
+    }
+    u32::from_be_bytes(accumulator)
+}
+
 impl From<PrivateKey> for KeyPair {
     fn from(private_key: PrivateKey) -> Self {
+        let public_key = (&private_key).into();
         KeyPair {
-            public_key: (&private_key).into(),
+            public_key,
             private_key,
+            index: fake_index(public_key.to_bytes().as_ref()),
         }
     }
 }
@@ -115,6 +146,7 @@ impl PemStorableKeyPair for KeyPair {
         KeyPair {
             private_key,
             public_key,
+            index: fake_index(public_key.to_bytes().as_ref()),
         }
     }
 }

--- a/common/crypto/src/asymmetric/identity/mod.rs
+++ b/common/crypto/src/asymmetric/identity/mod.rs
@@ -67,7 +67,6 @@ pub struct KeyPair {
     index: u32,
 }
 
-
 /// All keys will always have an index field populated this is to prevent anyone from figuring out if
 /// the keys are derived or random, and alter their behaviour based on that.
 impl KeyPair {

--- a/common/crypto/src/asymmetric/identity/mod.rs
+++ b/common/crypto/src/asymmetric/identity/mod.rs
@@ -67,6 +67,9 @@ pub struct KeyPair {
     index: u32,
 }
 
+
+/// All keys will always have an index field populated this is to prevent anyone from figuring out if
+/// the keys are derived or random, and alter their behaviour based on that.
 impl KeyPair {
     #[cfg(feature = "rand")]
     pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {

--- a/common/crypto/src/hkdf.rs
+++ b/common/crypto/src/hkdf.rs
@@ -32,6 +32,31 @@ where
     Ok(okm)
 }
 
+/// `DerivationMaterial` encapsulates parameters for deterministic key derivation using
+/// HKDF (SHA-512).
+///
+/// It consists of:
+///   - A master key (`master_key`): the base secret.
+///   - An index (`index`): ensures unique derivations.
+///   - A salt (`salt`): adds additional uniqueness.
+///
+/// Use the `derive_secret()` method to generate a 32-byte secret. To prepare for a new derivation,
+/// call the `next()` method, which increments the index. **It is the caller's responsibility to
+/// track and persist the derivation index if keys need to be rederived.**
+///
+/// # Example
+///
+/// ```rust
+/// let master_key = [0u8; 32]; // your secret master key
+/// let salt = "unique-salt-value".to_string();
+/// let material = DerivationMaterial::new(master_key, 0, salt);
+///
+/// // Derive a secret
+/// let secret = material.derive_secret().expect("Failed to derive secret");
+///
+/// // Prepare for the next derivation
+/// let next_material = material.next();
+/// ```
 pub struct DerivationMaterial {
     master_key: [u8; 32],
     index: u32,
@@ -56,6 +81,14 @@ impl DerivationMaterial {
             master_key,
             index,
             salt,
+        }
+    }
+
+    pub fn next(&self) -> Self {
+        Self {
+            master_key: self.master_key,
+            index: self.index + 1,
+            salt: self.salt.clone(),
         }
     }
 }

--- a/common/crypto/src/hkdf.rs
+++ b/common/crypto/src/hkdf.rs
@@ -86,7 +86,7 @@ impl DerivationMaterial {
         Ok(okm)
     }
 
-    pub fn new<T: AsRef<[u8]>>(master_key: T, index: u32, salt: T) -> Self {
+    pub fn new<T: AsRef<[u8]>>(master_key: T, index: u32, salt: &[u8]) -> Self {
         // Coerce master_key to [u8; 32]
         let mut hasher = Sha256::new();
         hasher.update(master_key.as_ref());
@@ -95,7 +95,7 @@ impl DerivationMaterial {
         Self {
             master_key,
             index,
-            salt: salt.as_ref().to_vec(),
+            salt: salt.to_vec(),
         }
     }
 

--- a/common/crypto/src/hkdf.rs
+++ b/common/crypto/src/hkdf.rs
@@ -8,6 +8,9 @@ use hkdf::{
     },
     Hkdf,
 };
+use sha2::Sha512;
+
+pub use hkdf::InvalidLength;
 
 /// Perform HKDF `extract` then `expand` as a single step.
 pub fn extract_then_expand<D>(
@@ -27,4 +30,32 @@ where
     hkdf.expand(info.unwrap_or(&[]), &mut okm)?;
 
     Ok(okm)
+}
+
+pub struct DerivationMaterial {
+    master_key: [u8; 32],
+    index: u32,
+    salt: String,
+}
+
+impl DerivationMaterial {
+    /// Derives a 32-byte seed from a master seed and an index using HKDF (with SHA-512).
+    ///
+    /// The `salt` and the use of the index (as info) bind this derivation to an application/client.
+    pub fn derive_secret(&self) -> Result<[u8; 32], hkdf::InvalidLength> {
+        let salt = self.salt.as_bytes();
+        let info = self.index.to_be_bytes(); // Use the index as info
+        let hk = Hkdf::<Sha512>::new(Some(salt), &self.master_key);
+        let mut okm = [0u8; 32];
+        hk.expand(&info, &mut okm)?;
+        Ok(okm)
+    }
+
+    pub fn new(master_key: [u8; 32], index: u32, salt: String) -> Self {
+        Self {
+            master_key,
+            index,
+            salt,
+        }
+    }
 }

--- a/common/crypto/src/hkdf.rs
+++ b/common/crypto/src/hkdf.rs
@@ -66,6 +66,14 @@ pub struct DerivationMaterial {
 }
 
 impl DerivationMaterial {
+    pub fn index(&self) -> u32 {
+        self.index
+    }
+
+    pub fn salt(&self) -> &[u8] {
+        &self.salt
+    }
+
     /// Derives a 32-byte seed from a master seed and an index using HKDF (with SHA-512).
     ///
     /// The `salt` and the use of the index (as info) bind this derivation to an application/client.


### PR DESCRIPTION
### `Adds DerivationMaterial and accompanying methods to builders`

`DerivationMaterial` encapsulates parameters for deterministic key derivation using HKDF (SHA-512).

It consists of:

- **Master Key (`master_key`)**: The base secret.
- **Index (`index`)**: Ensures unique derivations.
- **Salt (`salt`)**: Adds additional uniqueness.

Use the `derive_secret()` method to generate a 32-byte secret. To prepare for a new derivation, call the `next()` method which increments the index. **It is the caller's responsibility to track and persist the derivation index if keys need to be rederived.**

#### Example

```rust
let master_key = [0u8; 32]; // your secret master key
let salt = "unique-salt-value".to_string();
let material = DerivationMaterial::new(master_key, 0, salt.as_bytes());

// Derive a secret
let secret = material.derive_secret().expect("Failed to derive secret");

// Prepare for the next derivation
let next_material = material.next();
```
---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5440)
<!-- Reviewable:end -->