### PR TITLE
chore: fixed typo in API endpoint parameter

### DIFF
--- a/scripts/node_api_check.py
+++ b/scripts/node_api_check.py
@@ -45,7 +45,7 @@ class MainFunctions:
         print("\n\nNODE RESULTS FROM UNFILTERED QUERY\n")
 
         if args.markdown:
-            node_markdown = self._dataframe_to_markdown(node_df, ["RESULT"], ["API EDNPOINT"])
+            node_markdown = self._dataframe_to_markdown(node_df, ["RESULT"], ["API ENDPOINT"])
             print(node_markdown, "\n")
         else:
             self.print_neat_dict(node_dict)


### PR DESCRIPTION
I noticed a typo in the code where "API EDNPOINT" was used.
I’ve corrected it to "**API ENDPOINT**" to ensure proper spelling.

This should avoid any confusion or potential bugs related to that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5449)
<!-- Reviewable:end -->
