### PR TITLE
Condense core API functionalities and enable gzip decompression for reqwest payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8336,6 +8336,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "futures-core",

--- a/common/http-api-client/Cargo.toml
+++ b/common/http-api-client/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "gzip"] }
 http.workspace = true
 url = { workspace = true }
 once_cell = { workspace = true }

--- a/common/http-api-client/src/user_agent.rs
+++ b/common/http-api-client/src/user_agent.rs
@@ -7,11 +7,16 @@ use http::HeaderValue;
 use nym_bin_common::build_information::{BinaryBuildInformation, BinaryBuildInformationOwned};
 use serde::{Deserialize, Serialize};
 
+/// Characteristic elements sent to the API providing basic context information of the requesting client.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UserAgent {
+    /// The internal crate / application / subsystem making use of API client
     pub application: String,
+    /// version of the calling crate / application / subsystem
     pub version: String,
+    /// client platform
     pub platform: String,
+    /// source commit version for the calling calling crate / subsystem
     pub git_commit: String,
 }
 

--- a/nym-credential-proxy/nym-credential-proxy-requests/src/client.rs
+++ b/nym-credential-proxy/nym-credential-proxy-requests/src/client.rs
@@ -6,7 +6,9 @@ use crate::api::v1::ticketbook::models::{
     TicketbookWalletSharesResponse,
 };
 use async_trait::async_trait;
-use nym_http_api_client::{parse_response, HttpClientError, Params, PathSegments, NO_PARAMS};
+use nym_http_api_client::{
+    parse_response, ApiClient, HttpClientError, Params, PathSegments, NO_PARAMS,
+};
 use reqwest::IntoUrl;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};

--- a/wasm/zknym-lib/src/vpn_api_client/client.rs
+++ b/wasm/zknym-lib/src/vpn_api_client/client.rs
@@ -10,7 +10,7 @@ use crate::vpn_api_client::types::{
 use async_trait::async_trait;
 use nym_coconut::BlindSignRequest;
 pub use nym_http_api_client::Client;
-use nym_http_api_client::{parse_response, PathSegments, NO_PARAMS};
+use nym_http_api_client::{parse_response, ApiClient, PathSegments, NO_PARAMS};
 use reqwest::IntoUrl;
 use serde::de::DeserializeOwned;
 


### PR DESCRIPTION
This PR is intended to take out variables from our usage of HTTP requests in the `nym-http-api-client`. 

To do this the PR:
* Adds the `ApiClientCore` trait with the minimal feature required to send a request
* Turns all request sending into trait extension automatically implemented for any type that implements `ApiClientCore`

This has the benefit of consistent expected behavior for all clients using `nym-http-api-client`, including features added going forward. FOR EXAMPLE this pr adds a default header `"accept-encoding: gzip;q=1.0, *;q=0.5"` which indicates that compression is preferred whenever available. Other features to keep in mind here are things like configurable retries, domain fallbacks, etc.

Note: the `Apiclient` interface could be simplified, but that would require refactoring our downstream usages of the API. For now this isn't necessary as `ApiClient` is implemented automatically so it costs nothing to have it this way. It just allows divergent usage in downstream crates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5450)
<!-- Reviewable:end -->
