### PR TITLE
Move all workflows on ubuntu-20 to ubuntu-22

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04
+    runs-on: arc-ubuntu-22.04
     defaults:
       run:
         working-directory: documentation/docs

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Python3 modules
         run: sudo pip3 install pandas tabulate
       - name: Install rsync
-        run: sudo apt-get install rsync
+        run: sudo apt-get install -y rsync
       - uses: rlespinasse/github-slug-action@v3.x
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.0.0

--- a/.github/workflows/ci-binary-config-checker.yml
+++ b/.github/workflows/ci-binary-config-checker.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [arc-ubuntu-20.04]
+        platform: [arc-ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ci-build-ts.yml
+++ b/.github/workflows/ci-build-ts.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04
+    runs-on: arc-ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install rsync

--- a/.github/workflows/ci-build-ts.yml
+++ b/.github/workflows/ci-build-ts.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-22.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install rsync

--- a/.github/workflows/ci-build-upload-binaries.yml
+++ b/.github/workflows/ci-build-upload-binaries.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ arc-ubuntu-20.04 ]
+        platform: [ arc-ubuntu-22.04 ]
 
     runs-on: ${{ matrix.platform }}
     env:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ arc-ubuntu-20.04, custom-windows-11, custom-runner-mac-m1 ]
+        os: [ arc-ubuntu-22.04, custom-windows-11, custom-runner-mac-m1 ]
     runs-on: ${{ matrix.os }}
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/ci-contracts-schema.yml
+++ b/.github/workflows/ci-contracts-schema.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   check-schema:
     name: Generate and check schema
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/.github/workflows/ci-contracts-upload-binaries.yml
+++ b/.github/workflows/ci-contracts-upload-binaries.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ arc-ubuntu-20.04 ]
+        platform: [ arc-ubuntu-22.04 ]
 
     runs-on: ${{ matrix.platform }}
     env:

--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     # since it's going to be compiled into wasm, there's absolutely
     # no point in running CI on different OS-es
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python3 modules
         run: sudo pip3 install pandas tabulate
       - name: Install rsync
-        run: sudo apt-get install rsync
+        run: sudo apt-get install -y rsync
       - uses: rlespinasse/github-slug-action@v3.x
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.0.0

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04
+    runs-on: arc-ubuntu-22.04
     env:
       RUSTUP_PERMIT_COPY_RENAME: 1
     defaults:

--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-22.04
+    runs-on: ubuntu-22.04
     env:
       RUSTUP_PERMIT_COPY_RENAME: 1
     steps:

--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04
+    runs-on: arc-ubuntu-22.04
     env:
       RUSTUP_PERMIT_COPY_RENAME: 1
     steps:

--- a/.github/workflows/ci-nym-wallet-rust.yml
+++ b/.github/workflows/ci-nym-wallet-rust.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-ubuntu-20.04
+    runs-on: arc-ubuntu-22.04
     env:
       CARGO_TERM_COLOR: always
       RUSTUP_PERMIT_COPY_RENAME: 1

--- a/.github/workflows/ci-sdk-wasm.yml
+++ b/.github/workflows/ci-sdk-wasm.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   wasm:
-    runs-on: arc-ubuntu-20.04
+    runs-on: arc-ubuntu-22.04
     env:
       CARGO_TERM_COLOR: always
       RUSTUP_PERMIT_COPY_RENAME: 1

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [stable, beta]
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
       CARGO_TERM_COLOR: always
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install Dependencies (Linux)
         run: sudo apt-get update && sudo apt-get install -y build-essential curl wget libssl-dev libudev-dev squashfs-tools protobuf-compiler
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -59,7 +59,7 @@ jobs:
 
       # To avoid running out of disk space, skip generating debug symbols
       - name: Set debug to false (unix)
-        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-latest'
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-latest'
         run: |
           sed -i.bak 's/\[profile.dev\]/\[profile.dev\]\ndebug = false/' Cargo.toml
           git diff

--- a/.github/workflows/nightly-nym-wallet-build.yml
+++ b/.github/workflows/nightly-nym-wallet-build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
       CARGO_TERM_COLOR: always
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Dependencies (Linux)
         run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev squashfs-tools
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
 
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/nightly-security-audit.yml
+++ b/.github/workflows/nightly-security-audit.yml
@@ -5,7 +5,7 @@ on:
     - cron: '5 9 * * *'
 jobs:
   cargo-deny:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v4

--- a/.github/workflows/publish-nym-binaries.yml
+++ b/.github/workflows/publish-nym-binaries.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [custom-ubuntu-20.04]
+        platform: [custom-ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
 
     outputs:

--- a/.github/workflows/publish-nym-wallet-ubuntu.yml
+++ b/.github/workflows/publish-nym-wallet-ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [custom-ubuntu-20.04]
+        platform: [custom-ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
 
     outputs:

--- a/.github/workflows/publish-nyms5-android-apk.yml
+++ b/.github/workflows/publish-nyms5-android-apk.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build APK
-    runs-on: custom-ubuntu-20.04
+    runs-on: custom-ubuntu-22.04
     env:
       ANDROID_HOME: ${{ github.workspace }}/android-sdk
       NDK_VERSION: 25.2.9519653

--- a/.github/workflows/publish-sdk-npm.yml
+++ b/.github/workflows/publish-sdk-npm.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   publish:
-    runs-on: arc-ubuntu-20.04
+    runs-on: arc-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Ubuntu 20.04 runners are scheduled to be removed from set of github hosted runners. Now is as good a time as any to finally take the plunge to switch away from ubuntu-20.04 to the shiny oh so modern ubuntu-22.04 runners

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5455)
<!-- Reviewable:end -->
