### PR TITLE
Provide Interval context with node descriptor endpoints

### DIFF
--- a/nym-api/nym-api-requests/src/nym_nodes.rs
+++ b/nym-api/nym-api-requests/src/nym_nodes.rs
@@ -69,7 +69,7 @@ impl<T> PaginatedCachedNodesResponse<T> {
     }
 
     pub fn fresh(mut self, interval: Option<Interval>) -> Self {
-        let iv = interval.and_then(|i| Some(TopologyRequestStatus::Fresh(i)));
+        let iv = interval.map(TopologyRequestStatus::Fresh);
         self.status = iv;
         self
     }

--- a/nym-api/nym-api-requests/src/nym_nodes.rs
+++ b/nym-api/nym-api-requests/src/nym_nodes.rs
@@ -14,8 +14,18 @@ use std::net::IpAddr;
 use time::OffsetDateTime;
 use utoipa::ToSchema;
 
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, schemars::JsonSchema, utoipa::ToSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum TopologyRequestStatus {
+    NoUpdates,
+    Fresh(OffsetDateTimeJsonSchemaWrapper),
+}
+
+
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema, ToSchema)]
 pub struct CachedNodesResponse<T: ToSchema> {
+    pub epoch_uid: Option<u32>,
+    pub topology_request_status: Option<TopologyRequestStatus>,
     pub refreshed_at: OffsetDateTimeJsonSchemaWrapper,
     pub nodes: Vec<T>,
 }
@@ -37,6 +47,8 @@ impl<T: ToSchema> CachedNodesResponse<T> {
 
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaginatedCachedNodesResponse<T> {
+    pub epoch_uid: Option<u32>,
+    pub topology_request_status: Option<TopologyRequestStatus>,
     pub refreshed_at: OffsetDateTimeJsonSchemaWrapper,
     pub nodes: PaginatedResponse<T>,
 }

--- a/nym-api/nym-api-requests/src/nym_nodes.rs
+++ b/nym-api/nym-api-requests/src/nym_nodes.rs
@@ -8,7 +8,7 @@ use nym_crypto::asymmetric::x25519::serde_helpers::bs58_x25519_pubkey;
 use nym_crypto::asymmetric::{ed25519, x25519};
 use nym_mixnet_contract_common::nym_node::Role;
 use nym_mixnet_contract_common::reward_params::Performance;
-use nym_mixnet_contract_common::NodeId;
+use nym_mixnet_contract_common::{Interval, NodeId};
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use time::OffsetDateTime;
@@ -18,14 +18,11 @@ use utoipa::ToSchema;
 #[serde(rename_all = "kebab-case")]
 pub enum TopologyRequestStatus {
     NoUpdates,
-    Fresh(OffsetDateTimeJsonSchemaWrapper),
+    Fresh(Interval),
 }
-
 
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema, ToSchema)]
 pub struct CachedNodesResponse<T: ToSchema> {
-    pub epoch_uid: Option<u32>,
-    pub topology_request_status: Option<TopologyRequestStatus>,
     pub refreshed_at: OffsetDateTimeJsonSchemaWrapper,
     pub nodes: Vec<T>,
 }
@@ -47,8 +44,7 @@ impl<T: ToSchema> CachedNodesResponse<T> {
 
 #[derive(Clone, Debug, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PaginatedCachedNodesResponse<T> {
-    pub epoch_uid: Option<u32>,
-    pub topology_request_status: Option<TopologyRequestStatus>,
+    pub status: Option<TopologyRequestStatus>,
     pub refreshed_at: OffsetDateTimeJsonSchemaWrapper,
     pub nodes: PaginatedResponse<T>,
 }
@@ -68,6 +64,28 @@ impl<T> PaginatedCachedNodesResponse<T> {
                 },
                 data: nodes,
             },
+            status: None,
+        }
+    }
+
+    pub fn fresh(mut self, interval: Option<Interval>) -> Self {
+        let iv = interval.and_then(|i| Some(TopologyRequestStatus::Fresh(i)));
+        self.status = iv;
+        self
+    }
+
+    pub fn no_updates() -> Self {
+        PaginatedCachedNodesResponse {
+            refreshed_at: OffsetDateTime::now_utc().into(),
+            nodes: PaginatedResponse {
+                pagination: Pagination {
+                    total: 0,
+                    page: 0,
+                    size: 0,
+                },
+                data: Vec::new(),
+            },
+            status: Some(TopologyRequestStatus::NoUpdates),
         }
     }
 }

--- a/nym-api/src/nym_nodes/handlers/unstable/mod.rs
+++ b/nym-api/src/nym_nodes/handlers/unstable/mod.rs
@@ -114,7 +114,7 @@ impl From<NodesParamsWithRole> for NodesParams {
             no_legacy: params.no_legacy,
             page: params.page,
             per_page: params.per_page,
-            epoch_uid: params.epoch_uid,   
+            epoch_uid: params.epoch_uid,
         }
     }
 }

--- a/nym-api/src/nym_nodes/handlers/unstable/mod.rs
+++ b/nym-api/src/nym_nodes/handlers/unstable/mod.rs
@@ -85,6 +85,11 @@ struct NodesParamsWithRole {
     no_legacy: Option<bool>,
     page: Option<u32>,
     per_page: Option<u32>,
+
+    // Identifier for the current epoch of the topology state. When sent by a client we can check if
+    // the client already knows about the latest topology state, allowing a `no-updates` response
+    // instead of wasting bandwidth serving an unchanged topology.
+    epoch_uid: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, utoipa::IntoParams)]
@@ -95,6 +100,11 @@ struct NodesParams {
     no_legacy: Option<bool>,
     page: Option<u32>,
     per_page: Option<u32>,
+
+    // Identifier for the current epoch of the topology state. When sent by a client we can check if
+    // the client already knows about the latest topology state, allowing a `no-updates` response
+    // instead of wasting bandwidth serving an unchanged topology.
+    epoch_uid: Option<u32>,
 }
 
 impl From<NodesParamsWithRole> for NodesParams {
@@ -104,6 +114,7 @@ impl From<NodesParamsWithRole> for NodesParams {
             no_legacy: params.no_legacy,
             page: params.page,
             per_page: params.per_page,
+            epoch_uid: params.epoch_uid,   
         }
     }
 }

--- a/nym-api/src/nym_nodes/handlers/unstable/mod.rs
+++ b/nym-api/src/nym_nodes/handlers/unstable/mod.rs
@@ -89,7 +89,7 @@ struct NodesParamsWithRole {
     // Identifier for the current epoch of the topology state. When sent by a client we can check if
     // the client already knows about the latest topology state, allowing a `no-updates` response
     // instead of wasting bandwidth serving an unchanged topology.
-    epoch_uid: Option<u32>,
+    epoch_id: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, utoipa::IntoParams)]
@@ -104,7 +104,7 @@ struct NodesParams {
     // Identifier for the current epoch of the topology state. When sent by a client we can check if
     // the client already knows about the latest topology state, allowing a `no-updates` response
     // instead of wasting bandwidth serving an unchanged topology.
-    epoch_uid: Option<u32>,
+    epoch_id: Option<u32>,
 }
 
 impl From<NodesParamsWithRole> for NodesParams {
@@ -114,7 +114,7 @@ impl From<NodesParamsWithRole> for NodesParams {
             no_legacy: params.no_legacy,
             page: params.page,
             per_page: params.per_page,
-            epoch_uid: params.epoch_uid,
+            epoch_id: params.epoch_id,
         }
     }
 }

--- a/nym-api/src/nym_nodes/handlers/unstable/skimmed.rs
+++ b/nym-api/src/nym_nodes/handlers/unstable/skimmed.rs
@@ -131,7 +131,7 @@ where
         .to_owned();
 
     // 4.0 If the client indicates that they already know about the current topology send empty response
-    if let Some(client_known_epoch) = query_params.epoch_uid {
+    if let Some(client_known_epoch) = query_params.epoch_id {
         if let Some(ref interval) = maybe_interval {
             if client_known_epoch == interval.current_epoch_id() {
                 return Ok(Json(PaginatedCachedNodesResponse::no_updates()));

--- a/nym-api/src/nym_nodes/handlers/unstable/skimmed.rs
+++ b/nym-api/src/nym_nodes/handlers/unstable/skimmed.rs
@@ -14,7 +14,6 @@ use nym_api_requests::models::{
 };
 use nym_api_requests::nym_nodes::{
     CachedNodesResponse, NodeRole, NodeRoleQueryParam, PaginatedCachedNodesResponse, SkimmedNode,
-    TopologyRequestStatus,
 };
 use nym_api_requests::pagination::PaginatedResponse;
 use nym_mixnet_contract_common::NodeId;

--- a/nym-api/src/nym_nodes/handlers/unstable/skimmed.rs
+++ b/nym-api/src/nym_nodes/handlers/unstable/skimmed.rs
@@ -14,6 +14,7 @@ use nym_api_requests::models::{
 };
 use nym_api_requests::nym_nodes::{
     CachedNodesResponse, NodeRole, NodeRoleQueryParam, PaginatedCachedNodesResponse, SkimmedNode,
+    TopologyRequestStatus,
 };
 use nym_api_requests::pagination::PaginatedResponse;
 use nym_mixnet_contract_common::NodeId;
@@ -124,6 +125,21 @@ where
     // (ideally it'd be tied directly to the NI iterator, but I couldn't defeat the compiler)
     let describe_cache = state.describe_nodes_cache_data().await?;
 
+    let maybe_interval = state
+        .nym_contract_cache()
+        .current_interval()
+        .await
+        .to_owned();
+
+    // 4.0 If the client indicates that they already know about the current topology send empty response
+    if let Some(client_known_epoch) = query_params.epoch_uid {
+        if let Some(ref interval) = maybe_interval {
+            if client_known_epoch == interval.current_epoch_id() {
+                return Ok(Json(PaginatedCachedNodesResponse::no_updates()));
+            }
+        }
+    }
+
     // 4. start building the response
     let mut nodes =
         build_nym_nodes_response(&rewarded_set, nym_nodes_subset, &annotations, active_only);
@@ -137,10 +153,9 @@ where
             describe_cache.timestamp(),
         ]);
 
-        return Ok(Json(PaginatedCachedNodesResponse::new_full(
-            refreshed_at,
-            nodes,
-        )));
+        return Ok(Json(
+            PaginatedCachedNodesResponse::new_full(refreshed_at, nodes).fresh(maybe_interval),
+        ));
     }
 
     // 6. grab relevant legacy nodes
@@ -162,10 +177,9 @@ where
         annotated_legacy_nodes.timestamp(),
     ]);
 
-    Ok(Json(PaginatedCachedNodesResponse::new_full(
-        refreshed_at,
-        nodes,
-    )))
+    Ok(Json(
+        PaginatedCachedNodesResponse::new_full(refreshed_at, nodes).fresh(maybe_interval),
+    ))
 }
 
 /// Deprecated query that gets ALL gateways


### PR DESCRIPTION
Add current interval context information to existing enpoints using `build_skimmed_nodes_response` under the hood. This allows clients checking for a refresh to send the `epoch_uid` as a query parameter when fetching updates so the server can tell it that there have been no changes, instead of sending duplicate data over and over.

The changes in this PR should be backwards compatible and never interfere with existing clients. The additions to the `NodeParams` are optional, so there is no error if a client does not send them. Old clients will not send `epoch_uid` by accident so they cannot accidentally clear their set of known nodes.

In the response the status field is optional so if it is missing (e.g. if a new client talks to an old server) the connection still works. For old clients speaking to new servers, the json parsing will simply ignore extra information not included in the objects json spec.

Open to feedback on the approach here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5456)
<!-- Reviewable:end -->
