### PR TITLE
Trigger contracts CI on main workspace Cargo changes

### DIFF
--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - 'contracts/**'
       - 'common/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
       - '.github/workflows/ci-contracts.yml'
 
 jobs:


### PR DESCRIPTION
Since the contracts workspace depends on the common code in the main
workspace, and since the contracts are critical to not have regressions
in, trigger contracts CI on any changes to the workspace
Cargo.toml and lock files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5477)
<!-- Reviewable:end -->
