### PR TITLE
Clean stale partially received buffers

### DIFF
--- a/common/client-core/src/client/received_buffer.rs
+++ b/common/client-core/src/client/received_buffer.rs
@@ -96,9 +96,10 @@ impl<R: MessageReceiver> ReceivedMessagesBufferInner<R> {
                     }
                     None
                 }
-                _ => unreachable!(
-                    "no other error kind should have been returned here! If so, it's a bug!"
-                ),
+                _ => {
+                    error!("unexpected error occurred during message reconstruction: {err}");
+                    None
+                }
             },
             Ok(reconstruction_result) => match reconstruction_result {
                 Some((reconstructed_message, used_sets)) => {

--- a/common/client-core/src/client/received_buffer.rs
+++ b/common/client-core/src/client/received_buffer.rs
@@ -409,7 +409,6 @@ impl<R: MessageReceiver> ReceivedMessagesBuffer<R> {
         if !completed_messages.is_empty() {
             self.handle_reconstructed_messages(completed_messages).await
         }
-
         Ok(())
     }
 }

--- a/common/nymsphinx/chunking/src/reconstruction.rs
+++ b/common/nymsphinx/chunking/src/reconstruction.rs
@@ -33,6 +33,7 @@ struct ReconstructionBuffer {
     /// everything in order the whole time, allowing for O(1) insertions and O(n) reconstruction.
     fragments: Vec<Option<Fragment>>,
 
+    /// The timestamp of the last received fragment. Used for cleaning up stale buffers.
     last_fragment_timestamp: Instant,
 }
 
@@ -314,9 +315,12 @@ impl MessageReconstructor {
             let keep = now.duration_since(set_buf.last_fragment_timestamp)
                 < Self::INCOMPLETE_MESSAGE_TIMEOUT;
             if !keep {
-                warn!(
-                    "Removing stale buffer for set id {}",
-                    set_buf.fragments[0].as_ref().unwrap().id()
+                debug!(
+                    "Removing stale buffer for set id {:?}",
+                    set_buf
+                        .fragments
+                        .first()
+                        .and_then(|f| f.as_ref().map(|f| f.id()))
                 );
             }
             keep

--- a/common/nymsphinx/chunking/src/reconstruction.rs
+++ b/common/nymsphinx/chunking/src/reconstruction.rs
@@ -308,6 +308,7 @@ impl MessageReconstructor {
     }
 
     pub fn cleanup_stale_buffers(&mut self) {
+        warn!("Cleaning up stale buffers...");
         let now = Instant::now();
         self.reconstructed_sets.retain(|_, set_buf| {
             now.duration_since(set_buf.last_fragment_timestamp) < Self::INCOMPLETE_MESSAGE_TIMEOUT

--- a/common/nymsphinx/chunking/src/reconstruction.rs
+++ b/common/nymsphinx/chunking/src/reconstruction.rs
@@ -308,7 +308,7 @@ impl MessageReconstructor {
     }
 
     pub fn cleanup_stale_buffers(&mut self) {
-        info!("Cleaning up stale buffers...");
+        trace!("Cleaning up stale buffers");
         let now = Instant::now();
         self.reconstructed_sets.retain(|_, set_buf| {
             let keep = now.duration_since(set_buf.last_fragment_timestamp)

--- a/common/nymsphinx/chunking/src/reconstruction.rs
+++ b/common/nymsphinx/chunking/src/reconstruction.rs
@@ -164,7 +164,9 @@ pub struct MessageReconstructor {
 }
 
 impl MessageReconstructor {
-    const INCOMPLETE_MESSAGE_TIMEOUT: Duration = Duration::from_secs(300);
+    // We want to be very conservative here. We remove these to avoid memory leaks, but it's okay
+    // to wait for a long time before we do so.
+    const INCOMPLETE_MESSAGE_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
     /// Creates an empty `MessageReconstructor`.
     pub fn new() -> Self {

--- a/common/nymsphinx/chunking/src/reconstruction.rs
+++ b/common/nymsphinx/chunking/src/reconstruction.rs
@@ -308,10 +308,18 @@ impl MessageReconstructor {
     }
 
     pub fn cleanup_stale_buffers(&mut self) {
-        warn!("Cleaning up stale buffers...");
+        info!("Cleaning up stale buffers...");
         let now = Instant::now();
         self.reconstructed_sets.retain(|_, set_buf| {
-            now.duration_since(set_buf.last_fragment_timestamp) < Self::INCOMPLETE_MESSAGE_TIMEOUT
+            let keep = now.duration_since(set_buf.last_fragment_timestamp)
+                < Self::INCOMPLETE_MESSAGE_TIMEOUT;
+            if !keep {
+                warn!(
+                    "Removing stale buffer for set id {}",
+                    set_buf.fragments[0].as_ref().unwrap().id()
+                );
+            }
+            keep
         });
     }
 }


### PR DESCRIPTION
Clean up old `ReconstructionBuffer`s that have not received fragments in a long time. The motivation is that we want to allow the client to cap the number of retransmissions done, meaning we can't assume that these will eventually arrive

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5536)
<!-- Reviewable:end -->
