### PR TITLE
Tweak surb management to be more conservative

### DIFF
--- a/common/client-core/config-types/src/lib.rs
+++ b/common/client-core/config-types/src/lib.rs
@@ -50,7 +50,7 @@ const DEFAULT_MINIMUM_REPLY_SURB_THRESHOLD_BUFFER: usize = 0;
 // define how much to request at once
 // clients/client-core/src/client/replies/reply_controller.rs
 const DEFAULT_MINIMUM_REPLY_SURB_REQUEST_SIZE: u32 = 10;
-const DEFAULT_MAXIMUM_REPLY_SURB_REQUEST_SIZE: u32 = 100;
+const DEFAULT_MAXIMUM_REPLY_SURB_REQUEST_SIZE: u32 = 30;
 
 const DEFAULT_MAXIMUM_ALLOWED_SURB_REQUEST_SIZE: u32 = 500;
 

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -33,10 +33,12 @@ pub enum PreparationError {
     #[error(transparent)]
     NymTopologyError(#[from] NymTopologyError),
 
-    #[error("The received message cannot be sent using a single reply surb. It ended up getting split into {fragments} fragments.")]
+    #[error("message too long for a single SURB, splitting into {fragments} fragments.")]
     MessageTooLongForSingleSurb { fragments: usize },
 
-    #[error("Not enough reply SURBs to send the message. We have {available} available and require at least {required}.")]
+    #[error(
+        "not enough reply SURBs to send the message, available: {available} required: {required}."
+    )]
     NotEnoughSurbs { available: usize, required: usize },
 }
 

--- a/common/client-core/src/client/replies/reply_controller/mod.rs
+++ b/common/client-core/src/client/replies/reply_controller/mod.rs
@@ -746,7 +746,7 @@ where
             .request_additional_reply_surbs(target, request_size)
             .await
         {
-            warn!("failed to request additional surbs... - {err}")
+            info!("{err}")
         }
     }
 

--- a/service-providers/ip-packet-router/src/constants.rs
+++ b/service-providers/ip-packet-router/src/constants.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 pub(crate) const DISCONNECT_TIMER_INTERVAL: Duration = Duration::from_secs(10);
 
 // We consider a client inactive if it hasn't sent any mixnet packets in this duration
-pub(crate) const CLIENT_MIXNET_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+pub(crate) const CLIENT_MIXNET_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(60);
 
 // We consider a client handler inactive if it hasn't received any packets from the tun device in
 // this duration
-pub(crate) const CLIENT_HANDLER_ACTIVITY_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+pub(crate) const CLIENT_HANDLER_ACTIVITY_TIMEOUT: Duration = Duration::from_secs(5 * 60);


### PR DESCRIPTION
To reduce the risk of the IPR DoS the client:

- Lower the timeout until the IPR will disconnect a client
- Reduce fewer surbs at a time. Large surb requests increases the
  latency until all fragments in the response have been delivered. The
  efficiency gains of having large surb requests dimishes quickly for
  large sizes as well

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5570)
<!-- Reviewable:end -->
