### PR TITLE
Server Side internal DoT/DoH opt out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6241,7 +6241,6 @@ dependencies = [
  "nym-crypto",
  "nym-gateway",
  "nym-gateway-stats-storage",
- "nym-http-api-client",
  "nym-http-api-common",
  "nym-ip-packet-router",
  "nym-metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6355,6 +6355,7 @@ dependencies = [
  "nym-contracts-common",
  "nym-crypto",
  "nym-explorer-client",
+ "nym-http-api-client",
  "nym-network-defaults",
  "nym-node-metrics",
  "nym-node-requests",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6241,6 +6241,7 @@ dependencies = [
  "nym-crypto",
  "nym-gateway",
  "nym-gateway-stats-storage",
+ "nym-http-api-client",
  "nym-http-api-common",
  "nym-ip-packet-router",
  "nym-metrics",

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -23,12 +23,11 @@ use nym_api_requests::models::{
     NymNodeDescription, RewardEstimationResponse, StakeSaturationResponse,
 };
 use nym_api_requests::models::{LegacyDescribedGateway, MixNodeBondAnnotated};
-use nym_api_requests::nym_nodes::{NodesByAddressesResponse, SkimmedNode};
+use nym_api_requests::nym_nodes::SkimmedNode;
 use nym_coconut_dkg_common::types::EpochId;
 use nym_ecash_contract_common::deposit::DepositId;
 use nym_http_api_client::UserAgent;
 use nym_network_defaults::NymNetworkDetails;
-use std::net::IpAddr;
 use time::Date;
 use url::Url;
 
@@ -710,12 +709,5 @@ impl NymApiClient {
             .nym_api
             .issued_ticketbooks_challenge(expiration_date, deposits)
             .await?)
-    }
-
-    pub async fn nodes_by_addresses(
-        &self,
-        addresses: Vec<IpAddr>,
-    ) -> Result<NodesByAddressesResponse, ValidatorClientError> {
-        Ok(self.nym_api.nodes_by_addresses(addresses).await?)
     }
 }

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -23,11 +23,12 @@ use nym_api_requests::models::{
     NymNodeDescription, RewardEstimationResponse, StakeSaturationResponse,
 };
 use nym_api_requests::models::{LegacyDescribedGateway, MixNodeBondAnnotated};
-use nym_api_requests::nym_nodes::SkimmedNode;
+use nym_api_requests::nym_nodes::{NodesByAddressesResponse, SkimmedNode};
 use nym_coconut_dkg_common::types::EpochId;
 use nym_ecash_contract_common::deposit::DepositId;
 use nym_http_api_client::UserAgent;
 use nym_network_defaults::NymNetworkDetails;
+use std::net::IpAddr;
 use time::Date;
 use url::Url;
 
@@ -709,5 +710,12 @@ impl NymApiClient {
             .nym_api
             .issued_ticketbooks_challenge(expiration_date, deposits)
             .await?)
+    }
+
+    pub async fn nodes_by_addresses(
+        &self,
+        addresses: Vec<IpAddr>,
+    ) -> Result<NodesByAddressesResponse, ValidatorClientError> {
+        Ok(self.nym_api.nodes_by_addresses(addresses).await?)
     }
 }

--- a/common/client-libs/validator-client/src/coconut/mod.rs
+++ b/common/client-libs/validator-client/src/coconut/mod.rs
@@ -8,6 +8,7 @@ use nym_coconut_dkg_common::types::{EpochId, NodeIndex};
 use nym_coconut_dkg_common::verification_key::ContractVKShare;
 use nym_compact_ecash::error::CompactEcashError;
 use nym_compact_ecash::{Base58, VerificationKeyAuth};
+use nym_http_api_client::HttpClientError;
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
 use url::Url;
@@ -71,6 +72,12 @@ pub enum EcashApiError {
         #[from]
         source: crate::ValidatorClientError,
     },
+
+    #[error("error building or using HTTP client: {source}")]
+    ClientError {
+        #[from]
+        source: HttpClientError,
+    },
 }
 
 impl TryFrom<ContractVKShare> for EcashApiClient {
@@ -83,8 +90,19 @@ impl TryFrom<ContractVKShare> for EcashApiClient {
 
         let url_address = Url::parse(&share.announce_address)?;
 
+        // Note: we expect this to be used server-side (gateways / nodes / APIs) not client-side
+        // (vpn client etc.) so we use the system default resolver.
+        #[cfg(not(target_arch = "wasm32"))]
+        let api_client = NymApiClient {
+            nym_api: nym_http_api_client::ClientBuilder::new_with_url(url_address)
+                .no_hickory_dns()
+                .build()?,
+        };
+        #[cfg(target_arch = "wasm32")]
+        let api_client = NymApiClient::new(url_address);
+
         Ok(EcashApiClient {
-            api_client: NymApiClient::new(url_address),
+            api_client,
             verification_key: VerificationKeyAuth::try_from_bs58(&share.share)?,
             node_id: share.node_index,
             cosmos_address: share.owner.as_str().parse()?,

--- a/common/client-libs/validator-client/src/coconut/mod.rs
+++ b/common/client-libs/validator-client/src/coconut/mod.rs
@@ -83,6 +83,12 @@ impl TryFrom<ContractVKShare> for EcashApiClient {
 
         let url_address = Url::parse(&share.announce_address)?;
 
+        // The NymApiClient constructed here uses the default (hickory DoT/DoH) resolver because
+        // this EcashApiClient is used by both client and non-client applications.
+        //
+        // In non-client applications this resolver can cause warning logs about H2 connection
+        // failure. This indicates that the long lived https connection was closed by the remote
+        // peer and the resolver will have to reconnect. It should not impact actual functionality
         Ok(EcashApiClient {
             api_client: NymApiClient::new(url_address),
             verification_key: VerificationKeyAuth::try_from_bs58(&share.share)?,

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -22,7 +22,7 @@
 //!
 //! example log:
 //!
-//! ```
+//! ```txt
 //!   WARN /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hickory-proto-0.24.3/src/h2/h2_client_stream.rs:493: h2 connection failed: unexpected end of file
 //! ```
 #![deny(missing_docs)]

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
 //! DNS resolver configuration for internal lookups.
 //!
 //! The resolver itself is the set combination of the google, cloudflare, and quad9 endpoints
@@ -9,6 +12,19 @@
 //!
 //! Requires the `dns-over-https-rustls`, `webpki-roots` feature for the
 //! `hickory-resolver` crate
+//!
+//!
+//! Note: The hickory DoH resolver can cause warning logs about H2 connection failure. This
+//! indicates that the long lived https connection was closed by the remote peer and the resolver
+//! will have to reconnect. It should not impact actual functionality.
+//!
+//! code ref: https://github.com/hickory-dns/hickory-dns/blob/06a8b1ce9bd9322d8e6accf857d30257e1274427/crates/proto/src/h2/h2_client_stream.rs#L534
+//!
+//! example log:
+//!
+//! ```
+//!   WARN /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hickory-proto-0.24.3/src/h2/h2_client_stream.rs:493: h2 connection failed: unexpected end of file
+//! ```
 #![deny(missing_docs)]
 
 use crate::ClientBuilder;

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -33,6 +33,13 @@ impl ClientBuilder {
     /// Override the DNS resolver implementation used by the underlying http client.
     pub fn dns_resolver<R: Resolve + 'static>(mut self, resolver: Arc<R>) -> Self {
         self.reqwest_client_builder = self.reqwest_client_builder.dns_resolver(resolver);
+        self.use_secure_dns = false;
+        self
+    }
+
+    /// Override the DNS resolver implementation used by the underlying http client.
+    pub fn no_hickory_dns(mut self) -> Self {
+        self.use_secure_dns = false;
         self
     }
 }

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -228,6 +228,7 @@ pub struct ClientBuilder {
     timeout: Option<Duration>,
     custom_user_agent: bool,
     reqwest_client_builder: reqwest::ClientBuilder,
+    #[allow(dead_code)] // not dead code, just unused in wasm
     use_secure_dns: bool,
 }
 
@@ -240,7 +241,6 @@ impl ClientBuilder {
         U: IntoUrl,
         E: Display,
     {
-
         let str_url = url.as_str();
 
         // a naive check: if the provided URL does not start with http(s), add that scheme
@@ -258,7 +258,8 @@ impl ClientBuilder {
     pub fn new_with_url(url: Url) -> Self {
         if !url.scheme().starts_with("http") {
             let mut alt = url.clone();
-            #[allow(clippy::unwrap_used)] // https is always a valid protocol so unwrap is safe here
+            #[allow(clippy::unwrap_used)]
+            // https is always a valid protocol so unwrap is safe here
             alt.set_scheme("https").unwrap();
             warn!("the provided url ('{url}') does not contain scheme information. Changing it to '{alt}' ...");
             // TODO: or should we maybe default to https?

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -374,6 +374,9 @@ pub struct Client {
 impl Client {
     /// Create a new http `Client`
     // no timeout until https://github.com/seanmonstar/reqwest/issues/1135 is fixed
+    //
+    // In order to prevent interference in API requests at the DNS phase we default to a resolver
+    // that uses DoT and DoH.
     pub fn new(base_url: Url, timeout: Option<Duration>) -> Self {
         Self::new_url::<_, String>(base_url, timeout).expect(
             "we provided valid url and we were unwrapping previous construction errors anyway",

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -257,36 +257,30 @@ impl ClientBuilder {
     /// Constructs a new http `ClientBuilder` from a valid url.
     pub fn new_with_url(url: Url) -> Self {
         if !url.scheme().starts_with("http") {
-            let mut alt = url.clone();
-            #[allow(clippy::unwrap_used)]
-            // https is always a valid protocol so unwrap is safe here
-            alt.set_scheme("https").unwrap();
-            warn!("the provided url ('{url}') does not contain scheme information. Changing it to '{alt}' ...");
-            // TODO: or should we maybe default to https?
-            Self::new_with_url(alt)
-        } else {
-            #[cfg(target_arch = "wasm32")]
-            let reqwest_client_builder = reqwest::ClientBuilder::new();
+            warn!("the provided url ('{url}') does not use HTTP / HTTPS scheme");
+        }
 
-            #[cfg(not(target_arch = "wasm32"))]
-            let reqwest_client_builder = {
-                let r = reqwest::ClientBuilder::new();
+        #[cfg(target_arch = "wasm32")]
+        let reqwest_client_builder = reqwest::ClientBuilder::new();
 
-                // Note this is extra as the `gzip` feature for `reqwest` crate should be enabled which
-                // `"Enable[s] auto gzip decompression by checking the Content-Encoding response header."`
-                //
-                // I am going to leave it here anyways so that gzip decompression is attempted even if
-                // that feature is removed.
-                r.gzip(true)
-            };
+        #[cfg(not(target_arch = "wasm32"))]
+        let reqwest_client_builder = {
+            let r = reqwest::ClientBuilder::new();
 
-            ClientBuilder {
-                url,
-                timeout: None,
-                custom_user_agent: false,
-                reqwest_client_builder,
-                use_secure_dns: true,
-            }
+            // Note this is extra as the `gzip` feature for `reqwest` crate should be enabled which
+            // `"Enable[s] auto gzip decompression by checking the Content-Encoding response header."`
+            //
+            // I am going to leave it here anyways so that gzip decompression is attempted even if
+            // that feature is removed.
+            r.gzip(true)
+        };
+
+        ClientBuilder {
+            url,
+            timeout: None,
+            custom_user_agent: false,
+            reqwest_client_builder,
+            use_secure_dns: true,
         }
     }
 

--- a/nym-api/src/node_describe_cache/mod.rs
+++ b/nym-api/src/node_describe_cache/mod.rs
@@ -191,6 +191,7 @@ async fn try_get_client(
         // if provided host was malformed, no point in continuing
         let client = match nym_node_requests::api::Client::builder(address).and_then(|b| {
             b.with_timeout(Duration::from_secs(5))
+                .no_hickory_dns()
                 .with_user_agent("nym-api-describe-cache")
                 .build()
         }) {

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -29,6 +29,7 @@ nym-bin-common = { path = "../../common/bin-common", features = ["models"] }
 nym-node-status-client = { path = "../nym-node-status-client" }
 nym-crypto = { path = "../../common/crypto", features = ["asymmetric", "serde"] }
 nym-explorer-client = { path = "../../explorer-api/explorer-client" }
+nym-http-api-client = { path = "../../common/http-api-client" }
 nym-network-defaults = { path = "../../common/network-defaults" }
 nym-serde-helpers = { path = "../../common/serde-helpers"}
 nym-statistics-common = { path = "../../common/statistics" }

--- a/nym-node-status-api/nym-node-status-api/src/monitor/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/monitor/mod.rs
@@ -97,8 +97,12 @@ impl Monitor {
             .clone()
             .expect("rust sdk mainnet default missing api_url");
 
-        let api_client =
-            NymApiClient::new_with_timeout(default_api_url, self.nym_api_client_timeout);
+        let nym_api = nym_http_api_client::ClientBuilder::new_with_url(default_api_url)
+            .no_hickory_dns()
+            .with_timeout(self.nym_api_client_timeout)
+            .build::<&str>()?;
+
+        let api_client = NymApiClient { nym_api };
 
         let described_nodes = api_client
             .get_all_described_nodes()

--- a/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
@@ -57,7 +57,12 @@ async fn run(
         .clone()
         .expect("rust sdk mainnet default missing api_url");
 
-    let api_client = NymApiClient::new_with_timeout(default_api_url, nym_api_client_timeout);
+    let nym_api = nym_http_api_client::ClientBuilder::new_with_url(default_api_url)
+        .no_hickory_dns()
+        .with_timeout(nym_api_client_timeout)
+        .build::<&str>()?;
+
+    let api_client = NymApiClient { nym_api };
 
     //SW TBC what nodes exactly need to be scraped, the skimmed node endpoint seems to return more nodes
     let bonded_nodes = api_client.get_all_bonded_nym_nodes().await?;

--- a/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
@@ -175,6 +175,7 @@ impl MetricsScrapingData {
             let client = match nym_node_requests::api::Client::builder(address).and_then(|b| {
                 b.with_timeout(Duration::from_secs(5))
                     .with_user_agent("node-status-api-metrics-scraper")
+                    .no_hickory_dns()
                     .build()
             }) {
                 Ok(client) => client,

--- a/nym-node/Cargo.toml
+++ b/nym-node/Cargo.toml
@@ -71,7 +71,7 @@ nym-verloc = { path = "../common/verloc" }
 nym-metrics = { path = "../common/nym-metrics" }
 nym-gateway-stats-storage = { path = "../common/gateway-stats-storage" }
 nym-topology = { path = "../common/topology" }
-
+nym-http-api-client = { path = "../common/http-api-client" }
 
 # http server
 # useful for `#[axum_macros::debug_handler]`

--- a/nym-node/src/error.rs
+++ b/nym-node/src/error.rs
@@ -3,6 +3,7 @@
 
 use crate::node::http::error::NymNodeHttpError;
 use crate::wireguard::error::WireguardError;
+use nym_http_api_client::HttpClientError;
 use nym_ip_packet_router::error::ClientCoreError;
 use nym_validator_client::ValidatorClientError;
 use std::io;
@@ -208,4 +209,10 @@ pub enum ServiceProvidersError {
     // TODO: more granular errors
     #[error(transparent)]
     ExternalClientCore(#[from] ClientCoreError),
+}
+
+impl From<HttpClientError> for NymNodeError {
+    fn from(value: HttpClientError) -> Self {
+        Self::HttpFailure(NymNodeHttpError::ClientError { source: value })
+    }
 }

--- a/nym-node/src/node/http/error.rs
+++ b/nym-node/src/node/http/error.rs
@@ -3,6 +3,7 @@
 
 use std::io;
 use std::net::SocketAddr;
+use nym_http_api_client::HttpClientError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -23,5 +24,11 @@ pub enum NymNodeHttpError {
     KeyRecoveryError {
         #[from]
         source: nym_crypto::asymmetric::encryption::KeyRecoveryError,
+    },
+
+    #[error("error building or using HTTP client: {source}")]
+    ClientError {
+        #[from]
+        source: HttpClientError,
     },
 }

--- a/nym-node/src/node/http/error.rs
+++ b/nym-node/src/node/http/error.rs
@@ -1,9 +1,9 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_http_api_client::HttpClientError;
 use std::io;
 use std::net::SocketAddr;
-use nym_http_api_client::HttpClientError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Allow server side (nodes and nym-api) to use nym-http-api-client without  DoH/DoT resolver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5577)
<!-- Reviewable:end -->
