### PR TITLE
Export lane queue lengths in sdk

### DIFF
--- a/common/task/src/connections.rs
+++ b/common/task/src/connections.rs
@@ -103,4 +103,8 @@ impl LaneQueueLengthsInner {
     {
         self.map.entry(*lane).and_modify(f);
     }
+
+    pub fn total(&self) -> usize {
+        self.map.values().sum()
+    }
 }

--- a/sdk/rust/nym-sdk/src/mixnet.rs
+++ b/sdk/rust/nym-sdk/src/mixnet.rs
@@ -82,7 +82,7 @@ pub use nym_sphinx::{
 pub use nym_statistics_common::clients::{
     connection::ConnectionStatsEvent, ClientStatsEvents, ClientStatsSender,
 };
-pub use nym_task::connections::TransmissionLane;
+pub use nym_task::connections::{LaneQueueLengths, TransmissionLane};
 pub use nym_topology::{provider_trait::TopologyProvider, NymTopology};
 pub use paths::StoragePaths;
 pub use socks5_client::Socks5MixnetClient;


### PR DESCRIPTION
Export the lane queue length type to be able to implement backpressure outside of the sdk mixnet client

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5609)
<!-- Reviewable:end -->
