### PR TITLE
Rework IPR codec to extract out timer and implement AsyncWrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5771,6 +5771,7 @@ name = "nym-ip-packet-router"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bincode",
  "bs58",
  "bytes",

--- a/common/client-core/src/client/mix_traffic/mod.rs
+++ b/common/client-core/src/client/mix_traffic/mod.rs
@@ -52,7 +52,7 @@ impl MixTrafficController {
         let (message_sender, message_receiver) =
             tokio::sync::mpsc::channel(MIX_MESSAGE_RECEIVER_BUFFER_SIZE);
 
-        let (client_sender, client_receiver) = tokio::sync::mpsc::channel(1);
+        let (client_sender, client_receiver) = tokio::sync::mpsc::channel(8);
 
         (
             MixTrafficController {
@@ -77,7 +77,7 @@ impl MixTrafficController {
     ) {
         let (message_sender, message_receiver) =
             tokio::sync::mpsc::channel(MIX_MESSAGE_RECEIVER_BUFFER_SIZE);
-        let (client_sender, client_receiver) = tokio::sync::mpsc::channel(1);
+        let (client_sender, client_receiver) = tokio::sync::mpsc::channel(8);
         (
             MixTrafficController {
                 gateway_transceiver,

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -198,10 +198,10 @@ where
             trace!("we already had sender tag for {recipient}");
             existing
         } else {
-            info!("creating new sender tag for {recipient}");
+            debug!("creating new sender tag for {recipient}");
             let new_tag = AnonymousSenderTag::new_random(&mut self.rng);
             self.tag_storage.insert_new(recipient, new_tag);
-            info!("we'll be using {new_tag} for all anonymous messages sent to {recipient}");
+            info!("using {new_tag} for all anonymous messages sent to {recipient}");
             new_tag
         }
     }

--- a/common/client-core/src/client/real_messages_control/mod.rs
+++ b/common/client-core/src/client/real_messages_control/mod.rs
@@ -153,7 +153,7 @@ impl RealMessagesController<OsRng> {
         let rng = OsRng;
 
         // create channels for inter-task communication
-        let (real_message_sender, real_message_receiver) = tokio::sync::mpsc::channel(1);
+        let (real_message_sender, real_message_receiver) = tokio::sync::mpsc::channel(8);
         let (sent_notifier_tx, sent_notifier_rx) = mpsc::unbounded();
         let (ack_action_tx, ack_action_rx) = mpsc::unbounded();
         let ack_controller_connectors = AcknowledgementControllerConnectors::new(

--- a/common/ip-packet-requests/src/codec.rs
+++ b/common/ip-packet-requests/src/codec.rs
@@ -23,14 +23,12 @@ const LENGTH_PREFIX_SIZE: usize = 2;
 // long for the buffer to fill up, since this kills latency.
 pub struct MultiIpPacketCodec {
     buffer: BytesMut,
-    buffer_timeout: tokio::time::Interval,
 }
 
 impl MultiIpPacketCodec {
-    pub fn new(buffer_timeout: Duration) -> Self {
+    pub fn new() -> Self {
         MultiIpPacketCodec {
             buffer: BytesMut::new(),
-            buffer_timeout: tokio::time::interval(buffer_timeout),
         }
     }
 
@@ -40,56 +38,81 @@ impl MultiIpPacketCodec {
         bundled_packets.extend_from_slice(&packet);
         bundled_packets.freeze()
     }
+}
 
-    // Append a packet to the buffer and return the buffer if it's full
-    pub fn append_packet(&mut self, packet: Bytes) -> Option<Bytes> {
-        let mut bundled_packets = BytesMut::new();
-        self.encode(packet, &mut bundled_packets).unwrap();
-        if bundled_packets.is_empty() {
-            None
-        } else {
-            // log::info!("Sphinx packet utilization: {:.2}", self.buffer.len() as f64 / MAX_PACKET_SIZE as f64);
-            Some(bundled_packets.freeze())
+impl Default for MultiIpPacketCodec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The packet that we encode and decode with the MultiIpPacketCodec into bundled multi-ip packets.
+/// The data here is the actual IP packet that we want to send, not the bundled packets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IprPacket {
+    Data(Bytes),
+    Flush,
+}
+
+impl IprPacket {
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            IprPacket::Data(bytes) => bytes.as_ref(),
+            IprPacket::Flush => &[],
         }
     }
 
-    // Flush the current buffer and return it.
-    pub fn flush_current_buffer(&mut self) -> Bytes {
-        let mut output_buffer = BytesMut::new();
-        std::mem::swap(&mut output_buffer, &mut self.buffer);
-        output_buffer.freeze()
-    }
-
-    // Wait for the buffer_timeout to tick and then flush the buffer.
-    // This is useful when we want to send the buffer even if it's not full.
-    pub async fn buffer_timeout(&mut self) -> Option<Bytes> {
-        // Wait for buffer_timeout to tick
-        let _ = self.buffer_timeout.tick().await;
-
-        // Flush the buffer and return it
-        let packets = self.flush_current_buffer();
-        if packets.is_empty() {
-            None
-        } else {
-            Some(packets)
+    pub fn into_bytes(self) -> Bytes {
+        match self {
+            IprPacket::Data(bytes) => bytes,
+            IprPacket::Flush => Bytes::new(),
         }
     }
 }
 
-impl Encoder<Bytes> for MultiIpPacketCodec {
+impl From<Bytes> for IprPacket {
+    fn from(bytes: Bytes) -> Self {
+        IprPacket::Data(bytes)
+    }
+}
+
+impl From<Vec<u8>> for IprPacket {
+    fn from(bytes: Vec<u8>) -> Self {
+        IprPacket::Data(Bytes::from(bytes))
+    }
+}
+
+impl Encoder<IprPacket> for MultiIpPacketCodec {
     type Error = Error;
 
-    fn encode(&mut self, packet: Bytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        if self.buffer.is_empty() {
-            self.buffer_timeout.reset();
-        }
+    fn encode(&mut self, packet: IprPacket, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let packet = match packet {
+            IprPacket::Flush => {
+                dst.extend_from_slice(&self.buffer);
+                self.buffer = BytesMut::new();
+                return Ok(());
+            }
+            IprPacket::Data(packet) => packet,
+        };
+
         let packet_size = packet.len();
 
+        // If the existing buffer is empty, and the packet is too large, send it directly
+        if self.buffer.is_empty() && packet_size + LENGTH_PREFIX_SIZE > MAX_PACKET_SIZE {
+            // Add the packet size
+            dst.extend_from_slice(&(packet_size as u16).to_be_bytes());
+            // Add the packet to the buffer
+            dst.extend_from_slice(&packet);
+            return Ok(());
+        }
+
+        // If the packet doesn't fit in the existing buffer, send what we have now in the buffer
+        // and then add it to the next buffer
         if self.buffer.len() + packet_size + LENGTH_PREFIX_SIZE > MAX_PACKET_SIZE {
-            // If the packet doesn't fit in the buffer, send the buffer and then add it to the buffer
+            // Send the existing buffer
             dst.extend_from_slice(&self.buffer);
+            // Start a new buffer
             self.buffer = BytesMut::new();
-            self.buffer_timeout.reset();
         }
 
         // Add the packet size
@@ -103,7 +126,7 @@ impl Encoder<Bytes> for MultiIpPacketCodec {
 }
 
 impl Decoder for MultiIpPacketCodec {
-    type Item = Bytes;
+    type Item = IprPacket;
     type Error = Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
@@ -125,6 +148,86 @@ impl Decoder for MultiIpPacketCodec {
         // Read the packet
         let packet = src.split_to(packet_size);
 
-        Ok(Some(packet.freeze()))
+        Ok(Some(IprPacket::Data(packet.freeze())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_multi_ip_packet_codec_max_packet_size() {
+        let mut codec = MultiIpPacketCodec::new();
+        let mut buffer = BytesMut::new();
+
+        // A packet size that is large enough that two packets won't fit in the buffer
+        const PACKET_SIZE: usize = MAX_PACKET_SIZE - 100;
+
+        let packet1 = IprPacket::from(Bytes::from_static(&[0u8; PACKET_SIZE]));
+        let packet2 = IprPacket::from(Bytes::from_static(&[0u8; PACKET_SIZE]));
+
+        codec.encode(packet1.clone(), &mut buffer).unwrap();
+        assert_eq!(buffer.len(), 0);
+
+        codec.encode(packet2.clone(), &mut buffer).unwrap();
+        assert_eq!(buffer.len(), LENGTH_PREFIX_SIZE + PACKET_SIZE);
+
+        // First is the length prefix
+        assert_eq!(buffer[..2], (PACKET_SIZE as u16).to_be_bytes());
+        // Next is the packet
+        assert_eq!(&buffer[2..], packet1.as_bytes());
+    }
+
+    #[test]
+    fn encode_and_then_decode() {
+        let mut codec = MultiIpPacketCodec::new();
+        let mut buffer = BytesMut::new();
+
+        let packet = IprPacket::from(Bytes::from_static(&[0u8; 1000]));
+        codec.encode(packet.clone(), &mut buffer).unwrap();
+        codec.encode(packet.clone(), &mut buffer).unwrap();
+
+        let mut decoded_packets = Vec::new();
+        while let Some(decoded_packet) = codec.decode(&mut buffer).unwrap() {
+            decoded_packets.push(decoded_packet);
+        }
+
+        assert_eq!(decoded_packets.len(), 1);
+        assert_eq!(decoded_packets[0].as_bytes(), packet.as_bytes());
+    }
+
+    #[test]
+    fn encode_a_packat_that_is_too_large() {
+        let mut codec = MultiIpPacketCodec::new();
+        let mut buffer = BytesMut::new();
+
+        let packet = IprPacket::from(Bytes::from_static(
+            &[0u8; MAX_PACKET_SIZE + MAX_PACKET_SIZE],
+        ));
+        codec.encode(packet, &mut buffer).unwrap();
+        assert_eq!(
+            buffer.len(),
+            MAX_PACKET_SIZE + MAX_PACKET_SIZE + LENGTH_PREFIX_SIZE
+        );
+        codec.encode(IprPacket::Flush, &mut buffer).unwrap();
+        assert_eq!(
+            buffer.len(),
+            MAX_PACKET_SIZE + MAX_PACKET_SIZE + LENGTH_PREFIX_SIZE
+        );
+    }
+
+    #[test]
+    fn check_that_max_size_does_not_flush() {
+        let mut codec = MultiIpPacketCodec::new();
+        let mut buffer = BytesMut::new();
+
+        let packet = IprPacket::from(Bytes::from_static(&[0u8; MAX_PACKET_SIZE - 2]));
+        codec.encode(packet.clone(), &mut buffer).unwrap();
+        assert_eq!(buffer.len(), 0);
+
+        let packet = IprPacket::from(Bytes::from_static(&[0u8; MAX_PACKET_SIZE - 2]));
+        codec.encode(packet.clone(), &mut buffer).unwrap();
+        assert_eq!(buffer.len(), MAX_PACKET_SIZE);
     }
 }

--- a/common/task/src/connections.rs
+++ b/common/task/src/connections.rs
@@ -90,11 +90,9 @@ impl LaneQueueLengths {
             if lane_length < LANE_CONSIDERED_CLEAR {
                 break;
             }
-            if let Some(timeout) = timeout {
-                if total_time_waited.elapsed() > timeout {
-                    log::warn!("Timeout reached while waiting for queue to clear");
-                    break;
-                }
+            if timeout.is_some_and(|timeout| total_time_waited.elapsed() > timeout) {
+                log::warn!("Timeout reached while waiting for queue to clear");
+                break;
             }
             log::trace!("Waiting for queue to clear ({} items left)", lane_length);
             tokio::time::sleep(Duration::from_millis(100)).await;

--- a/sdk/rust/nym-sdk/src/error.rs
+++ b/sdk/rust/nym-sdk/src/error.rs
@@ -93,6 +93,9 @@ pub enum Error {
 
     #[error("this operation is currently unsupported: {details}")]
     Unsupported { details: String },
+
+    #[error(transparent)]
+    Bincode(#[from] bincode::Error),
 }
 
 impl Error {

--- a/sdk/rust/nym-sdk/src/mixnet.rs
+++ b/sdk/rust/nym-sdk/src/mixnet.rs
@@ -35,6 +35,7 @@ mod config;
 mod connection_state;
 mod native_client;
 mod paths;
+mod sink;
 mod socks5_client;
 mod traits;
 
@@ -85,5 +86,6 @@ pub use nym_statistics_common::clients::{
 pub use nym_task::connections::{LaneQueueLengths, TransmissionLane};
 pub use nym_topology::{provider_trait::TopologyProvider, NymTopology};
 pub use paths::StoragePaths;
+pub use sink::{MixnetMessageSink, MixnetMessageSinkTranslator};
 pub use socks5_client::Socks5MixnetClient;
 pub use traits::MixnetMessageSender;

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -823,10 +823,12 @@ where
     }
 }
 
+#[derive(Debug, Clone)]
 pub enum IncludedSurbs {
     Amount(u32),
     ExposeSelfAddress,
 }
+
 impl Default for IncludedSurbs {
     fn default() -> Self {
         Self::Amount(DEFAULT_NUMBER_OF_SURBS)

--- a/sdk/rust/nym-sdk/src/mixnet/sink.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/sink.rs
@@ -1,0 +1,248 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{ready, SinkExt};
+use nym_client_core::client::inbound_messages::InputMessage;
+use nym_sphinx::{
+    addressing::Recipient, anonymous_replies::requests::AnonymousSenderTag, params::PacketType,
+};
+use nym_task::connections::TransmissionLane;
+use tokio::{io::AsyncWrite, sync::mpsc, task::JoinHandle};
+use tokio_util::sync::PollSender;
+
+use crate::Error;
+
+use super::{IncludedSurbs, MixnetMessageSender};
+
+// The size of the buffer used to send messages to the mixnet. This is used to signal backpressure
+// to the caller when the buffer is full. The size is denominated in number of messages, not bytes.
+const SINK_BUFFER_SIZE_IN_MESSAGES: usize = 8;
+
+/// Traits that represents the ability to convert bytes into InputMessages that can be sent to the
+/// mixnet. This is typically used to set the destination and other sending parameters.
+pub trait MixnetMessageSinkTranslator: Unpin {
+    fn to_input_message(&self, bytes: &[u8]) -> Result<InputMessage, Error>;
+}
+
+/// The default implementation of MixnetMessageSinkTranslator that sends messages to a recipient or
+/// replies to a sender that has provided reply SURBs.
+#[derive(Clone, Debug)]
+pub struct DefaultMixnetMessageSinkTranslator {
+    destination: SinkDestination,
+    lane: TransmissionLane,
+    packet_type: Option<PacketType>,
+}
+
+/// The destination for messages feed to the mixnnet sink, used by the default implementation of
+/// MixnetMessageSinkTranslator.
+#[derive(Clone, Debug)]
+enum SinkDestination {
+    Recipient {
+        recipient: Box<Recipient>,
+        surbs: IncludedSurbs,
+    },
+    Reply(AnonymousSenderTag),
+}
+
+impl MixnetMessageSinkTranslator for DefaultMixnetMessageSinkTranslator {
+    fn to_input_message(&self, bytes: &[u8]) -> Result<InputMessage, Error> {
+        let bytes = bytes.to_vec();
+        match &self.destination {
+            SinkDestination::Recipient { recipient, surbs } => match surbs {
+                IncludedSurbs::ExposeSelfAddress => Ok(InputMessage::new_regular(
+                    **recipient,
+                    bytes,
+                    self.lane,
+                    self.packet_type,
+                )),
+                IncludedSurbs::Amount(surbs) => Ok(InputMessage::new_anonymous(
+                    **recipient,
+                    bytes,
+                    *surbs,
+                    self.lane,
+                    self.packet_type,
+                )),
+            },
+            SinkDestination::Reply(tag) => Ok(InputMessage::new_reply(
+                *tag,
+                bytes,
+                self.lane,
+                self.packet_type,
+            )),
+        }
+    }
+}
+
+/// Wrapper around MixnetMessageSender that implements AsyncWrite and takes bytes and sends them as
+/// InputMessages to the mixnet. This requires a BytesToInputMessage implementation to convert bytes
+/// to InputMessages, which typically means setting the destination and other sending parameters.
+pub struct MixnetMessageSink<F>
+where
+    F: MixnetMessageSinkTranslator,
+{
+    // The function that converts bytes into InputMessages
+    message_translator: F,
+
+    // Send messages to the mixnet sender task
+    tx: PollSender<InputMessage>,
+
+    // The handle for the mixnet sender task
+    send_task: JoinHandle<()>,
+}
+
+impl MixnetMessageSink<DefaultMixnetMessageSinkTranslator> {
+    /// Creates a new MixnetMessageSink that sends messages to the provided recipient. The messages
+    /// can also include SURBs to allow for anonymous communication.
+    ///
+    /// Typically you don't want to include SURBs here, but instead provide an initial set of SURBs
+    /// on the first message, and then let the recipient request more SURBs as needed.
+    ///
+    /// If you provide SURBs here, the recipient will very likely receive far more SURBs than they
+    /// need.
+    pub fn new_recipient_sink<Sender>(
+        mixnet_client_sender: Sender,
+        recipient: Recipient,
+        surbs: IncludedSurbs,
+    ) -> Self
+    where
+        Sender: MixnetMessageSender + Send + 'static,
+    {
+        let destination = SinkDestination::Recipient {
+            recipient: Box::new(recipient),
+            surbs,
+        };
+        let translator = DefaultMixnetMessageSinkTranslator {
+            destination,
+            lane: TransmissionLane::General,
+            packet_type: None,
+        };
+        Self::new_with_custom_translator(mixnet_client_sender, translator)
+    }
+
+    /// Creates a new MixnetMessageSink that sends messages to a recipient with the provided SURBs.
+    /// The messages are sent using the provided MixnetMessageSender.
+    pub fn new_reply_sink<Sender>(
+        mixnet_client_sender: Sender,
+        recipient_tag: AnonymousSenderTag,
+    ) -> Self
+    where
+        Sender: MixnetMessageSender + Send + 'static,
+    {
+        let destination = SinkDestination::Reply(recipient_tag);
+        let translator = DefaultMixnetMessageSinkTranslator {
+            destination,
+            lane: TransmissionLane::General,
+            packet_type: None,
+        };
+        Self::new_with_custom_translator(mixnet_client_sender, translator)
+    }
+}
+
+impl<F> MixnetMessageSink<F>
+where
+    F: MixnetMessageSinkTranslator,
+{
+    /// Creates a new MixnetMessageSink that sends messages to the mixnet using the provided
+    /// MixnetMessageSender. The messages are converted to InputMessages using the provided
+    /// MixnetMessageSinkTranslator.
+    ///
+    /// The usecase of this function is to allow for custom message translation, for example to
+    /// wrap messages in a specific way or to add additional metadata.
+    pub fn new_with_custom_translator<Sender>(
+        mixnet_client_sender: Sender,
+        message_translator: F,
+    ) -> Self
+    where
+        Sender: MixnetMessageSender + Send + 'static,
+    {
+        // Create a separate task to send messages to the mixnet. This is driven mostly by the
+        // implementation of AsyncWrite.
+        let (tx, send_task) = Self::start_sender_task(mixnet_client_sender);
+
+        // Wrap the sender in PollSener to make the AsyncWrite implementation more ergonomic
+        let tx = PollSender::new(tx);
+
+        MixnetMessageSink {
+            message_translator,
+            tx,
+            send_task,
+        }
+    }
+
+    fn start_sender_task<Sender>(
+        mixnet_client_sender: Sender,
+    ) -> (mpsc::Sender<InputMessage>, JoinHandle<()>)
+    where
+        Sender: MixnetMessageSender + Send + 'static,
+    {
+        let (tx, mut rx) = mpsc::channel(SINK_BUFFER_SIZE_IN_MESSAGES);
+
+        let send_task = tokio::spawn(async move {
+            while let Some(input_message) = rx.recv().await {
+                if let Err(err) = mixnet_client_sender.send(input_message).await {
+                    log::error!("failed to send packet to mixnet: {err}");
+                }
+            }
+        });
+
+        (tx, send_task)
+    }
+}
+
+impl<F> Drop for MixnetMessageSink<F>
+where
+    F: MixnetMessageSinkTranslator,
+{
+    fn drop(&mut self) {
+        self.send_task.abort();
+    }
+}
+
+impl<F> AsyncWrite for MixnetMessageSink<F>
+where
+    F: MixnetMessageSinkTranslator,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::result::Result<usize, std::io::Error>> {
+        ready!(self.tx.poll_ready_unpin(cx)).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::Other, "failed to send packet to mixnet")
+        })?;
+
+        let input_message = self
+            .message_translator
+            .to_input_message(buf)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+        // Pass it to the mixnet sender
+        self.tx.start_send_unpin(input_message).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::Other, "failed to send packet to mixnet")
+        })?;
+
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+    ) -> Poll<std::result::Result<(), std::io::Error>> {
+        ready!(self.tx.poll_flush_unpin(cx)).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::Other, "failed to send packet to mixnet")
+        })?;
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+    ) -> Poll<std::result::Result<(), std::io::Error>> {
+        self.poll_flush(cx)
+    }
+}

--- a/service-providers/ip-packet-router/Cargo.toml
+++ b/service-providers/ip-packet-router/Cargo.toml
@@ -41,9 +41,12 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util", "macros"] }
 tokio-util = { workspace = true, features = ["codec"] }
 url.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-tun.workspace = true
+
+[dev-dependencies]
+async-trait.workspace = true

--- a/service-providers/ip-packet-router/src/clients/connected_client_handler.rs
+++ b/service-providers/ip-packet-router/src/clients/connected_client_handler.rs
@@ -3,24 +3,28 @@
 
 use std::time::Duration;
 
-use bytes::Bytes;
+use bytes::BytesMut;
+use futures::SinkExt;
 use nym_ip_packet_requests::{
-    codec::MultiIpPacketCodec, v6::response::IpPacketResponse as IpPacketResponseV6,
+    codec::{IprPacket, MultiIpPacketCodec},
+    v6::response::IpPacketResponse as IpPacketResponseV6,
     v7::response::IpPacketResponse as IpPacketResponseV7,
     v8::response::IpPacketResponse as IpPacketResponseV8,
 };
-use nym_sdk::mixnet::MixnetMessageSender;
+use nym_sdk::mixnet::{
+    InputMessage, MixnetClientSender, MixnetMessageSink, MixnetMessageSinkTranslator,
+};
 use tokio::{
     sync::{mpsc, oneshot},
     time::interval,
 };
+use tokio_util::codec::FramedWrite;
 
 use crate::{
     clients::ConnectedClientId,
     constants::CLIENT_HANDLER_ACTIVITY_TIMEOUT,
     error::{IpPacketRouterError, Result},
     messages::ClientVersion,
-    util::create_message::create_input_message,
 };
 
 // Data flow
@@ -36,20 +40,18 @@ pub(crate) struct ConnectedClientHandler {
     // Channel to receive packets from the tun_listener
     forward_from_tun_rx: mpsc::UnboundedReceiver<Vec<u8>>,
 
-    // Channel to send packets to the mixnet
-    mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
-
     // Channel to receive close signal
     close_rx: oneshot::Receiver<()>,
 
     // Interval to check for activity timeout
     activity_timeout: tokio::time::Interval,
 
-    // Encoder to bundle multiple packets into a single one
-    encoder: MultiIpPacketCodec,
+    // The time we have to topup a payload before we send, regardless
+    payload_topup_interval: tokio::time::Interval,
 
-    // The version of the client
-    client_version: ClientVersion,
+    // The sender to the mixnet. It's a framed writer that bundles IP packets together to fill out
+    // the sphinx packet payload before sending.
+    mixnet_ip_packet_sink: FramedWrite<MixnetMessageSink<ToIprDataResponse>, MultiIpPacketCodec>,
 }
 
 impl ConnectedClientHandler {
@@ -57,7 +59,7 @@ impl ConnectedClientHandler {
         client_id: ConnectedClientId,
         buffer_timeout: Duration,
         client_version: ClientVersion,
-        mixnet_client_sender: nym_sdk::mixnet::MixnetClientSender,
+        mixnet_client_sender: MixnetClientSender,
     ) -> (
         mpsc::UnboundedSender<Vec<u8>>,
         oneshot::Sender<()>,
@@ -72,16 +74,30 @@ impl ConnectedClientHandler {
         let mut activity_timeout = interval(CLIENT_HANDLER_ACTIVITY_TIMEOUT);
         activity_timeout.reset();
 
-        let encoder = MultiIpPacketCodec::new(buffer_timeout);
+        let mut payload_topup_interval = interval(buffer_timeout);
+        payload_topup_interval.reset();
+
+        // The mixnet sink takes bytes, create IPR response types that the recipient can
+        // understand, and sends them as InputMessages to the mixnet.
+        let mixnet_client_sink = MixnetMessageSink::new_with_custom_translator(
+            mixnet_client_sender,
+            ToIprDataResponse {
+                send_to: client_id.clone(),
+                client_version,
+            },
+        );
+
+        // The mixnet ip packet sink takes IP packets, bundles them together, and sends them to the
+        // mixnet client sink
+        let mixnet_ip_packet_sink = FramedWrite::new(mixnet_client_sink, MultiIpPacketCodec::new());
 
         let connected_client_handler = ConnectedClientHandler {
             sent_by: client_id,
             forward_from_tun_rx,
-            mixnet_client_sender,
             close_rx,
             activity_timeout,
-            encoder,
-            client_version,
+            payload_topup_interval,
+            mixnet_ip_packet_sink,
         };
 
         let handle = tokio::spawn(async move {
@@ -93,41 +109,14 @@ impl ConnectedClientHandler {
         (forward_from_tun_tx, close_tx, handle)
     }
 
-    async fn create_ip_packet(&self, packets: Bytes) -> Result<Vec<u8>> {
-        match self.client_version {
-            ClientVersion::V6 => IpPacketResponseV6::new_ip_packet(packets).to_bytes(),
-            ClientVersion::V7 => IpPacketResponseV7::new_ip_packet(packets).to_bytes(),
-            ClientVersion::V8 => IpPacketResponseV8::new_ip_packet(packets).to_bytes(),
-        }
-        .map_err(|err| IpPacketRouterError::FailedToSerializeResponsePacket { source: err })
-    }
-
-    async fn send_packets_to_mixnet(&mut self, packets: Bytes) -> Result<()> {
-        let response_packet = self.create_ip_packet(packets).await?;
-        let input_message = create_input_message(&self.sent_by, response_packet);
-
-        self.mixnet_client_sender
-            .send(input_message)
-            .await
-            .map_err(|err| IpPacketRouterError::FailedToSendPacketToMixnet { source: err })
-    }
-
-    async fn handle_buffer_timeout(&mut self, packets: Bytes) -> Result<()> {
-        if !packets.is_empty() {
-            self.send_packets_to_mixnet(packets).await
-        } else {
-            Ok(())
-        }
-    }
-
     async fn handle_packet(&mut self, packet: Vec<u8>) -> Result<()> {
         self.activity_timeout.reset();
+        self.payload_topup_interval.reset();
 
-        if let Some(bundled_packets) = self.encoder.append_packet(packet.into()) {
-            self.send_packets_to_mixnet(bundled_packets).await
-        } else {
-            Ok(())
-        }
+        self.mixnet_ip_packet_sink
+            .send(IprPacket::from(packet))
+            .await
+            .map_err(|source| IpPacketRouterError::FailedToEncodeMixnetMessage { source })
     }
 
     async fn run(mut self) -> Result<()> {
@@ -141,16 +130,19 @@ impl ConnectedClientHandler {
                     log::info!("client handler stopping: activity timeout: {}", self.sent_by);
                     break;
                 },
-                packets = self.encoder.buffer_timeout() => match packets {
-                    Some(packets) => {
-                        if let Err(err) = self.handle_buffer_timeout(packets).await {
-                            log::error!("client handler: failed to handle buffer timeout: {err}");
-                        }
-                    },
-                    None => log::trace!("no packets to send"),
+                _ = self.payload_topup_interval.tick() => {
+                    // Send an empty packet to trigger the buffer timeout
+                    if let Err(err) = self.handle_packet(Vec::new()).await {
+                        log::error!("client handler: failed to handle packet: {err}");
+                    }
                 },
                 packet = self.forward_from_tun_rx.recv() => match packet {
                     Some(packet) => {
+                        // I don't think this should ever happen, so log this so we are aware of it
+                        if packet.is_empty() {
+                            log::warn!("client handler: received empty packet");
+                            continue;
+                        }
                         if let Err(err) = self.handle_packet(packet).await {
                             log::error!("client handler: failed to handle packet: {err}");
                         }
@@ -165,5 +157,147 @@ impl ConnectedClientHandler {
 
         log::debug!("ConnectedClientHandler: exiting");
         Ok(())
+    }
+}
+
+fn create_ip_packet_response(
+    packets: &[u8],
+    client_version: ClientVersion,
+) -> std::result::Result<Vec<u8>, bincode::Error> {
+    let packets = BytesMut::from(packets).freeze();
+    match client_version {
+        ClientVersion::V6 => IpPacketResponseV6::new_ip_packet(packets).to_bytes(),
+        ClientVersion::V7 => IpPacketResponseV7::new_ip_packet(packets).to_bytes(),
+        ClientVersion::V8 => IpPacketResponseV8::new_ip_packet(packets).to_bytes(),
+    }
+}
+
+// This struct is used by the sink to translate the the bundled IP packets into a IPR packet
+// responses that can be sent to the mixnet.
+struct ToIprDataResponse {
+    send_to: ConnectedClientId,
+    client_version: ClientVersion,
+}
+
+impl MixnetMessageSinkTranslator for ToIprDataResponse {
+    fn to_input_message(
+        &self,
+        bundled_ip_packets: &[u8],
+    ) -> std::result::Result<InputMessage, nym_sdk::Error> {
+        // Create a IPR packet response that the recipient can understand
+        let response_packet = create_ip_packet_response(bundled_ip_packets, self.client_version)?;
+
+        // Wrap the response packet in a mixnet input message
+        Ok(crate::util::create_message::create_input_message(
+            &self.send_to,
+            response_packet,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use nym_sdk::mixnet::{AnonymousSenderTag, MixnetMessageSender};
+    use tokio::sync::Notify;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct MockMixnetClientSender {
+        sent_messages: Arc<Mutex<Vec<InputMessage>>>,
+        notify: Arc<Notify>,
+    }
+
+    impl MockMixnetClientSender {
+        fn new() -> Self {
+            MockMixnetClientSender {
+                sent_messages: Arc::new(Mutex::new(Vec::new())),
+                notify: Arc::new(Notify::new()),
+            }
+        }
+
+        fn sent_messages(&self) -> Vec<String> {
+            let sent_messages = self.sent_messages.lock().unwrap();
+            sent_messages
+                .iter()
+                .map(|msg| format!("{msg:?}").to_owned())
+                .collect()
+        }
+
+        async fn wait_for_messages(&self, count: usize) {
+            loop {
+                if self.sent_messages.lock().unwrap().len() >= count {
+                    break;
+                }
+                self.notify.notified().await;
+            }
+        }
+    }
+
+    #[async_trait]
+    impl MixnetMessageSender for MockMixnetClientSender {
+        async fn send(&self, message: InputMessage) -> std::result::Result<(), nym_sdk::Error> {
+            let mut sent_messages = self.sent_messages.lock().unwrap();
+            sent_messages.push(message);
+            self.notify.notify_one();
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_combining_framed_write_and_mixnet_client_ip_packet_sender() {
+        let mixnet_client_sender = MockMixnetClientSender::new();
+        let sender_tag = AnonymousSenderTag::new_random(&mut rand::thread_rng());
+        let client_id = ConnectedClientId::AnonymousSenderTag(sender_tag);
+        let client_version = ClientVersion::V8;
+
+        let bytes_to_input_message = ToIprDataResponse {
+            send_to: client_id.clone(),
+            client_version,
+        };
+
+        let mixnet_ip_packet_sender = MixnetMessageSink::new_with_custom_translator(
+            mixnet_client_sender.clone(),
+            bytes_to_input_message,
+        );
+
+        let mut ip_packet_sender =
+            FramedWrite::new(mixnet_ip_packet_sender, MultiIpPacketCodec::new());
+
+        assert!(mixnet_client_sender.sent_messages().is_empty());
+
+        // Send two packets. These will be bundled together by the codec
+        ip_packet_sender
+            .send(IprPacket::Data(Bytes::from("hello".to_owned())))
+            .await
+            .expect("failed to send");
+
+        ip_packet_sender
+            .send(IprPacket::Data(Bytes::from("world".to_owned())))
+            .await
+            .expect("failed to send");
+
+        // Packets are still being collected by the codec
+        assert!(mixnet_client_sender.sent_messages().is_empty());
+
+        // The codec will bundle packets together until it fills out the sphinx packet payload, but
+        // we can trigger sending what it has accumulated so far by sending an explicit flush
+        ip_packet_sender
+            .send(IprPacket::Flush)
+            .await
+            .expect("failed to send");
+
+        // This will never been seen by the mixnet sender as it never gets further than the codec
+        ip_packet_sender
+            .send(IprPacket::Data(Bytes::from("never seen".to_owned())))
+            .await
+            .expect("failed to send");
+
+        mixnet_client_sender.wait_for_messages(1).await;
+        assert_eq!(mixnet_client_sender.sent_messages().len(), 1);
     }
 }

--- a/service-providers/ip-packet-router/src/clients/connected_client_handler.rs
+++ b/service-providers/ip-packet-router/src/clients/connected_client_handler.rs
@@ -137,11 +137,6 @@ impl ConnectedClientHandler {
                 },
                 packet = self.forward_from_tun_rx.recv() => match packet {
                     Some(packet) => {
-                        // I don't think this should ever happen, so log this so we are aware of it
-                        if packet.is_empty() {
-                            log::warn!("client handler: received empty packet");
-                            continue;
-                        }
                         if let Err(err) = self.handle_packet(IprPacket::from(packet)).await {
                             log::error!("client handler: failed to handle packet: {err}");
                         }

--- a/service-providers/ip-packet-router/src/error.rs
+++ b/service-providers/ip-packet-router/src/error.rs
@@ -61,6 +61,11 @@ pub enum IpPacketRouterError {
     #[error("failed to send packet to mixnet: {source}")]
     FailedToSendPacketToMixnet { source: nym_sdk::Error },
 
+    #[error("failed to encode mixnet message: {source}")]
+    FailedToEncodeMixnetMessage {
+        source: nym_ip_packet_requests::codec::Error,
+    },
+
     #[error("the provided socket address, '{addr}' is not covered by the exit policy!")]
     AddressNotCoveredByExitPolicy { addr: SocketAddr },
 

--- a/service-providers/ip-packet-router/src/util/generate_new_ip.rs
+++ b/service-providers/ip-packet-router/src/util/generate_new_ip.rs
@@ -65,7 +65,6 @@ mod tests {
         let mut rng = rand::rngs::mock::StepRng::new(0, 65540);
         for _ in 2..65535 {
             let pair = generate_random_ips_within_subnet(&mut rng);
-            println!("{:?}", pair);
             assert!(!map.contains(&pair));
             map.insert(pair);
         }


### PR DESCRIPTION
The goal is to be able to handle backpressure in the vpn client. For that we need to extract out the timer from the codec since we want to move control over that to the mixnet processor. Once the timer is removed we can reformulate the mixnet sender as a `Sink` wrapped in a `FramedWrite`

- Extract out timer from IPR codec
- Implement AsyncWrite on mixnet client sender
- Add functions to wait for lanes to clear on `LaneQueueLenghts`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5632)
<!-- Reviewable:end -->
