### PR TITLE
Add fd callback for initial authentication

### DIFF
--- a/common/client-core/src/cli_helpers/client_add_gateway.rs
+++ b/common/client-core/src/cli_helpers/client_add_gateway.rs
@@ -139,6 +139,8 @@ where
     let gateway_setup = GatewaySetup::New {
         specification: selection_spec,
         available_gateways,
+        #[cfg(unix)]
+        connection_fd_callback: None,
     };
 
     let init_details =

--- a/common/client-core/src/cli_helpers/client_init.rs
+++ b/common/client-core/src/cli_helpers/client_init.rs
@@ -187,6 +187,8 @@ where
     let gateway_setup = GatewaySetup::New {
         specification: selection_spec,
         available_gateways,
+        #[cfg(unix)]
+        connection_fd_callback: None,
     };
 
     let init_details =

--- a/common/client-core/src/init/types.rs
+++ b/common/client-core/src/init/types.rs
@@ -18,6 +18,8 @@ use nym_validator_client::client::IdentityKey;
 use nym_validator_client::nyxd::AccountId;
 use serde::Serialize;
 use std::fmt::{Debug, Display};
+#[cfg(unix)]
+use std::os::fd::RawFd;
 use std::sync::Arc;
 use time::OffsetDateTime;
 use url::Url;
@@ -208,6 +210,10 @@ pub enum GatewaySetup {
 
         // TODO: seems to be a bit inefficient to pass them by value
         available_gateways: Vec<RoutingNode>,
+
+        /// Callback useful for allowing initial connection to gateway
+        #[cfg(unix)]
+        connection_fd_callback: Option<Arc<dyn Fn(RawFd) + Send + Sync>>,
     },
 
     ReuseConnection {
@@ -231,6 +237,8 @@ impl Debug for GatewaySetup {
             GatewaySetup::New {
                 specification,
                 available_gateways,
+                #[cfg(unix)]
+                    connection_fd_callback: _,
             } => f
                 .debug_struct("GatewaySetup::New")
                 .field("specification", specification)
@@ -270,6 +278,8 @@ impl GatewaySetup {
                 additional_data: None,
             },
             available_gateways: vec![],
+            #[cfg(unix)]
+            connection_fd_callback: None,
         }
     }
 

--- a/common/client-libs/gateway-client/src/client/mod.rs
+++ b/common/client-libs/gateway-client/src/client/mod.rs
@@ -1065,6 +1065,7 @@ impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
         gateway_listener: Url,
         gateway_identity: identity::PublicKey,
         local_identity: Arc<identity::KeyPair>,
+        #[cfg(unix)] connection_fd_callback: Option<Arc<dyn Fn(RawFd) + Send + Sync>>,
     ) -> Self {
         log::trace!("Initialising gateway client");
         use futures::channel::mpsc;
@@ -1090,7 +1091,7 @@ impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
             stats_reporter: ClientStatsSender::new(None, task_client.clone()),
             negotiated_protocol: None,
             #[cfg(unix)]
-            connection_fd_callback: None,
+            connection_fd_callback,
             task_client,
         }
     }

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -543,6 +543,8 @@ where
         Ok(GatewaySetup::New {
             specification: selection_spec,
             available_gateways,
+            #[cfg(unix)]
+            connection_fd_callback: self.connection_fd_callback.clone(),
         })
     }
 


### PR DESCRIPTION
One thing that was missed was the registration ws connection that happens before the actual connection, if it's the first time connecting to a gateway. This PR extends connection fd callback to that initial connection, so that it can also be allowed by firewalls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5654)
<!-- Reviewable:end -->
