### PR TITLE
Minor fixes involving key cloning and hashing

### DIFF
--- a/common/authenticator-requests/src/v1/registration.rs
+++ b/common/authenticator-requests/src/v1/registration.rs
@@ -13,7 +13,7 @@ use std::{fmt, ops::Deref, str::FromStr};
 #[cfg(feature = "verify")]
 use hmac::{Hmac, Mac};
 #[cfg(feature = "verify")]
-use nym_crypto::asymmetric::encryption::PrivateKey;
+use nym_crypto::asymmetric::encryption::{PrivateKey, PublicKey};
 #[cfg(feature = "verify")]
 use sha2::Sha256;
 
@@ -82,16 +82,14 @@ impl GatewayClient {
         private_ip: IpAddr,
         nonce: u64,
     ) -> Self {
-        // convert from 1.0 x25519-dalek private key into 2.0 x25519-dalek
-        #[allow(clippy::expect_used)]
-        let static_secret = x25519_dalek::StaticSecret::from(local_secret.to_bytes());
-        let local_public: x25519_dalek::PublicKey = (&static_secret).into();
+        let local_public = PublicKey::from(local_secret);
+        let remote_public = PublicKey::from(remote_public);
 
-        let dh = static_secret.diffie_hellman(&remote_public);
+        let dh = local_secret.diffie_hellman(&remote_public);
 
         // TODO: change that to use our nym_crypto::hmac module instead
         #[allow(clippy::expect_used)]
-        let mut mac = HmacSha256::new_from_slice(dh.as_bytes())
+        let mut mac = HmacSha256::new_from_slice(&dh[..])
             .expect("x25519 shared secret is always 32 bytes long");
 
         mac.update(local_public.as_bytes());
@@ -99,7 +97,7 @@ impl GatewayClient {
         mac.update(&nonce.to_le_bytes());
 
         GatewayClient {
-            pub_key: PeerPublicKey::new(local_public),
+            pub_key: PeerPublicKey::new(local_public.into()),
             private_ip,
             mac: ClientMac(mac.finalize().into_bytes().to_vec()),
         }
@@ -109,11 +107,8 @@ impl GatewayClient {
     // Client should perform this step when generating its payload, using its own WG PK
     #[cfg(feature = "verify")]
     pub fn verify(&self, gateway_key: &PrivateKey, nonce: u64) -> Result<(), Error> {
-        // convert from 1.0 x25519-dalek private key into 2.0 x25519-dalek
-        #[allow(clippy::expect_used)]
-        let static_secret = x25519_dalek::StaticSecret::from(gateway_key.to_bytes());
-
-        let dh = static_secret.diffie_hellman(&self.pub_key);
+        // use gateways key as a ref to an x25519_dalek key
+        let dh = (gateway_key.as_ref()).diffie_hellman(&self.pub_key);
 
         // TODO: change that to use our nym_crypto::hmac module instead
         #[allow(clippy::expect_used)]

--- a/common/authenticator-requests/src/v2/registration.rs
+++ b/common/authenticator-requests/src/v2/registration.rs
@@ -14,7 +14,7 @@ use std::{fmt, ops::Deref, str::FromStr};
 #[cfg(feature = "verify")]
 use hmac::{Hmac, Mac};
 #[cfg(feature = "verify")]
-use nym_crypto::asymmetric::encryption::PrivateKey;
+use nym_crypto::asymmetric::encryption::{PrivateKey, PublicKey};
 #[cfg(feature = "verify")]
 use sha2::Sha256;
 
@@ -91,16 +91,14 @@ impl GatewayClient {
         private_ip: IpAddr,
         nonce: u64,
     ) -> Self {
-        // convert from 1.0 x25519-dalek private key into 2.0 x25519-dalek
-        #[allow(clippy::expect_used)]
-        let static_secret = x25519_dalek::StaticSecret::from(local_secret.to_bytes());
-        let local_public: x25519_dalek::PublicKey = (&static_secret).into();
+        let local_public = PublicKey::from(local_secret);
+        let remote_public = PublicKey::from(remote_public);
 
-        let dh = static_secret.diffie_hellman(&remote_public);
+        let dh = local_secret.diffie_hellman(&remote_public);
 
         // TODO: change that to use our nym_crypto::hmac module instead
         #[allow(clippy::expect_used)]
-        let mut mac = HmacSha256::new_from_slice(dh.as_bytes())
+        let mut mac = HmacSha256::new_from_slice(&dh[..])
             .expect("x25519 shared secret is always 32 bytes long");
 
         mac.update(local_public.as_bytes());
@@ -108,7 +106,7 @@ impl GatewayClient {
         mac.update(&nonce.to_le_bytes());
 
         GatewayClient {
-            pub_key: PeerPublicKey::new(local_public),
+            pub_key: PeerPublicKey::new(local_public.into()),
             private_ip,
             mac: ClientMac(mac.finalize().into_bytes().to_vec()),
         }
@@ -118,11 +116,8 @@ impl GatewayClient {
     // Client should perform this step when generating its payload, using its own WG PK
     #[cfg(feature = "verify")]
     pub fn verify(&self, gateway_key: &PrivateKey, nonce: u64) -> Result<(), Error> {
-        // convert from 1.0 x25519-dalek private key into 2.0 x25519-dalek
-        #[allow(clippy::expect_used)]
-        let static_secret = x25519_dalek::StaticSecret::from(gateway_key.to_bytes());
-
-        let dh = static_secret.diffie_hellman(&self.pub_key);
+        // use gateways key as a ref to an x25519_dalek key
+        let dh = (gateway_key.as_ref()).diffie_hellman(&self.pub_key);
 
         // TODO: change that to use our nym_crypto::hmac module instead
         #[allow(clippy::expect_used)]

--- a/common/authenticator-requests/src/v3/registration.rs
+++ b/common/authenticator-requests/src/v3/registration.rs
@@ -14,7 +14,7 @@ use std::{fmt, ops::Deref, str::FromStr};
 #[cfg(feature = "verify")]
 use hmac::{Hmac, Mac};
 #[cfg(feature = "verify")]
-use nym_crypto::asymmetric::encryption::PrivateKey;
+use nym_crypto::asymmetric::encryption::{PrivateKey, PublicKey};
 #[cfg(feature = "verify")]
 use sha2::Sha256;
 
@@ -91,16 +91,14 @@ impl GatewayClient {
         private_ip: IpAddr,
         nonce: u64,
     ) -> Self {
-        // convert from 1.0 x25519-dalek private key into 2.0 x25519-dalek
-        #[allow(clippy::expect_used)]
-        let static_secret = x25519_dalek::StaticSecret::from(local_secret.to_bytes());
-        let local_public: x25519_dalek::PublicKey = (&static_secret).into();
+        let local_public = PublicKey::from(local_secret);
+        let remote_public = PublicKey::from(remote_public);
 
-        let dh = static_secret.diffie_hellman(&remote_public);
+        let dh = local_secret.diffie_hellman(&remote_public);
 
         // TODO: change that to use our nym_crypto::hmac module instead
         #[allow(clippy::expect_used)]
-        let mut mac = HmacSha256::new_from_slice(dh.as_bytes())
+        let mut mac = HmacSha256::new_from_slice(&dh[..])
             .expect("x25519 shared secret is always 32 bytes long");
 
         mac.update(local_public.as_bytes());
@@ -108,7 +106,7 @@ impl GatewayClient {
         mac.update(&nonce.to_le_bytes());
 
         GatewayClient {
-            pub_key: PeerPublicKey::new(local_public),
+            pub_key: PeerPublicKey::new(local_public.into()),
             private_ip,
             mac: ClientMac(mac.finalize().into_bytes().to_vec()),
         }
@@ -118,11 +116,8 @@ impl GatewayClient {
     // Client should perform this step when generating its payload, using its own WG PK
     #[cfg(feature = "verify")]
     pub fn verify(&self, gateway_key: &PrivateKey, nonce: u64) -> Result<(), Error> {
-        // convert from 1.0 x25519-dalek private key into 2.0 x25519-dalek
-        #[allow(clippy::expect_used)]
-        let static_secret = x25519_dalek::StaticSecret::from(gateway_key.to_bytes());
-
-        let dh = static_secret.diffie_hellman(&self.pub_key);
+        // use gateways key as a ref to an x25519_dalek key
+        let dh = (gateway_key.as_ref()).diffie_hellman(&self.pub_key);
 
         // TODO: change that to use our nym_crypto::hmac module instead
         #[allow(clippy::expect_used)]

--- a/common/authenticator-requests/src/v4/registration.rs
+++ b/common/authenticator-requests/src/v4/registration.rs
@@ -15,7 +15,7 @@ use std::{fmt, ops::Deref, str::FromStr};
 #[cfg(feature = "verify")]
 use hmac::{Hmac, Mac};
 #[cfg(feature = "verify")]
-use nym_crypto::asymmetric::encryption::PrivateKey;
+use nym_crypto::asymmetric::encryption::{PrivateKey, PublicKey};
 #[cfg(feature = "verify")]
 use sha2::Sha256;
 
@@ -143,16 +143,14 @@ impl GatewayClient {
         private_ips: IpPair,
         nonce: u64,
     ) -> Self {
-        // convert from 1.0 x25519-dalek private key into 2.0 x25519-dalek
-        #[allow(clippy::expect_used)]
-        let static_secret = x25519_dalek::StaticSecret::from(local_secret.to_bytes());
-        let local_public: x25519_dalek::PublicKey = (&static_secret).into();
+        let local_public = PublicKey::from(local_secret);
+        let remote_public = PublicKey::from(remote_public);
 
-        let dh = static_secret.diffie_hellman(&remote_public);
+        let dh = local_secret.diffie_hellman(&remote_public);
 
         // TODO: change that to use our nym_crypto::hmac module instead
         #[allow(clippy::expect_used)]
-        let mut mac = HmacSha256::new_from_slice(dh.as_bytes())
+        let mut mac = HmacSha256::new_from_slice(&dh[..])
             .expect("x25519 shared secret is always 32 bytes long");
 
         mac.update(local_public.as_bytes());
@@ -160,7 +158,7 @@ impl GatewayClient {
         mac.update(&nonce.to_le_bytes());
 
         GatewayClient {
-            pub_key: PeerPublicKey::new(local_public),
+            pub_key: PeerPublicKey::new(local_public.into()),
             private_ips,
             mac: ClientMac(mac.finalize().into_bytes().to_vec()),
         }
@@ -170,11 +168,8 @@ impl GatewayClient {
     // Client should perform this step when generating its payload, using its own WG PK
     #[cfg(feature = "verify")]
     pub fn verify(&self, gateway_key: &PrivateKey, nonce: u64) -> Result<(), Error> {
-        // convert from 1.0 x25519-dalek private key into 2.0 x25519-dalek
-        #[allow(clippy::expect_used)]
-        let static_secret = x25519_dalek::StaticSecret::from(gateway_key.to_bytes());
-
-        let dh = static_secret.diffie_hellman(&self.pub_key);
+        // use gateways key as a ref to an x25519_dalek key
+        let dh = (gateway_key.as_ref()).diffie_hellman(&self.pub_key);
 
         // TODO: change that to use our nym_crypto::hmac module instead
         #[allow(clippy::expect_used)]

--- a/common/authenticator-requests/src/v5/registration.rs
+++ b/common/authenticator-requests/src/v5/registration.rs
@@ -168,13 +168,12 @@ impl GatewayClient {
     // Client should perform this step when generating its payload, using its own WG PK
     #[cfg(feature = "verify")]
     pub fn verify(&self, gateway_key: &PrivateKey, nonce: u64) -> Result<(), Error> {
-        let client_pubkey = PublicKey::from(*self.pub_key.deref());
-
-        let dh = gateway_key.diffie_hellman(&client_pubkey);
+        // use gateways key as a ref to an x25519_dalek key
+        let dh = (gateway_key.as_ref()).diffie_hellman(&self.pub_key);
 
         // TODO: change that to use our nym_crypto::hmac module instead
         #[allow(clippy::expect_used)]
-        let mut mac = HmacSha256::new_from_slice(&dh[..])
+        let mut mac = HmacSha256::new_from_slice(dh.as_bytes())
             .expect("x25519 shared secret is always 32 bytes long");
 
         mac.update(self.pub_key.as_bytes());

--- a/common/authenticator-requests/src/v5/registration.rs
+++ b/common/authenticator-requests/src/v5/registration.rs
@@ -143,8 +143,6 @@ impl GatewayClient {
         private_ips: IpPair,
         nonce: u64,
     ) -> Self {
-        // convert from 1.0 x25519-dalek private key into 2.0 x25519-dalek
-        #[allow(clippy::expect_used)]
         let local_public = PublicKey::from(local_secret);
         let remote_public = PublicKey::from(remote_public);
 
@@ -170,8 +168,6 @@ impl GatewayClient {
     // Client should perform this step when generating its payload, using its own WG PK
     #[cfg(feature = "verify")]
     pub fn verify(&self, gateway_key: &PrivateKey, nonce: u64) -> Result<(), Error> {
-        // convert from 1.0 x25519-dalek private key into 2.0 x25519-dalek
-        #[allow(clippy::expect_used)]
         let client_pubkey = PublicKey::from(*self.pub_key.deref());
 
         let dh = gateway_key.diffie_hellman(&client_pubkey);

--- a/common/crypto/src/asymmetric/encryption/mod.rs
+++ b/common/crypto/src/asymmetric/encryption/mod.rs
@@ -132,6 +132,10 @@ impl PublicKey {
         *self.0.as_bytes()
     }
 
+    pub fn as_bytes(&self) -> &[u8; PUBLIC_KEY_SIZE] {
+        self.0.as_bytes()
+    }
+
     pub fn from_bytes(b: &[u8]) -> Result<Self, KeyRecoveryError> {
         if b.len() != PUBLIC_KEY_SIZE {
             return Err(KeyRecoveryError::InvalidSizePublicKey {
@@ -228,7 +232,6 @@ impl<'a> From<&'a PrivateKey> for PublicKey {
         PublicKey((&pk.0).into())
     }
 }
-
 impl FromStr for PrivateKey {
     type Err = KeyRecoveryError;
 

--- a/common/crypto/src/asymmetric/identity/mod.rs
+++ b/common/crypto/src/asymmetric/identity/mod.rs
@@ -6,7 +6,6 @@ use ed25519_dalek::{SecretKey, Signer, SigningKey};
 pub use ed25519_dalek::{Verifier, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, SIGNATURE_LENGTH};
 use nym_pemstore::traits::{PemStorableKey, PemStorableKeyPair};
 use std::fmt::{self, Debug, Display, Formatter};
-use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use thiserror::Error;
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -154,16 +153,8 @@ impl PemStorableKeyPair for KeyPair {
 }
 
 /// ed25519 EdDSA Public Key
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct PublicKey(ed25519_dalek::VerifyingKey);
-
-impl Hash for PublicKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        // each public key has unique bytes representation which can be used
-        // for the hash implementation
-        self.to_bytes().hash(state)
-    }
-}
 
 impl Display for PublicKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/common/wireguard-types/src/public_key.rs
+++ b/common/wireguard-types/src/public_key.rs
@@ -6,13 +6,12 @@ use base64::engine::general_purpose;
 use base64::Engine;
 use serde::Serialize;
 use std::fmt;
-use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::str::FromStr;
 
 use x25519_dalek::PublicKey;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct PeerPublicKey(PublicKey);
 
 impl PeerPublicKey {
@@ -33,12 +32,6 @@ impl PeerPublicKey {
 impl fmt::Display for PeerPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", general_purpose::STANDARD.encode(self.0.as_bytes()))
-    }
-}
-
-impl Hash for PeerPublicKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.as_bytes().hash(state)
     }
 }
 


### PR DESCRIPTION
Adds fixes for several minor key related issues:
- copying a private keys to perform a DH
  - perform DH against the reference to the static key to prevent memory copy of secret key material
- hashing an x25519 public key without first converting to a canonical representation
  - use derived `Hash` implementation which internally [converts to a canonical representation](https://github.com/dalek-cryptography/curve25519-dalek/blob/fbf1fb5339b22eaf9925e520c90f1821f79ef5db/curve25519-dalek/src/montgomery.rs#L103) before hashing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5664)
<!-- Reviewable:end -->
