### PR TITLE
Make mix hops optional for Mixnet Client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5156,6 +5156,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
+ "tracing",
  "tungstenite 0.20.1",
  "url",
  "wasm-bindgen",
@@ -6609,7 +6610,6 @@ dependencies = [
 name = "nym-sphinx"
 version = "0.1.0"
 dependencies = [
- "log",
  "nym-crypto",
  "nym-metrics",
  "nym-mixnet-contract-common",
@@ -6629,6 +6629,7 @@ dependencies = [
  "rand_distr",
  "thiserror 2.0.12",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/common/client-core/Cargo.toml
+++ b/common/client-core/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 tokio = { workspace = true, features = ["macros"] }
 time = { workspace = true }
+tracing = { workspace = true }
 zeroize = { workspace = true }
 
 # internal

--- a/common/client-core/config-types/src/lib.rs
+++ b/common/client-core/config-types/src/lib.rs
@@ -414,6 +414,12 @@ pub struct Traffic {
     pub use_legacy_sphinx_format: bool,
 
     pub packet_type: PacketType,
+
+    /// Indicates whether to mix hops or not. If mix hops are enabled, traffic
+    /// will be routed as usual, to the entry gateway, through three mix nodes, egressing
+    /// through the exit gateway. If mix hops are disabled, traffic will be routed directly
+    /// from the entry gateway to the exit gateway, bypassing the mix nodes.
+    pub disable_mix_hops: bool,
 }
 
 impl Traffic {
@@ -444,6 +450,7 @@ impl Default for Traffic {
             // we should use the legacy format until sufficient number of nodes understand the
             // improved encoding
             use_legacy_sphinx_format: true,
+            disable_mix_hops: false,
         }
     }
 }

--- a/common/client-core/src/client/real_messages_control/mod.rs
+++ b/common/client-core/src/client/real_messages_control/mod.rs
@@ -103,6 +103,7 @@ impl<'a> From<&'a Config> for message_handler::Config {
         )
         .with_custom_primary_packet_size(cfg.traffic.primary_packet_size)
         .with_custom_secondary_packet_size(cfg.traffic.secondary_packet_size)
+        .disable_mix_hops(cfg.traffic.disable_mix_hops)
     }
 }
 

--- a/common/nymsphinx/Cargo.toml
+++ b/common/nymsphinx/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-log = { workspace = true }
+tracing = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 rand_chacha = { workspace = true }

--- a/common/nymsphinx/acknowledgements/src/surb_ack.rs
+++ b/common/nymsphinx/acknowledgements/src/surb_ack.rs
@@ -47,11 +47,17 @@ impl SurbAck {
         average_delay: time::Duration,
         topology: &NymRouteProvider,
         packet_type: PacketType,
+        disable_mix_hops: bool,
     ) -> Result<Self, NymTopologyError>
     where
         R: RngCore + CryptoRng,
     {
-        let route = topology.random_route_to_egress(rng, recipient.gateway())?;
+        let route = if disable_mix_hops {
+            topology.empty_route_to_egress(recipient.gateway())?
+        } else {
+            topology.random_route_to_egress(rng, recipient.gateway())?
+        };
+
         let delays = nym_sphinx_routing::generate_hop_delays(average_delay, route.len());
         let destination = recipient.as_sphinx_destination();
 

--- a/common/nymsphinx/anonymous-replies/src/reply_surb.rs
+++ b/common/nymsphinx/anonymous-replies/src/reply_surb.rs
@@ -106,6 +106,7 @@ impl ReplySurb {
         average_delay: Duration,
         use_legacy_surb_format: bool,
         topology: &NymRouteProvider,
+        _disable_mix_hops: bool, // TODO: support SURBs with no mix hops after changes to surb format / construction
     ) -> Result<Self, NymTopologyError>
     where
         R: RngCore + CryptoRng,

--- a/common/nymsphinx/chunking/src/fragment.rs
+++ b/common/nymsphinx/chunking/src/fragment.rs
@@ -272,6 +272,10 @@ impl Fragment {
         self.payload
     }
 
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
     /// Tries to recover `Fragment` from slice of bytes extracted from received sphinx packet.
     /// It can fail if payload would not fully fit in a single `Fragment` or some of the metadata
     /// is malformed or self-contradictory, for example if current_fragment > total_fragments.

--- a/common/nymsphinx/cover/src/lib.rs
+++ b/common/nymsphinx/cover/src/lib.rs
@@ -53,6 +53,7 @@ where
         average_ack_delay,
         topology,
         packet_type,
+        false, // make sure mix hops are enabled
     )?)
 }
 

--- a/common/nymsphinx/src/message.rs
+++ b/common/nymsphinx/src/message.rs
@@ -216,7 +216,7 @@ impl NymMessage {
             chunking::number_of_required_fragments(serialized_len, plaintext_per_packet);
 
         // by chunking I mean that currently the fragments hold variable amount of plaintext in them (I wish I had time to rewrite it...)
-        log::trace!(
+        tracing::trace!(
             "this message will use {serialized_len} bytes of PLAINTEXT (This does not account for Ack or chunking overhead). \
             With {packet_size:?} PacketSize ({plaintext_per_packet} of usable plaintext available) it will require {num_fragments} packet(s).",
         );
@@ -242,7 +242,7 @@ impl NymMessage {
 
         let wasted_space_percentage =
             (space_left as f32 / (bytes.len() + 1 + space_left) as f32) * 100.0;
-        log::trace!(
+        tracing::trace!(
             "Padding {self_display}: {} of raw plaintext bytes are required. \
             They're going to be put into {packets_used} sphinx packets with {space_left} bytes \
             of leftover space. {wasted_space_percentage:.1}% of packet capacity is going to \

--- a/common/topology/src/lib.rs
+++ b/common/topology/src/lib.rs
@@ -176,6 +176,17 @@ impl NymRouteProvider {
             .random_route_to_egress(rng, egress_identity, self.ignore_egress_epoch_roles)
     }
 
+    /// Returns a route directly to the egress point, which can be any known node
+    pub fn empty_route_to_egress(
+        &self,
+        egress_identity: NodeIdentity,
+    ) -> Result<Vec<SphinxNode>, NymTopologyError> {
+        let egress = self
+            .topology
+            .egress_node_by_identity(egress_identity, self.ignore_egress_epoch_roles)?;
+        Ok(vec![egress])
+    }
+
     pub fn random_path_to_egress<R>(
         &self,
         rng: &mut R,

--- a/common/wasm/client-core/src/config/mod.rs
+++ b/common/wasm/client-core/src/config/mod.rs
@@ -191,6 +191,12 @@ pub struct TrafficWasm {
 
     /// Controls whether the sent packets should use outfox as opposed to the default sphinx.
     pub use_outfox: bool,
+
+    /// Indicates whether to mix hops or not. If mix hops are enabled, traffic
+    /// will be routed as usual, to the entry gateway, through three mix nodes, egressing
+    /// through the exit gateway. If mix hops are disabled, traffic will be routed directly
+    /// from the entry gateway to the exit gateway, bypassing the mix nodes.
+    pub disable_mix_hops: bool,
 }
 
 impl Default for TrafficWasm {
@@ -224,6 +230,7 @@ impl From<TrafficWasm> for ConfigTraffic {
             secondary_packet_size: use_extended_packet_size,
             use_legacy_sphinx_format: traffic.use_legacy_sphinx_format,
             packet_type,
+            disable_mix_hops: traffic.disable_mix_hops,
         }
     }
 }
@@ -241,6 +248,7 @@ impl From<ConfigTraffic> for TrafficWasm {
             use_legacy_sphinx_format: traffic.use_legacy_sphinx_format,
             use_extended_packet_size: traffic.secondary_packet_size.is_some(),
             use_outfox: traffic.packet_type == PacketType::Outfox,
+            disable_mix_hops: traffic.disable_mix_hops,
         }
     }
 }

--- a/common/wasm/client-core/src/config/override.rs
+++ b/common/wasm/client-core/src/config/override.rs
@@ -148,6 +148,7 @@ impl From<TrafficWasmOverride> for TrafficWasm {
                 .use_extended_packet_size
                 .unwrap_or(def.use_extended_packet_size),
             use_outfox: value.use_outfox.unwrap_or(def.use_outfox),
+            disable_mix_hops: false, // not configured from js config override yet
         }
     }
 }


### PR DESCRIPTION
As is the route selection for packets, reply SURBs, and acknowledgements are selected deep withing the `MixnetClient` machinery. This makes custom route selection (i.e. for authenticating / registering wiregaurd mode vpn clients) is not supported.

This PR adds configuration toggle that allows `MixnetClient` to be built where packets are sent direct through entry to egress gateway nodes -- no mix hops. 


The intended usage in the VPN is something like this:
```rust
    let mut debug_config = nym_client_core::config::DebugConfig::default();
    if two_hop_mode {
        // If operating in two hop mode, we disable mix hops for the mixnet connection.
        debug_config.traffic.disable_mix_hops = true;
    }

    //...

    let builder = MixnetClientBuilder::new_with_storage(storage)
        .debug_config(debug_config)
        .build()
        .map_err(MixnetError::FailedToBuildMixnetClient)?
        .connect_to_mixnet()
        .await
        .expect("connection failed");
```

Notes:
* for now SURB messages are still constructed such that they will be routed though mix hops, as the packet format / parsing currently does not allow for variable route lengths.
* This does not add the ability for fully custom route selection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5696)
<!-- Reviewable:end -->
