### PR TITLE
Feature/updated sphinx payload keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9262,7 +9262,9 @@ dependencies = [
 
 [[package]]
 name = "sphinx-packet"
-version = "0.5.0"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c26f0c20d909fdda1c5d0ece3973127ca421984d55b000215df365e93722fc6e"
 dependencies = [
  "aes",
  "arrayref",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6666,6 +6666,7 @@ name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
 dependencies = [
  "bs58",
+ "log",
  "nym-crypto",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
@@ -9262,8 +9263,6 @@ dependencies = [
 [[package]]
 name = "sphinx-packet"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63a72efe7dce8a546d5cb855e60699ae69203d0d7e4335a654eb87e93d7d141"
 dependencies = [
  "aes",
  "arrayref",
@@ -12144,7 +12143,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "sphinx-packet"
-version = "0.6.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6666,7 +6666,6 @@ name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
 dependencies = [
  "bs58",
- "log",
  "nym-crypto",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
@@ -6677,6 +6676,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "thiserror 2.0.12",
+ "tracing",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12144,3 +12144,7 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "sphinx-packet"
+version = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -317,7 +317,7 @@ serde_with = "3.9.0"
 serde_yaml = "0.9.25"
 sha2 = "0.10.8"
 si-scale = "0.2.3"
-sphinx-packet = "=0.5.0"
+sphinx-packet = "0.5.0"
 sqlx = "0.7.4"
 strum = "0.26"
 strum_macros = "0.26"
@@ -406,6 +406,10 @@ wasm-bindgen = "0.2.99"
 wasm-bindgen-futures = "0.4.49"
 wasmtimer = "0.4.1"
 web-sys = "0.3.76"
+
+
+[patch.crates-io]
+sphinx-packet = { path = "../sphinx" }
 
 # Profile settings for individual crates
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -317,7 +317,7 @@ serde_with = "3.9.0"
 serde_yaml = "0.9.25"
 sha2 = "0.10.8"
 si-scale = "0.2.3"
-sphinx-packet = "0.5.0"
+sphinx-packet = "=0.6.0"
 sqlx = "0.7.4"
 strum = "0.26"
 strum_macros = "0.26"
@@ -408,8 +408,9 @@ wasmtimer = "0.4.1"
 web-sys = "0.3.76"
 
 
-[patch.crates-io]
-sphinx-packet = { path = "../sphinx" }
+# for local development:
+#[patch.crates-io]
+#sphinx-packet = { path = "../sphinx" }
 
 # Profile settings for individual crates
 

--- a/common/client-core/config-types/src/lib.rs
+++ b/common/client-core/config-types/src/lib.rs
@@ -65,7 +65,7 @@ const DEFAULT_MAXIMUM_REPLY_KEY_AGE: Duration = Duration::from_secs(24 * 60 * 60
 
 // stats reporting related
 
-/// Time interval between reporting statistics to the given provider if it exist
+/// Time interval between reporting statistics to the given provider if it exists
 const STATS_REPORT_INTERVAL_SECS: Duration = Duration::from_secs(300);
 
 use crate::error::InvalidTrafficModeFailure;
@@ -415,6 +415,10 @@ pub struct Traffic {
     /// Do not set it unless you understand the consequences of that change.
     pub secondary_packet_size: Option<PacketSize>,
 
+    /// Specify whether any constructed reply surbs should use the legacy format,
+    /// where the payload keys are explicitly attached rather than using the seeds
+    pub use_legacy_reply_surb_format: bool,
+
     pub packet_type: PacketType,
 }
 
@@ -442,6 +446,10 @@ impl Default for Traffic {
             primary_packet_size: PacketSize::RegularPacket,
             secondary_packet_size: None,
             packet_type: PacketType::Mix,
+
+            // we should use the legacy format until sufficient number of nodes understand the
+            // improved encoding
+            use_legacy_reply_surb_format: true,
         }
     }
 }

--- a/common/client-core/config-types/src/lib.rs
+++ b/common/client-core/config-types/src/lib.rs
@@ -415,9 +415,13 @@ pub struct Traffic {
     /// Do not set it unless you understand the consequences of that change.
     pub secondary_packet_size: Option<PacketSize>,
 
-    /// Specify whether any constructed reply surbs should use the legacy format,
+    /// Specify whether any constructed sphinx packets should use the legacy format,
     /// where the payload keys are explicitly attached rather than using the seeds
-    pub use_legacy_reply_surb_format: bool,
+    /// this affects any forward packets, acks and reply surbs
+    /// this flag should remain disabled until sufficient number of nodes on the network has upgraded
+    /// and support updated format.
+    /// in the case of reply surbs, the recipient must also understand the new encoding
+    pub use_legacy_sphinx_format: bool,
 
     pub packet_type: PacketType,
 }
@@ -449,7 +453,7 @@ impl Default for Traffic {
 
             // we should use the legacy format until sufficient number of nodes understand the
             // improved encoding
-            use_legacy_reply_surb_format: true,
+            use_legacy_sphinx_format: true,
         }
     }
 }

--- a/common/client-core/src/client/cover_traffic_stream.rs
+++ b/common/client-core/src/client/cover_traffic_stream.rs
@@ -62,6 +62,10 @@ where
     /// Optional secondary predefined packet size used for the loop cover messages.
     secondary_packet_size: Option<PacketSize>,
 
+    /// Specify whether any constructed packets should use the legacy format,
+    /// where the payload keys are explicitly attached rather than using the seeds
+    use_legacy_sphinx_format: bool,
+
     packet_type: PacketType,
 
     stats_tx: ClientStatsSender,
@@ -130,6 +134,7 @@ impl LoopCoverTrafficStream<OsRng> {
             topology_access,
             primary_packet_size: traffic_config.primary_packet_size,
             secondary_packet_size: traffic_config.secondary_packet_size,
+            use_legacy_sphinx_format: traffic_config.use_legacy_sphinx_format,
             packet_type: traffic_config.packet_type,
             stats_tx,
             task_client,
@@ -182,6 +187,7 @@ impl LoopCoverTrafficStream<OsRng> {
 
         let cover_message = match generate_loop_cover_packet(
             &mut self.rng,
+            self.use_legacy_sphinx_format,
             topology_ref,
             &self.ack_key,
             &self.our_full_destination,

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -109,6 +109,10 @@ pub(crate) struct Config {
 
     /// Optional secondary predefined packet size used for the encapsulated messages.
     secondary_packet_size: Option<PacketSize>,
+
+    /// Specify whether any constructed reply surbs should use the legacy format,
+    /// where the payload keys are explicitly attached rather than using the seeds
+    use_legacy_reply_surb_format: bool,
 }
 
 impl Config {
@@ -118,6 +122,7 @@ impl Config {
         average_packet_delay: Duration,
         average_ack_delay: Duration,
         deterministic_route_selection: bool,
+        use_legacy_reply_surb_format: bool,
     ) -> Self {
         Config {
             ack_key,
@@ -127,6 +132,7 @@ impl Config {
             average_ack_delay,
             primary_packet_size: PacketSize::default(),
             secondary_packet_size: None,
+            use_legacy_reply_surb_format,
         }
     }
 
@@ -186,6 +192,7 @@ where
             config.sender_address,
             config.average_packet_delay,
             config.average_ack_delay,
+            config.use_legacy_reply_surb_format,
         );
         MessageHandler {
             config,

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -112,7 +112,7 @@ pub(crate) struct Config {
 
     /// Specify whether any constructed reply surbs should use the legacy format,
     /// where the payload keys are explicitly attached rather than using the seeds
-    use_legacy_reply_surb_format: bool,
+    use_legacy_sphinx_format: bool,
 }
 
 impl Config {
@@ -132,7 +132,7 @@ impl Config {
             average_ack_delay,
             primary_packet_size: PacketSize::default(),
             secondary_packet_size: None,
-            use_legacy_reply_surb_format,
+            use_legacy_sphinx_format: use_legacy_reply_surb_format,
         }
     }
 
@@ -192,6 +192,7 @@ where
             config.sender_address,
             config.average_packet_delay,
             config.average_ack_delay,
+            config.use_legacy_sphinx_format,
         );
         MessageHandler {
             config,
@@ -261,7 +262,7 @@ where
         let topology = self.get_topology(&topology_permit)?;
 
         let reply_surbs = self.message_preparer.generate_reply_surbs(
-            self.config.use_legacy_reply_surb_format,
+            self.config.use_legacy_sphinx_format,
             amount,
             topology,
         )?;
@@ -530,7 +531,7 @@ where
             self.generate_reply_surbs_with_keys(amount as usize).await?;
 
         let message = NymMessage::new_repliable(RepliableMessage::new_additional_surbs(
-            self.config.use_legacy_reply_surb_format,
+            self.config.use_legacy_sphinx_format,
             sender_tag,
             reply_surbs,
         ));
@@ -569,7 +570,7 @@ where
             .await?;
 
         let message = NymMessage::new_repliable(RepliableMessage::new_data(
-            self.config.use_legacy_reply_surb_format,
+            self.config.use_legacy_sphinx_format,
             message,
             sender_tag,
             reply_surbs,

--- a/common/client-core/src/client/real_messages_control/mod.rs
+++ b/common/client-core/src/client/real_messages_control/mod.rs
@@ -99,6 +99,7 @@ impl<'a> From<&'a Config> for message_handler::Config {
             cfg.traffic.average_packet_delay,
             cfg.acks.average_ack_delay,
             cfg.traffic.deterministic_route_selection,
+            cfg.traffic.use_legacy_reply_surb_format,
         )
         .with_custom_primary_packet_size(cfg.traffic.primary_packet_size)
         .with_custom_secondary_packet_size(cfg.traffic.secondary_packet_size)

--- a/common/client-core/src/client/real_messages_control/mod.rs
+++ b/common/client-core/src/client/real_messages_control/mod.rs
@@ -99,7 +99,7 @@ impl<'a> From<&'a Config> for message_handler::Config {
             cfg.traffic.average_packet_delay,
             cfg.acks.average_ack_delay,
             cfg.traffic.deterministic_route_selection,
-            cfg.traffic.use_legacy_reply_surb_format,
+            cfg.traffic.use_legacy_sphinx_format,
         )
         .with_custom_primary_packet_size(cfg.traffic.primary_packet_size)
         .with_custom_secondary_packet_size(cfg.traffic.secondary_packet_size)

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -252,6 +252,7 @@ where
                 (
                     generate_loop_cover_packet(
                         &mut self.rng,
+                        self.config.traffic.use_legacy_sphinx_format,
                         topology_ref,
                         &self.config.ack_key,
                         &self.config.our_full_destination,

--- a/common/node-tester-utils/src/processor.rs
+++ b/common/node-tester-utils/src/processor.rs
@@ -69,7 +69,6 @@ where
     where
         T: DeserializeOwned,
     {
-        println!("process_mixnet message");
         let plaintext = self
             .message_receiver
             .recover_plaintext_from_regular_packet(

--- a/common/node-tester-utils/src/processor.rs
+++ b/common/node-tester-utils/src/processor.rs
@@ -69,6 +69,7 @@ where
     where
         T: DeserializeOwned,
     {
+        println!("process_mixnet message");
         let plaintext = self
             .message_receiver
             .recover_plaintext_from_regular_packet(

--- a/common/node-tester-utils/src/tester.rs
+++ b/common/node-tester-utils/src/tester.rs
@@ -39,6 +39,10 @@ pub struct NodeTester<R> {
     /// Average delay an acknowledgement packet is going to get delay at a single mixnode.
     average_ack_delay: Duration,
 
+    /// Specify whether any constructed packets should use the legacy format,
+    /// where the payload keys are explicitly attached rather than using the seeds
+    use_legacy_sphinx_format: bool,
+
     // while acks are going to be ignored they still need to be constructed
     // so that the gateway would be able to correctly process and forward the message
     ack_key: Arc<AckKey>,
@@ -57,6 +61,7 @@ where
         deterministic_route_selection: bool,
         average_packet_delay: Duration,
         average_ack_delay: Duration,
+        use_legacy_sphinx_format: bool,
         ack_key: Arc<AckKey>,
     ) -> Self {
         Self {
@@ -67,6 +72,7 @@ where
             deterministic_route_selection,
             average_packet_delay,
             average_ack_delay,
+            use_legacy_sphinx_format,
             ack_key,
         }
     }
@@ -244,6 +250,10 @@ where
 
 impl<R: CryptoRng + Rng> FragmentPreparer for NodeTester<R> {
     type Rng = R;
+
+    fn use_legacy_sphinx_format(&self) -> bool {
+        self.use_legacy_sphinx_format
+    }
 
     fn deterministic_route_selection(&self) -> bool {
         self.deterministic_route_selection

--- a/common/nymsphinx/acknowledgements/src/surb_ack.rs
+++ b/common/nymsphinx/acknowledgements/src/surb_ack.rs
@@ -37,8 +37,10 @@ pub enum SurbAckRecoveryError {
 }
 
 impl SurbAck {
+    #[allow(clippy::too_many_arguments)]
     pub fn construct<R>(
         rng: &mut R,
+        use_legacy_sphinx_format: bool,
         recipient: &Recipient,
         ack_key: &AckKey,
         marshaled_fragment_id: [u8; 5],
@@ -67,6 +69,7 @@ impl SurbAck {
                 Some(packet_size),
             )?,
             PacketType::Mix => NymPacket::sphinx_build(
+                use_legacy_sphinx_format,
                 packet_size,
                 surb_ack_payload,
                 &route,

--- a/common/nymsphinx/addressing/src/nodes.rs
+++ b/common/nymsphinx/addressing/src/nodes.rs
@@ -199,7 +199,7 @@ impl TryFrom<NodeAddressBytes> for NymNodeRoutingAddress {
     type Error = NymNodeRoutingAddressError;
 
     fn try_from(value: NodeAddressBytes) -> Result<Self, Self::Error> {
-        Self::try_from_bytes(value.as_bytes_ref())
+        Self::try_from_bytes(value.as_bytes())
     }
 }
 

--- a/common/nymsphinx/anonymous-replies/Cargo.toml
+++ b/common/nymsphinx/anonymous-replies/Cargo.toml
@@ -12,6 +12,7 @@ rand = { workspace = true }
 bs58 = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 nym-crypto = { path = "../../crypto", features = ["stream_cipher", "rand"] }
 nym-sphinx-addressing = { path = "../addressing" }
@@ -19,7 +20,6 @@ nym-sphinx-params = { path = "../params" }
 nym-sphinx-routing = { path = "../routing" }
 nym-sphinx-types = { path = "../types" }
 nym-topology = { path = "../../topology" }
-log = "0.4.27"
 
 [target."cfg(target_arch = \"wasm32\")".dependencies.wasm-bindgen]
 version = "0.2.95"

--- a/common/nymsphinx/anonymous-replies/Cargo.toml
+++ b/common/nymsphinx/anonymous-replies/Cargo.toml
@@ -19,6 +19,7 @@ nym-sphinx-params = { path = "../params" }
 nym-sphinx-routing = { path = "../routing" }
 nym-sphinx-types = { path = "../types" }
 nym-topology = { path = "../../topology" }
+log = "0.4.27"
 
 [target."cfg(target_arch = \"wasm32\")".dependencies.wasm-bindgen]
 version = "0.2.95"

--- a/common/nymsphinx/anonymous-replies/src/requests/mod.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests/mod.rs
@@ -207,6 +207,7 @@ impl RepliableMessage {
     }
 }
 
+#[derive(Debug)]
 #[repr(u8)]
 enum RepliableMessageContentTag {
     Data = 0,

--- a/common/nymsphinx/anonymous-replies/src/requests/mod.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests/mod.rs
@@ -133,26 +133,43 @@ impl Display for RepliableMessage {
 
 impl RepliableMessage {
     pub fn new_data(
+        use_legacy_surb_format: bool,
         data: Vec<u8>,
         sender_tag: AnonymousSenderTag,
         reply_surbs: Vec<ReplySurb>,
     ) -> Self {
-        RepliableMessage {
-            sender_tag,
-            content: RepliableMessageContent::Data(DataV1 {
+        let content = if use_legacy_surb_format {
+            RepliableMessageContent::Data(DataV1 {
                 message: data,
                 reply_surbs,
-            }),
+            })
+        } else {
+            RepliableMessageContent::DataV2(DataV2 {
+                message: data,
+                reply_surbs,
+            })
+        };
+
+        RepliableMessage {
+            sender_tag,
+            content,
         }
     }
 
     pub fn new_additional_surbs(
+        use_legacy_surb_format: bool,
         sender_tag: AnonymousSenderTag,
         reply_surbs: Vec<ReplySurb>,
     ) -> Self {
+        let content = if use_legacy_surb_format {
+            RepliableMessageContent::AdditionalSurbs(AdditionalSurbsV1 { reply_surbs })
+        } else {
+            RepliableMessageContent::AdditionalSurbsV2(AdditionalSurbsV2 { reply_surbs })
+        };
+
         RepliableMessage {
             sender_tag,
-            content: RepliableMessageContent::AdditionalSurbs(AdditionalSurbsV1 { reply_surbs }),
+            content,
         }
     }
 

--- a/common/nymsphinx/anonymous-replies/src/requests/v1.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests/v1.rs
@@ -3,10 +3,10 @@
 
 use crate::requests::InvalidReplyRequestError;
 use crate::ReplySurb;
-use log::{error, warn};
 use nym_sphinx_types::PAYLOAD_KEY_SIZE;
 use std::fmt::Display;
 use std::mem;
+use tracing::{error, warn};
 
 const fn v1_reply_surb_serialised_len() -> usize {
     // the SURB itself consists of SURB_header, first hop address and set of payload keys

--- a/common/nymsphinx/anonymous-replies/src/requests/v1.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests/v1.rs
@@ -1,0 +1,165 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::requests::InvalidReplyRequestError;
+use crate::ReplySurb;
+use log::warn;
+use nym_sphinx_types::PAYLOAD_KEY_SIZE;
+use std::fmt::Display;
+use std::mem;
+
+const fn v1_reply_surb_serialised_len() -> usize {
+    // the SURB itself consists of SURB_header, first hop address and set of payload keys
+    // for each hop (3x mix + egress)
+    ReplySurb::BASE_OVERHEAD + 4 * PAYLOAD_KEY_SIZE
+}
+
+const fn v1_reply_surbs_serialised_len(surbs: &[ReplySurb]) -> usize {
+    // when serialising surbs are always prepended with u32-encoded count
+    4 + surbs.len() * v1_reply_surb_serialised_len()
+}
+
+// this recovery code is shared between all legacy variants containing reply surbs
+// NUM_SURBS (u32) || SURB_DATA
+fn recover_reply_surbs_v1(
+    bytes: &[u8],
+) -> Result<(Vec<ReplySurb>, usize), InvalidReplyRequestError> {
+    let mut consumed = mem::size_of::<u32>();
+    if bytes.len() < consumed {
+        return Err(InvalidReplyRequestError::RequestTooShortToDeserialize);
+    }
+    let num_surbs = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+
+    let surb_size = v1_reply_surb_serialised_len();
+    if bytes[consumed..].len() < num_surbs as usize * surb_size {
+        return Err(InvalidReplyRequestError::RequestTooShortToDeserialize);
+    }
+
+    let mut reply_surbs = Vec::with_capacity(num_surbs as usize);
+    for _ in 0..num_surbs as usize {
+        let surb_bytes = &bytes[consumed..consumed + surb_size];
+        let reply_surb = ReplySurb::from_bytes(surb_bytes)?;
+        reply_surbs.push(reply_surb);
+
+        consumed += surb_size;
+    }
+
+    Ok((reply_surbs, consumed))
+}
+
+// length (u32) prefixed reply surbs with legacy serialisation of 4 hops and full payload keys attached
+fn reply_surbs_bytes_v1(reply_surbs: &[ReplySurb]) -> impl Iterator<Item = u8> + use<'_> {
+    let num_surbs = reply_surbs.len() as u32;
+
+    num_surbs
+        .to_be_bytes()
+        .into_iter()
+        .chain(reply_surbs.iter().flat_map(|s| s.to_bytes()))
+}
+
+#[derive(Debug)]
+pub struct DataV1 {
+    pub message: Vec<u8>,
+    pub reply_surbs: Vec<ReplySurb>,
+}
+
+impl Display for DataV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "V1 repliable {:.2} kiB data message with {} reply surbs attached",
+            self.message.len() as f64 / 1024.0,
+            self.reply_surbs.len(),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct AdditionalSurbsV1 {
+    pub reply_surbs: Vec<ReplySurb>,
+}
+
+impl Display for AdditionalSurbsV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "V1 repliable additional surbs message ({} reply surbs attached)",
+            self.reply_surbs.len(),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct HeartbeatV1 {
+    pub additional_reply_surbs: Vec<ReplySurb>,
+}
+
+impl Display for HeartbeatV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "V1 repliable heartbeat message ({} reply surbs attached)",
+            self.additional_reply_surbs.len(),
+        )
+    }
+}
+
+impl DataV1 {
+    pub fn into_bytes(self) -> Vec<u8> {
+        reply_surbs_bytes_v1(&self.reply_surbs)
+            .chain(self.message)
+            .collect()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, InvalidReplyRequestError> {
+        let (reply_surbs, n) = recover_reply_surbs_v1(bytes)?;
+        Ok(DataV1 {
+            message: bytes[n..].to_vec(),
+            reply_surbs,
+        })
+    }
+
+    pub fn serialized_len(&self) -> usize {
+        v1_reply_surbs_serialised_len(&self.reply_surbs) + self.message.len()
+    }
+}
+
+impl AdditionalSurbsV1 {
+    pub fn into_bytes(self) -> Vec<u8> {
+        reply_surbs_bytes_v1(&self.reply_surbs).collect()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, InvalidReplyRequestError> {
+        let (reply_surbs, n) = recover_reply_surbs_v1(bytes)?;
+        if n != 0 {
+            warn!("trailing {n} bytes after v1 additional surbs message");
+        }
+
+        Ok(AdditionalSurbsV1 { reply_surbs })
+    }
+
+    pub fn serialized_len(&self) -> usize {
+        v1_reply_surbs_serialised_len(&self.reply_surbs)
+    }
+}
+
+impl HeartbeatV1 {
+    pub fn into_bytes(self) -> Vec<u8> {
+        reply_surbs_bytes_v1(&self.additional_reply_surbs).collect()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, InvalidReplyRequestError> {
+        let (additional_reply_surbs, n) = recover_reply_surbs_v1(bytes)?;
+        if n != 0 {
+            warn!("trailing {n} bytes after v1 heartbeat message");
+        }
+
+        Ok(HeartbeatV1 {
+            additional_reply_surbs,
+        })
+    }
+
+    pub fn serialized_len(&self) -> usize {
+        v1_reply_surbs_serialised_len(&self.additional_reply_surbs)
+    }
+}

--- a/common/nymsphinx/anonymous-replies/src/requests/v1.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests/v1.rs
@@ -138,8 +138,10 @@ impl AdditionalSurbsV1 {
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, InvalidReplyRequestError> {
         let (reply_surbs, n) = recover_reply_surbs_v1(bytes)?;
-        if n != 0 {
-            warn!("trailing {n} bytes after v1 additional surbs message");
+        if n != bytes.len() {
+            let trailing = bytes.len() - n;
+
+            warn!("trailing {trailing} bytes after v1 additional surbs message");
         }
 
         Ok(AdditionalSurbsV1 { reply_surbs })
@@ -157,8 +159,10 @@ impl HeartbeatV1 {
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, InvalidReplyRequestError> {
         let (additional_reply_surbs, n) = recover_reply_surbs_v1(bytes)?;
-        if n != 0 {
-            warn!("trailing {n} bytes after v1 heartbeat message");
+        if n != bytes.len() {
+            let trailing = bytes.len() - n;
+
+            warn!("trailing {trailing} bytes after v1 heartbeat message");
         }
 
         Ok(HeartbeatV1 {

--- a/common/nymsphinx/anonymous-replies/src/requests/v1.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests/v1.rs
@@ -3,7 +3,7 @@
 
 use crate::requests::InvalidReplyRequestError;
 use crate::ReplySurb;
-use log::warn;
+use log::{error, warn};
 use nym_sphinx_types::PAYLOAD_KEY_SIZE;
 use std::fmt::Display;
 use std::mem;
@@ -14,7 +14,14 @@ const fn v1_reply_surb_serialised_len() -> usize {
     ReplySurb::BASE_OVERHEAD + 4 * PAYLOAD_KEY_SIZE
 }
 
-const fn v1_reply_surbs_serialised_len(surbs: &[ReplySurb]) -> usize {
+fn v1_reply_surbs_serialised_len(surbs: &[ReplySurb]) -> usize {
+    // sanity checks; this should probably be removed later on
+    if let Some(reply_surb) = surbs.first() {
+        if reply_surb.surb.uses_key_seeds() {
+            error!("using v1 surbs encoding with updated structure - the surbs will be unusable")
+        }
+    }
+
     // when serialising surbs are always prepended with u32-encoded count
     4 + surbs.len() * v1_reply_surb_serialised_len()
 }

--- a/common/nymsphinx/anonymous-replies/src/requests/v2.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests/v2.rs
@@ -3,7 +3,7 @@
 
 use crate::requests::InvalidReplyRequestError;
 use crate::ReplySurb;
-use log::warn;
+use log::{error, warn};
 use nym_sphinx_types::constants::PAYLOAD_KEY_SEED_SIZE;
 use std::fmt::Display;
 use std::iter::once;
@@ -24,6 +24,13 @@ fn reply_surbs_hops(reply_surbs: &[ReplySurb]) -> u8 {
 fn v2_reply_surbs_serialised_len(surbs: &[ReplySurb]) -> usize {
     let num_surbs = surbs.len();
     let num_hops = reply_surbs_hops(surbs);
+
+    // sanity checks; this should probably be removed later on
+    if let Some(reply_surb) = surbs.first() {
+        if !reply_surb.surb.uses_key_seeds() {
+            error!("using v2 surbs encoding with legacy structure - the surbs will be unusable")
+        }
+    }
 
     // when serialising surbs are always prepended with u16-encoded count an u8-encoded number of hops
     3 + num_surbs * v2_reply_surb_serialised_len(num_hops)

--- a/common/nymsphinx/anonymous-replies/src/requests/v2.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests/v2.rs
@@ -1,0 +1,178 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::requests::InvalidReplyRequestError;
+use crate::ReplySurb;
+use log::warn;
+use nym_sphinx_types::constants::PAYLOAD_KEY_SEED_SIZE;
+use std::fmt::Display;
+use std::iter::once;
+
+const fn v2_reply_surb_serialised_len(num_hops: u8) -> usize {
+    ReplySurb::BASE_OVERHEAD + num_hops as usize * PAYLOAD_KEY_SEED_SIZE
+}
+
+// sphinx doesn't support more than 5 hops (so cast to u8 is safe)
+// ASSUMPTION: all surbs are generated with the same parameters (if they're not, then the client is hurting itself)
+fn reply_surbs_hops(reply_surbs: &[ReplySurb]) -> u8 {
+    reply_surbs
+        .first()
+        .map(|reply_surb| reply_surb.surb.materials_count() as u8)
+        .unwrap_or_default()
+}
+
+fn v2_reply_surbs_serialised_len(surbs: &[ReplySurb]) -> usize {
+    let num_surbs = surbs.len();
+    let num_hops = reply_surbs_hops(surbs);
+
+    // when serialising surbs are always prepended with u16-encoded count an u8-encoded number of hops
+    3 + num_surbs * v2_reply_surb_serialised_len(num_hops)
+}
+
+// NUM_SURBS (u16) || HOPS (u8) || SURB_DATA
+fn recover_reply_surbs_v2(
+    bytes: &[u8],
+) -> Result<(Vec<ReplySurb>, usize), InvalidReplyRequestError> {
+    if bytes.len() < 2 {
+        return Err(InvalidReplyRequestError::RequestTooShortToDeserialize);
+    }
+
+    // we're not attaching more than 65k surbs...
+    let num_surbs = u16::from_be_bytes([bytes[0], bytes[1]]);
+    let num_hops = bytes[2];
+    let mut consumed = 3;
+
+    let surb_size = ReplySurb::v2_serialised_len(num_hops);
+    if bytes[consumed..].len() < num_surbs as usize * surb_size {
+        return Err(InvalidReplyRequestError::RequestTooShortToDeserialize);
+    }
+
+    let mut reply_surbs = Vec::with_capacity(num_surbs as usize);
+    for _ in 0..num_surbs as usize {
+        let surb_bytes = &bytes[consumed..consumed + surb_size];
+        let reply_surb = ReplySurb::from_bytes(surb_bytes)?;
+        reply_surbs.push(reply_surb);
+
+        consumed += surb_size;
+    }
+
+    Ok((reply_surbs, consumed))
+}
+
+fn reply_surbs_bytes_v2(reply_surbs: &[ReplySurb]) -> impl Iterator<Item = u8> + use<'_> {
+    let num_surbs = reply_surbs.len() as u16;
+    let num_hops = reply_surbs_hops(reply_surbs);
+
+    num_surbs
+        .to_be_bytes()
+        .into_iter()
+        .chain(once(num_hops))
+        .chain(reply_surbs.iter().flat_map(|surb| surb.to_bytes()))
+}
+
+#[derive(Debug)]
+pub struct DataV2 {
+    pub message: Vec<u8>,
+    pub reply_surbs: Vec<ReplySurb>,
+}
+
+impl Display for DataV2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "V2 repliable {:.2} kiB data message with {} reply surbs attached",
+            self.message.len() as f64 / 1024.0,
+            self.reply_surbs.len(),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct AdditionalSurbsV2 {
+    pub reply_surbs: Vec<ReplySurb>,
+}
+
+impl Display for AdditionalSurbsV2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "V2 repliable additional surbs message ({} reply surbs attached)",
+            self.reply_surbs.len(),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct HeartbeatV2 {
+    pub additional_reply_surbs: Vec<ReplySurb>,
+}
+
+impl Display for HeartbeatV2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "V2 repliable heartbeat message ({} reply surbs attached)",
+            self.additional_reply_surbs.len(),
+        )
+    }
+}
+
+impl DataV2 {
+    pub fn into_bytes(self) -> Vec<u8> {
+        reply_surbs_bytes_v2(&self.reply_surbs)
+            .chain(self.message)
+            .collect()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, InvalidReplyRequestError> {
+        let (reply_surbs, n) = recover_reply_surbs_v2(bytes)?;
+        Ok(DataV2 {
+            message: bytes[n..].to_vec(),
+            reply_surbs,
+        })
+    }
+
+    pub fn serialized_len(&self) -> usize {
+        v2_reply_surbs_serialised_len(&self.reply_surbs) + self.message.len()
+    }
+}
+
+impl AdditionalSurbsV2 {
+    pub fn into_bytes(self) -> Vec<u8> {
+        reply_surbs_bytes_v2(&self.reply_surbs).collect()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, InvalidReplyRequestError> {
+        let (reply_surbs, n) = recover_reply_surbs_v2(bytes)?;
+        if n != 0 {
+            warn!("trailing {n} bytes after v2 additional surbs message");
+        }
+
+        Ok(AdditionalSurbsV2 { reply_surbs })
+    }
+
+    pub fn serialized_len(&self) -> usize {
+        v2_reply_surbs_serialised_len(&self.reply_surbs)
+    }
+}
+
+impl HeartbeatV2 {
+    pub fn into_bytes(self) -> Vec<u8> {
+        reply_surbs_bytes_v2(&self.additional_reply_surbs).collect()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, InvalidReplyRequestError> {
+        let (additional_reply_surbs, n) = recover_reply_surbs_v2(bytes)?;
+        if n != 0 {
+            warn!("trailing {n} bytes after v2 heartbeat message");
+        }
+
+        Ok(HeartbeatV2 {
+            additional_reply_surbs,
+        })
+    }
+
+    pub fn serialized_len(&self) -> usize {
+        v2_reply_surbs_serialised_len(&self.additional_reply_surbs)
+    }
+}

--- a/common/nymsphinx/anonymous-replies/src/requests/v2.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests/v2.rs
@@ -151,8 +151,9 @@ impl AdditionalSurbsV2 {
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, InvalidReplyRequestError> {
         let (reply_surbs, n) = recover_reply_surbs_v2(bytes)?;
-        if n != 0 {
-            warn!("trailing {n} bytes after v2 additional surbs message");
+        if n != bytes.len() {
+            let trailing = bytes.len() - n;
+            warn!("trailing {trailing} bytes after v2 additional surbs message");
         }
 
         Ok(AdditionalSurbsV2 { reply_surbs })
@@ -170,8 +171,9 @@ impl HeartbeatV2 {
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, InvalidReplyRequestError> {
         let (additional_reply_surbs, n) = recover_reply_surbs_v2(bytes)?;
-        if n != 0 {
-            warn!("trailing {n} bytes after v2 heartbeat message");
+        if n != bytes.len() {
+            let trailing = bytes.len() - n;
+            warn!("trailing {trailing} bytes after v2 heartbeat message");
         }
 
         Ok(HeartbeatV2 {

--- a/common/nymsphinx/anonymous-replies/src/requests/v2.rs
+++ b/common/nymsphinx/anonymous-replies/src/requests/v2.rs
@@ -3,10 +3,10 @@
 
 use crate::requests::InvalidReplyRequestError;
 use crate::ReplySurb;
-use log::{error, warn};
 use nym_sphinx_types::constants::PAYLOAD_KEY_SEED_SIZE;
 use std::fmt::Display;
 use std::iter::once;
+use tracing::{error, warn};
 
 const fn v2_reply_surb_serialised_len(num_hops: u8) -> usize {
     ReplySurb::BASE_OVERHEAD + num_hops as usize * PAYLOAD_KEY_SEED_SIZE

--- a/common/nymsphinx/cover/src/lib.rs
+++ b/common/nymsphinx/cover/src/lib.rs
@@ -34,6 +34,7 @@ pub enum CoverMessageError {
 
 pub fn generate_loop_cover_surb_ack<R>(
     rng: &mut R,
+    use_legacy_sphinx_format: bool,
     topology: &NymRouteProvider,
     ack_key: &AckKey,
     full_address: &Recipient,
@@ -45,6 +46,7 @@ where
 {
     Ok(SurbAck::construct(
         rng,
+        use_legacy_sphinx_format,
         full_address,
         ack_key,
         COVER_FRAG_ID.to_bytes(),
@@ -57,6 +59,7 @@ where
 #[allow(clippy::too_many_arguments)]
 pub fn generate_loop_cover_packet<R>(
     rng: &mut R,
+    use_legacy_sphinx_format: bool,
     topology: &NymRouteProvider,
     ack_key: &AckKey,
     full_address: &Recipient,
@@ -71,6 +74,7 @@ where
     // we don't care about total ack delay - we will not be retransmitting it anyway
     let (_, ack_bytes) = generate_loop_cover_surb_ack(
         rng,
+        use_legacy_sphinx_format,
         topology,
         ack_key,
         full_address,
@@ -126,6 +130,7 @@ where
     // once merged, that's an easy rng injection point for sphinx packets : )
     let packet = match packet_type {
         PacketType::Mix => NymPacket::sphinx_build(
+            use_legacy_sphinx_format,
             packet_size.payload_size(),
             packet_payload,
             &route,

--- a/common/nymsphinx/framing/src/codec.rs
+++ b/common/nymsphinx/framing/src/codec.rs
@@ -209,8 +209,15 @@ mod packet_encoding {
             SphinxDelay::new_from_nanos(42),
             SphinxDelay::new_from_nanos(42),
         ];
-        NymPacket::sphinx_build(size.payload_size(), b"foomp", &route, &destination, &delays)
-            .unwrap()
+        NymPacket::sphinx_build(
+            false,
+            size.payload_size(),
+            b"foomp",
+            &route,
+            &destination,
+            &delays,
+        )
+        .unwrap()
     }
 
     #[test]

--- a/common/nymsphinx/framing/src/packet.rs
+++ b/common/nymsphinx/framing/src/packet.rs
@@ -4,7 +4,7 @@
 use crate::codec::NymCodecError;
 use bytes::{BufMut, BytesMut};
 use nym_sphinx_params::packet_sizes::PacketSize;
-use nym_sphinx_params::packet_version::PacketVersion;
+use nym_sphinx_params::packet_version::{PacketVersion, CURRENT_PACKET_VERSION};
 use nym_sphinx_params::PacketType;
 use nym_sphinx_types::NymPacket;
 
@@ -81,8 +81,7 @@ pub struct Header {
 }
 
 impl Header {
-    pub(crate) const LEGACY_SIZE: usize = 2;
-    pub(crate) const VERSIONED_SIZE: usize = 3;
+    pub(crate) const SIZE: usize = 3;
 
     pub fn outfox() -> Header {
         Header {
@@ -92,53 +91,39 @@ impl Header {
         }
     }
 
-    pub(crate) fn size(&self) -> usize {
-        if self.packet_version.is_legacy() {
-            Self::LEGACY_SIZE
-        } else {
-            Self::VERSIONED_SIZE
-        }
-    }
-
     pub(crate) fn encode(&self, dst: &mut BytesMut) {
-        // we reserve one byte for `packet_size` and the other for `mode`
-        dst.reserve(Self::LEGACY_SIZE);
-        if let Some(version) = self.packet_version.as_u8() {
-            dst.reserve(Self::VERSIONED_SIZE);
-            dst.put_u8(version)
-        }
+        dst.reserve(Self::SIZE);
 
+        dst.put_u8(self.packet_version.as_u8());
         dst.put_u8(self.packet_size as u8);
         dst.put_u8(self.packet_type as u8);
+
         // reserve bytes for the actual packet
         dst.reserve(self.packet_size.size());
     }
 
     pub(crate) fn decode(src: &mut BytesMut) -> Result<Option<Self>, NymCodecError> {
-        if src.len() < Self::LEGACY_SIZE {
+        if src.len() < Self::SIZE {
             // can't do anything if we don't have enough bytes - but reserve enough for the next call
-            src.reserve(Self::LEGACY_SIZE);
+            src.reserve(Self::SIZE);
             return Ok(None);
         }
 
-        let packet_version = PacketVersion::from(src[0]);
-        if packet_version.is_legacy() {
-            Ok(Some(Header {
-                packet_version,
-                packet_size: PacketSize::try_from(src[0])?,
-                packet_type: PacketType::try_from(src[1])?,
-            }))
-        } else if src.len() < Self::VERSIONED_SIZE {
-            // we're missing that 1 byte to read the full header...
-            src.reserve(Self::VERSIONED_SIZE);
-            Ok(None)
-        } else {
-            Ok(Some(Header {
-                packet_version,
-                packet_size: PacketSize::try_from(src[1])?,
-                packet_type: PacketType::try_from(src[2])?,
-            }))
+        let packet_version = PacketVersion::try_from(src[0])?;
+        if packet_version > CURRENT_PACKET_VERSION {
+            // received an unsupported packet version - we don't know how it's meant to look like!
+            // (this is in preparation for the dual support of breaking sphinx changes)
+            return Err(NymCodecError::UnsupportedPacketVersion {
+                received: packet_version,
+                max_supported: CURRENT_PACKET_VERSION,
+            });
         }
+
+        Ok(Some(Header {
+            packet_version,
+            packet_size: PacketSize::try_from(src[1])?,
+            packet_type: PacketType::try_from(src[2])?,
+        }))
     }
 }
 
@@ -165,7 +150,7 @@ mod header_encoding {
         // due to the hack used to get legacy mode compatibility
         let mut bytes = BytesMut::from(
             [
-                PacketVersion::new_versioned(123).as_u8().unwrap(),
+                PacketVersion::new().as_u8(),
                 unknown_packet_size,
                 PacketType::default() as u8,
             ]
@@ -180,7 +165,14 @@ mod header_encoding {
         // make sure this is still 'unknown' for if we make changes in the future
         assert!(PacketType::try_from(unknown_packet_type).is_err());
 
-        let mut bytes = BytesMut::from([PacketSize::default() as u8, unknown_packet_type].as_ref());
+        let mut bytes = BytesMut::from(
+            [
+                PacketVersion::new().as_u8(),
+                PacketSize::default() as u8,
+                unknown_packet_type,
+            ]
+            .as_ref(),
+        );
         assert!(Header::decode(&mut bytes).is_err())
     }
 
@@ -189,16 +181,16 @@ mod header_encoding {
         let mut empty_bytes = BytesMut::new();
         let decode_attempt_1 = Header::decode(&mut empty_bytes).unwrap();
         assert!(decode_attempt_1.is_none());
-        assert!(empty_bytes.capacity() > Header::LEGACY_SIZE);
+        assert!(empty_bytes.capacity() > Header::SIZE);
 
         let mut empty_bytes = BytesMut::with_capacity(1);
         let decode_attempt_2 = Header::decode(&mut empty_bytes).unwrap();
         assert!(decode_attempt_2.is_none());
-        assert!(empty_bytes.capacity() > Header::LEGACY_SIZE);
+        assert!(empty_bytes.capacity() > Header::SIZE);
     }
 
     #[test]
-    fn header_encoding_reserves_enough_bytes_for_full_sphinx_packet_in_legacy_mode() {
+    fn header_encoding_reserves_enough_bytes_for_full_sphinx_packet_() {
         let packet_sizes = vec![
             PacketSize::AckPacket,
             PacketSize::RegularPacket,
@@ -208,7 +200,7 @@ mod header_encoding {
         ];
         for packet_size in packet_sizes {
             let header = Header {
-                packet_version: PacketVersion::Legacy,
+                packet_version: PacketVersion::new(),
                 packet_size,
                 ..Default::default()
             };
@@ -219,23 +211,26 @@ mod header_encoding {
     }
 
     #[test]
-    fn header_encoding_reserves_enough_bytes_for_full_sphinx_packet_in_versioned_mode() {
-        let packet_sizes = vec![
-            PacketSize::AckPacket,
-            PacketSize::RegularPacket,
-            PacketSize::ExtendedPacket8,
-            PacketSize::ExtendedPacket16,
-            PacketSize::ExtendedPacket32,
-        ];
-        for packet_size in packet_sizes {
-            let header = Header {
-                packet_version: PacketVersion::Versioned(123),
-                packet_size,
-                ..Default::default()
-            };
-            let mut bytes = BytesMut::new();
-            header.encode(&mut bytes);
-            assert_eq!(bytes.capacity(), bytes.len() + packet_size.size())
+    fn header_decoding_will_reject_future_versions() {
+        let future_version = PacketVersion::try_from(123).unwrap();
+
+        let unchecked_header = Header {
+            packet_version: future_version,
+            packet_size: PacketSize::RegularPacket,
+            packet_type: PacketType::Mix,
+        };
+        let mut bytes = BytesMut::new();
+        unchecked_header.encode(&mut bytes);
+
+        match Header::decode(&mut bytes).unwrap_err() {
+            NymCodecError::UnsupportedPacketVersion {
+                received,
+                max_supported,
+            } => {
+                assert_eq!(received, future_version);
+                assert_eq!(max_supported, CURRENT_PACKET_VERSION);
+            }
+            _ => panic!("unexpected error variant"),
         }
     }
 }

--- a/common/nymsphinx/params/src/lib.rs
+++ b/common/nymsphinx/params/src/lib.rs
@@ -22,17 +22,6 @@ pub mod packet_version;
 pub const FRAG_ID_LEN: usize = 5;
 pub type SerializedFragmentIdentifier = [u8; FRAG_ID_LEN];
 
-// wait, wait, but why are we starting with version 7?
-// when packet header gets serialized, the following bytes (in that order) are put onto the wire:
-// - packet_version (starting with v1.1.0)
-// - packet_size indicator
-// - packet_type
-// it also just so happens that the only valid values for packet_size indicator include values 1-6
-// therefore if we receive byte `7` (or larger than that) we'll know we received a versioned packet,
-// otherwise we should treat it as legacy
-/// Increment it whenever we perform any breaking change in the wire format!
-const CURRENT_PACKET_VERSION_NUMBER: u8 = 7;
-
 // TODO: ask @AP about the choice of below algorithms
 
 /// Hashing algorithm used during hkdf for ephemeral shared key generation per sphinx packet payload.

--- a/common/nymsphinx/src/message.rs
+++ b/common/nymsphinx/src/message.rs
@@ -310,6 +310,7 @@ mod tests {
         // a single variant for each repliable and reply is enough as they are more thoroughly tested
         // internally
         let repliable = NymMessage::new_repliable(RepliableMessage::new_data(
+            true,
             vec![1, 2, 3, 4, 5],
             [42u8; 16].into(),
             vec![],

--- a/common/nymsphinx/src/message.rs
+++ b/common/nymsphinx/src/message.rs
@@ -92,6 +92,7 @@ impl NymMessage {
         NymMessage::Plain(msg)
     }
 
+    #[deprecated]
     pub fn new_repliable(msg: RepliableMessage) -> Self {
         NymMessage::Repliable(msg)
     }
@@ -113,7 +114,8 @@ impl NymMessage {
         match self {
             NymMessage::Plain(data) => data,
             NymMessage::Repliable(repliable) => match repliable.content {
-                RepliableMessageContent::Data { message, .. } => message,
+                RepliableMessageContent::Data(content) => content.message,
+                RepliableMessageContent::DataV2(content) => content.message,
                 _ => Vec::new(),
             },
             NymMessage::Reply(reply) => match reply.content {

--- a/common/nymsphinx/src/message.rs
+++ b/common/nymsphinx/src/message.rs
@@ -92,7 +92,6 @@ impl NymMessage {
         NymMessage::Plain(msg)
     }
 
-    #[deprecated]
     pub fn new_repliable(msg: RepliableMessage) -> Self {
         NymMessage::Repliable(msg)
     }

--- a/common/nymsphinx/src/preparer/mod.rs
+++ b/common/nymsphinx/src/preparer/mod.rs
@@ -306,10 +306,6 @@ pub struct MessagePreparer<R> {
     /// Average delay an acknowledgement packet is going to get delay at a single mixnode.
     average_ack_delay: Duration,
 
-    /// Specify whether any constructed reply surbs should use the legacy format,
-    /// where the payload keys are explicitly attached rather than using the seeds
-    use_legacy_reply_surb_format: bool,
-
     nonce: i32,
 }
 
@@ -323,7 +319,6 @@ where
         sender_address: Recipient,
         average_packet_delay: Duration,
         average_ack_delay: Duration,
-        use_legacy_reply_surb_format: bool,
     ) -> Self {
         let mut rng = rng;
         let nonce = rng.gen();
@@ -333,7 +328,6 @@ where
             sender_address,
             average_packet_delay,
             average_ack_delay,
-            use_legacy_reply_surb_format,
             nonce,
         }
     }
@@ -345,6 +339,7 @@ where
 
     pub fn generate_reply_surbs(
         &mut self,
+        use_legacy_reply_surb_format: bool,
         amount: usize,
         topology: &NymRouteProvider,
     ) -> Result<Vec<ReplySurb>, NymTopologyError> {
@@ -354,7 +349,7 @@ where
                 &mut self.rng,
                 &self.sender_address,
                 self.average_packet_delay,
-                self.use_legacy_reply_surb_format,
+                use_legacy_reply_surb_format,
                 topology,
             )?;
             reply_surbs.push(reply_surb)

--- a/common/nymsphinx/types/src/lib.rs
+++ b/common/nymsphinx/types/src/lib.rs
@@ -96,6 +96,7 @@ impl NymPacket {
         Ok(NymPacket::Sphinx(
             SphinxPacketBuilder::new()
                 .with_payload_size(size)
+                .with_version(X25519_WITH_EXPLICIT_PAYLOAD_KEYS_VERSION)
                 .build_packet(message, route, destination, delays)?,
         ))
     }

--- a/common/nymsphinx/types/src/lib.rs
+++ b/common/nymsphinx/types/src/lib.rs
@@ -87,18 +87,25 @@ impl fmt::Debug for NymPacket {
 impl NymPacket {
     #[cfg(feature = "sphinx")]
     pub fn sphinx_build<M: AsRef<[u8]>>(
+        use_legacy_sphinx_format: bool,
         size: usize,
         message: M,
         route: &[Node],
         destination: &Destination,
         delays: &[Delay],
     ) -> Result<NymPacket, NymPacketError> {
-        Ok(NymPacket::Sphinx(
-            SphinxPacketBuilder::new()
-                .with_payload_size(size)
-                .with_version(X25519_WITH_EXPLICIT_PAYLOAD_KEYS_VERSION)
-                .build_packet(message, route, destination, delays)?,
-        ))
+        let mut builder = SphinxPacketBuilder::new().with_payload_size(size);
+
+        if use_legacy_sphinx_format {
+            builder = builder.with_version(X25519_WITH_EXPLICIT_PAYLOAD_KEYS_VERSION)
+        };
+
+        Ok(NymPacket::Sphinx(builder.build_packet(
+            message,
+            route,
+            destination,
+            delays,
+        )?))
     }
     #[cfg(feature = "sphinx")]
     pub fn sphinx_from_bytes(bytes: &[u8]) -> Result<NymPacket, NymPacketError> {

--- a/common/nymsphinx/types/src/lib.rs
+++ b/common/nymsphinx/types/src/lib.rs
@@ -26,10 +26,13 @@ pub use sphinx_packet::{
     crypto::{self, PrivateKey, PublicKey},
     header::{self, delays, delays::Delay, ProcessedHeader, SphinxHeader, HEADER_SIZE},
     packet::builder::DEFAULT_PAYLOAD_SIZE,
-    payload::{Payload, PAYLOAD_OVERHEAD_SIZE},
+    payload::{
+        key::{PayloadKey, PayloadKeySeed},
+        Payload, PAYLOAD_OVERHEAD_SIZE,
+    },
     route::{Destination, DestinationAddressBytes, Node, NodeAddressBytes, SURBIdentifier},
     surb::{SURBMaterial, SURB},
-    version::Version,
+    version::*,
     Error as SphinxError, ProcessedPacket, ProcessedPacketData,
 };
 

--- a/common/wasm/client-core/src/config/mod.rs
+++ b/common/wasm/client-core/src/config/mod.rs
@@ -181,6 +181,14 @@ pub struct TrafficWasm {
     /// Controls whether the sent sphinx packet use the NON-DEFAULT bigger size.
     pub use_extended_packet_size: bool,
 
+    /// Specify whether any constructed sphinx packets should use the legacy format,
+    /// where the payload keys are explicitly attached rather than using the seeds
+    /// this affects any forward packets, acks and reply surbs
+    /// this flag should remain disabled until sufficient number of nodes on the network has upgraded
+    /// and support updated format.
+    /// in the case of reply surbs, the recipient must also understand the new encoding
+    pub use_legacy_sphinx_format: bool,
+
     /// Controls whether the sent packets should use outfox as opposed to the default sphinx.
     pub use_outfox: bool,
 }
@@ -214,6 +222,7 @@ impl From<TrafficWasm> for ConfigTraffic {
                 .disable_main_poisson_packet_distribution,
             primary_packet_size: PacketSize::RegularPacket,
             secondary_packet_size: use_extended_packet_size,
+            use_legacy_sphinx_format: traffic.use_legacy_sphinx_format,
             packet_type,
         }
     }
@@ -229,6 +238,7 @@ impl From<ConfigTraffic> for TrafficWasm {
             maximum_number_of_retransmissions: traffic.maximum_number_of_retransmissions,
             disable_main_poisson_packet_distribution: traffic
                 .disable_main_poisson_packet_distribution,
+            use_legacy_sphinx_format: traffic.use_legacy_sphinx_format,
             use_extended_packet_size: traffic.secondary_packet_size.is_some(),
             use_outfox: traffic.packet_type == PacketType::Outfox,
         }

--- a/common/wasm/client-core/src/config/override.rs
+++ b/common/wasm/client-core/src/config/override.rs
@@ -109,6 +109,15 @@ pub struct TrafficWasmOverride {
     #[tsify(optional)]
     pub use_extended_packet_size: Option<bool>,
 
+    /// Specify whether any constructed sphinx packets should use the legacy format,
+    /// where the payload keys are explicitly attached rather than using the seeds
+    /// this affects any forward packets, acks and reply surbs
+    /// this flag should remain disabled until sufficient number of nodes on the network has upgraded
+    /// and support updated format.
+    /// in the case of reply surbs, the recipient must also understand the new encoding
+    #[tsify(optional)]
+    pub use_legacy_sphinx_format: Option<bool>,
+
     /// Controls whether the sent packets should use outfox as opposed to the default sphinx.
     #[tsify(optional)]
     pub use_outfox: Option<bool>,
@@ -132,6 +141,9 @@ impl From<TrafficWasmOverride> for TrafficWasm {
             disable_main_poisson_packet_distribution: value
                 .disable_main_poisson_packet_distribution
                 .unwrap_or(def.disable_main_poisson_packet_distribution),
+            use_legacy_sphinx_format: value
+                .use_legacy_sphinx_format
+                .unwrap_or(def.use_legacy_sphinx_format),
             use_extended_packet_size: value
                 .use_extended_packet_size
                 .unwrap_or(def.use_extended_packet_size),

--- a/nym-api/src/network_monitor/monitor/preparer.rs
+++ b/nym-api/src/network_monitor/monitor/preparer.rs
@@ -129,6 +129,7 @@ impl PacketPreparer {
             false,
             DEFAULT_AVERAGE_PACKET_DELAY,
             DEFAULT_AVERAGE_ACK_DELAY,
+            true,
             self.ack_key.clone(),
         )
     }

--- a/nym-node/src/throughput_tester/client.rs
+++ b/nym-node/src/throughput_tester/client.rs
@@ -3,7 +3,6 @@
 
 use crate::throughput_tester::stats::ClientStats;
 use anyhow::bail;
-use arrayref::array_ref;
 use blake2::VarBlake2b;
 use chacha::ChaCha;
 use futures::{stream, SinkExt, Stream, StreamExt};
@@ -230,11 +229,7 @@ impl ThroughputTestingClient {
     }
 
     fn lioness_encrypt(&self, block: &mut [u8]) -> anyhow::Result<()> {
-        let lioness_cipher = Lioness::<VarBlake2b, ChaCha>::new_raw(array_ref!(
-            self.payload_key,
-            0,
-            lioness::RAW_KEY_SIZE
-        ));
+        let lioness_cipher = Lioness::<VarBlake2b, ChaCha>::new_raw(&self.payload_key);
         lioness_cipher.encrypt(block)?;
         Ok(())
     }

--- a/nym-node/src/throughput_tester/client.rs
+++ b/nym-node/src/throughput_tester/client.rs
@@ -159,7 +159,7 @@ impl ThroughputTestingClient {
         let payload = PacketSize::RegularPacket.payload_size();
 
         let forward_packet =
-            NymPacket::sphinx_build(payload, b"foomp", &route, &destination, &delays)?;
+            NymPacket::sphinx_build(true, payload, b"foomp", &route, &destination, &delays)?;
 
         // SAFETY: we constructed a sphinx packet...
         #[allow(clippy::unwrap_used)]

--- a/nym-node/src/throughput_tester/client.rs
+++ b/nym-node/src/throughput_tester/client.rs
@@ -174,7 +174,7 @@ impl ThroughputTestingClient {
             .diffie_hellman(&header.shared_secret);
         let payload_key = rederive_lioness_payload_key(shared_secret.as_bytes());
 
-        let unwrapped_payload = sphinx_packet.payload.unwrap(&payload_key)?;
+        let unwrapped_payload = sphinx_packet.payload.unwrap(payload_key)?;
         let unwrapped_forward_payload_bytes = unwrapped_payload.into_bytes();
 
         let start = Instant::now();

--- a/nym-outfox/src/packet.rs
+++ b/nym-outfox/src/packet.rs
@@ -131,7 +131,7 @@ impl OutfoxPacket {
                 &mut buffer[range],
                 &secret_key,
                 processing_node.pub_key,
-                destination_node.address.as_bytes_ref(),
+                destination_node.address.as_bytes(),
             )?;
         }
 

--- a/nym-outfox/tests/unittests.rs
+++ b/nym-outfox/tests/unittests.rs
@@ -138,11 +138,11 @@ mod tests {
         let mut packet = OutfoxPacket::try_from(packet_bytes.as_slice()).unwrap();
 
         let next_address = packet.decode_next_layer(&node1_pk).unwrap();
-        assert_eq!(next_address, node2.address.as_bytes());
+        assert_eq!(&next_address, node2.address.as_bytes());
         let next_address = packet.decode_next_layer(&node2_pk).unwrap();
-        assert_eq!(next_address, node3.address.as_bytes());
+        assert_eq!(&next_address, node3.address.as_bytes());
         let next_address = packet.decode_next_layer(&node3_pk).unwrap();
-        assert_eq!(next_address, gateway.address.as_bytes());
+        assert_eq!(&next_address, gateway.address.as_bytes());
         let destination_address = packet.decode_next_layer(&gateway_pk).unwrap();
         assert_eq!(destination_address, destination.address.as_bytes());
 
@@ -194,11 +194,11 @@ mod tests {
         let mut packet = OutfoxPacket::try_from(packet_bytes.as_slice()).unwrap();
 
         let next_address = packet.decode_next_layer(&node1_pk).unwrap();
-        assert_eq!(next_address, node2.address.as_bytes());
+        assert_eq!(&next_address, node2.address.as_bytes());
         let next_address = packet.decode_next_layer(&node2_pk).unwrap();
-        assert_eq!(next_address, node3.address.as_bytes());
+        assert_eq!(&next_address, node3.address.as_bytes());
         let next_address = packet.decode_next_layer(&node3_pk).unwrap();
-        assert_eq!(next_address, gateway.address.as_bytes());
+        assert_eq!(&next_address, gateway.address.as_bytes());
         let destination_address = packet.decode_next_layer(&gateway_pk).unwrap();
         assert_eq!(destination_address, destination.address.as_bytes());
 

--- a/wasm/node-tester/src/tester.rs
+++ b/wasm/node-tester/src/tester.rs
@@ -238,6 +238,7 @@ impl NymNodeTesterBuilder {
             false,
             Duration::from_millis(5),
             Duration::from_millis(5),
+            true,
             managed_keys.ack_key(),
         );
 


### PR DESCRIPTION
This PR uses the new version of the sphinx-packet that allows us to derive payload encryption keys from the seed rather than having to attach the keys themselves. what it means in practice is that each reply surb is now ~60% smaller.

However, while this sounds amazing, currently all of those functionalities are **DISABLED** by default. it is because it required nodes to actually understand the new scheme. it shouldn't be enabled until sufficient number of nodes, particularly mixnodes, has upgraded. I reckon it will take few releases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5698)
<!-- Reviewable:end -->
