### PR TITLE
libc + OS node version 

### DIFF
--- a/documentation/docs/pages/operators/binaries/pre-built-binaries.mdx
+++ b/documentation/docs/pages/operators/binaries/pre-built-binaries.mdx
@@ -7,7 +7,7 @@ import { MyTab } from 'components/generic-tabs.tsx';
 
 This page is for operators who prefer to download ready made binaries. The [Github releases page](https://github.com/nymtech/nym/releases) has pre-built binaries which work on **Ubuntu 22.04 and Debian 12 upwards**, but at this stage cannot be guaranteed to work everywhere. 
 
-They should work on any distro with `libc` >= v2.32 and above. 
+They should work on any distro with `libc` >= v2.33 and above. 
 
 If the pre-built binaries don't work or are unavailable for your system, you will need to build the platform yourself.
 

--- a/documentation/docs/pages/operators/binaries/pre-built-binaries.mdx
+++ b/documentation/docs/pages/operators/binaries/pre-built-binaries.mdx
@@ -7,7 +7,7 @@ import { MyTab } from 'components/generic-tabs.tsx';
 
 This page is for operators who prefer to download ready made binaries. The [Github releases page](https://github.com/nymtech/nym/releases) has pre-built binaries which work on **Ubuntu 22.04 and Debian 12 upwards**, but at this stage cannot be guaranteed to work everywhere. 
 
-They should work on any distro with `libc`  =< v2.32 and above. 
+They should work on any distro with `libc` >= v2.32 and above. 
 
 If the pre-built binaries don't work or are unavailable for your system, you will need to build the platform yourself.
 

--- a/documentation/docs/pages/operators/binaries/pre-built-binaries.mdx
+++ b/documentation/docs/pages/operators/binaries/pre-built-binaries.mdx
@@ -5,7 +5,9 @@ import { MyTab } from 'components/generic-tabs.tsx';
 
 # Pre-built Binaries
 
-This page is for operators who prefer to download ready made binaries. The [Github releases page](https://github.com/nymtech/nym/releases) has pre-built binaries which should work on Ubuntu 22.04 and other Debian-based systems, but at this stage cannot be guaranteed to work everywhere.
+This page is for operators who prefer to download ready made binaries. The [Github releases page](https://github.com/nymtech/nym/releases) has pre-built binaries which work on **Ubuntu 22.04 and Debian 12 upwards**, but at this stage cannot be guaranteed to work everywhere. 
+
+They should work on any distro with `libc`  =< v2.32 and above. 
 
 If the pre-built binaries don't work or are unavailable for your system, you will need to build the platform yourself.
 


### PR DESCRIPTION
Note on prebuilt binaries only working on Ubuntu22, Debian12, and distros with libc =< 2.32

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5705)
<!-- Reviewable:end -->
