### PR TITLE
[DOCs]: TimeNow and Vars value sync up

### DIFF
--- a/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
+++ b/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
@@ -1,1 +1,1 @@
-Wednesday, April 23rd 2025, 09:18:06 UTC
+Wednesday, April 30th 2025, 12:26:39 UTC


### PR DESCRIPTION
CI doesn't re-run the pre-build scripts scraping vars from APIs and TimeNow. Ran manually and pushing up to promote together with the laterst release PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5736)
<!-- Reviewable:end -->
