### PR TITLE
[DOCs/operators]: Tokenomics hotfix

### DIFF
--- a/documentation/docs/pages/operators/tokenomics/mixnet-rewards.mdx
+++ b/documentation/docs/pages/operators/tokenomics/mixnet-rewards.mdx
@@ -155,7 +155,7 @@ For the rewarded set selection weight, good [performance](#node-performance-calc
 For a comparison we made an example with 5 nodes, where first number is node performance and second stake saturation (assuming all of them [`config_score`](#config-score-calculation)) = 1 for simplification):
 
 <br />
-<AccordionTemplate name="✏️ Comparison example: Performance ^ 20 * total_stake calculation">
+<AccordionTemplate name="✏️ Calculation example: performance ^ 20 * node_stake_saturation">
 > node_1 = 1.00 ^ 20 \* 1.0 = **1** <br />
 > node_2 = 1.00 ^ 20 \* 0.5 = **0.5** <br />
 > node_3 = 0.99 ^ 20 \* 1.0 = **0.818** <br />


### PR DESCRIPTION
This PR fixes a small left over expression where we used `total_stake` instead of `node_stake_saturation`. 

*Note that while the end point is called `stake_saturation`, in docs we use `node_stake_saturation` to be specific and prevent confusion between this value and `stake_saturation_level`, a network optimal value (defined by NYM stake target divided by amount of bonded nodes) which each node aims to reach in order to have `node_stake_saturation` = 1.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5740)
<!-- Reviewable:end -->
