### PR TITLE
[Feature] `RememberMe` is the new don't `ForgetMe`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6255,7 +6255,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node-status-api"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,6 +5176,7 @@ dependencies = [
  "nym-pemstore",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
+ "nym-statistics-common",
  "serde",
  "thiserror 2.0.12",
  "url",
@@ -5707,6 +5708,7 @@ dependencies = [
  "nym-pemstore",
  "nym-serde-helpers",
  "nym-sphinx",
+ "nym-statistics-common",
  "nym-task",
  "rand 0.8.5",
  "serde",
@@ -5726,7 +5728,6 @@ dependencies = [
 name = "nym-gateway-stats-storage"
 version = "0.1.0"
 dependencies = [
- "nym-credentials-interface",
  "nym-node-metrics",
  "nym-sphinx",
  "nym-statistics-common",
@@ -6170,6 +6171,7 @@ dependencies = [
  "nym-sphinx-params",
  "nym-sphinx-routing",
  "nym-sphinx-types",
+ "nym-statistics-common",
  "nym-task",
  "nym-topology",
  "nym-types",
@@ -6787,6 +6789,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "si-scale",
+ "strum 0.26.3",
  "sysinfo",
  "thiserror 2.0.12",
  "time",

--- a/common/client-core/config-types/Cargo.toml
+++ b/common/client-core/config-types/Cargo.toml
@@ -19,6 +19,7 @@ nym-pemstore = { path = "../../pemstore", optional = true }
 # those are pulling so many deps T.T
 nym-sphinx-params = { path = "../../nymsphinx/params" }
 nym-sphinx-addressing = { path = "../../nymsphinx/addressing" }
+nym-statistics-common = { path = "../../statistics" }
 
 
 [features]

--- a/common/client-core/config-types/src/lib.rs
+++ b/common/client-core/config-types/src/lib.rs
@@ -5,6 +5,7 @@ use nym_config::defaults::NymNetworkDetails;
 use nym_config::serde_helpers::{de_maybe_stringified, ser_maybe_stringified};
 use nym_sphinx_addressing::Recipient;
 use nym_sphinx_params::{PacketSize, PacketType};
+use nym_statistics_common::types::SessionType;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use url::Url;
@@ -718,6 +719,9 @@ pub struct DebugConfig {
 
     /// Defines all configuration options related to the forget me flag.
     pub forget_me: ForgetMe,
+
+    /// Defines all configuration options related to the remember me flag.
+    pub remember_me: RememberMe,
 }
 
 impl DebugConfig {
@@ -741,6 +745,7 @@ impl Default for DebugConfig {
             reply_surbs: Default::default(),
             stats_reporting: Default::default(),
             forget_me: Default::default(),
+            remember_me: Default::default(),
         }
     }
 }
@@ -804,5 +809,59 @@ impl ForgetMe {
             client: false,
             stats: false,
         }
+    }
+}
+
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize, Copy)]
+pub struct RememberMe {
+    /// Signal that this client should be accounted for in the stats
+    stats: bool,
+
+    /// Type of the session to remember, if it should be remembered
+    session_type: SessionType,
+}
+
+impl RememberMe {
+    pub fn new_vpn() -> Self {
+        Self {
+            stats: true,
+            session_type: SessionType::Vpn,
+        }
+    }
+
+    pub fn new_mixnet() -> Self {
+        Self {
+            stats: true,
+            session_type: SessionType::Mixnet,
+        }
+    }
+
+    pub fn new_native() -> Self {
+        Self {
+            stats: true,
+            session_type: SessionType::Native,
+        }
+    }
+
+    pub fn new(stats: bool, session_type: SessionType) -> Self {
+        Self {
+            stats,
+            session_type,
+        }
+    }
+
+    pub fn new_none() -> Self {
+        Self {
+            stats: false,
+            session_type: SessionType::Unknown,
+        }
+    }
+
+    pub fn session_type(&self) -> SessionType {
+        self.session_type
+    }
+
+    pub fn stats(&self) -> bool {
+        self.stats
     }
 }

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -36,7 +36,7 @@ use crate::{config, spawn_future};
 use futures::channel::mpsc;
 use log::*;
 use nym_bandwidth_controller::BandwidthController;
-use nym_client_core_config_types::ForgetMe;
+use nym_client_core_config_types::{ForgetMe, RememberMe};
 use nym_client_core_gateways_storage::{GatewayDetails, GatewaysDetailsStore};
 use nym_credential_storage::storage::Storage as CredentialStorage;
 use nym_crypto::asymmetric::{ed25519, x25519};
@@ -235,6 +235,12 @@ where
     #[must_use]
     pub fn with_forget_me(mut self, forget_me: &ForgetMe) -> Self {
         self.config.debug.forget_me = *forget_me;
+        self
+    }
+
+    #[must_use]
+    pub fn with_remember_me(mut self, remember_me: &RememberMe) -> Self {
+        self.config.debug.remember_me = *remember_me;
         self
     }
 
@@ -930,6 +936,7 @@ where
             task_handle: shutdown,
             client_request_sender,
             forget_me: self.config.debug.forget_me,
+            remember_me: self.config.debug.remember_me,
         })
     }
 }
@@ -944,4 +951,5 @@ pub struct BaseClient {
     pub client_request_sender: ClientRequestSender,
     pub task_handle: TaskHandle,
     pub forget_me: ForgetMe,
+    pub remember_me: RememberMe,
 }

--- a/common/client-libs/gateway-client/src/socket_state.rs
+++ b/common/client-libs/gateway-client/src/socket_state.rs
@@ -10,7 +10,7 @@ use futures::channel::oneshot;
 use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, StreamExt};
 use nym_gateway_requests::shared_key::SharedGatewayKey;
-use nym_gateway_requests::{ServerResponse, SimpleGatewayRequestsError};
+use nym_gateway_requests::{SensitiveServerResponse, ServerResponse, SimpleGatewayRequestsError};
 use nym_task::TaskClient;
 use si_scale::helpers::bibytes2;
 use std::os::raw::c_int as RawFd;
@@ -187,6 +187,34 @@ impl PartiallyDelegatedRouter {
                         Err(GatewayClientError::TypedGatewayError(error))
                     }
                 }
+            }
+            ServerResponse::EncryptedResponse { ciphertext, nonce } => {
+                match SensitiveServerResponse::decrypt(
+                    &ciphertext,
+                    &nonce,
+                    self.shared_key.as_ref(),
+                ) {
+                    Ok(response) => match response {
+                        SensitiveServerResponse::ForgetMeAck {} => {
+                            info!("received forget me acknowledgement");
+                        }
+                        SensitiveServerResponse::RememberMeAck {} => {
+                            info!("received remember me acknowledgement");
+                        }
+                        SensitiveServerResponse::KeyUpgradeAck {} => {
+                            warn!(
+                                    "received illegal key upgrade acknowledgement in an authenticated client"
+                                );
+                        }
+                        _ => {
+                            warn!("received unknown SensitiveServerResponse");
+                        }
+                    },
+                    Err(e) => {
+                        error!("failed to handle encrypted response: {e}");
+                    }
+                }
+                Ok(())
             }
             other => {
                 let name = other.name();

--- a/common/gateway-requests/Cargo.toml
+++ b/common/gateway-requests/Cargo.toml
@@ -28,6 +28,7 @@ nym-crypto = { path = "../crypto", features = ["aead", "hashing"] }
 nym-pemstore = { path = "../pemstore" }
 nym-sphinx = { path = "../nymsphinx" }
 nym-serde-helpers = { path = "../serde-helpers", features = ["base64"] }
+nym-statistics-common = { path = "../statistics" }
 nym-task = { path = "../task" }
 
 nym-credentials = { path = "../credentials" }

--- a/common/gateway-requests/src/types/text_request/mod.rs
+++ b/common/gateway-requests/src/types/text_request/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 use nym_credentials_interface::CredentialSpendingData;
 use nym_crypto::asymmetric::ed25519;
 use nym_sphinx::DestinationAddressBytes;
+use nym_statistics_common::types::SessionType;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tungstenite::Message;
@@ -28,6 +29,9 @@ pub enum ClientRequest {
     ForgetMe {
         client: bool,
         stats: bool,
+    },
+    RememberMe {
+        session_type: SessionType,
     },
 }
 

--- a/common/gateway-requests/src/types/text_response.rs
+++ b/common/gateway-requests/src/types/text_response.rs
@@ -12,6 +12,7 @@ use tungstenite::Message;
 pub enum SensitiveServerResponse {
     KeyUpgradeAck {},
     ForgetMeAck {},
+    RememberMeAck {},
 }
 
 impl SensitiveServerResponse {

--- a/common/gateway-stats-storage/Cargo.toml
+++ b/common/gateway-stats-storage/Cargo.toml
@@ -22,7 +22,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 nym-sphinx = { path = "../nymsphinx" }
-nym-credentials-interface = { path = "../credentials-interface" }
 nym-node-metrics = { path = "../../nym-node/nym-node-metrics" }
 nym-statistics-common = { path = "../statistics" }
 

--- a/common/gateway-stats-storage/migrations/20250505120000_add_remember_column.sql
+++ b/common/gateway-stats-storage/migrations/20250505120000_add_remember_column.sql
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+ALTER TABLE sessions_active
+    ADD COLUMN remember INTEGER NOT NULL default 0;

--- a/common/gateway-stats-storage/src/lib.rs
+++ b/common/gateway-stats-storage/src/lib.rs
@@ -148,6 +148,16 @@ impl PersistentStatsStorage {
             .await?)
     }
 
+    pub async fn remember_active_session(
+        &self,
+        client_address: DestinationAddressBytes,
+    ) -> Result<(), StatsStorageError> {
+        Ok(self
+            .session_manager
+            .remember_active_session(client_address.as_base58_string())
+            .await?)
+    }
+
     pub async fn update_active_session_type(
         &self,
         client_address: DestinationAddressBytes,

--- a/common/gateway-stats-storage/src/lib.rs
+++ b/common/gateway-stats-storage/src/lib.rs
@@ -3,8 +3,9 @@
 
 use error::StatsStorageError;
 use models::StoredFinishedSession;
-use nym_node_metrics::entry::{ActiveSession, FinishedSession, SessionType};
+use nym_node_metrics::entry::{ActiveSession, FinishedSession};
 use nym_sphinx::DestinationAddressBytes;
+use nym_statistics_common::types::SessionType;
 use sessions::SessionManager;
 use sqlx::{
     sqlite::{SqliteAutoVacuum, SqliteSynchronous},

--- a/common/gateway-stats-storage/src/models.rs
+++ b/common/gateway-stats-storage/src/models.rs
@@ -1,7 +1,8 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use nym_node_metrics::entry::{ActiveSession, FinishedSession, SessionType};
+use nym_node_metrics::entry::{ActiveSession, FinishedSession};
+use nym_statistics_common::types::SessionType;
 use sqlx::prelude::FromRow;
 use time::OffsetDateTime;
 

--- a/common/gateway-stats-storage/src/models.rs
+++ b/common/gateway-stats-storage/src/models.rs
@@ -6,8 +6,6 @@ use nym_statistics_common::types::SessionType;
 use sqlx::prelude::FromRow;
 use time::OffsetDateTime;
 
-pub use nym_credentials_interface::TicketType;
-
 #[derive(FromRow)]
 pub struct StoredFinishedSession {
     duration_ms: i64,
@@ -23,25 +21,11 @@ impl From<StoredFinishedSession> for FinishedSession {
     }
 }
 
-pub trait ToSessionType {
-    fn to_session_type(&self) -> SessionType;
-}
-
-impl ToSessionType for TicketType {
-    fn to_session_type(&self) -> SessionType {
-        match self {
-            TicketType::V1MixnetEntry => SessionType::Mixnet,
-            TicketType::V1MixnetExit => SessionType::Mixnet,
-            TicketType::V1WireguardEntry => SessionType::Vpn,
-            TicketType::V1WireguardExit => SessionType::Vpn,
-        }
-    }
-}
-
 #[derive(FromRow)]
 pub(crate) struct StoredActiveSession {
     start_time: OffsetDateTime,
     typ: String,
+    remember: u8,
 }
 
 impl From<StoredActiveSession> for ActiveSession {
@@ -49,6 +33,7 @@ impl From<StoredActiveSession> for ActiveSession {
         ActiveSession {
             start: value.start_time,
             typ: SessionType::from_string(&value.typ),
+            remember: value.remember != 0,
         }
     }
 }

--- a/common/gateway-stats-storage/src/sessions.rs
+++ b/common/gateway-stats-storage/src/sessions.rs
@@ -107,10 +107,20 @@ impl SessionManager {
         typ: String,
     ) -> Result<()> {
         sqlx::query!(
-            "INSERT INTO sessions_active (client_address, start_time, typ) VALUES (?, ?, ?)",
+            "INSERT INTO sessions_active (client_address, start_time, typ, remember) VALUES (?, ?, ?, 0)",
             client_address_b58,
             start_time,
             typ
+        )
+        .execute(&self.connection_pool)
+        .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn remember_active_session(&self, client_address_b58: String) -> Result<()> {
+        sqlx::query!(
+            "UPDATE sessions_active SET remember = 1 WHERE client_address = ?",
+            client_address_b58,
         )
         .execute(&self.connection_pool)
         .await?;
@@ -136,14 +146,16 @@ impl SessionManager {
         &self,
         client_address_b58: String,
     ) -> Result<Option<StoredActiveSession>> {
-        sqlx::query_as("SELECT start_time, typ FROM sessions_active WHERE client_address = ?")
-            .bind(client_address_b58)
-            .fetch_optional(&self.connection_pool)
-            .await
+        sqlx::query_as(
+            "SELECT start_time, typ, remember FROM sessions_active WHERE client_address = ?",
+        )
+        .bind(client_address_b58)
+        .fetch_optional(&self.connection_pool)
+        .await
     }
 
     pub(crate) async fn get_all_active_sessions(&self) -> Result<Vec<StoredActiveSession>> {
-        sqlx::query_as("SELECT start_time, typ FROM sessions_active")
+        sqlx::query_as("SELECT start_time, typ, remember FROM sessions_active")
             .fetch_all(&self.connection_pool)
             .await
     }

--- a/common/statistics/Cargo.toml
+++ b/common/statistics/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
 si-scale = { workspace = true }
+strum = { workspace = true }
 
 nym-crypto = { path = "../crypto" }
 nym-sphinx = { path = "../nymsphinx" }

--- a/common/statistics/src/gateways.rs
+++ b/common/statistics/src/gateways.rs
@@ -1,9 +1,10 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use nym_credentials_interface::TicketType;
 use nym_sphinx::DestinationAddressBytes;
 use time::OffsetDateTime;
+
+use crate::types::SessionType;
 
 /// Channel for receiving incoming Stats events
 pub type GatewayStatsReceiver = tokio::sync::mpsc::UnboundedReceiver<GatewayStatsEvent>;
@@ -51,15 +52,9 @@ pub enum GatewaySessionEvent {
         /// Address of the remote client opening the connection
         client: DestinationAddressBytes,
     },
-    /// A new ecash ticket has been added / requested
-    EcashTicket {
-        /// Type of ecash ticket that has been created as part of the session
-        ticket_type: TicketType,
-        /// Address of the remote client opening the connection
-        client: DestinationAddressBytes,
-    },
-    SessionDelete {
-        /// Address of the remote client opening the connection
+    /// An active session should be given a type and remembered
+    SessionRemember {
+        session_type: SessionType,
         client: DestinationAddressBytes,
     },
 }
@@ -81,18 +76,13 @@ impl GatewaySessionEvent {
         }
     }
 
-    /// A new ecash ticket has been added / requested
-    pub fn new_ecash_ticket(
+    pub fn new_session_remember(
+        session_type: SessionType,
         client: DestinationAddressBytes,
-        ticket_type: TicketType,
     ) -> GatewaySessionEvent {
-        GatewaySessionEvent::EcashTicket {
-            ticket_type,
+        GatewaySessionEvent::SessionRemember {
+            session_type,
             client,
         }
-    }
-
-    pub fn new_session_delete(client: DestinationAddressBytes) -> GatewaySessionEvent {
-        GatewaySessionEvent::SessionDelete { client }
     }
 }

--- a/common/statistics/src/lib.rs
+++ b/common/statistics/src/lib.rs
@@ -22,6 +22,8 @@ pub mod error;
 pub mod gateways;
 /// Statistics reporting abstractions and implementations.
 pub mod report;
+/// Statistics related types.
+pub mod types;
 
 const CLIENT_ID_PREFIX: &str = "client_stats_id";
 

--- a/common/statistics/src/types.rs
+++ b/common/statistics/src/types.rs
@@ -1,0 +1,31 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    PartialEq,
+    Copy,
+    Clone,
+    strum::Display,
+    strum::EnumString,
+    Serialize,
+    Deserialize,
+    Default,
+    Debug,
+)]
+pub enum SessionType {
+    Vpn,
+    Mixnet,
+    Wasm,
+    Native,
+    Socks5,
+    #[default]
+    Unknown,
+}
+
+impl SessionType {
+    pub fn from_string<S: AsRef<str>>(s: S) -> Self {
+        s.as_ref().parse().unwrap_or_default()
+    }
+}

--- a/common/wasm/client-core/src/config/mod.rs
+++ b/common/wasm/client-core/src/config/mod.rs
@@ -5,9 +5,10 @@
 #![allow(clippy::drop_non_drop)]
 
 use crate::error::WasmCoreError;
-use nym_client_core::config::ForgetMe;
+use nym_client_core::config::{ForgetMe, RememberMe};
 use nym_config::helpers::OptionalSet;
 use nym_sphinx::params::{PacketSize, PacketType};
+use nym_statistics_common::types::SessionType;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use wasm_bindgen::prelude::*;
@@ -113,6 +114,8 @@ pub struct DebugWasm {
     pub stats_reporting: StatsReportingWasm,
 
     pub forget_me: ForgetMeWasm,
+
+    pub remember_me: RememberMeWasm,
 }
 
 impl Default for DebugWasm {
@@ -132,6 +135,7 @@ impl From<DebugWasm> for ConfigDebug {
             reply_surbs: debug.reply_surbs.into(),
             stats_reporting: debug.stats_reporting.into(),
             forget_me: debug.forget_me.into(),
+            remember_me: debug.remember_me.into(),
         }
     }
 }
@@ -147,6 +151,7 @@ impl From<ConfigDebug> for DebugWasm {
             reply_surbs: debug.reply_surbs.into(),
             stats_reporting: debug.stats_reporting.into(),
             forget_me: ForgetMeWasm::from(debug.forget_me),
+            remember_me: RememberMeWasm::from(debug.remember_me),
         }
     }
 }
@@ -592,6 +597,27 @@ impl From<ForgetMe> for ForgetMeWasm {
     fn from(value: ForgetMe) -> Self {
         Self {
             client: value.client(),
+            stats: value.stats(),
+        }
+    }
+}
+
+#[wasm_bindgen(inspectable)]
+#[derive(Debug, Copy, Clone, Deserialize, PartialEq, Serialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct RememberMeWasm {
+    pub stats: bool,
+}
+
+impl From<RememberMeWasm> for RememberMe {
+    fn from(value: RememberMeWasm) -> Self {
+        RememberMe::new(value.stats, SessionType::Wasm)
+    }
+}
+
+impl From<RememberMe> for RememberMeWasm {
+    fn from(value: RememberMe) -> Self {
+        Self {
             stats: value.stats(),
         }
     }

--- a/common/wasm/client-core/src/config/override.rs
+++ b/common/wasm/client-core/src/config/override.rs
@@ -9,7 +9,7 @@
 
 use super::{
     AcknowledgementsWasm, CoverTrafficWasm, DebugWasm, ForgetMeWasm, GatewayConnectionWasm,
-    ReplySurbsWasm, StatsReportingWasm, TopologyWasm, TrafficWasm,
+    RememberMeWasm, ReplySurbsWasm, StatsReportingWasm, TopologyWasm, TrafficWasm,
 };
 use crate::config::ConfigDebug;
 use serde::{Deserialize, Serialize};
@@ -50,6 +50,9 @@ pub struct DebugWasmOverride {
 
     #[tsify(optional)]
     pub forget_me: Option<ForgetMeWasmOverride>,
+
+    #[tsify(optional)]
+    pub remember_me: Option<RememberMeWasmOverride>,
 }
 
 impl From<DebugWasmOverride> for DebugWasm {
@@ -63,6 +66,7 @@ impl From<DebugWasmOverride> for DebugWasm {
             reply_surbs: value.reply_surbs.map(Into::into).unwrap_or_default(),
             stats_reporting: value.stats_reporting.map(Into::into).unwrap_or_default(),
             forget_me: value.forget_me.map(Into::into).unwrap_or_default(),
+            remember_me: value.remember_me.map(Into::into).unwrap_or_default(),
         }
     }
 }
@@ -452,6 +456,22 @@ impl From<ForgetMeWasmOverride> for ForgetMeWasm {
     fn from(value: ForgetMeWasmOverride) -> Self {
         ForgetMeWasm {
             client: value.client.unwrap_or_default(),
+            stats: value.stats.unwrap_or_default(),
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Clone, Serialize, Deserialize)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct RememberMeWasmOverride {
+    #[tsify(optional)]
+    pub stats: Option<bool>,
+}
+
+impl From<RememberMeWasmOverride> for RememberMeWasm {
+    fn from(value: RememberMeWasmOverride) -> Self {
+        RememberMeWasm {
             stats: value.stats.unwrap_or_default(),
         }
     }

--- a/gateway/src/node/client_handling/websocket/connection_handler/authenticated.rs
+++ b/gateway/src/node/client_handling/websocket/connection_handler/authenticated.rs
@@ -18,7 +18,6 @@ use nym_credential_verification::CredentialVerifier;
 use nym_credential_verification::{
     bandwidth_storage_manager::BandwidthStorageManager, ClientBandwidth,
 };
-use nym_credentials_interface::TicketType;
 use nym_gateway_requests::{
     types::{BinaryRequest, ServerResponse},
     ClientControlRequest, ClientRequest, GatewayRequestsError, SensitiveServerResponse,
@@ -27,7 +26,7 @@ use nym_gateway_requests::{
 use nym_gateway_storage::error::GatewayStorageError;
 use nym_node_metrics::events::MetricsEvent;
 use nym_sphinx::forwarding::packet::MixPacket;
-use nym_statistics_common::gateways::GatewaySessionEvent;
+use nym_statistics_common::{gateways::GatewaySessionEvent, types::SessionType};
 use nym_task::TaskClient;
 use nym_validator_client::coconut::EcashApiError;
 use rand::{random, CryptoRng, Rng};
@@ -258,7 +257,7 @@ impl<R, S> AuthenticatedHandler<R, S> {
             &self.client.shared_keys,
             iv,
         )?;
-        let maybe_ticket_type = TicketType::try_from_encoded(credential.data.payment.t_type);
+
         let mut verifier = CredentialVerifier::new(
             credential,
             self.inner.shared_state.ecash_verifier.clone(),
@@ -270,14 +269,6 @@ impl<R, S> AuthenticatedHandler<R, S> {
             .await
             .inspect_err(|verification_failure| debug!("{verification_failure}"))?;
         trace!("available total bandwidth: {available_total}");
-
-        if let Ok(ticket_type) = maybe_ticket_type {
-            self.inner.shared_state.metrics_sender.report_unchecked(
-                GatewaySessionEvent::new_ecash_ticket(self.client.address, ticket_type),
-            );
-        } else {
-            error!("Somehow verified a ticket with an unknown ticket type");
-        }
 
         Ok(ServerResponse::Bandwidth { available_total })
     }
@@ -334,7 +325,7 @@ impl<R, S> AuthenticatedHandler<R, S> {
     async fn handle_forget_me(
         &mut self,
         client: bool,
-        stats: bool,
+        _stats: bool,
     ) -> Result<ServerResponse, RequestHandlingError> {
         if client {
             self.inner()
@@ -343,10 +334,18 @@ impl<R, S> AuthenticatedHandler<R, S> {
                 .handle_forget_me(self.client.address)
                 .await?;
         }
-        if stats {
-            self.send_metrics(GatewaySessionEvent::new_session_delete(self.client.address));
-        }
         Ok(SensitiveServerResponse::ForgetMeAck {}.encrypt(&self.client.shared_keys)?)
+    }
+
+    async fn handle_remember_me(
+        &self,
+        session_type: SessionType,
+    ) -> Result<ServerResponse, RequestHandlingError> {
+        self.send_metrics(GatewaySessionEvent::new_session_remember(
+            session_type,
+            self.client.address,
+        ));
+        Ok(SensitiveServerResponse::RememberMeAck {}.encrypt(&self.client.shared_keys)?)
     }
 
     async fn handle_key_upgrade(
@@ -393,6 +392,9 @@ impl<R, S> AuthenticatedHandler<R, S> {
                 derived_key_digest,
             } => self.handle_key_upgrade(hkdf_salt, derived_key_digest).await,
             ClientRequest::ForgetMe { client, stats } => self.handle_forget_me(client, stats).await,
+            ClientRequest::RememberMe { session_type } => {
+                self.handle_remember_me(session_type).await
+            }
             _ => Err(RequestHandlingError::UnknownEncryptedTextRequest),
         }
     }

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-node-status-api"
-version = "2.3.0"
+version = "2.3.1"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
@@ -9,7 +9,7 @@ use nym_validator_client::{
 };
 use time::OffsetDateTime;
 
-use nym_node_metrics::entry::SessionType;
+use nym_statistics_common::types::SessionType;
 use std::collections::HashMap;
 use tokio::time::Duration;
 use tracing::instrument;

--- a/nym-node/Cargo.toml
+++ b/nym-node/Cargo.toml
@@ -63,6 +63,7 @@ nym-sphinx-types = { path = "../common/nymsphinx/types" }
 nym-sphinx-forwarding = { path = "../common/nymsphinx/forwarding" }
 nym-sphinx-routing = { path = "../common/nymsphinx/routing" }
 nym-sphinx-params = { path = "../common/nymsphinx/params" }
+nym-statistics-common = { path = "../common/statistics" }
 nym-task = { path = "../common/task" }
 nym-types = { path = "../common/types" }
 nym-validator-client = { path = "../common/client-libs/validator-client" }

--- a/nym-node/nym-node-metrics/src/entry.rs
+++ b/nym-node/nym-node-metrics/src/entry.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use nym_statistics_common::hash_identifier;
+use nym_statistics_common::{hash_identifier, types::SessionType};
 use std::time::Duration;
 use time::{Date, OffsetDateTime};
 use tokio::sync::{RwLock, RwLockReadGuard};
@@ -63,19 +63,6 @@ pub struct FinishedSession {
 impl FinishedSession {
     pub fn new(duration: Duration, typ: SessionType) -> Self {
         FinishedSession { duration, typ }
-    }
-}
-
-#[derive(PartialEq, Copy, Clone, strum::Display, strum::EnumString)]
-pub enum SessionType {
-    Vpn,
-    Mixnet,
-    Unknown,
-}
-
-impl SessionType {
-    pub fn from_string<S: AsRef<str>>(s: S) -> Self {
-        s.as_ref().parse().unwrap_or(Self::Unknown)
     }
 }
 

--- a/nym-node/nym-node-metrics/src/entry.rs
+++ b/nym-node/nym-node-metrics/src/entry.rs
@@ -69,6 +69,7 @@ impl FinishedSession {
 pub struct ActiveSession {
     pub start: OffsetDateTime,
     pub typ: SessionType,
+    pub remember: bool,
 }
 
 impl ActiveSession {
@@ -76,11 +77,15 @@ impl ActiveSession {
         ActiveSession {
             start: start_time,
             typ: SessionType::Unknown,
+            remember: false,
         }
     }
 
     pub fn set_type(&mut self, typ: SessionType) {
         self.typ = typ;
+    }
+    pub fn remember(&mut self) {
+        self.remember = true;
     }
 
     pub fn end_at(self, stop_time: OffsetDateTime) -> Option<FinishedSession> {


### PR DESCRIPTION
# Description

Sessions stats collected from gateway proved themselves to be incredibly noisy. In an effort to reduce the noise, `ForgetMe` was introduced at the end of sessions to prompt gateways to forget a specific session. 
This flag helped reduce the amount of noise, but alone it's not enough (e.g. `ForgetMe` can't be sent by non-sdk client)

Therefore we're turning the whole thing and around and introducing a `RememberMe` flag, to prompt the gateways to actually remember said session.

## What this PR does
- Disable the `stats` part of the `ForgetMe` flag. It's still there for compatibility, but it now has no effect
- Introduce a `RememberMe` message, that gets sent at the end of the connection by SDK clients. It include a session type to tag said session as well
- Change collection logic on gateways : The new default is to **NOT** record any session data, unless a `RememberMe` message was received. In that case, the session will get its type and be recorded. The data being served on the self-described API doesn't change

## What this PR doesn't do
- This PR doesn't allow native and socks5 client to use that `RememberMe` flag. It's impossible to send something right before stopping the process, since parts needed to do this might have already shut down on their own. This is already the case of the `ForgetMe` flag


### Once this is merged

The vpn-client code should use the `with_remember_me` option when building a MixnetClient, once it's gonna use a nym-core version that contains this PR
https://github.com/nymtech/nym-vpn-client/pull/2737

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5742)
<!-- Reviewable:end -->
