### PR TITLE
fix parallel feature in ecash crate with send + sync

### DIFF
--- a/common/nym_offline_compact_ecash/src/scheme/coin_indices_signatures.rs
+++ b/common/nym_offline_compact_ecash/src/scheme/coin_indices_signatures.rs
@@ -179,7 +179,7 @@ fn _aggregate_indices_signatures<B>(
     validate_shares: bool,
 ) -> Result<Vec<CoinIndexSignature>>
 where
-    B: Borrow<PartialCoinIndexSignature>,
+    B: Borrow<PartialCoinIndexSignature> + Send + Sync,
 {
     // Check if all indices are unique
     if signatures_shares
@@ -271,7 +271,7 @@ pub fn aggregate_indices_signatures<B>(
     signatures_shares: &[CoinIndexSignatureShare<B>],
 ) -> Result<Vec<CoinIndexSignature>>
 where
-    B: Borrow<PartialCoinIndexSignature>,
+    B: Borrow<PartialCoinIndexSignature> + Send + Sync,
 {
     _aggregate_indices_signatures(params, vk, signatures_shares, true)
 }

--- a/common/nym_offline_compact_ecash/src/scheme/expiration_date_signatures.rs
+++ b/common/nym_offline_compact_ecash/src/scheme/expiration_date_signatures.rs
@@ -38,7 +38,7 @@ impl From<AnnotatedExpirationDateSignature> for ExpirationDateSignature {
 
 pub struct ExpirationDateSignatureShare<B = PartialExpirationDateSignature>
 where
-    B: Borrow<PartialExpirationDateSignature>,
+    B: Borrow<PartialExpirationDateSignature> + Send + Sync,
 {
     pub index: SignerIndex,
     pub key: VerificationKeyAuth,
@@ -205,7 +205,7 @@ fn _aggregate_expiration_signatures<B>(
     validate_shares: bool,
 ) -> Result<Vec<ExpirationDateSignature>>
 where
-    B: Borrow<ExpirationDateSignature>,
+    B: Borrow<ExpirationDateSignature> + Send + Sync,
 {
     // Check if all indices are unique
     if signatures_shares
@@ -304,7 +304,7 @@ pub fn aggregate_expiration_signatures<B>(
     signatures_shares: &[ExpirationDateSignatureShare<B>],
 ) -> Result<Vec<ExpirationDateSignature>>
 where
-    B: Borrow<PartialExpirationDateSignature>,
+    B: Borrow<PartialExpirationDateSignature> + Send + Sync,
 {
     _aggregate_expiration_signatures(vk, expiration_date, signatures_shares, true)
 }


### PR DESCRIPTION
In the current state, the `nym-compact-ecash` crate doesn't compile with the feature flag `par_verify` and `par_signing` because generic type `B` is not `Send + Sync` and so `par_iter` can't be called on it.

This fixes that problem

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5744)
<!-- Reviewable:end -->
