### PR TITLE
feat: nym-api bincode + yaml support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4733,7 +4733,7 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nym-api"
-version = "1.1.56"
+version = "1.1.55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5808,6 +5808,7 @@ version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
  "axum-client-ip",
+ "bincode",
  "bytes",
  "colored",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5816,7 +5816,6 @@ dependencies = [
  "futures",
  "mime",
  "serde",
- "serde_json",
  "serde_yaml",
  "subtle 2.6.1",
  "tower 0.5.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5785,12 +5785,14 @@ name = "nym-http-api-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bincode",
  "bytes",
  "encoding_rs",
  "hickory-resolver",
  "http 1.3.1",
  "mime",
  "nym-bin-common",
+ "nym-http-api-common",
  "once_cell",
  "reqwest 0.12.15",
  "serde",

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -22,7 +22,7 @@ nym-group-contract-common = { path = "../../cosmwasm-smart-contracts/group-contr
 nym-serde-helpers = { path = "../../serde-helpers", features = ["hex", "base64"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-nym-http-api-client = { path = "../../../common/http-api-client" }
+nym-http-api-client = { path = "../../../common/http-api-client", features = ["bincode"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -383,8 +383,8 @@ impl NymApiClient {
     }
 
     #[must_use]
-    pub fn with_bincode(mut self) -> Self {
-        self.use_bincode = true;
+    pub fn with_bincode(mut self, use_bincode: bool) -> Self {
+        self.use_bincode = use_bincode;
         self
     }
 

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -351,6 +351,15 @@ pub struct NymApiClient {
     // we could re-implement the communication with the REST API on port 1317
 }
 
+impl From<nym_api::Client> for NymApiClient {
+    fn from(nym_api: nym_api::Client) -> Self {
+        NymApiClient {
+            use_bincode: false,
+            nym_api,
+        }
+    }
+}
+
 // we have to allow the use of deprecated method here as they're calling the deprecated trait methods
 #[allow(deprecated)]
 impl NymApiClient {

--- a/common/client-libs/validator-client/src/nym_api/mod.rs
+++ b/common/client-libs/validator-client/src/nym_api/mod.rs
@@ -318,6 +318,7 @@ pub trait NymApiClientExt: ApiClient {
         no_legacy: bool,
         page: Option<u32>,
         per_page: Option<u32>,
+        use_bincode: bool,
     ) -> Result<PaginatedCachedNodesResponse<SkimmedNode>, NymAPIError> {
         let mut params = Vec::new();
 
@@ -333,7 +334,11 @@ pub trait NymApiClientExt: ApiClient {
             params.push(("per_page", per_page.to_string()))
         }
 
-        self.get_json(
+        if use_bincode {
+            params.push(("output", "bincode".to_string()))
+        }
+
+        self.get_response(
             &[
                 routes::API_VERSION,
                 "unstable",
@@ -355,6 +360,7 @@ pub trait NymApiClientExt: ApiClient {
         no_legacy: bool,
         page: Option<u32>,
         per_page: Option<u32>,
+        use_bincode: bool,
     ) -> Result<PaginatedCachedNodesResponse<SkimmedNode>, NymAPIError> {
         let mut params = Vec::new();
 
@@ -370,7 +376,11 @@ pub trait NymApiClientExt: ApiClient {
             params.push(("per_page", per_page.to_string()))
         }
 
-        self.get_json(
+        if use_bincode {
+            params.push(("output", "bincode".to_string()))
+        }
+
+        self.get_response(
             &[
                 routes::API_VERSION,
                 "unstable",
@@ -392,6 +402,7 @@ pub trait NymApiClientExt: ApiClient {
         no_legacy: bool,
         page: Option<u32>,
         per_page: Option<u32>,
+        use_bincode: bool,
     ) -> Result<PaginatedCachedNodesResponse<SkimmedNode>, NymAPIError> {
         let mut params = Vec::new();
 
@@ -407,7 +418,11 @@ pub trait NymApiClientExt: ApiClient {
             params.push(("per_page", per_page.to_string()))
         }
 
-        self.get_json(
+        if use_bincode {
+            params.push(("output", "bincode".to_string()))
+        }
+
+        self.get_response(
             &[
                 routes::API_VERSION,
                 "unstable",
@@ -427,6 +442,7 @@ pub trait NymApiClientExt: ApiClient {
         no_legacy: bool,
         page: Option<u32>,
         per_page: Option<u32>,
+        use_bincode: bool,
     ) -> Result<PaginatedCachedNodesResponse<SkimmedNode>, NymAPIError> {
         let mut params = Vec::new();
 
@@ -442,7 +458,11 @@ pub trait NymApiClientExt: ApiClient {
             params.push(("per_page", per_page.to_string()))
         }
 
-        self.get_json(
+        if use_bincode {
+            params.push(("output", "bincode".to_string()))
+        }
+
+        self.get_response(
             &[
                 routes::API_VERSION,
                 "unstable",

--- a/common/http-api-client/Cargo.toml
+++ b/common/http-api-client/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+bincode = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json", "gzip"] }
 http.workspace = true
 url = { workspace = true }
@@ -26,7 +27,7 @@ bytes = { workspace = true }
 encoding_rs = { workspace = true }
 mime = { workspace = true }
 
-
+nym-http-api-common = { path = "../http-api-common", default-features = false, optional = true }
 nym-bin-common = { path = "../bin-common" }
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies]
@@ -39,3 +40,6 @@ features = ["tokio"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
+
+[features]
+bincode = ["dep:bincode", "nym-http-api-common", "nym-http-api-common/bincode"]

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -144,7 +144,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::time::Duration;
 use thiserror::Error;
-use tracing::{instrument, warn};
+use tracing::{debug, instrument, warn};
 use url::Url;
 
 use bytes::Bytes;
@@ -998,7 +998,7 @@ where
     // if content type header is missing, fallback to our old default, json
     let mime = try_get_mime_type(headers).unwrap_or(mime::APPLICATION_JSON);
 
-    tracing::debug!("attempting to parse response as {mime}");
+    debug!("attempting to parse response as {mime}");
 
     // unfortunately we can't use stronger typing for subtype as "bincode" is not a defined mime type
     match (mime.type_(), mime.subtype().as_str()) {
@@ -1006,7 +1006,7 @@ where
         #[cfg(feature = "bincode")]
         (mime::APPLICATION, "bincode") => decode_as_bincode(headers, content),
         (_, _) => {
-            warn!("unrecognised mime type {mime}. falling back to json decoding...");
+            debug!("unrecognised mime type {mime}. falling back to json decoding...");
             decode_as_json(headers, content)
         }
     }

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -147,7 +147,10 @@ use thiserror::Error;
 use tracing::{instrument, warn};
 use url::Url;
 
+use bytes::Bytes;
+use http::header::CONTENT_TYPE;
 use http::HeaderMap;
+use mime::Mime;
 pub use reqwest::IntoUrl;
 #[cfg(not(target_arch = "wasm32"))]
 use std::net::SocketAddr;
@@ -210,11 +213,8 @@ pub enum HttpClientError<E: Display = String> {
     #[error("failed to resolve request. status: '{status}', additional error message: {error}")]
     EndpointFailure { status: StatusCode, error: E },
 
-    #[error("failed to decode response body: {source} from {content}")]
-    ResponseDecodeFailure {
-        source: serde_json::Error,
-        content: String,
-    },
+    #[error("failed to decode response body: {message} from {content}")]
+    ResponseDecodeFailure { message: String, content: String },
 
     #[cfg(target_arch = "wasm32")]
     #[error("the request has timed out")]
@@ -698,7 +698,25 @@ pub trait ApiClient: ApiClientCore {
     /// defined key-value parameters, e.g. `[("since", "12345")]`. Attempt to parse the response
     /// into the provided type `T`.
     #[instrument(level = "debug", skip_all)]
+    // TODO: deprecate in favour of get_response that works based on mime type in the response
     async fn get_json<T, K, V, E>(
+        &self,
+        path: PathSegments<'_>,
+        params: Params<'_, K, V>,
+    ) -> Result<T, HttpClientError<E>>
+    where
+        for<'a> T: Deserialize<'a>,
+        K: AsRef<str> + Sync,
+        V: AsRef<str> + Sync,
+        E: Display + DeserializeOwned,
+    {
+        self.get_response(path, params).await
+    }
+
+    /// 'get' data from the segment-defined path, e.g. `["api", "v1", "mixnodes"]`, with tuple
+    /// defined key-value parameters, e.g. `[("since", "12345")]`. Attempt to parse the response
+    /// into the provided type `T` based on the content type header
+    async fn get_response<T, K, V, E>(
         &self,
         path: PathSegments<'_>,
         params: Params<'_, K, V>,
@@ -877,14 +895,10 @@ fn sanitize_url<K: AsRef<str>, V: AsRef<str>>(
     url
 }
 
-fn decode_as_text(bytes: &bytes::Bytes, headers: HeaderMap) -> String {
+fn decode_as_text(bytes: &bytes::Bytes, headers: &HeaderMap) -> String {
     use encoding_rs::{Encoding, UTF_8};
-    use mime::Mime;
 
-    let content_type = headers
-        .get(http::header::CONTENT_TYPE)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<Mime>().ok());
+    let content_type = try_get_mime_type(headers);
 
     let encoding_name = content_type
         .as_ref()
@@ -897,7 +911,7 @@ fn decode_as_text(bytes: &bytes::Bytes, headers: HeaderMap) -> String {
     text.into_owned()
 }
 
-/// Attempt to parse a json object from an HTTP response
+/// Attempt to parse a response object from an HTTP response
 #[instrument(level = "debug", skip_all)]
 pub async fn parse_response<T, E>(res: Response, allow_empty: bool) -> Result<T, HttpClientError<E>>
 where
@@ -919,16 +933,7 @@ where
         // internally reqwest is first retrieving bytes and then performing parsing via serde_json
         // (and similarly does the same thing for text())
         let full = res.bytes().await?;
-        match serde_json::from_slice(&full) {
-            Ok(data) => Ok(data),
-            Err(err) => {
-                let content = decode_as_text(&full, headers);
-                Err(HttpClientError::ResponseDecodeFailure {
-                    source: err,
-                    content,
-                })
-            }
-        }
+        decode_raw_response(&headers, full)
     } else if res.status() == StatusCode::NOT_FOUND {
         Err(HttpClientError::NotFound)
     } else {
@@ -945,6 +950,73 @@ where
             Err(HttpClientError::GenericRequestFailure(plaintext))
         }
     }
+}
+
+fn decode_as_json<T, E>(headers: &HeaderMap, content: Bytes) -> Result<T, HttpClientError<E>>
+where
+    T: DeserializeOwned,
+    E: DeserializeOwned + Display,
+{
+    match serde_json::from_slice(&content) {
+        Ok(data) => Ok(data),
+        Err(err) => {
+            let content = decode_as_text(&content, headers);
+            Err(HttpClientError::ResponseDecodeFailure {
+                message: err.to_string(),
+                content,
+            })
+        }
+    }
+}
+
+#[cfg(feature = "bincode")]
+fn decode_as_bincode<T, E>(headers: &HeaderMap, content: Bytes) -> Result<T, HttpClientError<E>>
+where
+    T: DeserializeOwned,
+    E: DeserializeOwned + Display,
+{
+    use bincode::Options;
+
+    let opts = nym_http_api_common::make_bincode_serializer();
+    match opts.deserialize(&content) {
+        Ok(data) => Ok(data),
+        Err(err) => {
+            let content = decode_as_text(&content, headers);
+            Err(HttpClientError::ResponseDecodeFailure {
+                message: err.to_string(),
+                content,
+            })
+        }
+    }
+}
+
+fn decode_raw_response<T, E>(headers: &HeaderMap, content: Bytes) -> Result<T, HttpClientError<E>>
+where
+    T: DeserializeOwned,
+    E: DeserializeOwned + Display,
+{
+    // if content type header is missing, fallback to our old default, json
+    let mime = try_get_mime_type(headers).unwrap_or(mime::APPLICATION_JSON);
+
+    tracing::debug!("attempting to parse response as {mime}");
+
+    // unfortunately we can't use stronger typing for subtype as "bincode" is not a defined mime type
+    match (mime.type_(), mime.subtype().as_str()) {
+        (mime::APPLICATION, "json") => decode_as_json(headers, content),
+        #[cfg(feature = "bincode")]
+        (mime::APPLICATION, "bincode") => decode_as_bincode(headers, content),
+        (_, _) => {
+            warn!("unrecognised mime type {mime}. falling back to json decoding...");
+            decode_as_json(headers, content)
+        }
+    }
+}
+
+fn try_get_mime_type(headers: &HeaderMap) -> Option<Mime> {
+    headers
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<Mime>().ok())
 }
 
 #[cfg(test)]

--- a/common/http-api-common/Cargo.toml
+++ b/common/http-api-common/Cargo.toml
@@ -11,22 +11,39 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum-client-ip.workspace = true
-axum.workspace = true
+axum = { workspace = true, optional = true }
+axum-client-ip = { workspace = true, optional = true }
 bincode = { workspace = true, optional = true }
-bytes = { workspace = true }
-colored.workspace = true
-futures = { workspace = true }
-mime = { workspace = true }
+bytes = { workspace = true, optional = true }
+colored = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
+mime = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
-serde_yaml = { workspace = true }
-subtle.workspace = true
-tower = { workspace = true }
+serde_yaml = { workspace = true, optional = true }
+subtle = { workspace = true, optional = true }
+tower = { workspace = true, optional = true }
 tracing.workspace = true
 utoipa = { workspace = true, optional = true }
-zeroize = { workspace = true }
+zeroize = { workspace = true, optional = true }
 
 [features]
+default = []
+output = [
+    "axum",
+    "bytes",
+    "mime",
+    "serde_yaml"
+]
+
+middleware = [
+    "axum",
+    "axum-client-ip",
+    "colored",
+    "futures",
+    "subtle",
+    "tower",
+    "zeroize"
+]
+
 utoipa = ["dep:utoipa"]
 bincode = ["dep:bincode"]

--- a/common/http-api-common/Cargo.toml
+++ b/common/http-api-common/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 [dependencies]
 axum-client-ip.workspace = true
 axum.workspace = true
+bincode = { workspace = true, optional = true }
 bytes = { workspace = true }
 colored.workspace = true
 futures = { workspace = true }
@@ -28,3 +29,4 @@ zeroize = { workspace = true }
 
 [features]
 utoipa = ["dep:utoipa"]
+bincode = ["dep:bincode"]

--- a/common/http-api-common/src/lib.rs
+++ b/common/http-api-common/src/lib.rs
@@ -1,9 +1,10 @@
-// Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
+// Copyright 2023-2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::http::{header, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
+use bincode::Options;
 use bytes::{BufMut, BytesMut};
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +14,8 @@ pub mod middleware;
 pub enum FormattedResponse<T> {
     Json(Json<T>),
     Yaml(Yaml<T>),
+    #[cfg(feature = "bincode")]
+    Bincode(Bincode<T>),
 }
 
 impl<T> IntoResponse for FormattedResponse<T>
@@ -23,6 +26,8 @@ where
         match self {
             FormattedResponse::Json(json_response) => json_response.into_response(),
             FormattedResponse::Yaml(yaml_response) => yaml_response.into_response(),
+            #[cfg(feature = "bincode")]
+            FormattedResponse::Bincode(bincode_response) => bincode_response.into_response(),
         }
     }
 }
@@ -34,6 +39,8 @@ pub enum Output {
     #[default]
     Json,
     Yaml,
+    #[cfg(feature = "bincode")]
+    Bincode,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Copy, Clone)]
@@ -48,6 +55,8 @@ impl Output {
         match self {
             Output::Json => FormattedResponse::Json(Json(data)),
             Output::Yaml => FormattedResponse::Yaml(Yaml(data)),
+            #[cfg(feature = "bincode")]
+            Output::Bincode => FormattedResponse::Bincode(Bincode(data)),
         }
     }
 }
@@ -74,6 +83,51 @@ where
                 [(
                     header::CONTENT_TYPE,
                     HeaderValue::from_static("application/yaml"),
+                )],
+                buf.into_inner().freeze(),
+            )
+                .into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+                )],
+                err.to_string(),
+            )
+                .into_response(),
+        }
+    }
+}
+
+// be explicit about those values because bincode uses different defaults in different places
+#[cfg(feature = "bincode")]
+pub fn make_bincode_serializer() -> impl bincode::Options {
+    use bincode::Options;
+    bincode::DefaultOptions::new()
+        .with_little_endian()
+        .with_varint_encoding()
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+#[must_use]
+#[cfg(feature = "bincode")]
+pub struct Bincode<T>(pub T);
+
+#[cfg(feature = "bincode")]
+impl<T> IntoResponse for Bincode<T>
+where
+    T: Serialize,
+{
+    // replicates axum's Json
+    fn into_response(self) -> Response {
+        let mut buf = BytesMut::with_capacity(128).writer();
+
+        match make_bincode_serializer().serialize_into(&mut buf, &self.0) {
+            Ok(()) => (
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/bincode"),
                 )],
                 buf.into_inner().freeze(),
             )

--- a/common/http-api-common/src/lib.rs
+++ b/common/http-api-common/src/lib.rs
@@ -1,113 +1,15 @@
 // Copyright 2023-2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use axum::http::{header, HeaderValue, StatusCode};
-use axum::response::{IntoResponse, Response};
-use axum::Json;
-use bytes::{BufMut, BytesMut};
-use serde::{Deserialize, Serialize};
-
+#[cfg(feature = "middleware")]
 pub mod middleware;
 
-#[derive(Debug, Clone)]
-pub enum FormattedResponse<T> {
-    Json(Json<T>),
-    Yaml(Yaml<T>),
-    #[cfg(feature = "bincode")]
-    Bincode(Bincode<T>),
-}
-impl<T> FormattedResponse<T> {
-    pub fn into_inner(self) -> T {
-        match self {
-            FormattedResponse::Json(inner) => inner.0,
-            FormattedResponse::Yaml(inner) => inner.0,
-            #[cfg(feature = "bincode")]
-            FormattedResponse::Bincode(inner) => inner.0,
-        }
-    }
-}
+#[cfg(feature = "output")]
+pub mod response;
 
-impl<T> IntoResponse for FormattedResponse<T>
-where
-    T: Serialize,
-{
-    fn into_response(self) -> Response {
-        match self {
-            FormattedResponse::Json(json_response) => json_response.into_response(),
-            FormattedResponse::Yaml(yaml_response) => yaml_response.into_response(),
-            #[cfg(feature = "bincode")]
-            FormattedResponse::Bincode(bincode_response) => bincode_response.into_response(),
-        }
-    }
-}
-
-#[derive(Default, Debug, Serialize, Deserialize, Copy, Clone)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[serde(rename_all = "lowercase")]
-pub enum Output {
-    #[default]
-    Json,
-    Yaml,
-    #[cfg(feature = "bincode")]
-    Bincode,
-}
-
-#[derive(Default, Debug, Serialize, Deserialize, Copy, Clone)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::IntoParams, utoipa::ToSchema))]
-#[serde(default)]
-pub struct OutputParams {
-    pub output: Option<Output>,
-}
-
-impl Output {
-    pub fn to_response<T: Serialize>(self, data: T) -> FormattedResponse<T> {
-        match self {
-            Output::Json => FormattedResponse::Json(Json(data)),
-            Output::Yaml => FormattedResponse::Yaml(Yaml(data)),
-            #[cfg(feature = "bincode")]
-            Output::Bincode => FormattedResponse::Bincode(Bincode(data)),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-#[must_use]
-pub struct Yaml<T>(pub T);
-
-impl<T> From<T> for Yaml<T> {
-    fn from(inner: T) -> Self {
-        Self(inner)
-    }
-}
-
-impl<T> IntoResponse for Yaml<T>
-where
-    T: Serialize,
-{
-    // replicates axum's Json
-    fn into_response(self) -> Response {
-        let mut buf = BytesMut::with_capacity(128).writer();
-        match serde_yaml::to_writer(&mut buf, &self.0) {
-            Ok(()) => (
-                [(
-                    header::CONTENT_TYPE,
-                    HeaderValue::from_static("application/yaml"),
-                )],
-                buf.into_inner().freeze(),
-            )
-                .into_response(),
-            Err(err) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                [(
-                    header::CONTENT_TYPE,
-                    HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
-                )],
-                err.to_string(),
-            )
-                .into_response(),
-        }
-    }
-}
+// don't break existing imports
+#[cfg(feature = "output")]
+pub use response::*;
 
 // be explicit about those values because bincode uses different defaults in different places
 #[cfg(feature = "bincode")]
@@ -116,41 +18,4 @@ pub fn make_bincode_serializer() -> impl bincode::Options {
     bincode::DefaultOptions::new()
         .with_little_endian()
         .with_varint_encoding()
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-#[must_use]
-#[cfg(feature = "bincode")]
-pub struct Bincode<T>(pub T);
-
-#[cfg(feature = "bincode")]
-impl<T> IntoResponse for Bincode<T>
-where
-    T: Serialize,
-{
-    // replicates axum's Json
-    fn into_response(self) -> Response {
-        use bincode::Options;
-        let mut buf = BytesMut::with_capacity(128).writer();
-
-        match make_bincode_serializer().serialize_into(&mut buf, &self.0) {
-            Ok(()) => (
-                [(
-                    header::CONTENT_TYPE,
-                    HeaderValue::from_static("application/bincode"),
-                )],
-                buf.into_inner().freeze(),
-            )
-                .into_response(),
-            Err(err) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                [(
-                    header::CONTENT_TYPE,
-                    HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
-                )],
-                err.to_string(),
-            )
-                .into_response(),
-        }
-    }
 }

--- a/common/http-api-common/src/response.rs
+++ b/common/http-api-common/src/response.rs
@@ -1,0 +1,145 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use bytes::{BufMut, BytesMut};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone)]
+pub enum FormattedResponse<T> {
+    Json(Json<T>),
+    Yaml(Yaml<T>),
+    #[cfg(feature = "bincode")]
+    Bincode(Bincode<T>),
+}
+impl<T> FormattedResponse<T> {
+    pub fn into_inner(self) -> T {
+        match self {
+            FormattedResponse::Json(inner) => inner.0,
+            FormattedResponse::Yaml(inner) => inner.0,
+            #[cfg(feature = "bincode")]
+            FormattedResponse::Bincode(inner) => inner.0,
+        }
+    }
+}
+
+impl<T> IntoResponse for FormattedResponse<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> Response {
+        match self {
+            FormattedResponse::Json(json_response) => json_response.into_response(),
+            FormattedResponse::Yaml(yaml_response) => yaml_response.into_response(),
+            #[cfg(feature = "bincode")]
+            FormattedResponse::Bincode(bincode_response) => bincode_response.into_response(),
+        }
+    }
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, Copy, Clone)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum Output {
+    #[default]
+    Json,
+    Yaml,
+    #[cfg(feature = "bincode")]
+    Bincode,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, Copy, Clone)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::IntoParams, utoipa::ToSchema))]
+#[serde(default)]
+pub struct OutputParams {
+    pub output: Option<Output>,
+}
+
+impl Output {
+    pub fn to_response<T: Serialize>(self, data: T) -> FormattedResponse<T> {
+        match self {
+            Output::Json => FormattedResponse::Json(Json(data)),
+            Output::Yaml => FormattedResponse::Yaml(Yaml(data)),
+            #[cfg(feature = "bincode")]
+            Output::Bincode => FormattedResponse::Bincode(Bincode(data)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+#[must_use]
+pub struct Yaml<T>(pub T);
+
+impl<T> From<T> for Yaml<T> {
+    fn from(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
+impl<T> IntoResponse for Yaml<T>
+where
+    T: Serialize,
+{
+    // replicates axum's Json
+    fn into_response(self) -> Response {
+        let mut buf = BytesMut::with_capacity(128).writer();
+        match serde_yaml::to_writer(&mut buf, &self.0) {
+            Ok(()) => (
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/yaml"),
+                )],
+                buf.into_inner().freeze(),
+            )
+                .into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+                )],
+                err.to_string(),
+            )
+                .into_response(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+#[must_use]
+#[cfg(feature = "bincode")]
+pub struct Bincode<T>(pub T);
+
+#[cfg(feature = "bincode")]
+impl<T> IntoResponse for Bincode<T>
+where
+    T: Serialize,
+{
+    // replicates axum's Json
+    fn into_response(self) -> Response {
+        use bincode::Options;
+        let mut buf = BytesMut::with_capacity(128).writer();
+
+        match crate::make_bincode_serializer().serialize_into(&mut buf, &self.0) {
+            Ok(()) => (
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/bincode"),
+                )],
+                buf.into_inner().freeze(),
+            )
+                .into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+                )],
+                err.to_string(),
+            )
+                .into_response(),
+        }
+    }
+}

--- a/nym-api/Cargo.toml
+++ b/nym-api/Cargo.toml
@@ -116,7 +116,7 @@ nym-bin-common = { path = "../common/bin-common", features = ["output_format", "
 nym-node-tester-utils = { path = "../common/node-tester-utils" }
 nym-node-requests = { path = "../nym-node/nym-node-requests" }
 nym-types = { path = "../common/types" }
-nym-http-api-common = { path = "../common/http-api-common", features = ["utoipa", "bincode"] }
+nym-http-api-common = { path = "../common/http-api-common", features = ["utoipa", "bincode", "output", "middleware"] }
 nym-serde-helpers = { path = "../common/serde-helpers", features = ["date"] }
 nym-ticketbooks-merkle = { path = "../common/ticketbooks-merkle" }
 nym-statistics-common = { path = "../common/statistics" }

--- a/nym-api/Cargo.toml
+++ b/nym-api/Cargo.toml
@@ -116,7 +116,7 @@ nym-bin-common = { path = "../common/bin-common", features = ["output_format", "
 nym-node-tester-utils = { path = "../common/node-tester-utils" }
 nym-node-requests = { path = "../nym-node/nym-node-requests" }
 nym-types = { path = "../common/types" }
-nym-http-api-common = { path = "../common/http-api-common", features = ["utoipa"] }
+nym-http-api-common = { path = "../common/http-api-common", features = ["utoipa", "bincode"] }
 nym-serde-helpers = { path = "../common/serde-helpers", features = ["date"] }
 nym-ticketbooks-merkle = { path = "../common/ticketbooks-merkle" }
 nym-statistics-common = { path = "../common/statistics" }

--- a/nym-api/src/ecash/api_routes/aggregation.rs
+++ b/nym-api/src/ecash/api_routes/aggregation.rs
@@ -7,12 +7,13 @@ use crate::ecash::state::EcashState;
 use crate::node_status_api::models::AxumResult;
 use crate::support::http::state::AppState;
 use axum::extract::{Query, State};
-use axum::{Json, Router};
+use axum::Router;
 use nym_api_requests::ecash::models::{
     AggregatedCoinIndicesSignatureResponse, AggregatedExpirationDateSignatureResponse,
 };
 use nym_api_requests::ecash::VerificationKeyResponse;
 use nym_ecash_time::{cred_exp_date, EcashTime};
+use nym_http_api_common::{FormattedResponse, Output};
 use nym_validator_client::nym_api::rfc_3339_date;
 use serde::Deserialize;
 use std::sync::Arc;
@@ -45,26 +46,32 @@ pub(crate) fn aggregation_routes() -> Router<AppState> {
     ),
     path = "/v1/ecash/master-verification-key",
     responses(
-        (status = 200, body = VerificationKeyResponse)
-    )
+        (status = 200, content(
+            (VerificationKeyResponse = "application/json"),
+            (VerificationKeyResponse = "application/yaml"),
+            (VerificationKeyResponse = "application/bincode")
+        ))
+    ),
 )]
 async fn master_verification_key(
     State(state): State<Arc<EcashState>>,
-    Query(EpochIdParam { epoch_id }): Query<EpochIdParam>,
-) -> AxumResult<Json<VerificationKeyResponse>> {
+    Query(EpochIdParam { epoch_id, output }): Query<EpochIdParam>,
+) -> AxumResult<FormattedResponse<VerificationKeyResponse>> {
     trace!("aggregated_verification_key request");
+    let output = output.unwrap_or_default();
 
     // see if we're not in the middle of new dkg
     state.ensure_dkg_not_in_progress().await?;
 
     let key = state.master_verification_key(epoch_id).await?;
 
-    Ok(Json(VerificationKeyResponse::new(key.clone())))
+    Ok(output.to_response(VerificationKeyResponse::new(key.clone())))
 }
 
 #[derive(Deserialize, IntoParams)]
 struct ExpirationDateParam {
     expiration_date: Option<String>,
+    output: Option<Output>,
 }
 
 #[utoipa::path(
@@ -75,14 +82,22 @@ struct ExpirationDateParam {
     ),
     path = "/v1/ecash/aggregated-expiration-date-signatures",
     responses(
-        (status = 200, body = AggregatedExpirationDateSignatureResponse)
-    )
+        (status = 200, content(
+            (AggregatedExpirationDateSignatureResponse = "application/json"),
+            (AggregatedExpirationDateSignatureResponse = "application/yaml"),
+            (AggregatedExpirationDateSignatureResponse = "application/bincode")
+        ))
+    ),
 )]
 async fn expiration_date_signatures(
     State(state): State<Arc<EcashState>>,
-    Query(ExpirationDateParam { expiration_date }): Query<ExpirationDateParam>,
-) -> AxumResult<Json<AggregatedExpirationDateSignatureResponse>> {
+    Query(ExpirationDateParam {
+        expiration_date,
+        output,
+    }): Query<ExpirationDateParam>,
+) -> AxumResult<FormattedResponse<AggregatedExpirationDateSignatureResponse>> {
     trace!("aggregated_expiration_date_signatures request");
+    let output = output.unwrap_or_default();
 
     let expiration_date = match expiration_date {
         None => cred_exp_date().ecash_date(),
@@ -97,11 +112,13 @@ async fn expiration_date_signatures(
         .master_expiration_date_signatures(expiration_date)
         .await?;
 
-    Ok(Json(AggregatedExpirationDateSignatureResponse {
-        epoch_id: expiration_date_signatures.epoch_id,
-        expiration_date,
-        signatures: expiration_date_signatures.signatures.clone(),
-    }))
+    Ok(
+        output.to_response(AggregatedExpirationDateSignatureResponse {
+            epoch_id: expiration_date_signatures.epoch_id,
+            expiration_date,
+            signatures: expiration_date_signatures.signatures.clone(),
+        }),
+    )
 }
 
 #[utoipa::path(
@@ -112,21 +129,26 @@ async fn expiration_date_signatures(
     ),
     path = "/v1/ecash/aggregated-coin-indices-signatures",
     responses(
-        (status = 200, body = AggregatedCoinIndicesSignatureResponse)
-    )
+        (status = 200, content(
+            (AggregatedCoinIndicesSignatureResponse = "application/json"),
+            (AggregatedCoinIndicesSignatureResponse = "application/yaml"),
+            (AggregatedCoinIndicesSignatureResponse = "application/bincode")
+        ))
+    ),
 )]
 async fn coin_indices_signatures(
-    Query(EpochIdParam { epoch_id }): Query<EpochIdParam>,
+    Query(EpochIdParam { epoch_id, output }): Query<EpochIdParam>,
     State(state): State<Arc<EcashState>>,
-) -> AxumResult<Json<AggregatedCoinIndicesSignatureResponse>> {
+) -> AxumResult<FormattedResponse<AggregatedCoinIndicesSignatureResponse>> {
     trace!("aggregated_coin_indices_signatures request");
 
+    let output = output.unwrap_or_default();
     // see if we're not in the middle of new dkg
     state.ensure_dkg_not_in_progress().await?;
 
     let coin_indices_signatures = state.master_coin_index_signatures(epoch_id).await?;
 
-    Ok(Json(AggregatedCoinIndicesSignatureResponse {
+    Ok(output.to_response(AggregatedCoinIndicesSignatureResponse {
         epoch_id: coin_indices_signatures.epoch_id,
         signatures: coin_indices_signatures.signatures.clone(),
     }))

--- a/nym-api/src/ecash/api_routes/helpers.rs
+++ b/nym-api/src/ecash/api_routes/helpers.rs
@@ -1,7 +1,10 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_http_api_common::Output;
+
 #[derive(serde::Deserialize, utoipa::IntoParams)]
 pub(super) struct EpochIdParam {
     pub(super) epoch_id: Option<u64>,
+    pub(super) output: Option<Output>,
 }

--- a/nym-api/src/ecash/api_routes/issued.rs
+++ b/nym-api/src/ecash/api_routes/issued.rs
@@ -13,6 +13,7 @@ use nym_api_requests::ecash::models::{
     IssuedTicketbooksForCountResponse, IssuedTicketbooksForResponse,
     IssuedTicketbooksOnCountResponse, SignableMessageBody,
 };
+use nym_http_api_common::{FormattedResponse, OutputParams};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::cmp::min;
@@ -80,15 +81,20 @@ pub(crate) struct IssuanceDatePathParam {
     path = "/issued-ticketbooks-count",
     context_path = "/v1/ecash",
     responses(
-        (status = 200, body = IssuedTicketbooksCountResponse),
+        (status = 200, content(
+            (IssuedTicketbooksCountResponse = "application/json"),
+            (IssuedTicketbooksCountResponse = "application/yaml"),
+            (IssuedTicketbooksCountResponse = "application/bincode")
+        )),
         (status = 400, body = String, description = "this nym-api is not an ecash signer in the current epoch"),
     )
 )]
 async fn issued_ticketbooks_count(
     Query(pagination): Query<PaginationRequest>,
     State(state): State<Arc<EcashState>>,
-) -> AxumResult<Json<IssuedTicketbooksCountResponse>> {
+) -> AxumResult<FormattedResponse<IssuedTicketbooksCountResponse>> {
     state.ensure_signer().await?;
+    let output = pagination.output.unwrap_or_default();
 
     let page = pagination.page.unwrap_or_default();
     let per_page = min(
@@ -98,9 +104,7 @@ async fn issued_ticketbooks_count(
         MAX_ISSUANCE_COUNT_PAGE_SIZE,
     );
 
-    Ok(Json(
-        state.get_issued_ticketbooks_count(page, per_page).await?,
-    ))
+    Ok(output.to_response(state.get_issued_ticketbooks_count(page, per_page).await?))
 }
 
 /// Returns number of issued ticketbooks for particular expiration date.
@@ -109,22 +113,28 @@ async fn issued_ticketbooks_count(
     tag = "Ecash",
     get,
     params(
-        ExpirationDatePathParam
+        ExpirationDatePathParam, OutputParams
     ),
     path = "/issued-ticketbooks-for-count/{expiration_date}",
     context_path = "/v1/ecash",
     responses(
-        (status = 200, body = IssuedTicketbooksForCountResponse),
+        (status = 200, content(
+            (IssuedTicketbooksForCountResponse = "application/json"),
+            (IssuedTicketbooksForCountResponse = "application/yaml"),
+            (IssuedTicketbooksForCountResponse = "application/bincode")
+        )),
         (status = 400, body = String, description = "this nym-api is not an ecash signer in the current epoch"),
     )
 )]
 async fn issued_ticketbooks_for_count(
+    Query(output): Query<OutputParams>,
     Path(ExpirationDatePathParam { expiration_date }): Path<ExpirationDatePathParam>,
     State(state): State<Arc<EcashState>>,
-) -> AxumResult<Json<IssuedTicketbooksForCountResponse>> {
+) -> AxumResult<FormattedResponse<IssuedTicketbooksForCountResponse>> {
     state.ensure_signer().await?;
+    let output = output.output.unwrap_or_default();
 
-    Ok(Json(
+    Ok(output.to_response(
         state
             .get_issued_ticketbooks_for_count(expiration_date)
             .await?,
@@ -137,46 +147,56 @@ async fn issued_ticketbooks_for_count(
     tag = "Ecash",
     get,
     params(
-        IssuanceDatePathParam
+        IssuanceDatePathParam, OutputParams
     ),
     path = "/issued-ticketbooks-on-count/{issuance_date}",
     context_path = "/v1/ecash",
     responses(
-        (status = 200, body = IssuedTicketbooksOnCountResponse),
+        (status = 200, content(
+            (IssuedTicketbooksOnCountResponse = "application/json"),
+            (IssuedTicketbooksOnCountResponse = "application/yaml"),
+            (IssuedTicketbooksOnCountResponse = "application/bincode")
+        )),
         (status = 400, body = String, description = "this nym-api is not an ecash signer in the current epoch"),
     )
 )]
 async fn issued_ticketbooks_on_count(
+    Query(output): Query<OutputParams>,
     Path(IssuanceDatePathParam { issuance_date }): Path<IssuanceDatePathParam>,
     State(state): State<Arc<EcashState>>,
-) -> AxumResult<Json<IssuedTicketbooksOnCountResponse>> {
+) -> AxumResult<FormattedResponse<IssuedTicketbooksOnCountResponse>> {
     state.ensure_signer().await?;
+    let output = output.output.unwrap_or_default();
 
-    Ok(Json(
-        state.get_issued_ticketbooks_on_count(issuance_date).await?,
-    ))
+    Ok(output.to_response(state.get_issued_ticketbooks_on_count(issuance_date).await?))
 }
 
 #[utoipa::path(
     tag = "Ecash",
     get,
     params(
-        ExpirationDatePathParam
+        ExpirationDatePathParam, OutputParams
     ),
     path = "/issued-ticketbooks-for/{expiration_date}",
     context_path = "/v1/ecash",
     responses(
-        (status = 200, body = IssuedTicketbooksForResponse),
+        (status = 200, content(
+            (IssuedTicketbooksForResponse = "application/json"),
+            (IssuedTicketbooksForResponse = "application/yaml"),
+            (IssuedTicketbooksForResponse = "application/bincode")
+        )),
         (status = 400, body = String, description = "this nym-api is not an ecash signer in the current epoch"),
     )
 )]
 async fn issued_ticketbooks_for(
+    Query(output): Query<OutputParams>,
     State(state): State<Arc<EcashState>>,
     Path(ExpirationDatePathParam { expiration_date }): Path<ExpirationDatePathParam>,
-) -> AxumResult<Json<IssuedTicketbooksForResponse>> {
+) -> AxumResult<FormattedResponse<IssuedTicketbooksForResponse>> {
     state.ensure_signer().await?;
+    let output = output.output.unwrap_or_default();
 
-    Ok(Json(
+    Ok(output.to_response(
         state
             .get_issued_ticketbooks_deposits_on(expiration_date)
             .await?
@@ -191,17 +211,24 @@ async fn issued_ticketbooks_for(
     path = "/issued-ticketbooks-challenge-commitment",
     context_path = "/v1/ecash",
     responses(
-        (status = 200, body = IssuedTicketbooksChallengeCommitmentResponse),
+        (status = 200, content(
+            (IssuedTicketbooksChallengeCommitmentResponse = "application/json"),
+            (IssuedTicketbooksChallengeCommitmentResponse = "application/yaml"),
+            (IssuedTicketbooksChallengeCommitmentResponse = "application/bincode")
+        )),
         (status = 400, body = String, description = "this nym-api is not an ecash signer in the current epoch"),
-    )
+    ),
+    params(OutputParams)
 )]
 async fn issued_ticketbooks_challenge_commitment(
+    Query(output): Query<OutputParams>,
     State(state): State<Arc<EcashState>>,
     Json(request): Json<IssuedTicketbooksChallengeCommitmentRequest>,
-) -> AxumResult<Json<IssuedTicketbooksChallengeCommitmentResponse>> {
+) -> AxumResult<FormattedResponse<IssuedTicketbooksChallengeCommitmentResponse>> {
     state.ensure_signer().await?;
+    let output = output.output.unwrap_or_default();
 
-    Ok(Json(
+    Ok(output.to_response(
         state
             .get_issued_ticketbooks_challenge_commitment(request)
             .await?
@@ -216,17 +243,24 @@ async fn issued_ticketbooks_challenge_commitment(
     path = "/issued-ticketbooks-data",
     context_path = "/v1/ecash",
     responses(
-        (status = 200, body = IssuedTicketbooksDataResponse),
+        (status = 200, content(
+            (IssuedTicketbooksDataResponse = "application/json"),
+            (IssuedTicketbooksDataResponse = "application/yaml"),
+            (IssuedTicketbooksDataResponse = "application/bincode")
+        )),
         (status = 400, body = String, description = "this nym-api is not an ecash signer in the current epoch"),
-    )
+    ),
+    params(OutputParams)
 )]
 async fn issued_ticketbooks_data(
+    Query(output): Query<OutputParams>,
     State(state): State<Arc<EcashState>>,
     Json(request): Json<IssuedTicketbooksDataRequest>,
-) -> AxumResult<Json<IssuedTicketbooksDataResponse>> {
+) -> AxumResult<FormattedResponse<IssuedTicketbooksDataResponse>> {
     state.ensure_signer().await?;
+    let output = output.output.unwrap_or_default();
 
-    Ok(Json(
+    Ok(output.to_response(
         state
             .get_issued_ticketbooks_data(request)
             .await?

--- a/nym-api/src/ecash/tests/mod.rs
+++ b/nym-api/src/ecash/tests/mod.rs
@@ -415,7 +415,8 @@ impl FakeChainState {
 
     // TODO: make it return a result
     fn execute_dkg_contract(&mut self, sender: MessageInfo, msg: &Binary) {
-        let exec_msg: nym_coconut_dkg_common::msg::ExecuteMsg = from_json(msg).unwrap();
+        let exec_msg: nym_coconut_dkg_common::msg::ExecuteMsg =
+            from_output.to_response(msg).unwrap();
         match exec_msg {
             nym_coconut_dkg_common::msg::ExecuteMsg::VerifyVerificationKeyShare {
                 owner,
@@ -1420,11 +1421,12 @@ impl TestFixture {
         let response = self
             .axum
             .post(&format!("/{API_VERSION}/{ECASH_ROUTES}/{ECASH_BLIND_SIGN}"))
-            .json(&req)
+            .output
+            .to_response(&req)
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);
-        response.json()
+        response.output.to_response()
     }
 
     async fn issued_ticketbooks_for_unchecked(
@@ -1439,7 +1441,7 @@ impl TestFixture {
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);
-        response.json()
+        response.output.to_response()
     }
 
     async fn issued_ticketbooks_challenge_commitment(
@@ -1452,7 +1454,8 @@ impl TestFixture {
             .post(&format!(
                 "/{API_VERSION}/{ECASH_ROUTES}/{ECASH_ISSUED_TICKETBOOKS_CHALLENGE_COMMITMENT}"
             ))
-            .json(
+            .output
+            .to_response(
                 &IssuedTicketbooksChallengeCommitmentRequestBody {
                     expiration_date,
                     deposits,
@@ -1472,7 +1475,7 @@ impl TestFixture {
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);
-        response.json()
+        response.output.to_response()
     }
 }
 
@@ -1518,7 +1521,8 @@ mod credential_tests {
         let response = test_fixture
             .axum
             .post(&format!("/{API_VERSION}/{ECASH_ROUTES}/{ECASH_BLIND_SIGN}"))
-            .json(&request_body)
+            .output
+            .to_response(&request_body)
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);
@@ -1702,7 +1706,8 @@ mod credential_tests {
         let response = test
             .axum
             .post(&format!("/{API_VERSION}/{ECASH_ROUTES}/{ECASH_BLIND_SIGN}"))
-            .json(&request_body)
+            .output
+            .to_response(&request_body)
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);

--- a/nym-api/src/ecash/tests/mod.rs
+++ b/nym-api/src/ecash/tests/mod.rs
@@ -415,8 +415,7 @@ impl FakeChainState {
 
     // TODO: make it return a result
     fn execute_dkg_contract(&mut self, sender: MessageInfo, msg: &Binary) {
-        let exec_msg: nym_coconut_dkg_common::msg::ExecuteMsg =
-            from_output.to_response(msg).unwrap();
+        let exec_msg: nym_coconut_dkg_common::msg::ExecuteMsg = from_json(msg).unwrap();
         match exec_msg {
             nym_coconut_dkg_common::msg::ExecuteMsg::VerifyVerificationKeyShare {
                 owner,
@@ -1421,12 +1420,11 @@ impl TestFixture {
         let response = self
             .axum
             .post(&format!("/{API_VERSION}/{ECASH_ROUTES}/{ECASH_BLIND_SIGN}"))
-            .output
-            .to_response(&req)
+            .json(&req)
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);
-        response.output.to_response()
+        response.json()
     }
 
     async fn issued_ticketbooks_for_unchecked(
@@ -1441,7 +1439,7 @@ impl TestFixture {
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);
-        response.output.to_response()
+        response.json()
     }
 
     async fn issued_ticketbooks_challenge_commitment(
@@ -1454,8 +1452,7 @@ impl TestFixture {
             .post(&format!(
                 "/{API_VERSION}/{ECASH_ROUTES}/{ECASH_ISSUED_TICKETBOOKS_CHALLENGE_COMMITMENT}"
             ))
-            .output
-            .to_response(
+            .json(
                 &IssuedTicketbooksChallengeCommitmentRequestBody {
                     expiration_date,
                     deposits,
@@ -1475,7 +1472,7 @@ impl TestFixture {
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);
-        response.output.to_response()
+        response.json()
     }
 }
 
@@ -1521,8 +1518,7 @@ mod credential_tests {
         let response = test_fixture
             .axum
             .post(&format!("/{API_VERSION}/{ECASH_ROUTES}/{ECASH_BLIND_SIGN}"))
-            .output
-            .to_response(&request_body)
+            .json(&request_body)
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);
@@ -1706,8 +1702,7 @@ mod credential_tests {
         let response = test
             .axum
             .post(&format!("/{API_VERSION}/{ECASH_ROUTES}/{ECASH_BLIND_SIGN}"))
-            .output
-            .to_response(&request_body)
+            .json(&request_body)
             .await;
 
         assert_eq!(response.status_code(), StatusCode::OK);

--- a/nym-api/src/node_status_api/handlers/mod.rs
+++ b/nym-api/src/node_status_api/handlers/mod.rs
@@ -4,10 +4,11 @@
 use crate::node_status_api::models::AxumResult;
 use crate::support::caching::cache::UninitialisedCache;
 use crate::support::http::state::AppState;
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::routing::get;
-use axum::{Json, Router};
+use axum::Router;
 use nym_api_requests::models::ConfigScoreDataResponse;
+use nym_http_api_common::{FormattedResponse, OutputParams};
 use nym_mixnet_contract_common::NodeId;
 use serde::Deserialize;
 use utoipa::IntoParams;
@@ -43,17 +44,25 @@ struct MixIdParam {
     path = "/config-score-details",
     context_path = "/v1/status",
     responses(
-        (status = 200, body = ConfigScoreDataResponse)
+        (status = 200, content(
+            (ConfigScoreDataResponse = "application/json"),
+            (ConfigScoreDataResponse = "application/yaml"),
+            (ConfigScoreDataResponse = "application/bincode")
+        ))
     ),
+    params(OutputParams)
 )]
 async fn config_score_details(
+    Query(output): Query<OutputParams>,
     State(state): State<AppState>,
-) -> AxumResult<Json<ConfigScoreDataResponse>> {
+) -> AxumResult<FormattedResponse<ConfigScoreDataResponse>> {
+    let output = output.output.unwrap_or_default();
+
     let data = state
         .nym_contract_cache()
         .maybe_config_score_data_owned()
         .await
         .ok_or(UninitialisedCache)?;
 
-    Ok(Json(data.into_inner().into()))
+    Ok(output.to_response(data.into_inner().into()))
 }

--- a/nym-api/src/nym_nodes/handlers/mod.rs
+++ b/nym-api/src/nym_nodes/handlers/mod.rs
@@ -15,9 +15,9 @@ use nym_api_requests::models::{
 };
 use nym_api_requests::pagination::{PaginatedResponse, Pagination};
 use nym_contracts_common::NaiveFloat;
+use nym_http_api_common::{FormattedResponse, Output, OutputParams};
 use nym_mixnet_contract_common::reward_params::Performance;
 use nym_mixnet_contract_common::NymNodeDetails;
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use time::{Date, OffsetDateTime};
@@ -55,10 +55,20 @@ pub(crate) fn nym_node_routes() -> Router<AppState> {
     path = "/rewarded-set",
     context_path = "/v1/nym-nodes",
     responses(
-        (status = 200, body = RewardedSetResponse)
+        (status = 200, content(
+            (RewardedSetResponse = "application/json"),
+            (RewardedSetResponse = "application/yaml"),
+            (RewardedSetResponse = "application/bincode")
+        ))
     ),
+    params(OutputParams)
 )]
-async fn rewarded_set(State(state): State<AppState>) -> AxumResult<Json<RewardedSetResponse>> {
+async fn rewarded_set(
+    Query(output): Query<OutputParams>,
+    State(state): State<AppState>,
+) -> AxumResult<FormattedResponse<RewardedSetResponse>> {
+    let output = output.output.unwrap_or_default();
+
     let cached_rewarded_set = state
         .nym_contract_cache()
         .rewarded_set()
@@ -67,7 +77,7 @@ async fn rewarded_set(State(state): State<AppState>) -> AxumResult<Json<Rewarded
         .ok_or(UninitialisedCache)?
         .into_inner();
 
-    Ok(Json(
+    Ok(output.to_response(
         nym_mixnet_contract_common::EpochRewardedSet::from(cached_rewarded_set).into(),
     ))
 }
@@ -136,16 +146,21 @@ async fn refresh_described(
     path = "/noise",
     context_path = "/v1/nym-nodes",
     responses(
-        (status = 200, body = PaginatedResponse<NoiseDetails>)
+        (status = 200, content(
+            (PaginatedResponse<NoiseDetails> = "application/json"),
+            (PaginatedResponse<NoiseDetails> = "application/yaml"),
+            (PaginatedResponse<NoiseDetails> = "application/bincode")
+        ))
     ),
     params(PaginationRequest)
 )]
 async fn nodes_noise(
     State(state): State<AppState>,
     Query(pagination): Query<PaginationRequest>,
-) -> AxumResult<Json<PaginatedResponse<NoiseDetails>>> {
+) -> AxumResult<FormattedResponse<PaginatedResponse<NoiseDetails>>> {
     // TODO: implement it
     let _ = pagination;
+    let output = pagination.output.unwrap_or_default();
 
     let describe_cache = state.describe_nodes_cache_data().await?;
 
@@ -167,7 +182,7 @@ async fn nodes_noise(
 
     let total = nodes.len();
 
-    Ok(Json(PaginatedResponse {
+    Ok(output.to_response(PaginatedResponse {
         pagination: Pagination {
             total,
             page: 0,
@@ -183,21 +198,26 @@ async fn nodes_noise(
     path = "/bonded",
     context_path = "/v1/nym-nodes",
     responses(
-        (status = 200, body = PaginatedResponse<NymNodeDetails>)
+        (status = 200, content(
+            (PaginatedResponse<NymNodeDetails> = "application/json"),
+            (PaginatedResponse<NymNodeDetails> = "application/yaml"),
+            (PaginatedResponse<NymNodeDetails> = "application/bincode")
+        ))
     ),
     params(PaginationRequest)
 )]
 async fn get_bonded_nodes(
     State(state): State<AppState>,
     Query(pagination): Query<PaginationRequest>,
-) -> Json<PaginatedResponse<NymNodeDetails>> {
+) -> FormattedResponse<PaginatedResponse<NymNodeDetails>> {
     // TODO: implement it
     let _ = pagination;
+    let output = pagination.output.unwrap_or_default();
 
     let details = state.nym_contract_cache().nym_nodes().await;
     let total = details.len();
 
-    Json(PaginatedResponse {
+    output.to_response(PaginatedResponse {
         pagination: Pagination {
             total,
             page: 0,
@@ -213,21 +233,26 @@ async fn get_bonded_nodes(
     path = "/described",
     context_path = "/v1/nym-nodes",
     responses(
-        (status = 200, body = PaginatedResponse<NymNodeDescription>)
+        (status = 200, content(
+            (PaginatedResponse<NymNodeDescription> = "application/json"),
+            (PaginatedResponse<NymNodeDescription> = "application/yaml"),
+            (PaginatedResponse<NymNodeDescription> = "application/bincode")
+        ))
     ),
     params(PaginationRequest)
 )]
 async fn get_described_nodes(
     State(state): State<AppState>,
     Query(pagination): Query<PaginationRequest>,
-) -> AxumResult<Json<PaginatedResponse<NymNodeDescription>>> {
+) -> AxumResult<FormattedResponse<PaginatedResponse<NymNodeDescription>>> {
     // TODO: implement it
     let _ = pagination;
+    let output = pagination.output.unwrap_or_default();
 
     let cache = state.described_nodes_cache.get().await?;
     let descriptions = cache.all_nodes().cloned().collect::<Vec<_>>();
 
-    Ok(Json(PaginatedResponse {
+    Ok(output.to_response(PaginatedResponse {
         pagination: Pagination {
             total: descriptions.len(),
             page: 0,
@@ -243,21 +268,28 @@ async fn get_described_nodes(
     path = "/annotation/{node_id}",
     context_path = "/v1/nym-nodes",
     responses(
-        (status = 200, body = AnnotationResponse)
+        (status = 200, content(
+            (AnnotationResponse = "application/json"),
+            (AnnotationResponse = "application/yaml"),
+            (AnnotationResponse = "application/bincode")
+        ))
     ),
-    params(NodeIdParam),
+    params(NodeIdParam, OutputParams),
 )]
 async fn get_node_annotation(
     Path(NodeIdParam { node_id }): Path<NodeIdParam>,
+    Query(output): Query<OutputParams>,
     State(state): State<AppState>,
-) -> AxumResult<Json<AnnotationResponse>> {
+) -> AxumResult<FormattedResponse<AnnotationResponse>> {
+    let output = output.output.unwrap_or_default();
+
     let annotations = state
         .node_status_cache
         .node_annotations()
         .await
         .ok_or_else(AxumErrorResponse::internal)?;
 
-    Ok(Json(AnnotationResponse {
+    Ok(output.to_response(AnnotationResponse {
         node_id,
         annotation: annotations.get(&node_id).cloned(),
     }))
@@ -269,21 +301,28 @@ async fn get_node_annotation(
     path = "/performance/{node_id}",
     context_path = "/v1/nym-nodes",
     responses(
-        (status = 200, body = NodePerformanceResponse)
+        (status = 200, content(
+            (NodePerformanceResponse = "application/json"),
+            (NodePerformanceResponse = "application/yaml"),
+            (NodePerformanceResponse = "application/bincode")
+        ))
     ),
-    params(NodeIdParam),
+    params(NodeIdParam, OutputParams),
 )]
 async fn get_current_node_performance(
     Path(NodeIdParam { node_id }): Path<NodeIdParam>,
+    Query(output): Query<OutputParams>,
     State(state): State<AppState>,
-) -> AxumResult<Json<NodePerformanceResponse>> {
+) -> AxumResult<FormattedResponse<NodePerformanceResponse>> {
+    let output = output.output.unwrap_or_default();
+
     let annotations = state
         .node_status_cache
         .node_annotations()
         .await
         .ok_or_else(AxumErrorResponse::internal)?;
 
-    Ok(Json(NodePerformanceResponse {
+    Ok(output.to_response(NodePerformanceResponse {
         node_id,
         performance: annotations
             .get(&node_id)
@@ -292,12 +331,13 @@ async fn get_current_node_performance(
 }
 
 // todo; probably extract it to requests crate
-#[derive(Debug, Serialize, Deserialize, Copy, Clone, IntoParams, ToSchema, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, IntoParams, ToSchema)]
 #[into_params(parameter_in = Query)]
 pub(crate) struct DateQuery {
     #[schema(value_type = String, example = "1970-01-01")]
-    #[schemars(with = "String")]
     pub(crate) date: Date,
+
+    pub(crate) output: Option<Output>,
 }
 
 #[utoipa::path(
@@ -306,21 +346,27 @@ pub(crate) struct DateQuery {
     path = "/historical-performance/{node_id}",
     context_path = "/v1/nym-nodes",
     responses(
-        (status = 200, body = NodeDatePerformanceResponse)
+        (status = 200, content(
+            (NodeDatePerformanceResponse = "application/json"),
+            (NodeDatePerformanceResponse = "application/yaml"),
+            (NodeDatePerformanceResponse = "application/bincode")
+        ))
     ),
     params(DateQuery, NodeIdParam)
 )]
 async fn get_historical_performance(
     Path(NodeIdParam { node_id }): Path<NodeIdParam>,
-    Query(DateQuery { date }): Query<DateQuery>,
+    Query(DateQuery { date, output }): Query<DateQuery>,
     State(state): State<AppState>,
-) -> AxumResult<Json<NodeDatePerformanceResponse>> {
+) -> AxumResult<FormattedResponse<NodeDatePerformanceResponse>> {
+    let output = output.unwrap_or_default();
+
     let uptime = state
         .storage()
         .get_historical_node_uptime_on(node_id, date)
         .await?;
 
-    Ok(Json(NodeDatePerformanceResponse {
+    Ok(output.to_response(NodeDatePerformanceResponse {
         node_id,
         date,
         performance: uptime.and_then(|u| {
@@ -337,7 +383,11 @@ async fn get_historical_performance(
     path = "/performance-history/{node_id}",
     context_path = "/v1/nym-nodes",
     responses(
-        (status = 200, body = PerformanceHistoryResponse)
+        (status = 200, content(
+            (PerformanceHistoryResponse = "application/json"),
+            (PerformanceHistoryResponse = "application/yaml"),
+            (PerformanceHistoryResponse = "application/bincode")
+        ))
     ),
     params(PaginationRequest, NodeIdParam)
 )]
@@ -345,9 +395,10 @@ async fn get_node_performance_history(
     Path(NodeIdParam { node_id }): Path<NodeIdParam>,
     State(state): State<AppState>,
     Query(pagination): Query<PaginationRequest>,
-) -> AxumResult<Json<PerformanceHistoryResponse>> {
+) -> AxumResult<FormattedResponse<PerformanceHistoryResponse>> {
     // TODO: implement it
     let _ = pagination;
+    let output = pagination.output.unwrap_or_default();
 
     let history = state
         .storage()
@@ -358,7 +409,7 @@ async fn get_node_performance_history(
         .collect::<Vec<_>>();
     let total = history.len();
 
-    Ok(Json(PerformanceHistoryResponse {
+    Ok(output.to_response(PerformanceHistoryResponse {
         node_id,
         history: PaginatedResponse {
             pagination: Pagination {
@@ -377,7 +428,11 @@ async fn get_node_performance_history(
     path = "/uptime-history/{node_id}",
     context_path = "/v1/nym-nodes",
     responses(
-        (status = 200, body = PerformanceHistoryResponse)
+        (status = 200, content(
+            (PerformanceHistoryResponse = "application/json"),
+            (PerformanceHistoryResponse = "application/yaml"),
+            (PerformanceHistoryResponse = "application/bincode")
+        ))
     ),
     params(PaginationRequest, NodeIdParam)
 )]
@@ -385,9 +440,10 @@ async fn get_node_uptime_history(
     Path(NodeIdParam { node_id }): Path<NodeIdParam>,
     State(state): State<AppState>,
     Query(pagination): Query<PaginationRequest>,
-) -> AxumResult<Json<UptimeHistoryResponse>> {
+) -> AxumResult<FormattedResponse<UptimeHistoryResponse>> {
     // TODO: implement it
     let _ = pagination;
+    let output = pagination.output.unwrap_or_default();
 
     let history = state
         .storage()
@@ -398,7 +454,7 @@ async fn get_node_uptime_history(
         .collect::<Vec<_>>();
     let total = history.len();
 
-    Ok(Json(UptimeHistoryResponse {
+    Ok(output.to_response(UptimeHistoryResponse {
         node_id,
         history: PaginatedResponse {
             pagination: Pagination {

--- a/nym-api/src/nym_nodes/handlers/unstable/full_fat.rs
+++ b/nym-api/src/nym_nodes/handlers/unstable/full_fat.rs
@@ -5,8 +5,8 @@ use crate::node_status_api::models::{AxumErrorResponse, AxumResult};
 use crate::nym_nodes::handlers::unstable::NodesParamsWithRole;
 use crate::support::http::state::AppState;
 use axum::extract::{Query, State};
-use axum::Json;
 use nym_api_requests::nym_nodes::{CachedNodesResponse, FullFatNode};
+use nym_http_api_common::FormattedResponse;
 
 #[utoipa::path(
     tag = "Unstable Nym Nodes",
@@ -22,6 +22,6 @@ use nym_api_requests::nym_nodes::{CachedNodesResponse, FullFatNode};
 pub(super) async fn nodes_detailed(
     _state: State<AppState>,
     _query_params: Query<NodesParamsWithRole>,
-) -> AxumResult<Json<CachedNodesResponse<FullFatNode>>> {
+) -> AxumResult<FormattedResponse<CachedNodesResponse<FullFatNode>>> {
     Err(AxumErrorResponse::not_implemented())
 }

--- a/nym-api/src/nym_nodes/handlers/unstable/mod.rs
+++ b/nym-api/src/nym_nodes/handlers/unstable/mod.rs
@@ -30,12 +30,13 @@ use crate::nym_nodes::handlers::unstable::skimmed::{
 };
 use crate::support::http::helpers::PaginationRequest;
 use crate::support::http::state::AppState;
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use nym_api_requests::nym_nodes::{
     NodeRoleQueryParam, NodesByAddressesRequestBody, NodesByAddressesResponse,
 };
+use nym_http_api_common::{FormattedResponse, Output, OutputParams};
 use serde::Deserialize;
 use std::collections::HashMap;
 use tower_http::compression::CompressionLayer;
@@ -98,6 +99,8 @@ struct NodesParamsWithRole {
     // the client already knows about the latest topology state, allowing a `no-updates` response
     // instead of wasting bandwidth serving an unchanged topology.
     epoch_id: Option<u32>,
+
+    output: Option<Output>,
 }
 
 #[derive(Debug, Deserialize, utoipa::IntoParams)]
@@ -113,6 +116,7 @@ struct NodesParams {
     // the client already knows about the latest topology state, allowing a `no-updates` response
     // instead of wasting bandwidth serving an unchanged topology.
     epoch_id: Option<u32>,
+    output: Option<Output>,
 }
 
 impl From<NodesParamsWithRole> for NodesParams {
@@ -123,6 +127,7 @@ impl From<NodesParamsWithRole> for NodesParams {
             page: params.page,
             per_page: params.per_page,
             epoch_id: params.epoch_id,
+            output: params.output,
         }
     }
 }
@@ -130,6 +135,7 @@ impl From<NodesParamsWithRole> for NodesParams {
 impl<'a> From<&'a NodesParams> for PaginationRequest {
     fn from(params: &'a NodesParams) -> Self {
         PaginationRequest {
+            output: params.output,
             page: params.page,
             per_page: params.per_page,
         }
@@ -143,19 +149,27 @@ impl<'a> From<&'a NodesParams> for PaginationRequest {
     path = "/by-addresses",
     context_path = "/v1/unstable/nym-nodes",
     responses(
-        (status = 200, body = NodesByAddressesResponse)
-    )
+        (status = 200, content(
+            (NodesByAddressesResponse = "application/json"),
+            (NodesByAddressesResponse = "application/yaml"),
+            (NodesByAddressesResponse = "application/bincode")
+        ))
+    ),
+    params(OutputParams)
 )]
 async fn nodes_by_addresses(
+    Query(output): Query<OutputParams>,
     state: State<AppState>,
     Json(body): Json<NodesByAddressesRequestBody>,
-) -> AxumResult<Json<NodesByAddressesResponse>> {
+) -> AxumResult<FormattedResponse<NodesByAddressesResponse>> {
     // if the request is too big, simply reject it
     if body.addresses.len() > 100 {
         return Err(AxumErrorResponse::bad_request(
             "requested too many addresses",
         ));
     }
+
+    let output = output.output.unwrap_or_default();
 
     // TODO: perhaps introduce different cache because realistically nym-api will receive
     // request for the same couple addresses from all nodes in quick succession
@@ -166,5 +180,5 @@ async fn nodes_by_addresses(
         existence.insert(address, describe_cache.node_with_address(address));
     }
 
-    Ok(Json(NodesByAddressesResponse { existence }))
+    Ok(output.to_response(NodesByAddressesResponse { existence }))
 }

--- a/nym-api/src/nym_nodes/handlers/unstable/semi_skimmed.rs
+++ b/nym-api/src/nym_nodes/handlers/unstable/semi_skimmed.rs
@@ -5,8 +5,8 @@ use crate::node_status_api::models::{AxumErrorResponse, AxumResult};
 use crate::nym_nodes::handlers::unstable::NodesParamsWithRole;
 use crate::support::http::state::AppState;
 use axum::extract::{Query, State};
-use axum::Json;
 use nym_api_requests::nym_nodes::{CachedNodesResponse, SemiSkimmedNode};
+use nym_http_api_common::FormattedResponse;
 
 #[utoipa::path(
     tag = "Unstable Nym Nodes",
@@ -22,6 +22,6 @@ use nym_api_requests::nym_nodes::{CachedNodesResponse, SemiSkimmedNode};
 pub(super) async fn nodes_expanded(
     _state: State<AppState>,
     _query_params: Query<NodesParamsWithRole>,
-) -> AxumResult<Json<CachedNodesResponse<SemiSkimmedNode>>> {
+) -> AxumResult<FormattedResponse<CachedNodesResponse<SemiSkimmedNode>>> {
     Err(AxumErrorResponse::not_implemented())
 }

--- a/nym-api/src/nym_nodes/handlers/unstable/skimmed.rs
+++ b/nym-api/src/nym_nodes/handlers/unstable/skimmed.rs
@@ -8,7 +8,6 @@ use crate::nym_nodes::handlers::unstable::{NodesParams, NodesParamsWithRole};
 use crate::support::caching::Cache;
 use crate::support::http::state::AppState;
 use axum::extract::{Query, State};
-use axum::Json;
 use nym_api_requests::models::{
     NodeAnnotation, NymNodeDescription, OffsetDateTimeJsonSchemaWrapper,
 };
@@ -16,6 +15,7 @@ use nym_api_requests::nym_nodes::{
     CachedNodesResponse, NodeRole, NodeRoleQueryParam, PaginatedCachedNodesResponse, SkimmedNode,
 };
 use nym_api_requests::pagination::PaginatedResponse;
+use nym_http_api_common::{FormattedResponse, Output};
 use nym_mixnet_contract_common::NodeId;
 use nym_topology::CachedEpochRewardedSet;
 use std::collections::HashMap;
@@ -24,7 +24,8 @@ use tokio::sync::RwLockReadGuard;
 use tracing::trace;
 use utoipa::ToSchema;
 
-pub type PaginatedSkimmedNodes = AxumResult<Json<PaginatedCachedNodesResponse<SkimmedNode>>>;
+pub type PaginatedSkimmedNodes =
+    AxumResult<FormattedResponse<PaginatedCachedNodesResponse<SkimmedNode>>>;
 
 /// Given all relevant caches, build part of response for JUST Nym Nodes
 fn build_nym_nodes_response<'a, NI>(
@@ -97,6 +98,7 @@ async fn build_skimmed_nodes_response<'a, NI, LG, Fut, LN>(
     nym_nodes_subset: NI,
     annotated_legacy_nodes_getter: LG,
     active_only: bool,
+    output: Output,
 ) -> PaginatedSkimmedNodes
 where
     // iterator returning relevant subset of nym-nodes (like mixing nym-nodes, entries, etc.)
@@ -134,7 +136,7 @@ where
     if let Some(client_known_epoch) = query_params.epoch_id {
         if let Some(ref interval) = maybe_interval {
             if client_known_epoch == interval.current_epoch_id() {
-                return Ok(Json(PaginatedCachedNodesResponse::no_updates()));
+                return Ok(output.to_response(PaginatedCachedNodesResponse::no_updates()));
             }
         }
     }
@@ -152,7 +154,7 @@ where
             describe_cache.timestamp(),
         ]);
 
-        return Ok(Json(
+        return Ok(output.to_response(
             PaginatedCachedNodesResponse::new_full(refreshed_at, nodes).fresh(maybe_interval),
         ));
     }
@@ -176,7 +178,7 @@ where
         annotated_legacy_nodes.timestamp(),
     ]);
 
-    Ok(Json(
+    Ok(output.to_response(
         PaginatedCachedNodesResponse::new_full(refreshed_at, nodes).fresh(maybe_interval),
     ))
 }
@@ -189,22 +191,30 @@ where
     path = "/gateways/skimmed",
     context_path = "/v1/unstable/nym-nodes",
     responses(
-        (status = 200, body = CachedNodesResponse<SkimmedNode>)
-    )
+        (status = 200, content(
+            (CachedNodesResponse<SkimmedNode> = "application/json"),
+            (CachedNodesResponse<SkimmedNode> = "application/yaml"),
+            (CachedNodesResponse<SkimmedNode> = "application/bincode")
+        ))
+    ),
 )]
 #[deprecated(note = "use '/v1/unstable/nym-nodes/entry-gateways/skimmed/all' instead")]
 pub(super) async fn deprecated_gateways_basic(
     state: State<AppState>,
     query_params: Query<NodesParams>,
-) -> AxumResult<Json<CachedNodesResponse<SkimmedNode>>> {
+) -> AxumResult<FormattedResponse<CachedNodesResponse<SkimmedNode>>> {
+    let output = query_params.output.unwrap_or_default();
+
     // 1. call '/v1/unstable/skimmed/entry-gateways/all'
-    let all_gateways = entry_gateways_basic_all(state, query_params).await?;
+    let all_gateways = entry_gateways_basic_all(state, query_params)
+        .await?
+        .into_inner();
 
     // 3. return result
-    Ok(Json(CachedNodesResponse {
+    Ok(output.to_response(CachedNodesResponse {
         refreshed_at: all_gateways.refreshed_at,
         // 2. remove pagination
-        nodes: all_gateways.0.nodes.data,
+        nodes: all_gateways.nodes.data,
     }))
 }
 
@@ -216,30 +226,40 @@ pub(super) async fn deprecated_gateways_basic(
     path = "/mixnodes/skimmed",
     context_path = "/v1/unstable/nym-nodes",
     responses(
-        (status = 200, body = CachedNodesResponse<SkimmedNode>)
-    )
+        (status = 200, content(
+            (CachedNodesResponse<SkimmedNode> = "application/json"),
+            (CachedNodesResponse<SkimmedNode> = "application/yaml"),
+            (CachedNodesResponse<SkimmedNode> = "application/bincode")
+        ))
+    ),
 )]
 #[deprecated(note = "use '/v1/unstable/nym-nodes/skimmed/mixnodes/active' instead")]
 pub(super) async fn deprecated_mixnodes_basic(
     state: State<AppState>,
     query_params: Query<NodesParams>,
-) -> AxumResult<Json<CachedNodesResponse<SkimmedNode>>> {
+) -> AxumResult<FormattedResponse<CachedNodesResponse<SkimmedNode>>> {
+    let output = query_params.output.unwrap_or_default();
+
     // 1. call '/v1/unstable/nym-nodes/skimmed/mixnodes/active'
-    let active_mixnodes = mixnodes_basic_active(state, query_params).await?;
+    let active_mixnodes = mixnodes_basic_active(state, query_params)
+        .await?
+        .into_inner();
 
     // 3. return result
-    Ok(Json(CachedNodesResponse {
+    Ok(output.to_response(CachedNodesResponse {
         refreshed_at: active_mixnodes.refreshed_at,
         // 2. remove pagination
-        nodes: active_mixnodes.0.nodes.data,
+        nodes: active_mixnodes.nodes.data,
     }))
 }
 
 async fn nodes_basic(
     state: State<AppState>,
-    Query(_query_params): Query<NodesParams>,
+    Query(query_params): Query<NodesParams>,
     active_only: bool,
 ) -> PaginatedSkimmedNodes {
+    let output = query_params.output.unwrap_or_default();
+
     // unfortunately we have to build the response semi-manually here as we need to add two sources of legacy nodes
 
     // 1. grab all relevant described nym-nodes
@@ -281,10 +301,7 @@ async fn nodes_basic(
         legacy_gateways.timestamp(),
     ]);
 
-    Ok(Json(PaginatedCachedNodesResponse::new_full(
-        refreshed_at,
-        nodes,
-    )))
+    Ok(output.to_response(PaginatedCachedNodesResponse::new_full(refreshed_at, nodes)))
 }
 
 #[allow(dead_code)] // not dead, used in OpenAPI docs
@@ -305,8 +322,12 @@ pub struct PaginatedCachedNodesResponseSchema {
     path = "",
     context_path = "/v1/unstable/nym-nodes/skimmed",
     responses(
-        (status = 200, body = PaginatedCachedNodesResponseSchema)
-    )
+        (status = 200, content(
+            (PaginatedCachedNodesResponseSchema = "application/json"),
+            (PaginatedCachedNodesResponseSchema = "application/yaml"),
+            (PaginatedCachedNodesResponseSchema = "application/bincode")
+        ))
+    ),
 )]
 pub(super) async fn nodes_basic_all(
     state: State<AppState>,
@@ -338,8 +359,12 @@ pub(super) async fn nodes_basic_all(
     path = "/active",
     context_path = "/v1/unstable/nym-nodes/skimmed",
     responses(
-        (status = 200, body = PaginatedCachedNodesResponseSchema)
-    )
+        (status = 200, content(
+            (PaginatedCachedNodesResponseSchema = "application/json"),
+            (PaginatedCachedNodesResponseSchema = "application/yaml"),
+            (PaginatedCachedNodesResponseSchema = "application/bincode")
+        ))
+    ),
 )]
 pub(super) async fn nodes_basic_active(
     state: State<AppState>,
@@ -367,6 +392,8 @@ async fn mixnodes_basic(
     query_params: Query<NodesParams>,
     active_only: bool,
 ) -> PaginatedSkimmedNodes {
+    let output = query_params.output.unwrap_or_default();
+
     // 1. grab all relevant described nym-nodes
     let describe_cache = state.describe_nodes_cache_data().await?;
     let mixing_nym_nodes = describe_cache.mixing_nym_nodes();
@@ -377,6 +404,7 @@ async fn mixnodes_basic(
         mixing_nym_nodes,
         |state| state.legacy_mixnode_annotations(),
         active_only,
+        output,
     )
     .await
 }
@@ -390,8 +418,12 @@ async fn mixnodes_basic(
     path = "/mixnodes/all",
     context_path = "/v1/unstable/nym-nodes/skimmed",
     responses(
-        (status = 200, body = PaginatedCachedNodesResponseSchema)
-    )
+        (status = 200, content(
+            (PaginatedCachedNodesResponseSchema = "application/json"),
+            (PaginatedCachedNodesResponseSchema = "application/yaml"),
+            (PaginatedCachedNodesResponseSchema = "application/bincode")
+        ))
+    ),
 )]
 pub(super) async fn mixnodes_basic_all(
     state: State<AppState>,
@@ -409,8 +441,12 @@ pub(super) async fn mixnodes_basic_all(
     path = "/mixnodes/active",
     context_path = "/v1/unstable/nym-nodes/skimmed",
     responses(
-        (status = 200, body = PaginatedCachedNodesResponseSchema)
-    )
+        (status = 200, content(
+            (PaginatedCachedNodesResponseSchema = "application/json"),
+            (PaginatedCachedNodesResponseSchema = "application/yaml"),
+            (PaginatedCachedNodesResponseSchema = "application/bincode")
+        ))
+    ),
 )]
 pub(super) async fn mixnodes_basic_active(
     state: State<AppState>,
@@ -424,6 +460,8 @@ async fn entry_gateways_basic(
     query_params: Query<NodesParams>,
     active_only: bool,
 ) -> PaginatedSkimmedNodes {
+    let output = query_params.output.unwrap_or_default();
+
     // 1. grab all relevant described nym-nodes
     let describe_cache = state.describe_nodes_cache_data().await?;
     let mixing_nym_nodes = describe_cache.entry_capable_nym_nodes();
@@ -434,6 +472,7 @@ async fn entry_gateways_basic(
         mixing_nym_nodes,
         |state| state.legacy_gateways_annotations(),
         active_only,
+        output,
     )
     .await
 }
@@ -447,8 +486,12 @@ async fn entry_gateways_basic(
     path = "/entry-gateways/active",
     context_path = "/v1/unstable/nym-nodes/skimmed",
     responses(
-        (status = 200, body = PaginatedCachedNodesResponseSchema)
-    )
+        (status = 200, content(
+            (PaginatedCachedNodesResponseSchema = "application/json"),
+            (PaginatedCachedNodesResponseSchema = "application/yaml"),
+            (PaginatedCachedNodesResponseSchema = "application/bincode")
+        ))
+    ),
 )]
 pub(super) async fn entry_gateways_basic_active(
     state: State<AppState>,
@@ -466,8 +509,12 @@ pub(super) async fn entry_gateways_basic_active(
     path = "/entry-gateways/all",
     context_path = "/v1/unstable/nym-nodes/skimmed",
     responses(
-        (status = 200, body = PaginatedCachedNodesResponseSchema)
-    )
+        (status = 200, content(
+            (PaginatedCachedNodesResponseSchema = "application/json"),
+            (PaginatedCachedNodesResponseSchema = "application/yaml"),
+            (PaginatedCachedNodesResponseSchema = "application/bincode")
+        ))
+    ),
 )]
 pub(super) async fn entry_gateways_basic_all(
     state: State<AppState>,
@@ -481,6 +528,8 @@ async fn exit_gateways_basic(
     query_params: Query<NodesParams>,
     active_only: bool,
 ) -> PaginatedSkimmedNodes {
+    let output = query_params.output.unwrap_or_default();
+
     // 1. grab all relevant described nym-nodes
     let describe_cache = state.describe_nodes_cache_data().await?;
     let mixing_nym_nodes = describe_cache.exit_capable_nym_nodes();
@@ -491,6 +540,7 @@ async fn exit_gateways_basic(
         mixing_nym_nodes,
         |state| state.legacy_gateways_annotations(),
         active_only,
+        output,
     )
     .await
 }
@@ -504,8 +554,12 @@ async fn exit_gateways_basic(
     path = "/exit-gateways/active",
     context_path = "/v1/unstable/nym-nodes/skimmed",
     responses(
-        (status = 200, body = PaginatedCachedNodesResponseSchema)
-    )
+        (status = 200, content(
+            (PaginatedCachedNodesResponseSchema = "application/json"),
+            (PaginatedCachedNodesResponseSchema = "application/yaml"),
+            (PaginatedCachedNodesResponseSchema = "application/bincode")
+        ))
+    ),
 )]
 pub(super) async fn exit_gateways_basic_active(
     state: State<AppState>,
@@ -523,8 +577,12 @@ pub(super) async fn exit_gateways_basic_active(
     path = "/exit-gateways/all",
     context_path = "/v1/unstable/nym-nodes/skimmed",
     responses(
-        (status = 200, body = PaginatedCachedNodesResponseSchema)
-    )
+        (status = 200, content(
+            (PaginatedCachedNodesResponseSchema = "application/json"),
+            (PaginatedCachedNodesResponseSchema = "application/yaml"),
+            (PaginatedCachedNodesResponseSchema = "application/bincode")
+        ))
+    ),
 )]
 pub(super) async fn exit_gateways_basic_all(
     state: State<AppState>,

--- a/nym-api/src/support/http/helpers.rs
+++ b/nym-api/src/support/http/helpers.rs
@@ -1,14 +1,15 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_http_api_common::Output;
 use nym_mixnet_contract_common::NodeId;
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, ToSchema, IntoParams)]
+#[derive(Serialize, Deserialize, Debug, ToSchema, IntoParams)]
 #[into_params(parameter_in = Query)]
 pub struct PaginationRequest {
+    pub output: Option<Output>,
     pub page: Option<u32>,
     pub per_page: Option<u32>,
 }

--- a/nym-credential-proxy/nym-credential-proxy-requests/Cargo.toml
+++ b/nym-credential-proxy/nym-credential-proxy-requests/Cargo.toml
@@ -36,6 +36,6 @@ features = ["tokio"]
 
 [features]
 default = ["query-types"]
-query-types = ["nym-http-api-common"]
+query-types = ["nym-http-api-common", "nym-http-api-common/output"]
 openapi = ["utoipa"]
 tsify = ["dep:tsify", "wasm-bindgen"]

--- a/nym-network-monitor/src/handlers.rs
+++ b/nym-network-monitor/src/handlers.rs
@@ -111,7 +111,7 @@ pub async fn graph_handler() -> Result<String, StatusCode> {
         (status = 200, description = "Returns a map of all fragments sent by the network monitor", body = FragmentsSent),
     )
 )]
-pub async fn sent_handler() -> FormattedResponse<FragmentsSent> {
+pub async fn sent_handler() -> Json<FragmentsSent> {
     Json(FragmentsSent(
         (*monitoring::FRAGMENTS_SENT)
             .clone()
@@ -127,7 +127,7 @@ pub async fn sent_handler() -> FormattedResponse<FragmentsSent> {
         (status = 200, description = "Returns a map of all fragments received by the network monitor", body = FragmentsReceived),
     )
 )]
-pub async fn recv_handler() -> FormattedResponse<FragmentsReceived> {
+pub async fn recv_handler() -> Json<FragmentsReceived> {
     Json(FragmentsReceived(
         (*monitoring::FRAGMENTS_RECEIVED)
             .clone()

--- a/nym-network-monitor/src/handlers.rs
+++ b/nym-network-monitor/src/handlers.rs
@@ -111,13 +111,13 @@ pub async fn graph_handler() -> Result<String, StatusCode> {
         (status = 200, description = "Returns a map of all fragments sent by the network monitor", body = FragmentsSent),
     )
 )]
-pub async fn sent_handler() -> FormattedResponse < FragmentsSent> {
-Json(FragmentsSent(
-( * monitoring::FRAGMENTS_SENT)
-.clone()
-.into_iter()
-.collect::< HashMap < _, _ > > (),
-))
+pub async fn sent_handler() -> FormattedResponse<FragmentsSent> {
+    Json(FragmentsSent(
+        (*monitoring::FRAGMENTS_SENT)
+            .clone()
+            .into_iter()
+            .collect::<HashMap<_, _>>(),
+    ))
 }
 
 #[utoipa::path(
@@ -127,13 +127,13 @@ Json(FragmentsSent(
         (status = 200, description = "Returns a map of all fragments received by the network monitor", body = FragmentsReceived),
     )
 )]
-pub async fn recv_handler() -> FormattedResponse < FragmentsReceived> {
-Json(FragmentsReceived(
-( * monitoring::FRAGMENTS_RECEIVED)
-.clone()
-.into_iter()
-.collect::< HashMap < _, _ > > (),
-))
+pub async fn recv_handler() -> FormattedResponse<FragmentsReceived> {
+    Json(FragmentsReceived(
+        (*monitoring::FRAGMENTS_RECEIVED)
+            .clone()
+            .into_iter()
+            .collect::<HashMap<_, _>>(),
+    ))
 }
 
 #[utoipa::path(
@@ -209,7 +209,7 @@ async fn send_receive_mixnet(state: AppState) -> Result<String, StatusCode> {
             Duration::from_secs(*MIXNET_TIMEOUT.get().expect("Set at the begining")),
             recv.write().await.next(),
         )
-            .await
+        .await
         {
             Ok(Some(received)) => {
                 debug!("Received: {}", String::from_utf8_lossy(&received.message));
@@ -226,7 +226,7 @@ async fn send_receive_mixnet(state: AppState) -> Result<String, StatusCode> {
             Duration::from_secs(5),
             mixnet_sender.send_plain_message(our_address, &msg),
         )
-            .await
+        .await
         {
             Ok(_) => debug!("Sent message: {msg}"),
             Err(e) => warn!("Failed to send message: {e}"),

--- a/nym-network-monitor/src/handlers.rs
+++ b/nym-network-monitor/src/handlers.rs
@@ -111,13 +111,13 @@ pub async fn graph_handler() -> Result<String, StatusCode> {
         (status = 200, description = "Returns a map of all fragments sent by the network monitor", body = FragmentsSent),
     )
 )]
-pub async fn sent_handler() -> Json<FragmentsSent> {
-    Json(FragmentsSent(
-        (*monitoring::FRAGMENTS_SENT)
-            .clone()
-            .into_iter()
-            .collect::<HashMap<_, _>>(),
-    ))
+pub async fn sent_handler() -> FormattedResponse < FragmentsSent> {
+Json(FragmentsSent(
+( * monitoring::FRAGMENTS_SENT)
+.clone()
+.into_iter()
+.collect::< HashMap < _, _ > > (),
+))
 }
 
 #[utoipa::path(
@@ -127,13 +127,13 @@ pub async fn sent_handler() -> Json<FragmentsSent> {
         (status = 200, description = "Returns a map of all fragments received by the network monitor", body = FragmentsReceived),
     )
 )]
-pub async fn recv_handler() -> Json<FragmentsReceived> {
-    Json(FragmentsReceived(
-        (*monitoring::FRAGMENTS_RECEIVED)
-            .clone()
-            .into_iter()
-            .collect::<HashMap<_, _>>(),
-    ))
+pub async fn recv_handler() -> FormattedResponse < FragmentsReceived> {
+Json(FragmentsReceived(
+( * monitoring::FRAGMENTS_RECEIVED)
+.clone()
+.into_iter()
+.collect::< HashMap < _, _ > > (),
+))
 }
 
 #[utoipa::path(
@@ -209,7 +209,7 @@ async fn send_receive_mixnet(state: AppState) -> Result<String, StatusCode> {
             Duration::from_secs(*MIXNET_TIMEOUT.get().expect("Set at the begining")),
             recv.write().await.next(),
         )
-        .await
+            .await
         {
             Ok(Some(received)) => {
                 debug!("Received: {}", String::from_utf8_lossy(&received.message));
@@ -226,7 +226,7 @@ async fn send_receive_mixnet(state: AppState) -> Result<String, StatusCode> {
             Duration::from_secs(5),
             mixnet_sender.send_plain_message(our_address, &msg),
         )
-        .await
+            .await
         {
             Ok(_) => debug!("Sent message: {msg}"),
             Err(e) => warn!("Failed to send message: {e}"),

--- a/nym-node-status-api/nym-node-status-api/src/monitor/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/monitor/mod.rs
@@ -102,7 +102,7 @@ impl Monitor {
             .with_timeout(self.nym_api_client_timeout)
             .build::<&str>()?;
 
-        let api_client = NymApiClient { nym_api };
+        let api_client = NymApiClient::from(nym_api);
 
         let described_nodes = api_client
             .get_all_described_nodes()
@@ -187,7 +187,7 @@ impl Monitor {
         tracing::info!("🟣 mixnodes_described: {}", mixnodes_described.len());
         let mixing_assigned_nodes = api_client
             .nym_api
-            .get_basic_active_mixing_assigned_nodes(false, None, None)
+            .get_basic_active_mixing_assigned_nodes(false, None, None, false)
             .await
             .log_error("get_basic_active_mixing_assigned_nodes")?
             .nodes

--- a/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/node_scraper/mod.rs
@@ -62,7 +62,7 @@ async fn run(
         .with_timeout(nym_api_client_timeout)
         .build::<&str>()?;
 
-    let api_client = NymApiClient { nym_api };
+    let api_client = NymApiClient::from(nym_api);
 
     //SW TBC what nodes exactly need to be scraped, the skimmed node endpoint seems to return more nodes
     let bonded_nodes = api_client.get_all_bonded_nym_nodes().await?;

--- a/nym-node/src/node/mod.rs
+++ b/nym-node/src/node/mod.rs
@@ -842,7 +842,7 @@ impl NymNode {
                     }
                 };
 
-            let client = NymApiClient { nym_api };
+            let client = NymApiClient::from(nym_api);
 
             // make new request every time in case previous one takes longer and invalidates the signature
             let request = NodeRefreshBody::new(self.ed25519_identity_keys.private_key());

--- a/nym-node/src/node/shared_network.rs
+++ b/nym-node/src/node/shared_network.rs
@@ -177,7 +177,7 @@ impl NetworkRefresher {
 
         let mut this = NetworkRefresher {
             querier: NodesQuerier {
-                client: NymApiClient { nym_api },
+                client: NymApiClient::from(nym_api),
                 nym_api_urls,
                 currently_used_api: 0,
             },

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -588,72 +588,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
- "itoa 1.0.15",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-client-ip"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eefda7e2b27e1bda4d6fa8a06b50803b8793769045918bc37ad062d48a6efac"
-dependencies = [
- "axum",
- "forwarded-header-value",
- "serde",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 1.0.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,16 +2245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "forwarded-header-value"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
-dependencies = [
- "nonempty",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,7 +3087,6 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
- "httpdate",
  "itoa 1.0.15",
  "pin-project-lite",
  "smallvec",
@@ -3825,12 +3748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,12 +3922,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "nonempty"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
 name = "nu-ansi-term"
@@ -4297,20 +4208,9 @@ dependencies = [
 name = "nym-http-api-common"
 version = "0.1.0"
 dependencies = [
- "axum",
- "axum-client-ip",
  "bincode",
- "bytes",
- "colored 2.2.0",
- "futures",
- "mime",
  "serde",
- "serde_json",
- "serde_yaml",
- "subtle",
- "tower",
  "tracing",
- "zeroize",
 ]
 
 [[package]]
@@ -6377,16 +6277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
-dependencies = [
- "itoa 1.0.15",
- "serde",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6446,19 +6336,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.8.0",
- "itoa 1.0.15",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -7708,7 +7585,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -7729,7 +7605,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -7955,12 +7830,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -588,6 +588,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "itoa 1.0.15",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-client-ip"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eefda7e2b27e1bda4d6fa8a06b50803b8793769045918bc37ad062d48a6efac"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "serde",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,6 +2311,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,6 +3163,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa 1.0.15",
  "pin-project-lite",
  "smallvec",
@@ -3748,6 +3825,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3922,6 +4005,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
 name = "nu-ansi-term"
@@ -4186,12 +4275,14 @@ name = "nym-http-api-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bincode",
  "bytes",
  "encoding_rs",
  "hickory-resolver",
  "http 1.3.1",
  "mime",
  "nym-bin-common",
+ "nym-http-api-common",
  "once_cell",
  "reqwest 0.12.15",
  "serde",
@@ -4200,6 +4291,26 @@ dependencies = [
  "tracing",
  "url",
  "wasmtimer",
+]
+
+[[package]]
+name = "nym-http-api-common"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "axum-client-ip",
+ "bincode",
+ "bytes",
+ "colored 2.2.0",
+ "futures",
+ "mime",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "subtle",
+ "tower",
+ "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -6266,6 +6377,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa 1.0.15",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6325,6 +6446,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.8.0",
+ "itoa 1.0.15",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -7574,6 +7708,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7594,6 +7729,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -7819,6 +7955,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/nyx-chain-watcher/src/http/api/status.rs
+++ b/nyx-chain-watcher/src/http/api/status.rs
@@ -35,8 +35,10 @@ pub(crate) fn routes() -> Router<AppState> {
         (status = 200, body = BinaryBuildInformationOwned)
     )
 )]
-async fn build_information(State(state): State<StatusState>) -> FormattedResponse < BinaryBuildInformationOwned> {
-Json(state.build_information.to_owned())
+async fn build_information(
+    State(state): State<StatusState>,
+) -> FormattedResponse<BinaryBuildInformationOwned> {
+    Json(state.build_information.to_owned())
 }
 
 #[utoipa::path(
@@ -48,14 +50,14 @@ Json(state.build_information.to_owned())
         (status = 200, body = HealthResponse)
     )
 )]
-async fn health(State(state): State<StatusState>) -> FormattedResponse < HealthResponse> {
-let uptime = state.startup_time.elapsed();
+async fn health(State(state): State<StatusState>) -> FormattedResponse<HealthResponse> {
+    let uptime = state.startup_time.elapsed();
 
-let health = HealthResponse {
-status: ApiStatus::Up,
-uptime: uptime.as_secs(),
-};
-Json(health)
+    let health = HealthResponse {
+        status: ApiStatus::Up,
+        uptime: uptime.as_secs(),
+    };
+    Json(health)
 }
 
 #[utoipa::path(
@@ -69,10 +71,10 @@ Json(health)
 )]
 pub(crate) async fn active_payment_watchers(
     State(state): State<AppState>,
-) -> FormattedResponse < ActivePaymentWatchersResponse> {
-Json(ActivePaymentWatchersResponse {
-watchers: state.registered_payment_watchers.deref().clone(),
-})
+) -> FormattedResponse<ActivePaymentWatchersResponse> {
+    Json(ActivePaymentWatchersResponse {
+        watchers: state.registered_payment_watchers.deref().clone(),
+    })
 }
 
 #[utoipa::path(
@@ -86,56 +88,56 @@ watchers: state.registered_payment_watchers.deref().clone(),
 )]
 pub(crate) async fn payment_listener_status(
     State(state): State<PaymentListenerState>,
-) -> FormattedResponse < PaymentListenerStatusResponse> {
-let guard = state.inner.read().await;
+) -> FormattedResponse<PaymentListenerStatusResponse> {
+    let guard = state.inner.read().await;
 
-// sorry for the nasty conversion code here, run out of time : (
-Json(PaymentListenerStatusResponse {
-last_checked: guard.last_checked,
-processed_payments_since_startup: guard.processed_payments_since_startup,
-watcher_errors_since_startup: guard.watcher_errors_since_startup,
-payment_listener_errors_since_startup: guard.payment_listener_errors_since_startup,
-last_processed_payment: guard
-.last_processed_payment
-.as_ref()
-.map( | p | ProcessedPayment {
-processed_at: p.processed_at,
-tx_hash: p.tx_hash.clone(),
-message_index: p.message_index,
-height: p.height,
-sender: p.sender.clone(),
-receiver: p.receiver.clone(),
-funds: p.funds.clone(),
-memo: p.memo.clone(),
-}),
-latest_failures: guard
-.latest_failures
-.iter()
-.map( | f | PaymentListenerFailureDetails {
-timestamp: f.timestamp,
-error: f.error.clone(),
-})
-.collect(),
-watchers: guard
-.watchers
-.iter()
-.map( | (w, state) | {
-(
-w.clone(),
-WatcherState {
-latest_failures: state
-.latest_failures
-.iter()
-.map( | f | WatcherFailureDetails {
-timestamp: f.timestamp,
-error: f.error.clone(),
-})
-.collect(),
-},
-)
-})
-.collect(),
-})
+    // sorry for the nasty conversion code here, run out of time : (
+    Json(PaymentListenerStatusResponse {
+        last_checked: guard.last_checked,
+        processed_payments_since_startup: guard.processed_payments_since_startup,
+        watcher_errors_since_startup: guard.watcher_errors_since_startup,
+        payment_listener_errors_since_startup: guard.payment_listener_errors_since_startup,
+        last_processed_payment: guard
+            .last_processed_payment
+            .as_ref()
+            .map(|p| ProcessedPayment {
+                processed_at: p.processed_at,
+                tx_hash: p.tx_hash.clone(),
+                message_index: p.message_index,
+                height: p.height,
+                sender: p.sender.clone(),
+                receiver: p.receiver.clone(),
+                funds: p.funds.clone(),
+                memo: p.memo.clone(),
+            }),
+        latest_failures: guard
+            .latest_failures
+            .iter()
+            .map(|f| PaymentListenerFailureDetails {
+                timestamp: f.timestamp,
+                error: f.error.clone(),
+            })
+            .collect(),
+        watchers: guard
+            .watchers
+            .iter()
+            .map(|(w, state)| {
+                (
+                    w.clone(),
+                    WatcherState {
+                        latest_failures: state
+                            .latest_failures
+                            .iter()
+                            .map(|f| WatcherFailureDetails {
+                                timestamp: f.timestamp,
+                                error: f.error.clone(),
+                            })
+                            .collect(),
+                    },
+                )
+            })
+            .collect(),
+    })
 }
 
 #[utoipa::path(
@@ -149,21 +151,21 @@ error: f.error.clone(),
 )]
 pub(crate) async fn price_scraper_status(
     State(state): State<PriceScraperState>,
-) -> FormattedResponse < PriceScraperStatusResponse> {
-let guard = state.inner.read().await;
-Json(PriceScraperStatusResponse {
-last_success: guard
-.last_success
-.as_ref()
-.map( | s | PriceScraperLastSuccess {
-timestamp: s.timestamp,
-response: s.response.clone(),
-}),
-last_failure: guard.last_failure.as_ref().map( | f | PriceScraperLastError {
-timestamp: f.timestamp,
-message: f.message.clone(),
-}),
-})
+) -> FormattedResponse<PriceScraperStatusResponse> {
+    let guard = state.inner.read().await;
+    Json(PriceScraperStatusResponse {
+        last_success: guard
+            .last_success
+            .as_ref()
+            .map(|s| PriceScraperLastSuccess {
+                timestamp: s.timestamp,
+                response: s.response.clone(),
+            }),
+        last_failure: guard.last_failure.as_ref().map(|f| PriceScraperLastError {
+            timestamp: f.timestamp,
+            message: f.message.clone(),
+        }),
+    })
 }
 
 #[utoipa::path(
@@ -177,52 +179,52 @@ message: f.message.clone(),
 )]
 pub(crate) async fn bank_module_status(
     State(state): State<BankScraperModuleState>,
-) -> FormattedResponse < BankModuleStatusResponse> {
-let guard = state.inner.read().await;
-Json(BankModuleStatusResponse {
-processed_bank_msgs_since_startup: guard.processed_bank_msgs_since_startup,
-processed_bank_msgs_to_watched_addresses_since_startup: guard
-.processed_bank_msgs_to_watched_addresses_since_startup,
-rejected_bank_msgs_to_watched_addresses_since_startup: guard
-.rejected_bank_msgs_to_watched_addresses_since_startup,
-last_seen_bank_msgs: guard
-.last_seen_bank_msgs
-.iter()
-.map(| msg | BankMsgDetails {
-processed_at: msg.processed_at,
-tx_hash: msg.tx_hash.clone(),
-height: msg.height,
-index: msg.index,
-from: msg.from.clone(),
-to: msg.to.clone(),
-amount: msg.amount.clone(),
-memo: msg.memo.clone(),
-})
-.collect(),
-last_seen_watched_bank_msgs: guard
-.last_seen_watched_bank_msgs
-.iter()
-.map( | msg| BankMsgDetails {
-processed_at: msg.processed_at,
-tx_hash: msg.tx_hash.clone(),
-height: msg.height,
-index: msg.index,
-from: msg.from.clone(),
-to: msg.to.clone(),
-amount: msg.amount.clone(),
-memo: msg.memo.clone(),
-})
-.collect(),
-last_rejected_watched_bank_msgs: guard
-.last_rejected_watched_bank_msgs
-.iter()
-.map( | r| BankMsgRejection {
-rejected_at: r.rejected_at,
-tx_hash: r.tx_hash.clone(),
-height: r.height,
-index: r.index,
-error: r.error.clone(),
-})
-.collect(),
-})
+) -> FormattedResponse<BankModuleStatusResponse> {
+    let guard = state.inner.read().await;
+    Json(BankModuleStatusResponse {
+        processed_bank_msgs_since_startup: guard.processed_bank_msgs_since_startup,
+        processed_bank_msgs_to_watched_addresses_since_startup: guard
+            .processed_bank_msgs_to_watched_addresses_since_startup,
+        rejected_bank_msgs_to_watched_addresses_since_startup: guard
+            .rejected_bank_msgs_to_watched_addresses_since_startup,
+        last_seen_bank_msgs: guard
+            .last_seen_bank_msgs
+            .iter()
+            .map(|msg| BankMsgDetails {
+                processed_at: msg.processed_at,
+                tx_hash: msg.tx_hash.clone(),
+                height: msg.height,
+                index: msg.index,
+                from: msg.from.clone(),
+                to: msg.to.clone(),
+                amount: msg.amount.clone(),
+                memo: msg.memo.clone(),
+            })
+            .collect(),
+        last_seen_watched_bank_msgs: guard
+            .last_seen_watched_bank_msgs
+            .iter()
+            .map(|msg| BankMsgDetails {
+                processed_at: msg.processed_at,
+                tx_hash: msg.tx_hash.clone(),
+                height: msg.height,
+                index: msg.index,
+                from: msg.from.clone(),
+                to: msg.to.clone(),
+                amount: msg.amount.clone(),
+                memo: msg.memo.clone(),
+            })
+            .collect(),
+        last_rejected_watched_bank_msgs: guard
+            .last_rejected_watched_bank_msgs
+            .iter()
+            .map(|r| BankMsgRejection {
+                rejected_at: r.rejected_at,
+                tx_hash: r.tx_hash.clone(),
+                height: r.height,
+                index: r.index,
+                error: r.error.clone(),
+            })
+            .collect(),
+    })
 }

--- a/nyx-chain-watcher/src/http/api/status.rs
+++ b/nyx-chain-watcher/src/http/api/status.rs
@@ -35,8 +35,8 @@ pub(crate) fn routes() -> Router<AppState> {
         (status = 200, body = BinaryBuildInformationOwned)
     )
 )]
-async fn build_information(State(state): State<StatusState>) -> Json<BinaryBuildInformationOwned> {
-    Json(state.build_information.to_owned())
+async fn build_information(State(state): State<StatusState>) -> FormattedResponse < BinaryBuildInformationOwned> {
+Json(state.build_information.to_owned())
 }
 
 #[utoipa::path(
@@ -48,14 +48,14 @@ async fn build_information(State(state): State<StatusState>) -> Json<BinaryBuild
         (status = 200, body = HealthResponse)
     )
 )]
-async fn health(State(state): State<StatusState>) -> Json<HealthResponse> {
-    let uptime = state.startup_time.elapsed();
+async fn health(State(state): State<StatusState>) -> FormattedResponse < HealthResponse> {
+let uptime = state.startup_time.elapsed();
 
-    let health = HealthResponse {
-        status: ApiStatus::Up,
-        uptime: uptime.as_secs(),
-    };
-    Json(health)
+let health = HealthResponse {
+status: ApiStatus::Up,
+uptime: uptime.as_secs(),
+};
+Json(health)
 }
 
 #[utoipa::path(
@@ -69,10 +69,10 @@ async fn health(State(state): State<StatusState>) -> Json<HealthResponse> {
 )]
 pub(crate) async fn active_payment_watchers(
     State(state): State<AppState>,
-) -> Json<ActivePaymentWatchersResponse> {
-    Json(ActivePaymentWatchersResponse {
-        watchers: state.registered_payment_watchers.deref().clone(),
-    })
+) -> FormattedResponse < ActivePaymentWatchersResponse> {
+Json(ActivePaymentWatchersResponse {
+watchers: state.registered_payment_watchers.deref().clone(),
+})
 }
 
 #[utoipa::path(
@@ -86,56 +86,56 @@ pub(crate) async fn active_payment_watchers(
 )]
 pub(crate) async fn payment_listener_status(
     State(state): State<PaymentListenerState>,
-) -> Json<PaymentListenerStatusResponse> {
-    let guard = state.inner.read().await;
+) -> FormattedResponse < PaymentListenerStatusResponse> {
+let guard = state.inner.read().await;
 
-    // sorry for the nasty conversion code here, run out of time : (
-    Json(PaymentListenerStatusResponse {
-        last_checked: guard.last_checked,
-        processed_payments_since_startup: guard.processed_payments_since_startup,
-        watcher_errors_since_startup: guard.watcher_errors_since_startup,
-        payment_listener_errors_since_startup: guard.payment_listener_errors_since_startup,
-        last_processed_payment: guard
-            .last_processed_payment
-            .as_ref()
-            .map(|p| ProcessedPayment {
-                processed_at: p.processed_at,
-                tx_hash: p.tx_hash.clone(),
-                message_index: p.message_index,
-                height: p.height,
-                sender: p.sender.clone(),
-                receiver: p.receiver.clone(),
-                funds: p.funds.clone(),
-                memo: p.memo.clone(),
-            }),
-        latest_failures: guard
-            .latest_failures
-            .iter()
-            .map(|f| PaymentListenerFailureDetails {
-                timestamp: f.timestamp,
-                error: f.error.clone(),
-            })
-            .collect(),
-        watchers: guard
-            .watchers
-            .iter()
-            .map(|(w, state)| {
-                (
-                    w.clone(),
-                    WatcherState {
-                        latest_failures: state
-                            .latest_failures
-                            .iter()
-                            .map(|f| WatcherFailureDetails {
-                                timestamp: f.timestamp,
-                                error: f.error.clone(),
-                            })
-                            .collect(),
-                    },
-                )
-            })
-            .collect(),
-    })
+// sorry for the nasty conversion code here, run out of time : (
+Json(PaymentListenerStatusResponse {
+last_checked: guard.last_checked,
+processed_payments_since_startup: guard.processed_payments_since_startup,
+watcher_errors_since_startup: guard.watcher_errors_since_startup,
+payment_listener_errors_since_startup: guard.payment_listener_errors_since_startup,
+last_processed_payment: guard
+.last_processed_payment
+.as_ref()
+.map( | p | ProcessedPayment {
+processed_at: p.processed_at,
+tx_hash: p.tx_hash.clone(),
+message_index: p.message_index,
+height: p.height,
+sender: p.sender.clone(),
+receiver: p.receiver.clone(),
+funds: p.funds.clone(),
+memo: p.memo.clone(),
+}),
+latest_failures: guard
+.latest_failures
+.iter()
+.map( | f | PaymentListenerFailureDetails {
+timestamp: f.timestamp,
+error: f.error.clone(),
+})
+.collect(),
+watchers: guard
+.watchers
+.iter()
+.map( | (w, state) | {
+(
+w.clone(),
+WatcherState {
+latest_failures: state
+.latest_failures
+.iter()
+.map( | f | WatcherFailureDetails {
+timestamp: f.timestamp,
+error: f.error.clone(),
+})
+.collect(),
+},
+)
+})
+.collect(),
+})
 }
 
 #[utoipa::path(
@@ -149,21 +149,21 @@ pub(crate) async fn payment_listener_status(
 )]
 pub(crate) async fn price_scraper_status(
     State(state): State<PriceScraperState>,
-) -> Json<PriceScraperStatusResponse> {
-    let guard = state.inner.read().await;
-    Json(PriceScraperStatusResponse {
-        last_success: guard
-            .last_success
-            .as_ref()
-            .map(|s| PriceScraperLastSuccess {
-                timestamp: s.timestamp,
-                response: s.response.clone(),
-            }),
-        last_failure: guard.last_failure.as_ref().map(|f| PriceScraperLastError {
-            timestamp: f.timestamp,
-            message: f.message.clone(),
-        }),
-    })
+) -> FormattedResponse < PriceScraperStatusResponse> {
+let guard = state.inner.read().await;
+Json(PriceScraperStatusResponse {
+last_success: guard
+.last_success
+.as_ref()
+.map( | s | PriceScraperLastSuccess {
+timestamp: s.timestamp,
+response: s.response.clone(),
+}),
+last_failure: guard.last_failure.as_ref().map( | f | PriceScraperLastError {
+timestamp: f.timestamp,
+message: f.message.clone(),
+}),
+})
 }
 
 #[utoipa::path(
@@ -177,52 +177,52 @@ pub(crate) async fn price_scraper_status(
 )]
 pub(crate) async fn bank_module_status(
     State(state): State<BankScraperModuleState>,
-) -> Json<BankModuleStatusResponse> {
-    let guard = state.inner.read().await;
-    Json(BankModuleStatusResponse {
-        processed_bank_msgs_since_startup: guard.processed_bank_msgs_since_startup,
-        processed_bank_msgs_to_watched_addresses_since_startup: guard
-            .processed_bank_msgs_to_watched_addresses_since_startup,
-        rejected_bank_msgs_to_watched_addresses_since_startup: guard
-            .rejected_bank_msgs_to_watched_addresses_since_startup,
-        last_seen_bank_msgs: guard
-            .last_seen_bank_msgs
-            .iter()
-            .map(|msg| BankMsgDetails {
-                processed_at: msg.processed_at,
-                tx_hash: msg.tx_hash.clone(),
-                height: msg.height,
-                index: msg.index,
-                from: msg.from.clone(),
-                to: msg.to.clone(),
-                amount: msg.amount.clone(),
-                memo: msg.memo.clone(),
-            })
-            .collect(),
-        last_seen_watched_bank_msgs: guard
-            .last_seen_watched_bank_msgs
-            .iter()
-            .map(|msg| BankMsgDetails {
-                processed_at: msg.processed_at,
-                tx_hash: msg.tx_hash.clone(),
-                height: msg.height,
-                index: msg.index,
-                from: msg.from.clone(),
-                to: msg.to.clone(),
-                amount: msg.amount.clone(),
-                memo: msg.memo.clone(),
-            })
-            .collect(),
-        last_rejected_watched_bank_msgs: guard
-            .last_rejected_watched_bank_msgs
-            .iter()
-            .map(|r| BankMsgRejection {
-                rejected_at: r.rejected_at,
-                tx_hash: r.tx_hash.clone(),
-                height: r.height,
-                index: r.index,
-                error: r.error.clone(),
-            })
-            .collect(),
-    })
+) -> FormattedResponse < BankModuleStatusResponse> {
+let guard = state.inner.read().await;
+Json(BankModuleStatusResponse {
+processed_bank_msgs_since_startup: guard.processed_bank_msgs_since_startup,
+processed_bank_msgs_to_watched_addresses_since_startup: guard
+.processed_bank_msgs_to_watched_addresses_since_startup,
+rejected_bank_msgs_to_watched_addresses_since_startup: guard
+.rejected_bank_msgs_to_watched_addresses_since_startup,
+last_seen_bank_msgs: guard
+.last_seen_bank_msgs
+.iter()
+.map(| msg | BankMsgDetails {
+processed_at: msg.processed_at,
+tx_hash: msg.tx_hash.clone(),
+height: msg.height,
+index: msg.index,
+from: msg.from.clone(),
+to: msg.to.clone(),
+amount: msg.amount.clone(),
+memo: msg.memo.clone(),
+})
+.collect(),
+last_seen_watched_bank_msgs: guard
+.last_seen_watched_bank_msgs
+.iter()
+.map( | msg| BankMsgDetails {
+processed_at: msg.processed_at,
+tx_hash: msg.tx_hash.clone(),
+height: msg.height,
+index: msg.index,
+from: msg.from.clone(),
+to: msg.to.clone(),
+amount: msg.amount.clone(),
+memo: msg.memo.clone(),
+})
+.collect(),
+last_rejected_watched_bank_msgs: guard
+.last_rejected_watched_bank_msgs
+.iter()
+.map( | r| BankMsgRejection {
+rejected_at: r.rejected_at,
+tx_hash: r.tx_hash.clone(),
+height: r.height,
+index: r.index,
+error: r.error.clone(),
+})
+.collect(),
+})
 }

--- a/nyx-chain-watcher/src/http/api/status.rs
+++ b/nyx-chain-watcher/src/http/api/status.rs
@@ -35,9 +35,7 @@ pub(crate) fn routes() -> Router<AppState> {
         (status = 200, body = BinaryBuildInformationOwned)
     )
 )]
-async fn build_information(
-    State(state): State<StatusState>,
-) -> FormattedResponse<BinaryBuildInformationOwned> {
+async fn build_information(State(state): State<StatusState>) -> Json<BinaryBuildInformationOwned> {
     Json(state.build_information.to_owned())
 }
 
@@ -50,7 +48,7 @@ async fn build_information(
         (status = 200, body = HealthResponse)
     )
 )]
-async fn health(State(state): State<StatusState>) -> FormattedResponse<HealthResponse> {
+async fn health(State(state): State<StatusState>) -> Json<HealthResponse> {
     let uptime = state.startup_time.elapsed();
 
     let health = HealthResponse {
@@ -71,7 +69,7 @@ async fn health(State(state): State<StatusState>) -> FormattedResponse<HealthRes
 )]
 pub(crate) async fn active_payment_watchers(
     State(state): State<AppState>,
-) -> FormattedResponse<ActivePaymentWatchersResponse> {
+) -> Json<ActivePaymentWatchersResponse> {
     Json(ActivePaymentWatchersResponse {
         watchers: state.registered_payment_watchers.deref().clone(),
     })
@@ -88,7 +86,7 @@ pub(crate) async fn active_payment_watchers(
 )]
 pub(crate) async fn payment_listener_status(
     State(state): State<PaymentListenerState>,
-) -> FormattedResponse<PaymentListenerStatusResponse> {
+) -> Json<PaymentListenerStatusResponse> {
     let guard = state.inner.read().await;
 
     // sorry for the nasty conversion code here, run out of time : (
@@ -151,7 +149,7 @@ pub(crate) async fn payment_listener_status(
 )]
 pub(crate) async fn price_scraper_status(
     State(state): State<PriceScraperState>,
-) -> FormattedResponse<PriceScraperStatusResponse> {
+) -> Json<PriceScraperStatusResponse> {
     let guard = state.inner.read().await;
     Json(PriceScraperStatusResponse {
         last_success: guard
@@ -179,7 +177,7 @@ pub(crate) async fn price_scraper_status(
 )]
 pub(crate) async fn bank_module_status(
     State(state): State<BankScraperModuleState>,
-) -> FormattedResponse<BankModuleStatusResponse> {
+) -> Json<BankModuleStatusResponse> {
     let guard = state.inner.read().await;
     Json(BankModuleStatusResponse {
         processed_bank_msgs_since_startup: guard.processed_bank_msgs_since_startup,


### PR DESCRIPTION
this PR introduces support for nym-api to return responses as either bincode or yaml (on top of existing, default, json). furthermore, initial client support for nodes-related queries is introduced. further endpoints can be enhanced by simply pushing `("output", "bincode")` params.

here is the sample response size difference when using json vs bincode (with and without gzip enabled on top of it):
| endpoint                                            | json    | json + gzip | bincode | bincode + gzip |
| --------------------------------------------------- | ------- | ----------- | ------- | -------------- |
| `/v1/nym-nodes/described`                           | 882,684 | 204,265     | 437,204 | 192,752        |
| `/v1/unstable/nym-nodes/skimmed/entry-gateways/all` | 116,268 | 27,991      | 39,755  | 25,589         |
| `/v1/unstable/nym-nodes/skimmed/mixnodes/active`    | 44,646  | 11,371      | 14,021  | 10,235         |
| `/v1/ecash/aggregated-coin-indices-signatures`      | 11,669  | 6,037       | 4,952   | 4,980          |
| `/v1/network/chain-status`                          | 1,523   | 828         | 1,004   | 585            |
| `/v1/nym-nodes/rewarded-set`                        | 1,221   | 616         | 679     | 529            |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5745)
<!-- Reviewable:end -->
