### PR TITLE
Downgrade deranged crate to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -4733,7 +4733,7 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nym-api"
-version = "1.1.55"
+version = "1.1.56"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
Downgrade the crate `deranged` from 0.4.1 to 0.4.0, as 0.4.1 was yanked
and is flagged by `cargo audit`.

VPN-3380

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5746)
<!-- Reviewable:end -->
