### PR TITLE
Instrument create_request

### DIFF
--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -519,6 +519,7 @@ pub trait ApiClientCore {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ApiClientCore for Client {
+    #[instrument(level = "debug", skip_all, fields(path=?path))]
     fn create_request<B, K, V>(
         &self,
         method: reqwest::Method,


### PR DESCRIPTION
In the vpn-api client we create requests directly, so let's instrument
them as well as the currently instrumented top-level function get_json
doesn't capture that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5760)
<!-- Reviewable:end -->
