### PR TITLE
Fetch the topology from the nym-api concurrently

### DIFF
--- a/common/client-core/src/client/topology_control/nym_api_provider.rs
+++ b/common/client-core/src/client/topology_control/nym_api_provider.rs
@@ -86,20 +86,13 @@ impl NymApiTopologyProvider {
     }
 
     async fn get_current_compatible_topology(&mut self) -> Option<NymTopology> {
-        let rewarded_set = self
-            .validator_client
-            .get_current_rewarded_set()
-            .await
-            .inspect_err(|err| error!("failed to get current rewarded set: {err}"))
-            .ok()?;
+        let rewarded_set_fut = self.validator_client.get_current_rewarded_set();
 
-        let mut topology = NymTopology::new_empty(rewarded_set);
+        let topology = if self.config.use_extended_topology {
+            let all_nodes_fut = self.validator_client.get_all_basic_nodes();
 
-        if self.config.use_extended_topology {
-            let all_nodes = self
-                .validator_client
-                .get_all_basic_nodes()
-                .await
+            // Join rewarded_set_fut and all_nodes_fut concurrently
+            let (rewarded_set, all_nodes) = futures::try_join!(rewarded_set_fut, all_nodes_fut)
                 .inspect_err(|err| error!("failed to get network nodes: {err}"))
                 .ok()?;
 
@@ -107,26 +100,28 @@ impl NymApiTopologyProvider {
                 "there are {} nodes on the network (before filtering)",
                 all_nodes.len()
             );
+            let mut topology = NymTopology::new_empty(rewarded_set);
             topology.add_additional_nodes(all_nodes.iter().filter(|n| {
                 n.performance.round_to_integer() >= self.config.min_node_performance()
             }));
+
+            topology
         } else {
             // if we're not using extended topology, we're only getting active set mixnodes and gateways
 
-            let mixnodes = self
+            let mixnodes_fut = self
                 .validator_client
-                .get_all_basic_active_mixing_assigned_nodes()
-                .await
-                .inspect_err(|err| error!("failed to get network mixnodes: {err}"))
-                .ok()?;
+                .get_all_basic_active_mixing_assigned_nodes();
 
             // TODO: we really should be getting ACTIVE gateways only
-            let gateways = self
-                .validator_client
-                .get_all_basic_entry_assigned_nodes()
-                .await
-                .inspect_err(|err| error!("failed to get network gateways: {err}"))
-                .ok()?;
+            let gateways_fut = self.validator_client.get_all_basic_entry_assigned_nodes();
+
+            let (rewarded_set, mixnodes, gateways) =
+                futures::try_join!(rewarded_set_fut, mixnodes_fut, gateways_fut)
+                    .inspect_err(|err| {
+                        error!("failed to get network nodes: {err}");
+                    })
+                    .ok()?;
 
             debug!(
                 "there are {} mixnodes and {} gateways in total (before performance filtering)",
@@ -134,12 +129,15 @@ impl NymApiTopologyProvider {
                 gateways.len()
             );
 
+            let mut topology = NymTopology::new_empty(rewarded_set);
             topology.add_additional_nodes(mixnodes.iter().filter(|m| {
                 m.performance.round_to_integer() >= self.config.min_mixnode_performance
             }));
             topology.add_additional_nodes(gateways.iter().filter(|m| {
                 m.performance.round_to_integer() >= self.config.min_gateway_performance
             }));
+
+            topology
         };
 
         if !topology.is_minimally_routable() {

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -698,7 +698,7 @@ pub trait ApiClient: ApiClientCore {
     /// 'get' json data from the segment-defined path, e.g. `["api", "v1", "mixnodes"]`, with tuple
     /// defined key-value parameters, e.g. `[("since", "12345")]`. Attempt to parse the response
     /// into the provided type `T`.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "debug", skip_all, fields(path=?path))]
     // TODO: deprecate in favour of get_response that works based on mime type in the response
     async fn get_json<T, K, V, E>(
         &self,


### PR DESCRIPTION
When fetching the topology from the nym-api, multiple GET are done. We can do these concurrently as a simple way to speed things up.

Some basic testing locally for me shows about 30% less time for the mixnet client to connect

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5767)
<!-- Reviewable:end -->
