### PR TITLE
Expanded Accept Encoding for `reqwest`

### DIFF
--- a/common/http-api-client/Cargo.toml
+++ b/common/http-api-client/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 bincode = { workspace = true }
-reqwest = { workspace = true, features = ["json", "gzip"] }
+reqwest = { workspace = true, features = ["json", "gzip", "deflate", "brotli", "zstd"] }
 http.workspace = true
 url = { workspace = true }
 once_cell = { workspace = true }

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -288,14 +288,18 @@ impl ClientBuilder {
 
         #[cfg(not(target_arch = "wasm32"))]
         let reqwest_client_builder = {
-            let r = reqwest::ClientBuilder::new();
-
-            // Note this is extra as the `gzip` feature for `reqwest` crate should be enabled which
-            // `"Enable[s] auto gzip decompression by checking the Content-Encoding response header."`
+            // Note: I believe the manual enable calls for the compression methods are extra
+            // as the various compression features for `reqwest` crate should be enabled
+            // just by including the feature which:
+            // `"Enable[s] auto decompression by checking the Content-Encoding response header."`
             //
-            // I am going to leave it here anyways so that gzip decompression is attempted even if
-            // that feature is removed.
-            r.gzip(true)
+            // I am going to leave these here anyways so that removing a decompression method
+            // from the features list will throw an error if it is not also removed here.
+            reqwest::ClientBuilder::new()
+                .gzip(true)
+                .deflate(true)
+                .brotli(true)
+                .zstd(true)
         };
 
         ClientBuilder {
@@ -558,11 +562,6 @@ impl ApiClientCore for Client {
         let url = sanitize_url(&self.base_url, path, params);
 
         let mut request = self.reqwest_client.request(method.clone(), url);
-
-        // Indicate that compressed responses are preferred, but if not supported other encodings are fine.
-        // TODO: Down the road we can be more selective about adding this, but it's inclusion here guarantees
-        // that we use compression when available.
-        request = request.header(reqwest::header::ACCEPT_ENCODING, "gzip;q=1.0, *;q=0.5");
 
         if let Some(body) = json_body {
             request = request.json(body);


### PR DESCRIPTION
## Problem

The accept encoding that we are sending has a logic fallacy in that it is supposed to prefer gzip, and fall back to plaintext. What it actually requests is gzip, but if that isn't available, anything else is fine. This is an issue because some cloud cached API endpoints are optimistic about support for `br` and the `reqwest` client isn't  actually configured to handle decompressing that so it returns the still encoded value to the calling application instead of the expected json. 

## Solution

Enable support for more content encoding types through `reqwest`. This gives the server side more flexibility, which it seems to want, and we now only request the specific `content-encodings` that we will definitely be able to parse. Applications using the api client should no longer receive data still encoded as `reqwest` should manage decompressing it for us.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5779)
<!-- Reviewable:end -->
