### PR TITLE
[DOCs/operators]: Rewards calculator quick tweak

### DIFF
--- a/documentation/docs/components/operators/interactive/calculators/reward-calculator.jsx
+++ b/documentation/docs/components/operators/interactive/calculators/reward-calculator.jsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react'
 
 export default function RewardsCalculator() {
-  const [a, setA] = useState(0)
+  const [a, setA] = useState(5241)
   const [b, setB] = useState(0)
   const [c, setC] = useState(0)
   const [d, setD] = useState(0)
-  const [e, setE] = useState(0)
+  const [e, setE] = useState(1034081)
 
   const result =
     e !== 0
@@ -117,4 +117,3 @@ export default function RewardsCalculator() {
     </div>
   )
 }
-

--- a/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
+++ b/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
@@ -1,1 +1,1 @@
-Thursday, May 15th 2025, 13:46:20 UTC
+Tuesday, May 20th 2025, 12:46:16 UTC


### PR DESCRIPTION
This hard-coded intermittent solution will by default list a value corresponding with an onchain data rather than 0, while letting the operator to change these values in case they changed since the docs build. 

This hardcoded way is a quick tweak which will be changed within a week for a scraper filling the values on book build based on real chain data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5786)
<!-- Reviewable:end -->
