### PR TITLE
QoL: RequestPath trait for http-api-client

### DIFF
--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1059,6 +1059,12 @@ mod tests {
             sanitize_url(&base_url, "/foo//bar/", NO_PARAMS).as_str()
         );
 
+        // (and leading slash doesn't matter)
+        assert_eq!(
+            "http://foomp.com/foo/bar",
+            sanitize_url(&base_url, "foo//bar/", NO_PARAMS).as_str()
+        );
+
         // works with 1 segment
         assert_eq!(
             "http://foomp.com/foo",

--- a/common/http-api-client/src/path.rs
+++ b/common/http-api-client/src/path.rs
@@ -1,0 +1,59 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Debug;
+
+/// Collection of URL Path Segments
+pub type PathSegments<'a> = &'a [&'a str];
+
+fn sanitize_fragment(segment: &str) -> &str {
+    segment.trim_matches(|c: char| c.is_whitespace() || c == '/')
+}
+
+pub trait RequestPath: Debug {
+    fn to_sanitized_segments(&self) -> Vec<&str>;
+}
+
+macro_rules! impl_stringified_sanitized_segments {
+    ($frag_iter:expr) => {{
+        let mut path_segments = Vec::new();
+
+        for segment in $frag_iter {
+            if !segment.is_empty() {
+                path_segments.push(sanitize_fragment(segment));
+            }
+        }
+
+        path_segments
+    }};
+}
+
+impl RequestPath for PathSegments<'_> {
+    fn to_sanitized_segments(&self) -> Vec<&str> {
+        impl_stringified_sanitized_segments!(self.iter())
+    }
+}
+
+impl<const N: usize> RequestPath for &[&str; N] {
+    fn to_sanitized_segments(&self) -> Vec<&str> {
+        impl_stringified_sanitized_segments!(self.iter())
+    }
+}
+
+impl RequestPath for &str {
+    fn to_sanitized_segments(&self) -> Vec<&str> {
+        impl_stringified_sanitized_segments!(self.split('/'))
+    }
+}
+
+impl RequestPath for String {
+    fn to_sanitized_segments(&self) -> Vec<&str> {
+        impl_stringified_sanitized_segments!(self.split('/'))
+    }
+}
+
+impl RequestPath for &String {
+    fn to_sanitized_segments(&self) -> Vec<&str> {
+        impl_stringified_sanitized_segments!(self.split('/'))
+    }
+}

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -415,11 +415,14 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
 dependencies = [
+ "brotli",
  "flate2",
  "futures-core",
  "memchr",
  "pin-project-lite",
  "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -940,6 +943,8 @@ version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -3528,6 +3533,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.2",
+ "libc",
+]
 
 [[package]]
 name = "jpeg-decoder"
@@ -9268,6 +9283,34 @@ dependencies = [
  "crossbeam-utils",
  "indexmap 2.8.0",
  "memchr",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]


### PR DESCRIPTION
something that has been bothering me for quite a while now. those `PathSegments` in `ApiClient` weren't very user-friendly. instead I've defined a `RequestPath` trait that allows you to also pass a good old `&str` or `String` and internally it does exactly the same sanitization as before. `PathSegments` are also fully supported to not break any existing compatibility.

what it means is that both of the below are equally valid now:

```rust

// old way
    self.get_json(
        &[
            routes::API_VERSION,
            routes::API_STATUS_ROUTES,
            routes::HEALTH,
        ],
        NO_PARAMS,
    )
    .await

// new alternative way
  self.get_json("/v1/status/health", NO_PARAMS).await;

```

I will probably revisit `params` with the same approach in the future.

I'm adding significantly more people than required for review just so that you're aware of this change : )

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5788)
<!-- Reviewable:end -->
