### PR TITLE
[DOCs/operators]: Hotfix - Round decimalds to common convention

### DIFF
--- a/documentation/docs/components/operators/interactive/calculators/reward-calculator.jsx
+++ b/documentation/docs/components/operators/interactive/calculators/reward-calculator.jsx
@@ -5,20 +5,23 @@ import RewardParams from 'components/outputs/api-scraping-outputs/reward-params.
 
 export default function RewardsCalculator() {
   const [a, setA] = useState(
-    Math.round(Number(RewardParams.interval.epoch_reward_budget) / 1_000_000)
+    Number(
+      (Number(RewardParams.interval.epoch_reward_budget) / 1_000_000).toFixed(6)
+    )
   )
   const [b, setB] = useState(0)
   const [c, setC] = useState(0)
   const [d, setD] = useState(0)
   const [e, setE] = useState(
-    Math.round(Number(RewardParams.interval.stake_saturation_point) / 1_000_000)
+    Number(
+      (Number(RewardParams.interval.stake_saturation_point) / 1_000_000).toFixed(6)
+    )
   )
-
   const result =
     e !== 0
       ? `${(
           a * b * c * ((1 / 240) + 0.3 * ((d / e) / 240)) * 1 / (1 + 0.3)
-        ).toFixed(4)} NYM`
+        ).toFixed(6)} NYM`
       : '—'
 
   return (

--- a/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
+++ b/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
@@ -1,1 +1,1 @@
-Wednesday, May 21st 2025, 09:16:14 UTC
+Wednesday, May 21st 2025, 13:50:05 UTC


### PR DESCRIPTION
All decimals in Reward calculator will be round to 6 by default following cosmos convention.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5791)
<!-- Reviewable:end -->
