### PR TITLE
HTTP Discovery objects & network defaults

### DIFF
--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::ApiUrlConst;
 #[cfg(feature = "network")]
 use crate::{DenomDetails, ValidatorDetails};
 
@@ -29,10 +30,30 @@ pub const COCONUT_DKG_CONTRACT_ADDRESS: &str =
 pub const REWARDING_VALIDATOR_ADDRESS: &str = "n10yyd98e2tuwu0f7ypz9dy3hhjw7v772q6287gy";
 
 pub const NYXD_URL: &str = "https://rpc.nymtech.net";
-pub const NYM_API: &str = "https://validator.nymtech.net/api/";
 pub const NYXD_WS: &str = "wss://rpc.nymtech.net/websocket";
 pub const EXPLORER_API: &str = "https://explorer.nymtech.net/api/";
+pub const NYM_API: &str = "https://validator.nymtech.net/api/";
+pub const NYM_APIS: &[ApiUrlConst] = &[
+    ApiUrlConst {
+        url: NYM_API,
+        front_urls: None,
+    },
+    ApiUrlConst {
+        url: "https://validator.global.ssl.fastly.net/api/",
+        front_urls: Some(&["https://yelp.global.ssl.fastly.net"]),
+    },
+];
 pub const NYM_VPN_API: &str = "https://nymvpn.com/api/";
+pub const NYM_VPN_APIS: &[ApiUrlConst] = &[
+    ApiUrlConst {
+        url: NYM_VPN_API,
+        front_urls: None,
+    },
+    ApiUrlConst {
+        url: "https://nymvpn.global.ssl.fastly.net/api/",
+        front_urls: Some(&["https://yelp.global.ssl.fastly.net"]),
+    },
+];
 
 // I'm making clippy mad on purpose, because that url HAS TO be updated and deployed before merging
 pub const EXIT_POLICY_URL: &str =

--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -36,22 +36,26 @@ pub const NYM_API: &str = "https://validator.nymtech.net/api/";
 pub const NYM_APIS: &[ApiUrlConst] = &[
     ApiUrlConst {
         url: NYM_API,
-        front_urls: None,
+        front_hosts: None,
     },
     ApiUrlConst {
-        url: "https://validator.global.ssl.fastly.net/api/",
-        front_urls: Some(&["https://yelp.global.ssl.fastly.net"]),
+        url: "https://nym-fronntdoor.vercel.app/api/",
+        front_hosts: Some(&["vercel.app", "vercel.com"]),
+    },
+    ApiUrlConst {
+        url: "https://nym-frontdoor.global.ssl.fastly.net/api/",
+        front_hosts: Some(&["yelp.global.ssl.fastly.net"]),
     },
 ];
 pub const NYM_VPN_API: &str = "https://nymvpn.com/api/";
 pub const NYM_VPN_APIS: &[ApiUrlConst] = &[
     ApiUrlConst {
         url: NYM_VPN_API,
-        front_urls: None,
+        front_hosts: Some(&["vercel.app", "vercel.com"]),
     },
     ApiUrlConst {
-        url: "https://nymvpn.global.ssl.fastly.net/api/",
-        front_urls: Some(&["https://yelp.global.ssl.fastly.net"]),
+        url: "https://nymvpn-frontdoor.global.ssl.fastly.net/api/",
+        front_hosts: Some(&["yelp.global.ssl.fastly.net"]),
     },
 ];
 

--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -1,9 +1,8 @@
 // Copyright 2021 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ApiUrlConst;
 #[cfg(feature = "network")]
-use crate::{DenomDetails, ValidatorDetails};
+use crate::{ApiUrlConst, DenomDetails, ValidatorDetails};
 
 pub const NETWORK_NAME: &str = "mainnet";
 
@@ -33,6 +32,7 @@ pub const NYXD_URL: &str = "https://rpc.nymtech.net";
 pub const NYXD_WS: &str = "wss://rpc.nymtech.net/websocket";
 pub const EXPLORER_API: &str = "https://explorer.nymtech.net/api/";
 pub const NYM_API: &str = "https://validator.nymtech.net/api/";
+#[cfg(feature = "network")]
 pub const NYM_APIS: &[ApiUrlConst] = &[
     ApiUrlConst {
         url: NYM_API,
@@ -48,6 +48,7 @@ pub const NYM_APIS: &[ApiUrlConst] = &[
     },
 ];
 pub const NYM_VPN_API: &str = "https://nymvpn.com/api/";
+#[cfg(feature = "network")]
 pub const NYM_VPN_APIS: &[ApiUrlConst] = &[
     ApiUrlConst {
         url: NYM_VPN_API,

--- a/common/network-defaults/src/network.rs
+++ b/common/network-defaults/src/network.rs
@@ -57,7 +57,9 @@ impl From<ApiUrlConst<'_>> for ApiUrl {
     fn from(value: ApiUrlConst) -> Self {
         ApiUrl {
             url: value.url.to_string(),
-            front_urls: value.front_urls.map(|slice| slice.iter().map(|s| s.to_string()).collect()),
+            front_urls: value
+                .front_urls
+                .map(|slice| slice.iter().map(|s| s.to_string()).collect()),
         }
     }
 }

--- a/common/network-defaults/src/network.rs
+++ b/common/network-defaults/src/network.rs
@@ -44,21 +44,27 @@ pub struct NymNetworkDetails {
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, JsonSchema)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct ApiUrl {
+    /// Expects a string formatted Url
+    ///
+    /// see https://docs.rs/url/latest/url/struct.Url.html
     pub url: String,
-    pub front_urls: Option<Vec<String>>,
+    /// Optional alternative equivalent hostnames. Each entry must parse as valid Host
+    ///
+    /// see https://docs.rs/url/latest/url/enum.Host.html
+    pub front_hosts: Option<Vec<String>>,
 }
 
 pub struct ApiUrlConst<'a> {
     pub url: &'a str,
-    pub front_urls: Option<&'a [&'a str]>,
+    pub front_hosts: Option<&'a [&'a str]>,
 }
 
 impl From<ApiUrlConst<'_>> for ApiUrl {
     fn from(value: ApiUrlConst) -> Self {
         ApiUrl {
             url: value.url.to_string(),
-            front_urls: value
-                .front_urls
+            front_hosts: value
+                .front_hosts
                 .map(|slice| slice.iter().map(|s| s.to_string()).collect()),
         }
     }

--- a/common/network-defaults/src/network.rs
+++ b/common/network-defaults/src/network.rs
@@ -48,6 +48,20 @@ pub struct ApiUrl {
     pub front_urls: Option<Vec<String>>,
 }
 
+pub struct ApiUrlConst<'a> {
+    pub url: &'a str,
+    pub front_urls: Option<&'a [&'a str]>,
+}
+
+impl From<ApiUrlConst<'_>> for ApiUrl {
+    fn from(value: ApiUrlConst) -> Self {
+        ApiUrl {
+            url: value.url.to_string(),
+            front_urls: value.front_urls.map(|slice| slice.iter().map(|s| s.to_string()).collect()),
+        }
+    }
+}
+
 // by default we assume the same defaults as mainnet, i.e. same prefixes and denoms
 impl Default for NymNetworkDetails {
     fn default() -> Self {

--- a/common/network-defaults/src/network.rs
+++ b/common/network-defaults/src/network.rs
@@ -37,6 +37,15 @@ pub struct NymNetworkDetails {
     pub contracts: NymContracts,
     pub explorer_api: Option<String>,
     pub nym_vpn_api_url: Option<String>,
+    pub nym_api_urls: Option<Vec<ApiUrl>>,
+    pub nym_vpn_api_urls: Option<Vec<ApiUrl>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, JsonSchema)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub struct ApiUrl {
+    pub url: String,
+    pub front_urls: Option<Vec<String>>,
 }
 
 // by default we assume the same defaults as mainnet, i.e. same prefixes and denoms
@@ -67,6 +76,8 @@ impl NymNetworkDetails {
             contracts: Default::default(),
             explorer_api: Default::default(),
             nym_vpn_api_url: Default::default(),
+            nym_api_urls: Default::default(),
+            nym_vpn_api_urls: Default::default(),
         }
     }
 
@@ -154,6 +165,8 @@ impl NymNetworkDetails {
             },
             explorer_api: parse_optional_str(mainnet::EXPLORER_API),
             nym_vpn_api_url: parse_optional_str(mainnet::NYM_VPN_API),
+            nym_api_urls: None,
+            nym_vpn_api_urls: None,
         }
     }
 

--- a/nym-wallet/nym-wallet-types/src/network/sandbox.rs
+++ b/nym-wallet/nym-wallet-types/src/network/sandbox.rs
@@ -55,5 +55,7 @@ pub(crate) fn network_details() -> nym_network_defaults::NymNetworkDetails {
         },
         explorer_api: parse_optional_str(EXPLORER_API),
         nym_vpn_api_url: None,
+        nym_vpn_api_urls: None,
+        nym_api_urls: None,
     }
 }

--- a/tools/internal/testnet-manager/src/manager/network.rs
+++ b/tools/internal/testnet-manager/src/manager/network.rs
@@ -83,6 +83,8 @@ impl<'a> From<&'a LoadedNetwork> for nym_config::defaults::NymNetworkDetails {
             contracts,
             explorer_api: None,
             nym_vpn_api_url: None,
+            nym_vpn_api_urls: None,
+            nym_api_urls: None,
         }
     }
 }

--- a/tools/internal/testnet-manager/src/manager/network_init.rs
+++ b/tools/internal/testnet-manager/src/manager/network_init.rs
@@ -40,6 +40,8 @@ impl InitCtx {
             contracts: Default::default(),
             explorer_api: None,
             nym_vpn_api_url: None,
+            nym_vpn_api_urls: None,
+            nym_api_urls: None,
         };
         Ok(Config::try_from_nym_network_details(&network_details)?)
     }


### PR DESCRIPTION
Add configuration options for expanded API urls provided by the discovery env objects.

see NET-335 & NET-337

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5814)
<!-- Reviewable:end -->
