### PR TITLE
Bug Fix for Wallet build

### DIFF
--- a/common/client-libs/validator-client/src/connection_tester.rs
+++ b/common/client-libs/validator-client/src/connection_tester.rs
@@ -5,7 +5,6 @@ use crate::{NymApiClient, QueryHttpRpcNyxdClient, ValidatorClientError};
 use colored::Colorize;
 use core::fmt;
 use itertools::Itertools;
-// use nym_http_api_client::Url;
 use nym_network_defaults::NymNetworkDetails;
 use std::collections::HashMap;
 use std::hash::BuildHasher;

--- a/common/client-libs/validator-client/src/connection_tester.rs
+++ b/common/client-libs/validator-client/src/connection_tester.rs
@@ -5,12 +5,13 @@ use crate::{NymApiClient, QueryHttpRpcNyxdClient, ValidatorClientError};
 use colored::Colorize;
 use core::fmt;
 use itertools::Itertools;
-use nym_http_api_client::Url;
+// use nym_http_api_client::Url;
 use nym_network_defaults::NymNetworkDetails;
 use std::collections::HashMap;
 use std::hash::BuildHasher;
 use std::time::Duration;
 use tokio::time::timeout;
+use url::Url;
 
 const MAX_URLS_TESTED: usize = 200;
 const CONNECTION_TEST_TIMEOUT_SEC: u64 = 2;
@@ -88,7 +89,7 @@ fn setup_connection_tests<H: BuildHasher + 'static>(
     });
 
     let api_connection_test_clients = api_urls.map(|(network, url)| {
-        ClientForConnectionTest::Api(network, url.clone(), NymApiClient::new(url.into()))
+        ClientForConnectionTest::Api(network, url.clone(), NymApiClient::new(url))
     });
 
     nyxd_connection_test_clients.chain(api_connection_test_clients)


### PR DESCRIPTION
Revert url used for connection-tester to default `url::Url`

For now I don't think we need any of the advanced HTTP features in the connection tester, despite these being API urls as this is used for the Wallet, no the VPN client. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5820)
<!-- Reviewable:end -->
