### PR TITLE
[Stats API] Infallible network view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7186,7 +7186,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum 0.7.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,8 +2251,8 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
- "nym-coconut-dkg-common",
- "nym-contracts-common",
+ "nym-coconut-dkg-common 0.1.0",
+ "nym-contracts-common 0.5.0",
 ]
 
 [[package]]
@@ -2330,8 +2330,8 @@ dependencies = [
  "dashmap",
  "dirs",
  "futures",
- "nym-bin-common",
- "nym-crypto",
+ "nym-bin-common 0.6.0",
+ "nym-crypto 0.4.0",
  "nym-sdk",
  "serde",
  "tempfile",
@@ -3750,11 +3750,11 @@ dependencies = [
  "clap",
  "dirs",
  "importer-contract",
- "nym-bin-common",
- "nym-mixnet-contract-common",
- "nym-network-defaults",
- "nym-validator-client",
- "nym-vesting-contract-common",
+ "nym-bin-common 0.6.0",
+ "nym-mixnet-contract-common 0.6.0",
+ "nym-network-defaults 0.1.0",
+ "nym-validator-client 0.1.0",
+ "nym-vesting-contract-common 0.7.0",
  "serde",
  "serde_json",
  "tokio",
@@ -4454,8 +4454,8 @@ dependencies = [
  "async-trait",
  "futures",
  "js-sys",
- "nym-bin-common",
- "nym-http-api-client",
+ "nym-bin-common 0.6.0",
+ "nym-http-api-client 0.1.0",
  "nym-ordered-buffer",
  "nym-service-providers-common",
  "nym-socks5-requests",
@@ -4479,9 +4479,9 @@ dependencies = [
  "anyhow",
  "clap",
  "futures",
- "nym-bin-common",
- "nym-crypto",
- "nym-network-defaults",
+ "nym-bin-common 0.6.0",
+ "nym-crypto 0.4.0",
+ "nym-network-defaults 0.1.0",
  "nym-sdk",
  "tokio",
  "tracing",
@@ -4823,37 +4823,37 @@ dependencies = [
  "itertools 0.14.0",
  "k256",
  "moka",
- "nym-api-requests",
+ "nym-api-requests 0.1.0",
  "nym-bandwidth-controller",
- "nym-bin-common",
- "nym-coconut-dkg-common",
- "nym-compact-ecash",
- "nym-config",
- "nym-contracts-common",
+ "nym-bin-common 0.6.0",
+ "nym-coconut-dkg-common 0.1.0",
+ "nym-compact-ecash 0.1.0",
+ "nym-config 0.1.0",
+ "nym-contracts-common 0.5.0",
  "nym-credential-storage",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
  "nym-dkg",
- "nym-ecash-contract-common",
- "nym-ecash-time",
+ "nym-ecash-contract-common 0.1.0",
+ "nym-ecash-time 0.1.0",
  "nym-gateway-client",
- "nym-http-api-common",
+ "nym-http-api-common 0.1.0",
  "nym-inclusion-probability",
- "nym-mixnet-contract-common",
- "nym-multisig-contract-common",
- "nym-node-requests",
+ "nym-mixnet-contract-common 0.6.0",
+ "nym-multisig-contract-common 0.1.0",
+ "nym-node-requests 0.1.0",
  "nym-node-tester-utils",
- "nym-pemstore",
- "nym-serde-helpers",
+ "nym-pemstore 0.3.0",
+ "nym-serde-helpers 0.1.0",
  "nym-sphinx",
  "nym-statistics-common",
  "nym-task",
- "nym-ticketbooks-merkle",
+ "nym-ticketbooks-merkle 0.1.0",
  "nym-topology",
  "nym-types",
- "nym-validator-client",
- "nym-vesting-contract-common",
+ "nym-validator-client 0.1.0",
+ "nym-vesting-contract-common 0.7.0",
  "pin-project",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4892,17 +4892,17 @@ dependencies = [
  "getset",
  "hex",
  "humantime-serde",
- "nym-compact-ecash",
- "nym-config",
- "nym-contracts-common",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-ecash-time",
- "nym-mixnet-contract-common",
- "nym-network-defaults",
- "nym-node-requests",
- "nym-serde-helpers",
- "nym-ticketbooks-merkle",
+ "nym-compact-ecash 0.1.0",
+ "nym-config 0.1.0",
+ "nym-contracts-common 0.5.0",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-ecash-time 0.1.0",
+ "nym-mixnet-contract-common 0.6.0",
+ "nym-network-defaults 0.1.0",
+ "nym-node-requests 0.1.0",
+ "nym-serde-helpers 0.1.0",
+ "nym-ticketbooks-merkle 0.1.0",
  "rand_chacha 0.3.1",
  "schemars",
  "serde",
@@ -4914,6 +4914,40 @@ dependencies = [
  "time",
  "tracing",
  "ts-rs",
+ "utoipa",
+]
+
+[[package]]
+name = "nym-api-requests"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "bs58",
+ "cosmrs",
+ "cosmwasm-std",
+ "ecdsa",
+ "getset",
+ "hex",
+ "humantime-serde",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-node-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-ticketbooks-merkle 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tendermint",
+ "tendermint-rpc",
+ "thiserror 2.0.12",
+ "time",
  "utoipa",
 ]
 
@@ -4943,16 +4977,16 @@ dependencies = [
  "log",
  "mock_instant",
  "nym-authenticator-requests",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-client-core",
- "nym-config",
+ "nym-config 0.1.0",
  "nym-credential-verification",
- "nym-credentials-interface",
- "nym-crypto",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
  "nym-gateway-requests",
  "nym-gateway-storage",
  "nym-id",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0",
  "nym-sdk",
  "nym-service-provider-requests-common",
  "nym-service-providers-common",
@@ -4960,7 +4994,7 @@ dependencies = [
  "nym-task",
  "nym-types",
  "nym-wireguard",
- "nym-wireguard-types",
+ "nym-wireguard-types 0.1.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -4978,12 +5012,12 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "hmac",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-network-defaults",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-network-defaults 0.1.0",
  "nym-service-provider-requests-common",
  "nym-sphinx",
- "nym-wireguard-types",
+ "nym-wireguard-types 0.1.0",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.9",
@@ -4999,13 +5033,13 @@ dependencies = [
  "log",
  "nym-credential-storage",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-ecash-contract-common",
- "nym-ecash-time",
- "nym-network-defaults",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-ecash-contract-common 0.1.0",
+ "nym-ecash-time 0.1.0",
+ "nym-network-defaults 0.1.0",
  "nym-task",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "rand 0.8.5",
  "thiserror 2.0.12",
  "url",
@@ -5035,6 +5069,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-bin-common"
+version = "0.6.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "const-str",
+ "log",
+ "schemars",
+ "serde",
+ "utoipa",
+ "vergen",
+]
+
+[[package]]
 name = "nym-bity-integration"
 version = "0.1.0"
 dependencies = [
@@ -5043,7 +5090,7 @@ dependencies = [
  "eyre",
  "k256",
  "nym-cli-commands",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -5063,10 +5110,10 @@ dependencies = [
  "dotenvy",
  "inquire",
  "log",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-cli-commands",
- "nym-network-defaults",
- "nym-validator-client",
+ "nym-network-defaults 0.1.0",
+ "nym-validator-client 0.1.0",
  "serde",
  "serde_json",
  "tap",
@@ -5096,28 +5143,28 @@ dependencies = [
  "k256",
  "log",
  "nym-bandwidth-controller",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-client-core",
- "nym-coconut-dkg-common",
- "nym-config",
- "nym-contracts-common",
+ "nym-coconut-dkg-common 0.1.0",
+ "nym-config 0.1.0",
+ "nym-contracts-common 0.5.0",
  "nym-credential-proxy-requests",
  "nym-credential-storage",
  "nym-credential-utils",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-ecash-contract-common",
- "nym-ecash-time",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-ecash-contract-common 0.1.0",
+ "nym-ecash-time 0.1.0",
  "nym-id",
- "nym-mixnet-contract-common",
- "nym-multisig-contract-common",
- "nym-network-defaults",
- "nym-pemstore",
+ "nym-mixnet-contract-common 0.6.0",
+ "nym-multisig-contract-common 0.1.0",
+ "nym-network-defaults 0.1.0",
+ "nym-pemstore 0.3.0",
  "nym-sphinx",
  "nym-types",
- "nym-validator-client",
- "nym-vesting-contract-common",
+ "nym-validator-client 0.1.0",
+ "nym-vesting-contract-common 0.7.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -5141,21 +5188,21 @@ dependencies = [
  "futures",
  "log",
  "nym-bandwidth-controller",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-client-core",
  "nym-client-websocket-requests",
- "nym-config",
+ "nym-config 0.1.0",
  "nym-credential-storage",
  "nym-credentials",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-gateway-requests",
  "nym-id",
- "nym-network-defaults",
- "nym-pemstore",
+ "nym-network-defaults 0.1.0",
+ "nym-pemstore 0.3.0",
  "nym-sphinx",
  "nym-task",
  "nym-topology",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -5188,25 +5235,25 @@ dependencies = [
  "nym-client-core-config-types",
  "nym-client-core-gateways-storage",
  "nym-client-core-surb-storage",
- "nym-config",
+ "nym-config 0.1.0",
  "nym-credential-storage",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-ecash-time",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-ecash-time 0.1.0",
  "nym-gateway-client",
  "nym-gateway-requests",
- "nym-http-api-client",
+ "nym-http-api-client 0.1.0",
  "nym-id",
  "nym-metrics",
  "nym-mixnet-client",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0",
  "nym-nonexhaustive-delayqueue",
- "nym-pemstore",
+ "nym-pemstore 0.3.0",
  "nym-sphinx",
  "nym-statistics-common",
  "nym-task",
  "nym-topology",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -5234,8 +5281,8 @@ name = "nym-client-core-config-types"
 version = "0.1.0"
 dependencies = [
  "humantime-serde",
- "nym-config",
- "nym-pemstore",
+ "nym-config 0.1.0",
+ "nym-pemstore 0.3.0",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-statistics-common",
@@ -5251,7 +5298,7 @@ dependencies = [
  "async-trait",
  "cosmrs",
  "log",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-gateway-requests",
  "serde",
  "sqlx",
@@ -5269,7 +5316,7 @@ dependencies = [
  "async-trait",
  "dashmap",
  "log",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-sphinx",
  "nym-task",
  "sqlx",
@@ -5285,7 +5332,7 @@ dependencies = [
  "anyhow",
  "futures",
  "js-sys",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-node-tester-utils",
  "nym-node-tester-wasm",
  "rand 0.8.5",
@@ -5319,8 +5366,22 @@ dependencies = [
  "cw-utils",
  "cw2",
  "cw4",
- "nym-contracts-common",
- "nym-multisig-contract-common",
+ "nym-contracts-common 0.5.0",
+ "nym-multisig-contract-common 0.1.0",
+]
+
+[[package]]
+name = "nym-coconut-dkg-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils",
+ "cw2",
+ "cw4",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
 ]
 
 [[package]]
@@ -5336,10 +5397,33 @@ dependencies = [
  "ff",
  "group",
  "itertools 0.14.0",
- "nym-network-defaults",
- "nym-pemstore",
+ "nym-network-defaults 0.1.0",
+ "nym-pemstore 0.3.0",
  "rand 0.8.5",
  "rayon",
+ "serde",
+ "sha2 0.10.9",
+ "subtle 2.6.1",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-compact-ecash"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "bincode",
+ "bls12_381",
+ "bs58",
+ "cfg-if",
+ "digest 0.10.7",
+ "ff",
+ "group",
+ "itertools 0.14.0",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.9",
  "subtle 2.6.1",
@@ -5354,7 +5438,22 @@ dependencies = [
  "dirs",
  "handlebars",
  "log",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0",
+ "serde",
+ "thiserror 2.0.12",
+ "toml 0.8.22",
+ "url",
+]
+
+[[package]]
+name = "nym-config"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "dirs",
+ "handlebars",
+ "log",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
  "serde",
  "thiserror 2.0.12",
  "toml 0.8.22",
@@ -5378,13 +5477,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-contracts-common"
+version = "0.5.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "bs58",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "schemars",
+ "serde",
+ "thiserror 2.0.12",
+ "vergen",
+]
+
+[[package]]
 name = "nym-cpp-ffi"
 version = "0.1.2"
 dependencies = [
  "anyhow",
  "bs58",
  "lazy_static",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-ffi-shared",
  "nym-sdk",
  "nym-sphinx-anonymous-replies",
@@ -5406,17 +5520,17 @@ dependencies = [
  "dotenvy",
  "futures",
  "humantime",
- "nym-bin-common",
- "nym-compact-ecash",
- "nym-config",
+ "nym-bin-common 0.6.0",
+ "nym-compact-ecash 0.1.0",
+ "nym-config 0.1.0",
  "nym-credential-proxy-requests",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-ecash-contract-common",
- "nym-http-api-common",
- "nym-network-defaults",
- "nym-validator-client",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-ecash-contract-common 0.1.0",
+ "nym-http-api-common 0.1.0",
+ "nym-network-defaults 0.1.0",
+ "nym-validator-client 0.1.0",
  "rand 0.8.5",
  "reqwest 0.12.15",
  "serde",
@@ -5445,10 +5559,10 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-http-api-client",
- "nym-http-api-common",
- "nym-serde-helpers",
+ "nym-credentials-interface 0.1.0",
+ "nym-http-api-client 0.1.0",
+ "nym-http-api-common 0.1.0",
+ "nym-serde-helpers 0.1.0",
  "reqwest 0.12.15",
  "schemars",
  "serde",
@@ -5468,9 +5582,9 @@ dependencies = [
  "async-trait",
  "bincode",
  "log",
- "nym-compact-ecash",
+ "nym-compact-ecash 0.1.0",
  "nym-credentials",
- "nym-ecash-time",
+ "nym-ecash-time 0.1.0",
  "serde",
  "sqlx",
  "thiserror 2.0.12",
@@ -5485,12 +5599,12 @@ dependencies = [
  "log",
  "nym-bandwidth-controller",
  "nym-client-core",
- "nym-config",
+ "nym-config 0.1.0",
  "nym-credential-storage",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-ecash-time",
- "nym-validator-client",
+ "nym-credentials-interface 0.1.0",
+ "nym-ecash-time 0.1.0",
+ "nym-validator-client 0.1.0",
  "thiserror 2.0.12",
  "time",
  "tokio",
@@ -5504,14 +5618,14 @@ dependencies = [
  "cosmwasm-std",
  "cw-utils",
  "futures",
- "nym-api-requests",
+ "nym-api-requests 0.1.0",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-ecash-contract-common",
+ "nym-credentials-interface 0.1.0",
+ "nym-ecash-contract-common 0.1.0",
  "nym-gateway-requests",
  "nym-gateway-storage",
  "nym-task",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "rand 0.8.5",
  "si-scale",
  "thiserror 2.0.12",
@@ -5528,14 +5642,14 @@ dependencies = [
  "bls12_381",
  "cosmrs",
  "log",
- "nym-api-requests",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-ecash-contract-common",
- "nym-ecash-time",
- "nym-network-defaults",
- "nym-serde-helpers",
- "nym-validator-client",
+ "nym-api-requests 0.1.0",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-ecash-contract-common 0.1.0",
+ "nym-ecash-time 0.1.0",
+ "nym-network-defaults 0.1.0",
+ "nym-serde-helpers 0.1.0",
+ "nym-validator-client 0.1.0",
  "rand 0.8.5",
  "serde",
  "thiserror 2.0.12",
@@ -5548,9 +5662,26 @@ name = "nym-credentials-interface"
 version = "0.1.0"
 dependencies = [
  "bls12_381",
- "nym-compact-ecash",
- "nym-ecash-time",
- "nym-network-defaults",
+ "nym-compact-ecash 0.1.0",
+ "nym-ecash-time 0.1.0",
+ "nym-network-defaults 0.1.0",
+ "rand 0.8.5",
+ "serde",
+ "strum 0.26.3",
+ "thiserror 2.0.12",
+ "time",
+ "utoipa",
+]
+
+[[package]]
+name = "nym-credentials-interface"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "bls12_381",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-ecash-time 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
  "rand 0.8.5",
  "serde",
  "strum 0.26.3",
@@ -5575,13 +5706,30 @@ dependencies = [
  "generic-array 0.14.7",
  "hkdf",
  "hmac",
- "nym-pemstore",
- "nym-sphinx-types",
+ "nym-pemstore 0.3.0",
+ "nym-sphinx-types 0.2.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
  "serde_bytes",
  "sha2 0.10.9",
+ "subtle-encoding",
+ "thiserror 2.0.12",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "nym-crypto"
+version = "0.4.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "bs58",
+ "ed25519-dalek",
+ "nym-pemstore 0.3.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-sphinx-types 0.2.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "serde",
+ "serde_bytes",
  "subtle-encoding",
  "thiserror 2.0.12",
  "x25519-dalek",
@@ -5599,8 +5747,8 @@ dependencies = [
  "ff",
  "group",
  "lazy_static",
- "nym-contracts-common",
- "nym-pemstore",
+ "nym-contracts-common 0.5.0",
+ "nym-pemstore 0.3.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -5621,7 +5769,21 @@ dependencies = [
  "cw-controllers",
  "cw-utils",
  "cw2",
- "nym-multisig-contract-common",
+ "nym-multisig-contract-common 0.1.0",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "nym-ecash-contract-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "bs58",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers",
+ "cw-utils",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
  "thiserror 2.0.12",
 ]
 
@@ -5629,7 +5791,15 @@ dependencies = [
 name = "nym-ecash-time"
 version = "0.1.0"
 dependencies = [
- "nym-compact-ecash",
+ "nym-compact-ecash 0.1.0",
+ "time",
+]
+
+[[package]]
+name = "nym-ecash-time"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
  "time",
 ]
 
@@ -5654,14 +5824,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-exit-policy"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tracing",
+ "utoipa",
+]
+
+[[package]]
 name = "nym-ffi-shared"
 version = "0.2.1"
 dependencies = [
  "anyhow",
  "bs58",
  "lazy_static",
- "nym-bin-common",
- "nym-crypto",
+ "nym-bin-common 0.6.0",
+ "nym-crypto 0.4.0",
  "nym-sdk",
  "nym-sphinx-anonymous-replies",
  "tokio",
@@ -5681,19 +5863,19 @@ dependencies = [
  "defguard_wireguard_rs",
  "futures",
  "ipnetwork",
- "nym-api-requests",
+ "nym-api-requests 0.1.0",
  "nym-authenticator",
  "nym-credential-verification",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
  "nym-gateway-requests",
  "nym-gateway-stats-storage",
  "nym-gateway-storage",
  "nym-ip-packet-router",
  "nym-mixnet-client",
  "nym-mixnode-common",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0",
  "nym-network-requester",
  "nym-node-metrics",
  "nym-sdk",
@@ -5702,9 +5884,9 @@ dependencies = [
  "nym-task",
  "nym-topology",
  "nym-types",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "nym-wireguard",
- "nym-wireguard-types",
+ "nym-wireguard-types 0.1.0",
  "rand 0.8.5",
  "sha2 0.10.9",
  "sqlx",
@@ -5729,16 +5911,16 @@ dependencies = [
  "nym-bandwidth-controller",
  "nym-credential-storage",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
  "nym-gateway-requests",
- "nym-http-api-client",
- "nym-network-defaults",
- "nym-pemstore",
+ "nym-http-api-client 0.1.0",
+ "nym-network-defaults 0.1.0",
+ "nym-pemstore 0.3.0",
  "nym-sphinx",
  "nym-statistics-common",
  "nym-task",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "rand 0.8.5",
  "serde",
  "si-scale",
@@ -5764,12 +5946,12 @@ dependencies = [
  "bs58",
  "futures",
  "generic-array 0.14.7",
- "nym-compact-ecash",
+ "nym-compact-ecash 0.1.0",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-pemstore",
- "nym-serde-helpers",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-pemstore 0.3.0",
+ "nym-serde-helpers 0.1.0",
  "nym-sphinx",
  "nym-statistics-common",
  "nym-task",
@@ -5808,7 +5990,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "defguard_wireguard_rs",
- "nym-credentials-interface",
+ "nym-credentials-interface 0.1.0",
  "nym-gateway-requests",
  "nym-sphinx",
  "sqlx",
@@ -5824,8 +6006,8 @@ version = "0.2.2"
 dependencies = [
  "anyhow",
  "lazy_static",
- "nym-bin-common",
- "nym-crypto",
+ "nym-bin-common 0.6.0",
+ "nym-crypto 0.4.0",
  "nym-ffi-shared",
  "nym-sdk",
  "nym-sphinx-anonymous-replies",
@@ -5847,6 +6029,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-group-contract-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "cosmwasm-schema",
+ "cw-controllers",
+ "cw4",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "nym-http-api-client"
 version = "0.1.0"
 dependencies = [
@@ -5858,14 +6052,38 @@ dependencies = [
  "http 1.3.1",
  "itertools 0.14.0",
  "mime",
- "nym-bin-common",
- "nym-http-api-common",
+ "nym-bin-common 0.6.0",
+ "nym-http-api-common 0.1.0",
  "once_cell",
  "reqwest 0.12.15",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "nym-http-api-client"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "bytes",
+ "encoding_rs",
+ "hickory-resolver",
+ "http 1.3.1",
+ "mime",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-http-api-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "once_cell",
+ "reqwest 0.12.15",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
  "tracing",
  "url",
  "wasmtimer",
@@ -5893,6 +6111,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-http-api-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "bincode",
+ "serde",
+ "tracing",
+]
+
+[[package]]
 name = "nym-id"
 version = "0.1.0"
 dependencies = [
@@ -5911,7 +6139,7 @@ dependencies = [
  "anyhow",
  "bs58",
  "clap",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-credential-storage",
  "nym-id",
  "tokio",
@@ -5933,8 +6161,8 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "bytes",
- "nym-bin-common",
- "nym-crypto",
+ "nym-bin-common 0.6.0",
+ "nym-crypto 0.4.0",
  "nym-service-provider-requests-common",
  "nym-sphinx",
  "rand 0.8.5",
@@ -5958,14 +6186,14 @@ dependencies = [
  "etherparse",
  "futures",
  "log",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-client-core",
- "nym-config",
- "nym-crypto",
- "nym-exit-policy",
+ "nym-config 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-exit-policy 0.1.0",
  "nym-id",
  "nym-ip-packet-requests",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0",
  "nym-network-requester",
  "nym-sdk",
  "nym-service-provider-requests-common",
@@ -5975,7 +6203,7 @@ dependencies = [
  "nym-tun",
  "nym-types",
  "nym-wireguard",
- "nym-wireguard-types",
+ "nym-wireguard-types 0.1.0",
  "rand 0.8.5",
  "reqwest 0.12.15",
  "serde",
@@ -6034,7 +6262,7 @@ dependencies = [
  "cw-storage-plus",
  "cw2",
  "humantime-serde",
- "nym-contracts-common",
+ "nym-contracts-common 0.5.0",
  "rand_chacha 0.3.1",
  "schemars",
  "semver 1.0.26",
@@ -6048,6 +6276,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-mixnet-contract-common"
+version = "0.6.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "bs58",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers",
+ "cw-storage-plus",
+ "humantime-serde",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "schemars",
+ "semver 1.0.26",
+ "serde",
+ "serde-json-wasm",
+ "serde_repr",
+ "thiserror 2.0.12",
+ "time",
+ "utoipa",
+]
+
+[[package]]
 name = "nym-mixnode-common"
 version = "0.1.0"
 dependencies = [
@@ -6055,15 +6305,15 @@ dependencies = [
  "futures",
  "humantime-serde",
  "log",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-metrics",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-forwarding",
  "nym-sphinx-framing",
  "nym-sphinx-params",
- "nym-sphinx-types",
+ "nym-sphinx-types 0.2.0",
  "nym-task",
  "rand 0.8.5",
  "serde",
@@ -6077,6 +6327,22 @@ dependencies = [
 [[package]]
 name = "nym-multisig-contract-common"
 version = "0.1.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw3",
+ "cw4",
+ "schemars",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "nym-multisig-contract-common"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -6104,6 +6370,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-network-defaults"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "cargo_metadata 0.18.1",
+ "dotenvy",
+ "log",
+ "regex",
+ "schemars",
+ "serde",
+ "url",
+ "utoipa",
+]
+
+[[package]]
 name = "nym-network-monitor"
 version = "1.0.2"
 dependencies = [
@@ -6113,16 +6394,16 @@ dependencies = [
  "dashmap",
  "futures",
  "log",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-client-core",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-gateway-requests",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0",
  "nym-sdk",
  "nym-sphinx",
  "nym-topology",
  "nym-types",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "petgraph",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -6151,16 +6432,16 @@ dependencies = [
  "ipnetwork",
  "log",
  "nym-async-file-watcher",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-client-core",
  "nym-client-websocket-requests",
- "nym-config",
+ "nym-config 0.1.0",
  "nym-credential-storage",
  "nym-credentials",
- "nym-crypto",
- "nym-exit-policy",
+ "nym-crypto 0.4.0",
+ "nym-exit-policy 0.1.0",
  "nym-id",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0",
  "nym-ordered-buffer",
  "nym-sdk",
  "nym-service-providers-common",
@@ -6215,37 +6496,37 @@ dependencies = [
  "ipnetwork",
  "lioness",
  "nym-authenticator",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-client-core-config-types",
- "nym-config",
- "nym-crypto",
+ "nym-config 0.1.0",
+ "nym-crypto 0.4.0",
  "nym-gateway",
  "nym-gateway-stats-storage",
- "nym-http-api-client",
- "nym-http-api-common",
+ "nym-http-api-client 0.1.0",
+ "nym-http-api-common 0.1.0",
  "nym-ip-packet-router",
  "nym-metrics",
  "nym-mixnet-client",
  "nym-network-requester",
  "nym-node-metrics",
- "nym-node-requests",
+ "nym-node-requests 0.1.0",
  "nym-nonexhaustive-delayqueue",
- "nym-pemstore",
+ "nym-pemstore 0.3.0",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-forwarding",
  "nym-sphinx-framing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types",
+ "nym-sphinx-types 0.2.0",
  "nym-statistics-common",
  "nym-task",
  "nym-topology",
  "nym-types",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "nym-verloc",
  "nym-wireguard",
- "nym-wireguard-types",
+ "nym-wireguard-types 0.1.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -6289,11 +6570,11 @@ dependencies = [
  "celes",
  "humantime",
  "humantime-serde",
- "nym-bin-common",
- "nym-crypto",
- "nym-exit-policy",
- "nym-http-api-client",
- "nym-wireguard-types",
+ "nym-bin-common 0.6.0",
+ "nym-crypto 0.4.0",
+ "nym-exit-policy 0.1.0",
+ "nym-http-api-client 0.1.0",
+ "nym-wireguard-types 0.1.0",
  "rand_chacha 0.3.1",
  "schemars",
  "serde",
@@ -6306,13 +6587,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-node-requests"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "celes",
+ "humantime",
+ "humantime-serde",
+ "nym-bin-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-crypto 0.4.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-exit-policy 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-wireguard-types 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "schemars",
+ "serde",
+ "serde_json",
+ "strum 0.26.3",
+ "thiserror 2.0.12",
+ "time",
+ "utoipa",
+]
+
+[[package]]
 name = "nym-node-status-agent"
 version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "nym-bin-common",
- "nym-crypto",
+ "nym-bin-common 0.6.0",
+ "nym-crypto 0.4.0",
  "nym-node-status-client",
  "rand 0.8.5",
  "tempfile",
@@ -6335,20 +6637,20 @@ dependencies = [
  "futures-util",
  "itertools 0.14.0",
  "moka",
- "nym-bin-common",
- "nym-contracts-common",
- "nym-crypto",
- "nym-http-api-client",
- "nym-http-api-common",
- "nym-mixnet-contract-common",
- "nym-network-defaults",
+ "nym-bin-common 0.6.0",
+ "nym-contracts-common 0.5.0",
+ "nym-crypto 0.4.0",
+ "nym-http-api-client 0.1.0",
+ "nym-http-api-common 0.1.0",
+ "nym-mixnet-contract-common 0.6.0",
+ "nym-network-defaults 0.1.0",
  "nym-node-metrics",
- "nym-node-requests",
+ "nym-node-requests 0.1.0",
  "nym-node-status-client",
- "nym-serde-helpers",
+ "nym-serde-helpers 0.1.0",
  "nym-statistics-common",
  "nym-task",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
@@ -6378,8 +6680,8 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "bincode",
- "nym-crypto",
- "nym-http-api-client",
+ "nym-crypto 0.4.0",
+ "nym-http-api-client 0.1.0",
  "reqwest 0.12.15",
  "serde",
  "serde_json",
@@ -6393,7 +6695,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "log",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-sphinx",
  "nym-sphinx-params",
  "nym-task",
@@ -6444,8 +6746,8 @@ dependencies = [
  "anyhow",
  "clap",
  "log",
- "nym-bin-common",
- "nym-network-defaults",
+ "nym-bin-common 0.6.0",
+ "nym-network-defaults 0.1.0",
  "nym-sdk",
  "nym-service-providers-common",
  "nym-socks5-requests",
@@ -6490,6 +6792,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-pemstore"
+version = "0.3.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "pem",
+ "tracing",
+]
+
+[[package]]
 name = "nym-pool-contract-common"
 version = "0.1.0"
 dependencies = [
@@ -6522,15 +6833,15 @@ dependencies = [
  "httpcodec",
  "log",
  "nym-bandwidth-controller",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-client-core",
  "nym-credential-storage",
  "nym-credential-utils",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
  "nym-gateway-requests",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0",
  "nym-ordered-buffer",
  "nym-service-providers-common",
  "nym-socks5-client-core",
@@ -6540,7 +6851,7 @@ dependencies = [
  "nym-statistics-common",
  "nym-task",
  "nym-topology",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "parking_lot",
  "rand 0.8.5",
  "reqwest 0.12.15",
@@ -6571,6 +6882,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-serde-helpers"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "hex",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "nym-service-provider-requests-common"
 version = "0.1.0"
 dependencies = [
@@ -6586,7 +6909,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "log",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-sdk",
  "nym-socks5-requests",
  "nym-sphinx-anonymous-replies",
@@ -6603,21 +6926,21 @@ dependencies = [
  "bs58",
  "clap",
  "log",
- "nym-bin-common",
+ "nym-bin-common 0.6.0",
  "nym-client-core",
- "nym-config",
+ "nym-config 0.1.0",
  "nym-credential-storage",
  "nym-credentials",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-gateway-requests",
  "nym-id",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0",
  "nym-ordered-buffer",
- "nym-pemstore",
+ "nym-pemstore 0.3.0",
  "nym-socks5-client-core",
  "nym-sphinx",
  "nym-topology",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -6639,17 +6962,17 @@ dependencies = [
  "log",
  "nym-bandwidth-controller",
  "nym-client-core",
- "nym-config",
- "nym-contracts-common",
+ "nym-config 0.1.0",
+ "nym-contracts-common 0.5.0",
  "nym-credential-storage",
- "nym-mixnet-contract-common",
- "nym-network-defaults",
+ "nym-mixnet-contract-common 0.6.0",
+ "nym-network-defaults 0.1.0",
  "nym-service-providers-common",
  "nym-socks5-proxy-helpers",
  "nym-socks5-requests",
  "nym-sphinx",
  "nym-task",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "pin-project",
  "rand 0.8.5",
  "reqwest 0.12.15",
@@ -6682,7 +7005,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "log",
- "nym-exit-policy",
+ "nym-exit-policy 0.1.0",
  "nym-service-providers-common",
  "nym-sphinx-addressing",
  "serde",
@@ -6695,9 +7018,9 @@ dependencies = [
 name = "nym-sphinx"
 version = "0.1.0"
 dependencies = [
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-metrics",
- "nym-mixnet-contract-common",
+ "nym-mixnet-contract-common 0.6.0",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -6707,7 +7030,7 @@ dependencies = [
  "nym-sphinx-framing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types",
+ "nym-sphinx-types 0.2.0",
  "nym-topology",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -6722,12 +7045,12 @@ name = "nym-sphinx-acknowledgements"
 version = "0.1.0"
 dependencies = [
  "generic-array 0.14.7",
- "nym-crypto",
- "nym-pemstore",
+ "nym-crypto 0.4.0",
+ "nym-pemstore 0.3.0",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types",
+ "nym-sphinx-types 0.2.0",
  "nym-topology",
  "rand 0.8.5",
  "serde",
@@ -6739,8 +7062,8 @@ dependencies = [
 name = "nym-sphinx-addressing"
 version = "0.1.0"
 dependencies = [
- "nym-crypto",
- "nym-sphinx-types",
+ "nym-crypto 0.4.0",
+ "nym-sphinx-types 0.2.0",
  "rand 0.8.5",
  "serde",
  "thiserror 2.0.12",
@@ -6751,11 +7074,11 @@ name = "nym-sphinx-anonymous-replies"
 version = "0.1.0"
 dependencies = [
  "bs58",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types",
+ "nym-sphinx-types 0.2.0",
  "nym-topology",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -6770,11 +7093,11 @@ version = "0.1.0"
 dependencies = [
  "dashmap",
  "log",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-metrics",
  "nym-sphinx-addressing",
  "nym-sphinx-params",
- "nym-sphinx-types",
+ "nym-sphinx-types 0.2.0",
  "rand 0.8.5",
  "serde",
  "thiserror 2.0.12",
@@ -6785,14 +7108,14 @@ dependencies = [
 name = "nym-sphinx-cover"
 version = "0.1.0"
 dependencies = [
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-sphinx-acknowledgements",
  "nym-sphinx-addressing",
  "nym-sphinx-chunking",
  "nym-sphinx-forwarding",
  "nym-sphinx-params",
  "nym-sphinx-routing",
- "nym-sphinx-types",
+ "nym-sphinx-types 0.2.0",
  "nym-topology",
  "rand 0.8.5",
  "thiserror 2.0.12",
@@ -6805,7 +7128,7 @@ dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
  "nym-sphinx-params",
- "nym-sphinx-types",
+ "nym-sphinx-types 0.2.0",
  "thiserror 2.0.12",
 ]
 
@@ -6818,7 +7141,7 @@ dependencies = [
  "nym-sphinx-addressing",
  "nym-sphinx-forwarding",
  "nym-sphinx-params",
- "nym-sphinx-types",
+ "nym-sphinx-types 0.2.0",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
@@ -6829,8 +7152,8 @@ dependencies = [
 name = "nym-sphinx-params"
 version = "0.1.0"
 dependencies = [
- "nym-crypto",
- "nym-sphinx-types",
+ "nym-crypto 0.4.0",
+ "nym-sphinx-types 0.2.0",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -6840,7 +7163,7 @@ name = "nym-sphinx-routing"
 version = "0.1.0"
 dependencies = [
  "nym-sphinx-addressing",
- "nym-sphinx-types",
+ "nym-sphinx-types 0.2.0",
  "thiserror 2.0.12",
 ]
 
@@ -6854,6 +7177,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-sphinx-types"
+version = "0.2.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "nym-statistics-api"
 version = "0.1.0"
 dependencies = [
@@ -6862,12 +7193,12 @@ dependencies = [
  "axum-extra",
  "celes",
  "clap",
- "nym-bin-common",
- "nym-http-api-client",
- "nym-http-api-common",
+ "nym-bin-common 0.6.0",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-http-api-common 0.1.0",
  "nym-statistics-common",
  "nym-task",
- "nym-validator-client",
+ "nym-validator-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
  "serde",
  "serde_json",
  "sqlx",
@@ -6889,8 +7220,8 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "log",
- "nym-credentials-interface",
- "nym-crypto",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
  "nym-metrics",
  "nym-sphinx",
  "nym-task",
@@ -6942,8 +7273,8 @@ dependencies = [
 name = "nym-ticketbooks-merkle"
 version = "0.1.0"
 dependencies = [
- "nym-credentials-interface",
- "nym-serde-helpers",
+ "nym-credentials-interface 0.1.0",
+ "nym-serde-helpers 0.1.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rs_merkle",
@@ -6956,17 +7287,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-ticketbooks-merkle"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "nym-credentials-interface 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "rs_merkle",
+ "schemars",
+ "serde",
+ "sha2 0.10.9",
+ "time",
+ "utoipa",
+]
+
+[[package]]
 name = "nym-topology"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "nym-api-requests",
- "nym-config",
- "nym-crypto",
- "nym-mixnet-contract-common",
+ "nym-api-requests 0.1.0",
+ "nym-config 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-mixnet-contract-common 0.6.0",
  "nym-sphinx-addressing",
  "nym-sphinx-routing",
- "nym-sphinx-types",
+ "nym-sphinx-types 0.2.0",
  "rand 0.8.5",
  "reqwest 0.12.15",
  "serde",
@@ -6984,7 +7330,7 @@ version = "0.1.0"
 dependencies = [
  "etherparse",
  "log",
- "nym-wireguard-types",
+ "nym-wireguard-types 0.1.0",
  "thiserror 2.0.12",
  "tokio",
  "tokio-tun",
@@ -7001,11 +7347,11 @@ dependencies = [
  "hmac",
  "itertools 0.14.0",
  "log",
- "nym-config",
- "nym-crypto",
- "nym-mixnet-contract-common",
- "nym-validator-client",
- "nym-vesting-contract-common",
+ "nym-config 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-mixnet-contract-common 0.6.0",
+ "nym-validator-client 0.1.0",
+ "nym-vesting-contract-common 0.7.0",
  "reqwest 0.12.15",
  "schemars",
  "serde",
@@ -7040,19 +7386,19 @@ dependencies = [
  "flate2",
  "futures",
  "itertools 0.14.0",
- "nym-api-requests",
- "nym-coconut-dkg-common",
- "nym-compact-ecash",
- "nym-config",
- "nym-contracts-common",
- "nym-ecash-contract-common",
- "nym-group-contract-common",
- "nym-http-api-client",
- "nym-mixnet-contract-common",
- "nym-multisig-contract-common",
- "nym-network-defaults",
- "nym-serde-helpers",
- "nym-vesting-contract-common",
+ "nym-api-requests 0.1.0",
+ "nym-coconut-dkg-common 0.1.0",
+ "nym-compact-ecash 0.1.0",
+ "nym-config 0.1.0",
+ "nym-contracts-common 0.5.0",
+ "nym-ecash-contract-common 0.1.0",
+ "nym-group-contract-common 0.1.0",
+ "nym-http-api-client 0.1.0",
+ "nym-mixnet-contract-common 0.6.0",
+ "nym-multisig-contract-common 0.1.0",
+ "nym-network-defaults 0.1.0",
+ "nym-serde-helpers 0.1.0",
+ "nym-vesting-contract-common 0.7.0",
  "prost 0.13.5",
  "reqwest 0.12.15",
  "serde",
@@ -7070,6 +7416,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-validator-client"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bip32",
+ "bip39",
+ "colored",
+ "cosmrs",
+ "cosmwasm-std",
+ "cw-controllers",
+ "cw-utils",
+ "cw2",
+ "cw3",
+ "cw4",
+ "eyre",
+ "flate2",
+ "futures",
+ "itertools 0.14.0",
+ "nym-api-requests 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-coconut-dkg-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-compact-ecash 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-ecash-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-group-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-http-api-client 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-multisig-contract-common 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-serde-helpers 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-vesting-contract-common 0.7.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "prost 0.13.5",
+ "reqwest 0.12.15",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tendermint-rpc",
+ "thiserror 2.0.12",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+ "zeroize",
+]
+
+[[package]]
 name = "nym-validator-rewarder"
 version = "0.3.0"
 dependencies = [
@@ -7080,21 +7475,21 @@ dependencies = [
  "futures",
  "humantime",
  "humantime-serde",
- "nym-bin-common",
- "nym-coconut-dkg-common",
- "nym-compact-ecash",
- "nym-config",
- "nym-contracts-common",
+ "nym-bin-common 0.6.0",
+ "nym-coconut-dkg-common 0.1.0",
+ "nym-compact-ecash 0.1.0",
+ "nym-config 0.1.0",
+ "nym-contracts-common 0.5.0",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-ecash-time",
- "nym-network-defaults",
- "nym-pemstore",
- "nym-serde-helpers",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-ecash-time 0.1.0",
+ "nym-network-defaults 0.1.0",
+ "nym-pemstore 0.3.0",
+ "nym-serde-helpers 0.1.0",
  "nym-task",
- "nym-ticketbooks-merkle",
- "nym-validator-client",
+ "nym-ticketbooks-merkle 0.1.0",
+ "nym-validator-client 0.1.0",
  "nyxd-scraper",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -7118,9 +7513,9 @@ dependencies = [
  "bytes",
  "futures",
  "humantime",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-task",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "rand 0.8.5",
  "thiserror 2.0.12",
  "time",
@@ -7137,11 +7532,24 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw2",
- "nym-contracts-common",
- "nym-mixnet-contract-common",
+ "nym-contracts-common 0.5.0",
+ "nym-mixnet-contract-common 0.6.0",
  "serde",
  "thiserror 2.0.12",
  "ts-rs",
+]
+
+[[package]]
+name = "nym-vesting-contract-common"
+version = "0.7.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "nym-contracts-common 0.5.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-mixnet-contract-common 0.6.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "serde",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7151,13 +7559,13 @@ dependencies = [
  "bs58",
  "getrandom 0.2.15",
  "js-sys",
- "nym-bin-common",
- "nym-compact-ecash",
+ "nym-bin-common 0.6.0",
+ "nym-compact-ecash 0.1.0",
  "nym-credential-proxy-requests",
  "nym-credentials",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-ecash-time",
+ "nym-credentials-interface 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-ecash-time 0.1.0",
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
@@ -7176,12 +7584,12 @@ dependencies = [
  "cosmrs",
  "cosmwasm-std",
  "hex-literal",
- "nym-config",
- "nym-mixnet-contract-common",
- "nym-network-defaults",
+ "nym-config 0.1.0",
+ "nym-mixnet-contract-common 0.6.0",
+ "nym-network-defaults 0.1.0",
  "nym-types",
- "nym-validator-client",
- "nym-vesting-contract-common",
+ "nym-validator-client 0.1.0",
+ "nym-vesting-contract-common 0.7.0",
  "serde",
  "serde_json",
  "strum 0.23.0",
@@ -7202,12 +7610,12 @@ dependencies = [
  "log",
  "nym-authenticator-requests",
  "nym-credential-verification",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-gateway-storage",
- "nym-network-defaults",
+ "nym-network-defaults 0.1.0",
  "nym-node-metrics",
  "nym-task",
- "nym-wireguard-types",
+ "nym-wireguard-types 0.1.0",
  "thiserror 2.0.12",
  "time",
  "tokio",
@@ -7222,10 +7630,24 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "log",
- "nym-config",
- "nym-crypto",
- "nym-network-defaults",
+ "nym-config 0.1.0",
+ "nym-crypto 0.4.0",
+ "nym-network-defaults 0.1.0",
  "rand 0.8.5",
+ "serde",
+ "thiserror 2.0.12",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "nym-wireguard-types"
+version = "0.1.0"
+source = "git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar#e9bb9792ab723a1ad5fe40cb292dc08d4eb40c2f"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "nym-config 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
+ "nym-network-defaults 0.1.0 (git+https://github.com/nymtech/nym?branch=release/2025.11-cheddar)",
  "serde",
  "thiserror 2.0.12",
  "x25519-dalek",
@@ -7246,8 +7668,8 @@ dependencies = [
  "humantime-serde",
  "nix 0.27.1",
  "nym-async-file-watcher",
- "nym-bin-common",
- "nym-config",
+ "nym-bin-common 0.6.0",
+ "nym-config 0.1.0",
  "nym-task",
  "reqwest 0.12.15",
  "serde",
@@ -7270,11 +7692,11 @@ dependencies = [
  "axum 0.7.9",
  "chrono",
  "clap",
- "nym-bin-common",
- "nym-config",
- "nym-network-defaults",
+ "nym-bin-common 0.6.0",
+ "nym-config 0.1.0",
+ "nym-network-defaults 0.1.0",
  "nym-task",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "nyxd-scraper",
  "reqwest 0.12.15",
  "schemars",
@@ -9971,19 +10393,19 @@ dependencies = [
  "cw-utils",
  "dkg-bypass-contract",
  "indicatif",
- "nym-bin-common",
- "nym-coconut-dkg-common",
- "nym-compact-ecash",
- "nym-config",
- "nym-contracts-common",
- "nym-crypto",
- "nym-ecash-contract-common",
- "nym-group-contract-common",
- "nym-mixnet-contract-common",
- "nym-multisig-contract-common",
- "nym-pemstore",
- "nym-validator-client",
- "nym-vesting-contract-common",
+ "nym-bin-common 0.6.0",
+ "nym-coconut-dkg-common 0.1.0",
+ "nym-compact-ecash 0.1.0",
+ "nym-config 0.1.0",
+ "nym-contracts-common 0.5.0",
+ "nym-crypto 0.4.0",
+ "nym-ecash-contract-common 0.1.0",
+ "nym-group-contract-common 0.1.0",
+ "nym-mixnet-contract-common 0.6.0",
+ "nym-multisig-contract-common 0.1.0",
+ "nym-pemstore 0.3.0",
+ "nym-validator-client 0.1.0",
+ "nym-vesting-contract-common 0.7.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -10650,11 +11072,11 @@ name = "ts-rs-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "nym-api-requests",
- "nym-mixnet-contract-common",
+ "nym-api-requests 0.1.0",
+ "nym-mixnet-contract-common 0.6.0",
  "nym-types",
- "nym-validator-client",
- "nym-vesting-contract-common",
+ "nym-validator-client 0.1.0",
+ "nym-vesting-contract-common 0.7.0",
  "nym-wallet-types",
  "ts-rs",
  "walkdir",
@@ -11098,9 +11520,9 @@ dependencies = [
  "anyhow",
  "clap",
  "comfy-table",
- "nym-bin-common",
- "nym-network-defaults",
- "nym-validator-client",
+ "nym-bin-common 0.6.0",
+ "nym-network-defaults 0.1.0",
+ "nym-validator-client 0.1.0",
  "serde",
  "serde_json",
  "strum 0.26.3",
@@ -11325,16 +11747,16 @@ dependencies = [
  "js-sys",
  "nym-bandwidth-controller",
  "nym-client-core",
- "nym-config",
+ "nym-config 0.1.0",
  "nym-credential-storage",
- "nym-crypto",
+ "nym-crypto 0.4.0",
  "nym-gateway-client",
  "nym-sphinx",
  "nym-sphinx-acknowledgements",
  "nym-statistics-common",
  "nym-task",
  "nym-topology",
- "nym-validator-client",
+ "nym-validator-client 0.1.0",
  "rand 0.8.5",
  "serde",
  "serde-wasm-bindgen 0.6.5",
@@ -12192,11 +12614,11 @@ dependencies = [
  "bs58",
  "getrandom 0.2.15",
  "js-sys",
- "nym-bin-common",
- "nym-compact-ecash",
+ "nym-bin-common 0.6.0",
+ "nym-compact-ecash 0.1.0",
  "nym-credentials",
- "nym-crypto",
- "nym-http-api-client",
+ "nym-crypto 0.4.0",
+ "nym-http-api-client 0.1.0",
  "rand 0.8.5",
  "reqwest 0.12.15",
  "serde",

--- a/nym-statistics-api/Cargo.toml
+++ b/nym-statistics-api/Cargo.toml
@@ -39,7 +39,6 @@ utoipauto.workspace = true
 
 #internal
 nym-bin-common = { path = "../common/bin-common" }
-nym-http-api-client = { path = "../common/http-api-client" }
 nym-http-api-common = { path = "../common/http-api-common", features = [
     "middleware",
 ] }
@@ -47,7 +46,9 @@ nym-statistics-common = { path = "../common/statistics", features = [
     "openapi",
 ] }
 nym-task = { path = "../common/task" }
-nym-validator-client = { path = "../common/client-libs/validator-client" }
+
+nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "release/2025.11-cheddar" }
+nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "release/2025.11-cheddar" } # current develop is compatible with current deployed API
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/nym-statistics-api/Cargo.toml
+++ b/nym-statistics-api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-statistics-api"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-statistics-api/Cargo.toml
+++ b/nym-statistics-api/Cargo.toml
@@ -48,7 +48,7 @@ nym-statistics-common = { path = "../common/statistics", features = [
 nym-task = { path = "../common/task" }
 
 nym-http-api-client = { git = "https://github.com/nymtech/nym", branch = "release/2025.11-cheddar" }
-nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "release/2025.11-cheddar" } # current develop is compatible with current deployed API
+nym-validator-client = { git = "https://github.com/nymtech/nym", branch = "release/2025.11-cheddar" } # current develop is incompatible with current deployed API
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/nym-statistics-api/src/main.rs
+++ b/nym-statistics-api/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
         args.nym_api_url,
         shutdown_manager.child_token("network-refresher"),
     )
-    .await?;
+    .await;
 
     let http_server =
         http::server::build_http_api(storage, network_refresher.network_view(), args.http_port)


### PR DESCRIPTION
Current `develop` API client doesn't work with currently deployed nym API

This PR downgrades the clients to `cheddar` for compatibility and make building the network view infallible, so that any future incompatibility doesn't prevent the stats API to start

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5825)
<!-- Reviewable:end -->
