### PR TITLE
[Stats API] IP from nginx headers if available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7224,10 +7224,11 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics-api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
+ "axum-client-ip",
  "axum-extra",
  "celes",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7224,7 +7224,7 @@ dependencies = [
 
 [[package]]
 name = "nym-statistics-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "axum 0.7.9",

--- a/nym-statistics-api/Cargo.toml
+++ b/nym-statistics-api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-statistics-api"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-statistics-api/Cargo.toml
+++ b/nym-statistics-api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-statistics-api"
-version = "0.1.1"
+version = "0.1.2"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
@@ -16,6 +16,7 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace = true
 axum = { workspace = true, features = ["tokio", "macros"] }
+axum-client-ip.workspace = true
 axum-extra = { workspace = true, features = ["typed-header"] }
 celes.workspace = true
 clap = { workspace = true, features = ["cargo", "derive", "env", "string"] }

--- a/nym-statistics-api/src/storage/models.rs
+++ b/nym-statistics-api/src/storage/models.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::IpAddr;
 
 use axum_extra::headers::UserAgent;
 use celes::Country;
@@ -53,13 +53,13 @@ impl ConnectionInfoDto {
     pub(crate) fn maybe_new(
         received_at: OffsetDateTime,
         stats_report: &VpnClientStatsReport,
-        received_from: SocketAddr,
+        received_from: IpAddr,
         maybe_country: Option<Country>,
         from_mixnet: bool,
     ) -> Option<Self> {
         stats_report.basic_usage.as_ref().map(|usage_report| Self {
             received_at,
-            received_from: received_from.ip().to_string(),
+            received_from: received_from.to_string(),
             connection_time_ms: usage_report.connection_time_ms,
             two_hop: usage_report.two_hop,
             country_code: maybe_country.map(|c| c.alpha2.into()),


### PR DESCRIPTION
The stats API on k8s is behind a reverse proxy, so we need to take the IP address from the headers if available

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5830)
<!-- Reviewable:end -->
