### PR TITLE
Use display when printing paths

### DIFF
--- a/common/credential-storage/src/persistent_storage/mod.rs
+++ b/common/credential-storage/src/persistent_storage/mod.rs
@@ -54,8 +54,8 @@ impl PersistentStorage {
     /// * `database_path`: path to the database.
     pub async fn init<P: AsRef<Path>>(database_path: P) -> Result<Self, StorageError> {
         debug!(
-            "Attempting to connect to database {:?}",
-            database_path.as_ref().as_os_str()
+            "Attempting to connect to database {}",
+            database_path.as_ref().display()
         );
 
         let opts = sqlx::sqlite::SqliteConnectOptions::new()

--- a/common/gateway-stats-storage/src/lib.rs
+++ b/common/gateway-stats-storage/src/lib.rs
@@ -33,8 +33,8 @@ impl PersistentStatsStorage {
     /// * `database_path`: path to the database.
     pub async fn init<P: AsRef<Path> + Send>(database_path: P) -> Result<Self, StatsStorageError> {
         debug!(
-            "Attempting to connect to database {:?}",
-            database_path.as_ref().as_os_str()
+            "Attempting to connect to database {}",
+            database_path.as_ref().display()
         );
 
         // TODO: we can inject here more stuff based on our gateway global config

--- a/common/gateway-storage/src/lib.rs
+++ b/common/gateway-storage/src/lib.rs
@@ -82,8 +82,8 @@ impl GatewayStorage {
         message_retrieval_limit: i64,
     ) -> Result<Self, GatewayStorageError> {
         debug!(
-            "Attempting to connect to database {:?}",
-            database_path.as_ref().as_os_str()
+            "Attempting to connect to database {}",
+            database_path.as_ref().display()
         );
 
         // TODO: we can inject here more stuff based on our gateway global config


### PR DESCRIPTION
`PathBuf` and `Path` support a special method for printing paths – `display()`. Let's use it for display purposes as it looks better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5853)
<!-- Reviewable:end -->
