### PR TITLE
Make Mix hops optional for Mixnet Client SURBs

### DIFF
--- a/common/client-core/config-types/src/lib.rs
+++ b/common/client-core/config-types/src/lib.rs
@@ -445,10 +445,7 @@ impl Default for Traffic {
             primary_packet_size: PacketSize::RegularPacket,
             secondary_packet_size: None,
             packet_type: PacketType::Mix,
-
-            // we should use the legacy format until sufficient number of nodes understand the
-            // improved encoding
-            use_legacy_sphinx_format: true,
+            use_legacy_sphinx_format: false,
             disable_mix_hops: false,
         }
     }

--- a/common/client-core/config-types/src/lib.rs
+++ b/common/client-core/config-types/src/lib.rs
@@ -445,7 +445,10 @@ impl Default for Traffic {
             primary_packet_size: PacketSize::RegularPacket,
             secondary_packet_size: None,
             packet_type: PacketType::Mix,
-            use_legacy_sphinx_format: false,
+
+            // we should use the legacy format until sufficient number of nodes understand the
+            // improved encoding
+            use_legacy_sphinx_format: true,
             disable_mix_hops: false,
         }
     }

--- a/common/client-core/config-types/src/lib.rs
+++ b/common/client-core/config-types/src/lib.rs
@@ -418,6 +418,9 @@ pub struct Traffic {
     /// will be routed as usual, to the entry gateway, through three mix nodes, egressing
     /// through the exit gateway. If mix hops are disabled, traffic will be routed directly
     /// from the entry gateway to the exit gateway, bypassing the mix nodes.
+    ///
+    /// This overrides the `use_legacy_sphinx_format` setting as reduced mix hops
+    /// requires use of the updated SURB packet format.
     pub disable_mix_hops: bool,
 }
 

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -105,6 +105,9 @@ pub(crate) struct Config {
     /// will be routed as usual, to the entry gateway, through three mix nodes, egressing
     /// through the exit gateway. If mix hops are disabled, traffic will be routed directly
     /// from the entry gateway to the exit gateway, bypassing the mix nodes.
+    ///
+    /// This overrides the `use_legacy_sphinx_format` setting as reduced mix hops
+    /// requires use of the updated SURB packet format.
     disable_mix_hops: bool,
 
     /// Average delay a data packet is going to get delay at a single mixnode.
@@ -159,6 +162,9 @@ impl Config {
     }
 
     /// Configure whether messages senders using this config should use mix hops or not when sending messages.
+    ///
+    /// This overrides the `use_legacy_sphinx_format` setting as disabled mix hops
+    /// requires use of the updated SURB packet format.
     pub fn disable_mix_hops(mut self, disable_mix_hops: bool) -> Self {
         self.disable_mix_hops = disable_mix_hops;
         self

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -167,6 +167,7 @@ impl Config {
     /// requires use of the updated SURB packet format.
     pub fn disable_mix_hops(mut self, disable_mix_hops: bool) -> Self {
         self.disable_mix_hops = disable_mix_hops;
+        self.use_legacy_sphinx_format = false;
         self
     }
 }

--- a/common/nymsphinx/anonymous-replies/src/reply_surb.rs
+++ b/common/nymsphinx/anonymous-replies/src/reply_surb.rs
@@ -64,12 +64,16 @@ impl ReplySurb {
         average_delay: Duration,
         use_legacy_surb_format: bool,
         topology: &NymRouteProvider,
-        _disable_mix_hops: bool, // TODO: support SURBs with no mix hops after changes to surb format / construction
+        disable_mix_hops: bool,
     ) -> Result<Self, NymTopologyError>
     where
         R: RngCore + CryptoRng,
     {
-        let route = topology.random_route_to_egress(rng, recipient.gateway())?;
+        let route = if disable_mix_hops && !use_legacy_surb_format {
+            topology.empty_route_to_egress(recipient.gateway())?
+        } else {
+            topology.random_route_to_egress(rng, recipient.gateway())?
+        };
         let delays = nym_sphinx_routing::generate_hop_delays(average_delay, route.len());
         let destination = recipient.as_sphinx_destination();
 

--- a/common/nymsphinx/anonymous-replies/src/reply_surb.rs
+++ b/common/nymsphinx/anonymous-replies/src/reply_surb.rs
@@ -59,10 +59,10 @@ impl ReplySurb {
     /// Construct a ResplySurb object. Selects mix hops for the surb unique to this
     /// individual construction.
     ///
-    /// If mix hops are disabled, the route will consistency of the recipient 
+    /// If mix hops are disabled, the route will consistency of the recipient
     /// (i.e. the ingress hop) only. When `disable_mix_hops` is enabled
-    /// `use_legacy_surb_format` is ignored as disabled mix hops requires use of 
-    /// the updated SURB format. 
+    /// `use_legacy_surb_format` is ignored as disabled mix hops requires use of
+    /// the updated SURB format.
     // TODO: should this return `ReplySURBError` for consistency sake
     // or keep `NymTopologyError` because it's the only error it can actually return?
     pub fn construct<R>(

--- a/common/nymsphinx/src/preparer/mod.rs
+++ b/common/nymsphinx/src/preparer/mod.rs
@@ -335,6 +335,9 @@ pub struct MessagePreparer<R> {
     /// will be routed as usual, to the entry gateway, through three mix nodes, egressing
     /// through the exit gateway. If mix hops are disabled, traffic will be routed directly
     /// from the entry gateway to the exit gateway, bypassing the mix nodes.
+    ///
+    /// This overrides the `use_legacy_sphinx_format` setting as reduced/disabled mix hops
+    /// requires use of the updated SURB packet format.
     pub disable_mix_hops: bool,
 }
 

--- a/common/nymsphinx/src/preparer/mod.rs
+++ b/common/nymsphinx/src/preparer/mod.rs
@@ -388,7 +388,7 @@ where
                 self.average_packet_delay,
                 use_legacy_reply_surb_format,
                 topology,
-                disabled_mix_hops, // TODO: support SURBs with no mix hops after changes to surb format / construction
+                disabled_mix_hops,
             )?
             .with_key_rotation(key_rotation);
             reply_surbs.push(reply_surb)

--- a/common/wasm/client-core/src/config/mod.rs
+++ b/common/wasm/client-core/src/config/mod.rs
@@ -201,6 +201,9 @@ pub struct TrafficWasm {
     /// will be routed as usual, to the entry gateway, through three mix nodes, egressing
     /// through the exit gateway. If mix hops are disabled, traffic will be routed directly
     /// from the entry gateway to the exit gateway, bypassing the mix nodes.
+    ///
+    /// This overrides the `use_legacy_sphinx_format` setting as reduced/disabeld mix hops
+    /// requires use of the updated SURB packet format.
     pub disable_mix_hops: bool,
 }
 


### PR DESCRIPTION
Allow SURBs to be sent configured to only use gateways in mixnet return path.

Follow on to #5696

Tested as working with mainnet vpnd/vpnc client for a handful of manual connections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5861)
<!-- Reviewable:end -->
