### PR TITLE
listen for shutdown signals during nym-node startup

### DIFF
--- a/gateway/src/node/internal_service_providers.rs
+++ b/gateway/src/node/internal_service_providers.rs
@@ -128,6 +128,8 @@ where
             }
         });
 
+        // TODO: if something is blocking during SP startup, the below will wait forever
+        // we need to introduce additional timeouts here.
         let on_start_data = self
             .on_start_rx
             .await

--- a/nym-statistics-api/src/main.rs
+++ b/nym-statistics-api/src/main.rs
@@ -48,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("Started HTTP server on port {}", args.http_port);
 
     shutdown_manager.close();
-    shutdown_manager.wait_for_shutdown_signal().await;
+    shutdown_manager.run_until_shutdown().await;
 
     Ok(())
 }


### PR DESCRIPTION
this is to avoid situation where the process can't be killed without 'kill -9' because the logic to listen to shutdown signals hasn't been hit yet

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5879)
<!-- Reviewable:end -->
