### PR TITLE
Feature/dkg snapshot epoch

### DIFF
--- a/common/client-libs/validator-client/src/nyxd/contract_traits/dkg_query_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/dkg_query_client.rs
@@ -41,6 +41,11 @@ pub trait DkgQueryClient {
         self.query_dkg_contract(request).await
     }
 
+    async fn get_epoch_at_height(&self, height: u64) -> Result<Option<Epoch>, NyxdError> {
+        let request = DkgQueryMsg::GetEpochStateAtHeight { height };
+        self.query_dkg_contract(request).await
+    }
+
     async fn can_advance_state(&self) -> Result<StateAdvanceResponse, NyxdError> {
         let request = DkgQueryMsg::CanAdvanceState {};
         self.query_dkg_contract(request).await
@@ -299,6 +304,9 @@ mod tests {
         match msg {
             DkgQueryMsg::GetState {} => client.get_state().ignore(),
             DkgQueryMsg::GetCurrentEpochState {} => client.get_current_epoch().ignore(),
+            DkgQueryMsg::GetEpochStateAtHeight { height } => {
+                client.get_epoch_at_height(height).ignore()
+            }
             DkgQueryMsg::CanAdvanceState {} => client.can_advance_state().ignore(),
             DkgQueryMsg::GetCurrentEpochThreshold {} => {
                 client.get_current_epoch_threshold().ignore()

--- a/common/cosmwasm-smart-contracts/coconut-dkg/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/coconut-dkg/src/msg.rs
@@ -84,6 +84,9 @@ pub enum QueryMsg {
     #[cfg_attr(feature = "schema", returns(Epoch))]
     GetCurrentEpochState {},
 
+    #[cfg_attr(feature = "schema", returns(Option<Epoch>))]
+    GetEpochStateAtHeight { height: u64 },
+
     #[cfg_attr(feature = "schema", returns(u64))]
     GetCurrentEpochThreshold {},
 

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1091,6 +1091,7 @@ dependencies = [
 name = "nym-coconut-dkg"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",

--- a/contracts/coconut-dkg/Cargo.toml
+++ b/contracts/coconut-dkg/Cargo.toml
@@ -29,6 +29,7 @@ cw4 = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 easy-addr = { path = "../../common/cosmwasm-smart-contracts/easy_addr" }
 cw-multi-test = { workspace = true }
 cw4-group = { path = "../multisig/cw4-group" }

--- a/contracts/coconut-dkg/schema/nym-coconut-dkg.json
+++ b/contracts/coconut-dkg/schema/nym-coconut-dkg.json
@@ -364,6 +364,29 @@
       {
         "type": "object",
         "required": [
+          "get_epoch_state_at_height"
+        ],
+        "properties": {
+          "get_epoch_state_at_height": {
+            "type": "object",
+            "required": [
+              "height"
+            ],
+            "properties": {
+              "height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
           "get_current_epoch_threshold"
         ],
         "properties": {
@@ -2032,6 +2055,271 @@
       "definitions": {
         "Addr": {
           "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        }
+      }
+    },
+    "get_epoch_state_at_height": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Nullable_Epoch",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Epoch"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "definitions": {
+        "Epoch": {
+          "type": "object",
+          "required": [
+            "epoch_id",
+            "state",
+            "state_progress",
+            "time_configuration"
+          ],
+          "properties": {
+            "deadline": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Timestamp"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "epoch_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "state": {
+              "$ref": "#/definitions/EpochState"
+            },
+            "state_progress": {
+              "$ref": "#/definitions/StateProgress"
+            },
+            "time_configuration": {
+              "$ref": "#/definitions/TimeConfiguration"
+            }
+          },
+          "additionalProperties": false
+        },
+        "EpochState": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "waiting_initialisation",
+                "in_progress"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "public_key_submission"
+              ],
+              "properties": {
+                "public_key_submission": {
+                  "type": "object",
+                  "required": [
+                    "resharing"
+                  ],
+                  "properties": {
+                    "resharing": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "dealing_exchange"
+              ],
+              "properties": {
+                "dealing_exchange": {
+                  "type": "object",
+                  "required": [
+                    "resharing"
+                  ],
+                  "properties": {
+                    "resharing": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "verification_key_submission"
+              ],
+              "properties": {
+                "verification_key_submission": {
+                  "type": "object",
+                  "required": [
+                    "resharing"
+                  ],
+                  "properties": {
+                    "resharing": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "verification_key_validation"
+              ],
+              "properties": {
+                "verification_key_validation": {
+                  "type": "object",
+                  "required": [
+                    "resharing"
+                  ],
+                  "properties": {
+                    "resharing": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "verification_key_finalization"
+              ],
+              "properties": {
+                "verification_key_finalization": {
+                  "type": "object",
+                  "required": [
+                    "resharing"
+                  ],
+                  "properties": {
+                    "resharing": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "StateProgress": {
+          "type": "object",
+          "required": [
+            "registered_dealers",
+            "registered_resharing_dealers",
+            "submitted_dealings",
+            "submitted_key_shares",
+            "verified_keys"
+          ],
+          "properties": {
+            "registered_dealers": {
+              "description": "Counts the number of dealers that have registered in this epoch.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "registered_resharing_dealers": {
+              "description": "Counts the number of resharing dealers that have registered in this epoch. This field is only populated during a resharing exchange. It is always <= registered_dealers.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "submitted_dealings": {
+              "description": "Counts the number of fully received dealings (i.e. full chunks) from all the allowed dealers.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "submitted_key_shares": {
+              "description": "Counts the number of submitted verification key shared from the dealers.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "verified_keys": {
+              "description": "Counts the number of verified key shares.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        "TimeConfiguration": {
+          "type": "object",
+          "required": [
+            "dealing_exchange_time_secs",
+            "in_progress_time_secs",
+            "public_key_submission_time_secs",
+            "verification_key_finalization_time_secs",
+            "verification_key_submission_time_secs",
+            "verification_key_validation_time_secs"
+          ],
+          "properties": {
+            "dealing_exchange_time_secs": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "in_progress_time_secs": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "public_key_submission_time_secs": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "verification_key_finalization_time_secs": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "verification_key_submission_time_secs": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "verification_key_validation_time_secs": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
           "type": "string"
         }
       }

--- a/contracts/coconut-dkg/schema/raw/query.json
+++ b/contracts/coconut-dkg/schema/raw/query.json
@@ -31,6 +31,29 @@
     {
       "type": "object",
       "required": [
+        "get_epoch_state_at_height"
+      ],
+      "properties": {
+        "get_epoch_state_at_height": {
+          "type": "object",
+          "required": [
+            "height"
+          ],
+          "properties": {
+            "height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
         "get_current_epoch_threshold"
       ],
       "properties": {

--- a/contracts/coconut-dkg/schema/raw/response_to_get_epoch_state_at_height.json
+++ b/contracts/coconut-dkg/schema/raw/response_to_get_epoch_state_at_height.json
@@ -1,0 +1,265 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Nullable_Epoch",
+  "anyOf": [
+    {
+      "$ref": "#/definitions/Epoch"
+    },
+    {
+      "type": "null"
+    }
+  ],
+  "definitions": {
+    "Epoch": {
+      "type": "object",
+      "required": [
+        "epoch_id",
+        "state",
+        "state_progress",
+        "time_configuration"
+      ],
+      "properties": {
+        "deadline": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Timestamp"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "epoch_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "state": {
+          "$ref": "#/definitions/EpochState"
+        },
+        "state_progress": {
+          "$ref": "#/definitions/StateProgress"
+        },
+        "time_configuration": {
+          "$ref": "#/definitions/TimeConfiguration"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EpochState": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "waiting_initialisation",
+            "in_progress"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "public_key_submission"
+          ],
+          "properties": {
+            "public_key_submission": {
+              "type": "object",
+              "required": [
+                "resharing"
+              ],
+              "properties": {
+                "resharing": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "dealing_exchange"
+          ],
+          "properties": {
+            "dealing_exchange": {
+              "type": "object",
+              "required": [
+                "resharing"
+              ],
+              "properties": {
+                "resharing": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "verification_key_submission"
+          ],
+          "properties": {
+            "verification_key_submission": {
+              "type": "object",
+              "required": [
+                "resharing"
+              ],
+              "properties": {
+                "resharing": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "verification_key_validation"
+          ],
+          "properties": {
+            "verification_key_validation": {
+              "type": "object",
+              "required": [
+                "resharing"
+              ],
+              "properties": {
+                "resharing": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "verification_key_finalization"
+          ],
+          "properties": {
+            "verification_key_finalization": {
+              "type": "object",
+              "required": [
+                "resharing"
+              ],
+              "properties": {
+                "resharing": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "StateProgress": {
+      "type": "object",
+      "required": [
+        "registered_dealers",
+        "registered_resharing_dealers",
+        "submitted_dealings",
+        "submitted_key_shares",
+        "verified_keys"
+      ],
+      "properties": {
+        "registered_dealers": {
+          "description": "Counts the number of dealers that have registered in this epoch.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "registered_resharing_dealers": {
+          "description": "Counts the number of resharing dealers that have registered in this epoch. This field is only populated during a resharing exchange. It is always <= registered_dealers.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "submitted_dealings": {
+          "description": "Counts the number of fully received dealings (i.e. full chunks) from all the allowed dealers.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "submitted_key_shares": {
+          "description": "Counts the number of submitted verification key shared from the dealers.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "verified_keys": {
+          "description": "Counts the number of verified key shares.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "TimeConfiguration": {
+      "type": "object",
+      "required": [
+        "dealing_exchange_time_secs",
+        "in_progress_time_secs",
+        "public_key_submission_time_secs",
+        "verification_key_finalization_time_secs",
+        "verification_key_submission_time_secs",
+        "verification_key_validation_time_secs"
+      ],
+      "properties": {
+        "dealing_exchange_time_secs": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "in_progress_time_secs": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "public_key_submission_time_secs": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "verification_key_finalization_time_secs": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "verification_key_submission_time_secs": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "verification_key_validation_time_secs": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/coconut-dkg/src/contract.rs
+++ b/contracts/coconut-dkg/src/contract.rs
@@ -14,7 +14,7 @@ use crate::dealings::queries::{
 use crate::dealings::transactions::{try_commit_dealings_chunk, try_submit_dealings_metadata};
 use crate::epoch_state::queries::{
     query_can_advance_state, query_current_epoch, query_current_epoch_threshold,
-    query_epoch_threshold,
+    query_epoch_at_height, query_epoch_threshold,
 };
 use crate::epoch_state::storage::save_epoch;
 use crate::epoch_state::transactions::{
@@ -135,6 +135,9 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> Result<QueryResponse, C
     let response = match msg {
         QueryMsg::GetState {} => to_json_binary(&query_state(deps.storage)?)?,
         QueryMsg::GetCurrentEpochState {} => to_json_binary(&query_current_epoch(deps.storage)?)?,
+        QueryMsg::GetEpochStateAtHeight { height } => {
+            to_json_binary(&query_epoch_at_height(deps.storage, height)?)?
+        }
         QueryMsg::CanAdvanceState {} => {
             to_json_binary(&query_can_advance_state(deps.storage, env)?)?
         }

--- a/contracts/coconut-dkg/src/dealers/queries.rs
+++ b/contracts/coconut-dkg/src/dealers/queries.rs
@@ -5,7 +5,7 @@ use crate::dealers::storage::{
     self, get_dealer_details, get_dealer_index, get_registration_details, DEALERS_INDICES,
     EPOCH_DEALERS_MAP,
 };
-use crate::epoch_state::storage::CURRENT_EPOCH;
+use crate::epoch_state::storage::load_current_epoch;
 use cosmwasm_std::{Deps, Order, StdResult};
 use cw_storage_plus::Bound;
 use nym_coconut_dkg_common::dealer::{
@@ -23,7 +23,7 @@ pub fn query_registered_dealer_details(
 
     let epoch_id = match epoch_id {
         Some(epoch_id) => epoch_id,
-        None => CURRENT_EPOCH.load(deps.storage)?.epoch_id,
+        None => load_current_epoch(deps.storage)?.epoch_id,
     };
 
     Ok(RegisteredDealerDetails {
@@ -36,7 +36,7 @@ pub fn query_dealer_details(
     dealer_address: String,
 ) -> StdResult<DealerDetailsResponse> {
     let addr = deps.api.addr_validate(&dealer_address)?;
-    let current_epoch_id = CURRENT_EPOCH.load(deps.storage)?.epoch_id;
+    let current_epoch_id = load_current_epoch(deps.storage)?.epoch_id;
 
     // if the address has registration data for the current epoch, it means it's an active dealer
     if let Ok(dealer_details) = get_dealer_details(deps.storage, &addr, current_epoch_id) {
@@ -157,7 +157,7 @@ pub fn query_current_dealers_paged(
     start_after: Option<String>,
     limit: Option<u32>,
 ) -> StdResult<PagedDealerResponse> {
-    let current_epoch_id = CURRENT_EPOCH.load(deps.storage)?.epoch_id;
+    let current_epoch_id = load_current_epoch(deps.storage)?.epoch_id;
     query_epoch_dealers_paged(deps, current_epoch_id, start_after, limit)
 }
 

--- a/contracts/coconut-dkg/src/dealers/transactions.rs
+++ b/contracts/coconut-dkg/src/dealers/transactions.rs
@@ -4,7 +4,7 @@
 use crate::dealers::storage::{
     get_or_assign_index, is_dealer, save_dealer_details_if_not_a_dealer,
 };
-use crate::epoch_state::storage::CURRENT_EPOCH;
+use crate::epoch_state::storage::{load_current_epoch, update_epoch};
 use crate::epoch_state::utils::check_epoch_state;
 use crate::error::ContractError;
 use crate::state::storage::STATE;
@@ -34,7 +34,7 @@ pub fn try_add_dealer(
     announce_address: String,
     resharing: bool,
 ) -> Result<Response, ContractError> {
-    let epoch = CURRENT_EPOCH.load(deps.storage)?;
+    let epoch = load_current_epoch(deps.storage)?;
     check_epoch_state(deps.storage, EpochState::PublicKeySubmission { resharing })?;
 
     // make sure this potential dealer actually belong to the group
@@ -68,7 +68,7 @@ pub fn try_add_dealer(
         );
 
     // increment the number of registered dealers
-    CURRENT_EPOCH.update(deps.storage, |epoch| -> StdResult<_> {
+    update_epoch(deps.storage, |epoch| -> StdResult<_> {
         let mut updated_epoch = epoch;
         updated_epoch.state_progress.registered_dealers += 1;
 

--- a/contracts/coconut-dkg/src/dealings/transactions.rs
+++ b/contracts/coconut-dkg/src/dealings/transactions.rs
@@ -197,7 +197,7 @@ pub fn try_commit_dealings_chunk(
     // there won't be a lot of them
     if metadata.is_complete() {
         epoch.state_progress.submitted_dealings += 1;
-        save_epoch(deps.storage, &epoch)?;
+        save_epoch(deps.storage, env.block.height, &epoch)?;
     }
 
     Ok(Response::new())
@@ -310,7 +310,7 @@ pub(crate) mod tests {
         );
 
         // same index, but next epoch
-        update_epoch(deps.as_mut().storage, |mut epoch| {
+        update_epoch(deps.as_mut().storage, env.block.height, |mut epoch| {
             epoch.epoch_id += 1;
             Ok(epoch)
         })

--- a/contracts/coconut-dkg/src/dealings/transactions.rs
+++ b/contracts/coconut-dkg/src/dealings/transactions.rs
@@ -206,7 +206,6 @@ pub fn try_commit_dealings_chunk(
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::epoch_state::storage::update_epoch;
     use crate::epoch_state::transactions::{try_advance_epoch_state, try_initiate_dkg};
     use crate::support::tests::fixtures::{dealing_metadata_fixture, partial_dealing_fixture};
     use crate::support::tests::helpers;
@@ -310,11 +309,10 @@ pub(crate) mod tests {
         );
 
         // same index, but next epoch
-        update_epoch(deps.as_mut().storage, env.block.height, |mut epoch| {
-            epoch.epoch_id += 1;
-            Ok(epoch)
-        })
-        .unwrap();
+        let mut epoch = load_current_epoch(&deps.storage).unwrap();
+        epoch.epoch_id += 1;
+        save_epoch(deps.as_mut().storage, epoch.epoch_id, &epoch).unwrap();
+
         re_register_dealer(deps.as_mut(), &info.sender);
 
         try_submit_dealings_metadata(

--- a/contracts/coconut-dkg/src/epoch_state/queries.rs
+++ b/contracts/coconut-dkg/src/epoch_state/queries.rs
@@ -1,10 +1,12 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::epoch_state::storage::{load_current_epoch, EPOCH_THRESHOLDS, THRESHOLD};
+use crate::epoch_state::storage::{
+    load_current_epoch, EPOCH_THRESHOLDS, HISTORICAL_EPOCH, THRESHOLD,
+};
 use crate::epoch_state::utils::check_state_completion;
 use crate::error::ContractError;
-use cosmwasm_std::{Env, Storage};
+use cosmwasm_std::{Env, StdResult, Storage};
 use nym_coconut_dkg_common::types::{Epoch, EpochId, EpochState, StateAdvanceResponse};
 
 pub(crate) fn query_can_advance_state(
@@ -35,6 +37,13 @@ pub(crate) fn query_can_advance_state(
 
 pub(crate) fn query_current_epoch(storage: &dyn Storage) -> Result<Epoch, ContractError> {
     load_current_epoch(storage).map_err(|_| ContractError::EpochNotInitialised)
+}
+
+pub(crate) fn query_epoch_at_height(
+    storage: &dyn Storage,
+    height: u64,
+) -> StdResult<Option<Epoch>> {
+    HISTORICAL_EPOCH.may_load_at_height(storage, height)
 }
 
 pub(crate) fn query_current_epoch_threshold(

--- a/contracts/coconut-dkg/src/epoch_state/queries.rs
+++ b/contracts/coconut-dkg/src/epoch_state/queries.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::epoch_state::storage::{CURRENT_EPOCH, EPOCH_THRESHOLDS, THRESHOLD};
+use crate::epoch_state::storage::{load_current_epoch, EPOCH_THRESHOLDS, THRESHOLD};
 use crate::epoch_state::utils::check_state_completion;
 use crate::error::ContractError;
 use cosmwasm_std::{Env, Storage};
@@ -11,7 +11,7 @@ pub(crate) fn query_can_advance_state(
     storage: &dyn Storage,
     env: Env,
 ) -> Result<StateAdvanceResponse, ContractError> {
-    let epoch = CURRENT_EPOCH.load(storage)?;
+    let epoch = load_current_epoch(storage)?;
 
     if epoch.state == EpochState::WaitingInitialisation {
         return Ok(StateAdvanceResponse::default());
@@ -34,9 +34,7 @@ pub(crate) fn query_can_advance_state(
 }
 
 pub(crate) fn query_current_epoch(storage: &dyn Storage) -> Result<Epoch, ContractError> {
-    CURRENT_EPOCH
-        .load(storage)
-        .map_err(|_| ContractError::EpochNotInitialised)
+    load_current_epoch(storage).map_err(|_| ContractError::EpochNotInitialised)
 }
 
 pub(crate) fn query_current_epoch_threshold(

--- a/contracts/coconut-dkg/src/epoch_state/storage.rs
+++ b/contracts/coconut-dkg/src/epoch_state/storage.rs
@@ -23,20 +23,13 @@ pub const EPOCH_THRESHOLDS: Map<EpochId, u64> = Map::new("epoch_thresholds");
 #[allow(deprecated)]
 pub fn save_epoch(storage: &mut dyn Storage, height: u64, epoch: &Epoch) -> StdResult<()> {
     CURRENT_EPOCH.save(storage, epoch)?;
-    HISTORICAL_EPOCH.save(storage, epoch, height)
-}
-
-#[cfg(test)]
-#[allow(deprecated)]
-pub(crate) fn update_epoch<A>(storage: &mut dyn Storage, height: u64, action: A) -> StdResult<()>
-where
-    A: Fn(Epoch) -> Result<Epoch, cosmwasm_std::StdError>,
-{
-    let current = load_current_epoch(storage)?;
-    let updated = action(current)?;
-    save_epoch(storage, height, &updated)?;
-
-    Ok(())
+    // NOTE: we save data for the PREVIOUS height.
+    // currently cw-plus snapshot is treated as if it happened at the beginning of a block,
+    // meaning if we create checkpoint at heights 10 and heights 20 and then query for value
+    // at height 20, it will still return value that was saved at height 10.
+    // the correct one will only be returned from heights >= 21.
+    // this is not what we want. if dkg state was updated at height 20, we want that updated state immediately.
+    HISTORICAL_EPOCH.save(storage, epoch, height - 1)
 }
 
 #[allow(deprecated)]
@@ -48,4 +41,88 @@ pub fn load_current_epoch(storage: &dyn Storage) -> StdResult<Epoch> {
         debug_assert_eq!(current, historical);
     }
     CURRENT_EPOCH.load(storage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::mock_dependencies;
+
+    #[test]
+    fn check_cw_plus_snapshot_behaviour_hasnt_changed() {
+        // so currently cw-plus snapshot is treated as if it happened at the beginning of a block,
+        // meaning if we create checkpoint at heights 10 and heights 20 and then query for value
+        // at height 20, it will still return value that was saved at height 10.
+        // the correct one will only be returned from heights >= 21.
+        // this is not what we want. if dkg state was updated at height 20, we want that updated state immediately.
+        //
+        // this test ensures that behaviour hasn't changed so that we wouldn't accidentally introduce inconsistency
+        const DUMMY_SNAPSHOT: SnapshotItem<u64> =
+            SnapshotItem::new("a", "b", "c", Strategy::EveryBlock);
+
+        let mut deps = mock_dependencies();
+        DUMMY_SNAPSHOT.save(&mut deps.storage, &10, 10).unwrap();
+        DUMMY_SNAPSHOT.save(&mut deps.storage, &20, 20).unwrap();
+        DUMMY_SNAPSHOT.save(&mut deps.storage, &30, 30).unwrap();
+
+        assert_eq!(DUMMY_SNAPSHOT.load(&deps.storage).unwrap(), 30);
+        assert_eq!(
+            DUMMY_SNAPSHOT
+                .may_load_at_height(&deps.storage, 40)
+                .unwrap(),
+            Some(30)
+        );
+        assert_eq!(
+            DUMMY_SNAPSHOT
+                .may_load_at_height(&deps.storage, 31)
+                .unwrap(),
+            Some(30)
+        );
+        assert_eq!(
+            DUMMY_SNAPSHOT
+                .may_load_at_height(&deps.storage, 30)
+                .unwrap(),
+            Some(20)
+        );
+        assert_eq!(
+            DUMMY_SNAPSHOT
+                .may_load_at_height(&deps.storage, 29)
+                .unwrap(),
+            Some(20)
+        );
+        assert_eq!(
+            DUMMY_SNAPSHOT
+                .may_load_at_height(&deps.storage, 21)
+                .unwrap(),
+            Some(20)
+        );
+        assert_eq!(
+            DUMMY_SNAPSHOT
+                .may_load_at_height(&deps.storage, 20)
+                .unwrap(),
+            Some(10)
+        );
+        assert_eq!(
+            DUMMY_SNAPSHOT
+                .may_load_at_height(&deps.storage, 19)
+                .unwrap(),
+            Some(10)
+        );
+        assert_eq!(
+            DUMMY_SNAPSHOT
+                .may_load_at_height(&deps.storage, 11)
+                .unwrap(),
+            Some(10)
+        );
+        assert_eq!(
+            DUMMY_SNAPSHOT
+                .may_load_at_height(&deps.storage, 10)
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            DUMMY_SNAPSHOT.may_load_at_height(&deps.storage, 9).unwrap(),
+            None
+        );
+    }
 }

--- a/contracts/coconut-dkg/src/epoch_state/storage.rs
+++ b/contracts/coconut-dkg/src/epoch_state/storage.rs
@@ -40,7 +40,7 @@ pub fn load_current_epoch(storage: &dyn Storage) -> StdResult<Epoch> {
         let historical = HISTORICAL_EPOCH.load(storage);
         debug_assert_eq!(current, historical);
     }
-    CURRENT_EPOCH.load(storage)
+    HISTORICAL_EPOCH.load(storage)
 }
 
 #[cfg(test)]

--- a/contracts/coconut-dkg/src/epoch_state/storage.rs
+++ b/contracts/coconut-dkg/src/epoch_state/storage.rs
@@ -1,9 +1,13 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use cosmwasm_std::{StdResult, Storage};
 use cw_storage_plus::{Item, Map, SnapshotItem, Strategy};
 use nym_coconut_dkg_common::types::{Epoch, EpochId};
 
+#[deprecated]
+// leave old values in storage for backwards compatibility, but make sure everything in the contract
+// uses the new reference
 pub(crate) const CURRENT_EPOCH: Item<Epoch> = Item::new("current_epoch");
 pub const HISTORICAL_EPOCH: SnapshotItem<Epoch> = SnapshotItem::new(
     "historical_epoch",
@@ -16,3 +20,21 @@ pub const THRESHOLD: Item<u64> = Item::new("threshold");
 
 pub const EPOCH_THRESHOLDS: Map<EpochId, u64> = Map::new("epoch_thresholds");
 
+#[allow(deprecated)]
+pub fn save_epoch(storage: &mut dyn Storage, epoch: &Epoch) -> StdResult<()> {
+    CURRENT_EPOCH.save(storage, epoch)
+}
+
+#[allow(deprecated)]
+pub fn update_epoch<A>(storage: &mut dyn Storage, action: A) -> StdResult<()>
+where
+    A: FnOnce(Epoch) -> Result<Epoch, cosmwasm_std::StdError>,
+{
+    CURRENT_EPOCH.update(storage, action)?;
+    Ok(())
+}
+
+#[allow(deprecated)]
+pub fn load_current_epoch(storage: &dyn Storage) -> StdResult<Epoch> {
+    CURRENT_EPOCH.load(storage)
+}

--- a/contracts/coconut-dkg/src/epoch_state/storage.rs
+++ b/contracts/coconut-dkg/src/epoch_state/storage.rs
@@ -23,13 +23,7 @@ pub const EPOCH_THRESHOLDS: Map<EpochId, u64> = Map::new("epoch_thresholds");
 #[allow(deprecated)]
 pub fn save_epoch(storage: &mut dyn Storage, height: u64, epoch: &Epoch) -> StdResult<()> {
     CURRENT_EPOCH.save(storage, epoch)?;
-    // NOTE: we save data for the PREVIOUS height.
-    // currently cw-plus snapshot is treated as if it happened at the beginning of a block,
-    // meaning if we create checkpoint at heights 10 and heights 20 and then query for value
-    // at height 20, it will still return value that was saved at height 10.
-    // the correct one will only be returned from heights >= 21.
-    // this is not what we want. if dkg state was updated at height 20, we want that updated state immediately.
-    HISTORICAL_EPOCH.save(storage, epoch, height - 1)
+    HISTORICAL_EPOCH.save(storage, epoch, height)
 }
 
 #[allow(deprecated)]
@@ -52,84 +46,6 @@ mod tests {
     use cosmwasm_std::{Addr, Env};
     use nym_coconut_dkg_common::types::EpochState;
     use std::ops::{Deref, DerefMut};
-
-    #[test]
-    fn check_cw_plus_snapshot_behaviour_hasnt_changed() {
-        // so currently cw-plus snapshot is treated as if it happened at the beginning of a block,
-        // meaning if we create checkpoint at heights 10 and heights 20 and then query for value
-        // at height 20, it will still return value that was saved at height 10.
-        // the correct one will only be returned from heights >= 21.
-        // this is not what we want. if dkg state was updated at height 20, we want that updated state immediately.
-        //
-        // this test ensures that behaviour hasn't changed so that we wouldn't accidentally introduce inconsistency
-        const DUMMY_SNAPSHOT: SnapshotItem<u64> =
-            SnapshotItem::new("a", "b", "c", Strategy::EveryBlock);
-
-        let mut deps = mock_dependencies();
-        DUMMY_SNAPSHOT.save(&mut deps.storage, &10, 10).unwrap();
-        DUMMY_SNAPSHOT.save(&mut deps.storage, &20, 20).unwrap();
-        DUMMY_SNAPSHOT.save(&mut deps.storage, &30, 30).unwrap();
-
-        assert_eq!(DUMMY_SNAPSHOT.load(&deps.storage).unwrap(), 30);
-        assert_eq!(
-            DUMMY_SNAPSHOT
-                .may_load_at_height(&deps.storage, 40)
-                .unwrap(),
-            Some(30)
-        );
-        assert_eq!(
-            DUMMY_SNAPSHOT
-                .may_load_at_height(&deps.storage, 31)
-                .unwrap(),
-            Some(30)
-        );
-        assert_eq!(
-            DUMMY_SNAPSHOT
-                .may_load_at_height(&deps.storage, 30)
-                .unwrap(),
-            Some(20)
-        );
-        assert_eq!(
-            DUMMY_SNAPSHOT
-                .may_load_at_height(&deps.storage, 29)
-                .unwrap(),
-            Some(20)
-        );
-        assert_eq!(
-            DUMMY_SNAPSHOT
-                .may_load_at_height(&deps.storage, 21)
-                .unwrap(),
-            Some(20)
-        );
-        assert_eq!(
-            DUMMY_SNAPSHOT
-                .may_load_at_height(&deps.storage, 20)
-                .unwrap(),
-            Some(10)
-        );
-        assert_eq!(
-            DUMMY_SNAPSHOT
-                .may_load_at_height(&deps.storage, 19)
-                .unwrap(),
-            Some(10)
-        );
-        assert_eq!(
-            DUMMY_SNAPSHOT
-                .may_load_at_height(&deps.storage, 11)
-                .unwrap(),
-            Some(10)
-        );
-        assert_eq!(
-            DUMMY_SNAPSHOT
-                .may_load_at_height(&deps.storage, 10)
-                .unwrap(),
-            None
-        );
-        assert_eq!(
-            DUMMY_SNAPSHOT.may_load_at_height(&deps.storage, 9).unwrap(),
-            None
-        );
-    }
 
     #[test]
     fn full_dkg_correctly_updates_historical_epoch() -> anyhow::Result<()> {
@@ -242,14 +158,14 @@ mod tests {
             .is_none());
         assert_eq!(
             HISTORICAL_EPOCH
-                .may_load_at_height(deps.as_mut().storage, init_height)?
+                .may_load_at_height(deps.as_mut().storage, init_height + 1)?
                 .unwrap()
                 .state,
             EpochState::WaitingInitialisation
         );
         assert_eq!(
             HISTORICAL_EPOCH
-                .may_load_at_height(deps.as_mut().storage, pub_key_submission_height)?
+                .may_load_at_height(deps.as_mut().storage, pub_key_submission_height + 1)?
                 .unwrap()
                 .state,
             EpochState::PublicKeySubmission { resharing: false }
@@ -257,7 +173,7 @@ mod tests {
 
         assert_eq!(
             HISTORICAL_EPOCH
-                .may_load_at_height(deps.as_mut().storage, dealing_exchange_height)?
+                .may_load_at_height(deps.as_mut().storage, dealing_exchange_height + 1)?
                 .unwrap()
                 .state,
             EpochState::DealingExchange { resharing: false }
@@ -265,7 +181,10 @@ mod tests {
 
         assert_eq!(
             HISTORICAL_EPOCH
-                .may_load_at_height(deps.as_mut().storage, verification_key_submission_height)?
+                .may_load_at_height(
+                    deps.as_mut().storage,
+                    verification_key_submission_height + 1
+                )?
                 .unwrap()
                 .state,
             EpochState::VerificationKeySubmission { resharing: false }
@@ -273,7 +192,10 @@ mod tests {
 
         assert_eq!(
             HISTORICAL_EPOCH
-                .may_load_at_height(deps.as_mut().storage, verification_key_validation_height)?
+                .may_load_at_height(
+                    deps.as_mut().storage,
+                    verification_key_validation_height + 1
+                )?
                 .unwrap()
                 .state,
             EpochState::VerificationKeyValidation { resharing: false }
@@ -281,7 +203,10 @@ mod tests {
 
         assert_eq!(
             HISTORICAL_EPOCH
-                .may_load_at_height(deps.as_mut().storage, verification_key_finalization_height)?
+                .may_load_at_height(
+                    deps.as_mut().storage,
+                    verification_key_finalization_height + 1
+                )?
                 .unwrap()
                 .state,
             EpochState::VerificationKeyFinalization { resharing: false }
@@ -289,7 +214,7 @@ mod tests {
 
         assert_eq!(
             HISTORICAL_EPOCH
-                .may_load_at_height(deps.as_mut().storage, in_progress_height)?
+                .may_load_at_height(deps.as_mut().storage, in_progress_height + 1)?
                 .unwrap()
                 .state,
             EpochState::InProgress

--- a/contracts/coconut-dkg/src/epoch_state/storage.rs
+++ b/contracts/coconut-dkg/src/epoch_state/storage.rs
@@ -1,11 +1,18 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use cw_storage_plus::{Item, Map};
+use cw_storage_plus::{Item, Map, SnapshotItem, Strategy};
 use nym_coconut_dkg_common::types::{Epoch, EpochId};
 
 pub(crate) const CURRENT_EPOCH: Item<Epoch> = Item::new("current_epoch");
+pub const HISTORICAL_EPOCH: SnapshotItem<Epoch> = SnapshotItem::new(
+    "historical_epoch",
+    "historical_epoch__checkpoints",
+    "historical_epoch__changelog",
+    Strategy::EveryBlock,
+);
 
 pub const THRESHOLD: Item<u64> = Item::new("threshold");
 
 pub const EPOCH_THRESHOLDS: Map<EpochId, u64> = Map::new("epoch_thresholds");
+

--- a/contracts/coconut-dkg/src/epoch_state/transactions/mod.rs
+++ b/contracts/coconut-dkg/src/epoch_state/transactions/mod.rs
@@ -37,7 +37,7 @@ pub(crate) fn try_initiate_dkg(
     // the first exchange won't involve resharing
     let initial_state = EpochState::PublicKeySubmission { resharing: false };
     let initial_epoch = Epoch::new(initial_state, 0, epoch.time_configuration, env.block.time);
-    save_epoch(deps.storage, &initial_epoch)?;
+    save_epoch(deps.storage, env.block.height, &initial_epoch)?;
 
     Ok(Response::default())
 }
@@ -57,7 +57,7 @@ pub(crate) fn try_trigger_reset(
     }
 
     let next_epoch = current_epoch.next_reset(env.block.time);
-    save_epoch(deps.storage, &next_epoch)?;
+    save_epoch(deps.storage, env.block.height, &next_epoch)?;
 
     reset_dkg_state(deps.storage)?;
 
@@ -79,7 +79,7 @@ pub(crate) fn try_trigger_resharing(
     }
 
     let next_epoch = current_epoch.next_resharing(env.block.time);
-    save_epoch(deps.storage, &next_epoch)?;
+    save_epoch(deps.storage, env.block.height, &next_epoch)?;
 
     reset_dkg_state(deps.storage)?;
 

--- a/contracts/coconut-dkg/src/epoch_state/transactions/mod.rs
+++ b/contracts/coconut-dkg/src/epoch_state/transactions/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::epoch_state::storage::{CURRENT_EPOCH, THRESHOLD};
+use crate::epoch_state::storage::{load_current_epoch, save_epoch, THRESHOLD};
 use crate::error::ContractError;
 use crate::state::storage::DKG_ADMIN;
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Response, Storage};
@@ -29,7 +29,7 @@ pub(crate) fn try_initiate_dkg(
     // only the admin is allowed to kick start the process
     DKG_ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
 
-    let epoch = CURRENT_EPOCH.load(deps.storage)?;
+    let epoch = load_current_epoch(deps.storage)?;
     if !matches!(epoch.state, EpochState::WaitingInitialisation) {
         return Err(ContractError::AlreadyInitialised);
     }
@@ -37,7 +37,7 @@ pub(crate) fn try_initiate_dkg(
     // the first exchange won't involve resharing
     let initial_state = EpochState::PublicKeySubmission { resharing: false };
     let initial_epoch = Epoch::new(initial_state, 0, epoch.time_configuration, env.block.time);
-    CURRENT_EPOCH.save(deps.storage, &initial_epoch)?;
+    save_epoch(deps.storage, &initial_epoch)?;
 
     Ok(Response::default())
 }
@@ -49,7 +49,7 @@ pub(crate) fn try_trigger_reset(
 ) -> Result<Response, ContractError> {
     // only the admin is allowed to trigger DKG reset
     DKG_ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
-    let current_epoch = CURRENT_EPOCH.load(deps.storage)?;
+    let current_epoch = load_current_epoch(deps.storage)?;
 
     // only allow reset when the DKG exchange isn't in progress
     if !current_epoch.state.is_in_progress() {
@@ -57,7 +57,7 @@ pub(crate) fn try_trigger_reset(
     }
 
     let next_epoch = current_epoch.next_reset(env.block.time);
-    CURRENT_EPOCH.save(deps.storage, &next_epoch)?;
+    save_epoch(deps.storage, &next_epoch)?;
 
     reset_dkg_state(deps.storage)?;
 
@@ -71,7 +71,7 @@ pub(crate) fn try_trigger_resharing(
 ) -> Result<Response, ContractError> {
     // only the admin is allowed to trigger DKG resharing
     DKG_ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
-    let current_epoch = CURRENT_EPOCH.load(deps.storage)?;
+    let current_epoch = load_current_epoch(deps.storage)?;
 
     // only allow resharing when the DKG exchange isn't in progress
     if !current_epoch.state.is_in_progress() {
@@ -79,7 +79,7 @@ pub(crate) fn try_trigger_resharing(
     }
 
     let next_epoch = current_epoch.next_resharing(env.block.time);
-    CURRENT_EPOCH.save(deps.storage, &next_epoch)?;
+    save_epoch(deps.storage, &next_epoch)?;
 
     reset_dkg_state(deps.storage)?;
 
@@ -89,6 +89,7 @@ pub(crate) fn try_trigger_resharing(
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use crate::epoch_state::storage::load_current_epoch;
     use crate::support::tests::helpers::{init_contract, ADMIN_ADDRESS};
     use cosmwasm_std::testing::{message_info, mock_env};
     use cosmwasm_std::Addr;
@@ -99,7 +100,7 @@ pub(crate) mod tests {
         let mut deps = init_contract();
         let env = mock_env();
 
-        let initial_epoch_info = CURRENT_EPOCH.load(&deps.storage).unwrap();
+        let initial_epoch_info = load_current_epoch(&deps.storage).unwrap();
         assert!(initial_epoch_info.deadline.is_none());
 
         let not_admin = deps.api.addr_make("not an admin");
@@ -125,7 +126,7 @@ pub(crate) mod tests {
         assert_eq!(ContractError::AlreadyInitialised, res);
 
         // sets the correct epoch data
-        let epoch = CURRENT_EPOCH.load(&deps.storage).unwrap();
+        let epoch = load_current_epoch(&deps.storage).unwrap();
         assert_eq!(epoch.epoch_id, 0);
         assert_eq!(
             epoch.state,

--- a/contracts/coconut-dkg/src/epoch_state/utils.rs
+++ b/contracts/coconut-dkg/src/epoch_state/utils.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::epoch_state::storage::CURRENT_EPOCH;
+use crate::epoch_state::storage::load_current_epoch;
 use crate::error::ContractError;
 use crate::state::storage::STATE;
 use cosmwasm_std::Storage;
@@ -52,7 +52,7 @@ pub(crate) fn check_epoch_state(
     storage: &dyn Storage,
     against: EpochState,
 ) -> Result<(), ContractError> {
-    let epoch_state = CURRENT_EPOCH.load(storage)?.state;
+    let epoch_state = load_current_epoch(storage)?.state;
     if epoch_state != against {
         Err(ContractError::IncorrectEpochState {
             current_state: epoch_state.to_string(),
@@ -66,6 +66,7 @@ pub(crate) fn check_epoch_state(
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
+    use crate::epoch_state::storage::save_epoch;
     use crate::support::tests::helpers::init_contract;
     use cosmwasm_std::testing::mock_env;
     use cosmwasm_std::Timestamp;
@@ -210,12 +211,11 @@ pub(crate) mod test {
         let env = mock_env();
 
         for fixed_state in EpochState::first().all_until(EpochState::InProgress) {
-            CURRENT_EPOCH
-                .save(
-                    deps.as_mut().storage,
-                    &Epoch::new(fixed_state, 0, TimeConfiguration::default(), env.block.time),
-                )
-                .unwrap();
+            save_epoch(
+                deps.as_mut().storage,
+                &Epoch::new(fixed_state, 0, TimeConfiguration::default(), env.block.time),
+            )
+            .unwrap();
             for against_state in EpochState::first().all_until(EpochState::InProgress) {
                 let ret = check_epoch_state(deps.as_mut().storage, against_state);
                 if fixed_state == against_state {

--- a/contracts/coconut-dkg/src/epoch_state/utils.rs
+++ b/contracts/coconut-dkg/src/epoch_state/utils.rs
@@ -213,6 +213,7 @@ pub(crate) mod test {
         for fixed_state in EpochState::first().all_until(EpochState::InProgress) {
             save_epoch(
                 deps.as_mut().storage,
+                env.block.height,
                 &Epoch::new(fixed_state, 0, TimeConfiguration::default(), env.block.time),
             )
             .unwrap();

--- a/contracts/coconut-dkg/src/error.rs
+++ b/contracts/coconut-dkg/src/error.rs
@@ -10,6 +10,9 @@ use thiserror::Error;
 /// Custom errors for contract failure conditions.
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
+    #[error("could not perform contract migration: {comment}")]
+    FailedMigration { comment: String },
+
     #[error(transparent)]
     Std(#[from] StdError),
 

--- a/contracts/coconut-dkg/src/lib.rs
+++ b/contracts/coconut-dkg/src/lib.rs
@@ -11,6 +11,7 @@ mod dealers;
 mod dealings;
 mod epoch_state;
 pub mod error;
+mod queued_migrations;
 mod state;
 mod support;
 mod verification_key_shares;

--- a/contracts/coconut-dkg/src/queued_migrations.rs
+++ b/contracts/coconut-dkg/src/queued_migrations.rs
@@ -1,0 +1,21 @@
+// Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::epoch_state::storage::HISTORICAL_EPOCH;
+use crate::error::ContractError;
+use cosmwasm_std::{DepsMut, Env};
+
+pub fn introduce_historical_epochs(deps: DepsMut, env: Env) -> Result<(), ContractError> {
+    if HISTORICAL_EPOCH.may_load(deps.storage)?.is_some() {
+        return Err(ContractError::FailedMigration {
+            comment: "this migration has already been run before".to_string(),
+        });
+    }
+
+    #[allow(deprecated)]
+    let current = crate::epoch_state::storage::CURRENT_EPOCH.load(deps.storage)?;
+    // we won't have information on intermediate states prior to now, but that's not the end of the world
+    HISTORICAL_EPOCH.save(deps.storage, &current, env.block.height)?;
+
+    Ok(())
+}

--- a/contracts/coconut-dkg/src/support/tests/fixtures.rs
+++ b/contracts/coconut-dkg/src/support/tests/fixtures.rs
@@ -12,8 +12,8 @@ pub const TEST_MIX_DENOM: &str = "unym";
 
 pub fn vk_share_fixture(owner: &str, index: u64) -> ContractVKShare {
     ContractVKShare {
-        share: format!("share{}", index),
-        announce_address: format!("localhost:{}", index),
+        share: format!("share{index}"),
+        announce_address: format!("localhost:{index}"),
         node_index: index,
         owner: Addr::unchecked(owner),
         epoch_id: index,
@@ -43,7 +43,7 @@ pub fn dealing_metadata_fixture() -> Vec<DealingChunkInfo> {
 
 pub fn dealer_details_fixture(api: &MockApi, assigned_index: u64) -> DealerDetails {
     DealerDetails {
-        address: api.addr_make(&format!("owner{}", assigned_index)),
+        address: api.addr_make(&format!("owner{assigned_index}")),
         bte_public_key_with_proof: "".to_string(),
         ed25519_identity: "".to_string(),
         announce_address: "".to_string(),

--- a/contracts/coconut-dkg/src/support/tests/helpers.rs
+++ b/contracts/coconut-dkg/src/support/tests/helpers.rs
@@ -3,7 +3,7 @@
 
 use crate::contract::instantiate;
 use crate::dealers::storage::{DEALERS_INDICES, EPOCH_DEALERS_MAP};
-use crate::epoch_state::storage::CURRENT_EPOCH;
+use crate::epoch_state::storage::load_current_epoch;
 use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env, MockApi, MockQuerier};
 use cosmwasm_std::{
     from_json, to_json_binary, Addr, ContractResult, DepsMut, Empty, MemoryStorage, OwnedDeps,
@@ -27,7 +27,7 @@ pub const MULTISIG_CONTRACT: &str = addr!("multisig contract address");
 pub(crate) static GROUP_MEMBERS: Mutex<Vec<(Member, u64)>> = Mutex::new(Vec::new());
 
 pub fn re_register_dealer(deps: DepsMut, dealer: &Addr) {
-    let epoch_id = CURRENT_EPOCH.load(deps.storage).unwrap().epoch_id;
+    let epoch_id = load_current_epoch(deps.storage).unwrap().epoch_id;
     let previous = epoch_id - 1;
     let details = EPOCH_DEALERS_MAP
         .load(deps.storage, (previous, dealer))
@@ -38,7 +38,7 @@ pub fn re_register_dealer(deps: DepsMut, dealer: &Addr) {
 }
 
 pub fn add_current_dealer(deps: DepsMut<'_>, details: &DealerDetails) {
-    let epoch_id = CURRENT_EPOCH.load(deps.storage).unwrap().epoch_id;
+    let epoch_id = load_current_epoch(deps.storage).unwrap().epoch_id;
     insert_dealer(deps, epoch_id, details)
 }
 

--- a/contracts/coconut-dkg/src/verification_key_shares/queries.rs
+++ b/contracts/coconut-dkg/src/verification_key_shares/queries.rs
@@ -99,7 +99,7 @@ pub(crate) mod tests {
         let mut deps = init_contract();
         let limit = 2;
         for n in 0..1000 {
-            let owner = format!("owner{}", n);
+            let owner = format!("owner{n}");
             let vk_share = vk_share_fixture(&owner, 0);
             let sender = Addr::unchecked(owner);
             vk_shares()
@@ -115,7 +115,7 @@ pub(crate) mod tests {
     fn vk_shares_paged_retrieval_has_default_limit() {
         let mut deps = init_contract();
         for n in 0..1000 {
-            let owner = format!("owner{}", n);
+            let owner = format!("owner{n}");
             let vk_share = vk_share_fixture(&owner, 0);
             let sender = Addr::unchecked(owner);
             vk_shares()
@@ -136,7 +136,7 @@ pub(crate) mod tests {
     fn vk_shares_paged_retrieval_has_max_limit() {
         let mut deps = init_contract();
         for n in 0..1000 {
-            let owner = format!("owner{}", n);
+            let owner = format!("owner{n}");
             let vk_share = vk_share_fixture(&owner, 0);
             let sender = Addr::unchecked(owner);
             vk_shares()


### PR DESCRIPTION
NET-501

> In order to determine if singer quorum has been down at particular height, we need to know with certainty the dkg epoch id corresponding to given block height.

this PR makes it possible. every time epoch state is changed (due to DKG progress), snapshot is saved and can be queried. this doesn't work for past data, but given mainnet has only had a single DKG instance, that's not an issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5900)
<!-- Reviewable:end -->
