### PR TITLE
sqlx-pool-guard: obtain filename from connect options

### DIFF
--- a/common/client-core/surb-storage/src/backend/fs_backend/manager.rs
+++ b/common/client-core/surb-storage/src/backend/fs_backend/manager.rs
@@ -37,7 +37,7 @@ impl StorageManager {
             .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
             .synchronous(SqliteSynchronous::Normal)
             .auto_vacuum(SqliteAutoVacuum::Incremental)
-            .filename(&database_path)
+            .filename(database_path)
             .create_if_missing(fresh)
             .disable_statement_logging();
 
@@ -49,8 +49,7 @@ impl StorageManager {
             }
         };
 
-        let connection_pool =
-            SqlitePoolGuard::new(database_path.as_ref().to_path_buf(), connection_pool);
+        let connection_pool = SqlitePoolGuard::new(connection_pool);
 
         if let Err(err) = sqlx::migrate!("./fs_surbs_migrations")
             .run(&*connection_pool)

--- a/common/credential-storage/src/persistent_storage/mod.rs
+++ b/common/credential-storage/src/persistent_storage/mod.rs
@@ -63,7 +63,7 @@ impl PersistentStorage {
             .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
             .synchronous(SqliteSynchronous::Normal)
             .auto_vacuum(SqliteAutoVacuum::Incremental)
-            .filename(&database_path)
+            .filename(database_path)
             .create_if_missing(true)
             .disable_statement_logging();
 
@@ -75,8 +75,7 @@ impl PersistentStorage {
             }
         };
 
-        let connection_pool =
-            SqlitePoolGuard::new(database_path.as_ref().to_path_buf(), connection_pool);
+        let connection_pool = SqlitePoolGuard::new(connection_pool);
 
         if let Err(err) = sqlx::migrate!("./migrations").run(&*connection_pool).await {
             error!("Failed to perform migration on the SQLx database: {err}");

--- a/sqlx-pool-guard/src/lib.rs
+++ b/sqlx-pool-guard/src/lib.rs
@@ -39,7 +39,12 @@ pub struct SqlitePoolGuard {
 
 impl SqlitePoolGuard {
     /// Create new instance providing path to database and connection pool
-    pub fn new(database_path: PathBuf, connection_pool: sqlx::SqlitePool) -> Self {
+    pub fn new(connection_pool: sqlx::SqlitePool) -> Self {
+        let database_path = connection_pool
+            .connect_options()
+            .get_filename()
+            .to_path_buf();
+
         Self {
             database_path,
             connection_pool,
@@ -160,7 +165,7 @@ mod tests {
             .await
             .unwrap();
 
-        let guard = SqlitePoolGuard::new(database_path.clone(), connection_pool);
+        let guard = SqlitePoolGuard::new(connection_pool);
         assert!(
             guard
                 .wait_for_db_files_close()


### PR DESCRIPTION
This is a minor improvement that avoids the need of passing the database path for the sqlx connection pool. I realized that connect options already contain it, so there is no need to pass the same information separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5905)
<!-- Reviewable:end -->
