### PR TITLE
Make allowed_ips unique

### DIFF
--- a/common/gateway-storage/migrations/20250605120000_trim_wireguard_peer_data.sql
+++ b/common/gateway-storage/migrations/20250605120000_trim_wireguard_peer_data.sql
@@ -8,7 +8,7 @@ DELETE FROM wireguard_peer WHERE client_id IS NULL;
 CREATE TABLE wireguard_peer_new
 (
     public_key                      TEXT                            NOT NULL PRIMARY KEY UNIQUE,
-    allowed_ips                     BLOB                            NOT NULL,
+    allowed_ips                     BLOB                            NOT NULL UNIQUE,
     client_id                       INTEGER REFERENCES clients(id)  NOT NULL
 );
 


### PR DESCRIPTION
Make a slight change to the last merged migration, without introducing a complete new migration. In case someone built from the b975d08342939915550f5a14a3016efb98e540b5 commit, `cargo clean -p nym-gateway-storage` fixes the build error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5912)
<!-- Reviewable:end -->
