### PR TITLE
feat: introduce additional checks when attempting to send to bounded channels

### DIFF
--- a/common/client-core/src/client/real_messages_control/acknowledgement_control/input_message_listener.rs
+++ b/common/client-core/src/client/real_messages_control/acknowledgement_control/input_message_listener.rs
@@ -226,6 +226,11 @@ where
 
         while !self.task_client.is_shutdown() {
             tokio::select! {
+                biased;
+                _ = self.task_client.recv() => {
+                    tracing::trace!("InputMessageListener: Received shutdown");
+                    break;
+                }
                 input_msg = self.input_receiver.recv() => match input_msg {
                     Some(input_msg) => {
                         self.on_input_message(input_msg).await;
@@ -235,9 +240,7 @@ where
                         break;
                     }
                 },
-                _ = self.task_client.recv() => {
-                    tracing::trace!("InputMessageListener: Received shutdown");
-                }
+
             }
         }
         self.task_client.recv_timeout().await;

--- a/common/client-core/src/client/real_messages_control/message_handler.rs
+++ b/common/client-core/src/client/real_messages_control/message_handler.rs
@@ -548,6 +548,7 @@ where
             pending_acks.push(pending_ack);
         }
 
+        drop(topology_permit);
         self.insert_pending_acks(pending_acks);
         self.forward_messages(real_messages, lane).await;
 
@@ -730,17 +731,21 @@ where
 
     // tells real message sender (with the poisson timer) to send this to the mix network
     pub(crate) async fn forward_messages(
-        &self,
+        &mut self,
         messages: Vec<RealMessage>,
         transmission_lane: TransmissionLane,
     ) {
-        if let Err(err) = self
-            .real_message_sender
-            .send((messages, transmission_lane))
-            .await
-        {
-            if !self.task_client.is_shutdown_poll() {
-                error!("Failed to forward messages to the real message sender: {err}");
+        tokio::select! {
+            biased;
+            _ = self.task_client.recv() => {
+                trace!("received shutdown while attempting to forward mixnet messages");
+            }
+            sending_res = self.real_message_sender.send((messages, transmission_lane)) => {
+                if sending_res.is_err() {
+                    error!(
+                        "failed to forward mixnet messages due to closed channel (outside of shutdown!)"
+                    );
+                }
             }
         }
     }

--- a/common/client-libs/gateway-client/src/client/mod.rs
+++ b/common/client-libs/gateway-client/src/client/mod.rs
@@ -201,7 +201,7 @@ impl<C, St> GatewayClient<C, St> {
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn establish_connection(&mut self) -> Result<(), GatewayClientError> {
         debug!(
-            "Attemting to establish connection to gateway at: {}",
+            "Attempting to establish connection to gateway at: {}",
             self.gateway_address
         );
         let (ws_stream, _) = connect_async(

--- a/common/client-libs/gateway-client/src/socket_state.rs
+++ b/common/client-libs/gateway-client/src/socket_state.rs
@@ -337,7 +337,7 @@ impl PartiallyDelegatedHandle {
         // check if the split stream didn't error out
         let receive_res = stream_receiver
             .try_recv()
-            .expect("stream sender was somehow dropped without sending anything!");
+            .map_err(|_| GatewayClientError::ConnectionAbruptlyClosed)?;
 
         if let Some(res) = receive_res {
             let _res = res?;

--- a/common/task/src/spawn.rs
+++ b/common/task/src/spawn.rs
@@ -10,6 +10,7 @@ where
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[track_caller]
 pub fn spawn<F>(future: F)
 where
     F: Future + Send + 'static,
@@ -18,6 +19,7 @@ where
     tokio::spawn(future);
 }
 
+#[track_caller]
 pub fn spawn_with_report_error<F, T, E>(future: F, mut shutdown: TaskClient)
 where
     F: Future<Output = Result<T, E>> + Send + 'static,


### PR DESCRIPTION
(or to a fallible gateway)

hopefully should resolve NET-538 / VPN-3782

I imagine it might have to be cherry-picked to some patched emmental branch

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5941)
<!-- Reviewable:end -->
