### PR TITLE
Remove freshness check on testrun submit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6390,7 +6390,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node-status-api"
-version = "3.2.2"
+version = "3.3.0"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -6444,7 +6444,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node-status-client"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6401,6 +6401,7 @@ dependencies = [
  "clap",
  "cosmwasm-std",
  "futures-util",
+ "humantime",
  "itertools 0.14.0",
  "moka",
  "nym-bin-common",

--- a/nym-node-status-api/nym-node-status-agent/run.sh
+++ b/nym-node-status-api/nym-node-status-agent/run.sh
@@ -16,12 +16,17 @@ set -a
 source "${monorepo_root}/envs/${ENVIRONMENT}.env"
 set +a
 
+if [ -z "$NYM_NODE_MNEMONICS" ]; then
+  echo "NYM_NODE_MNEMONICS is required to run an agent"
+  exit 1
+fi
+
 export RUST_LOG="info"
-export NODE_STATUS_AGENT_SERVER_ADDRESS="http://127.0.0.1"
-export NODE_STATUS_AGENT_SERVER_PORT="8000"
-export NODE_STATUS_AGENT_PROBE_PATH="$crate_root/nym-gateway-probe"
+NODE_STATUS_AGENT_SERVER_ADDRESS="http://127.0.0.1"
+NODE_STATUS_AGENT_SERVER_PORT="8000"
+SERVER="${NODE_STATUS_AGENT_SERVER_ADDRESS}|${NODE_STATUS_AGENT_SERVER_PORT}"
 export NODE_STATUS_AGENT_AUTH_KEY="BjyC9SsHAZUzPRkQR4sPTvVrp4GgaquTh5YfSJksvvWT"
-export NODE_STATUS_AGENT_PROBE_MNEMONIC="$MNEMONIC"
+export NODE_STATUS_AGENT_PROBE_PATH="$crate_root/nym-gateway-probe"
 export NODE_STATUS_AGENT_PROBE_EXTRA_ARGS="netstack-download-timeout-sec=30,netstack-num-ping=2,netstack-send-timeout-sec=1,netstack-recv-timeout-sec=1"
 
 workers=${1:-1}
@@ -48,7 +53,7 @@ function swarm() {
     local workers=$1
 
     for ((i = 1; i <= workers; i++)); do
-        ${monorepo_root}/target/release/nym-node-status-agent run-probe &
+        ${monorepo_root}/target/release/nym-node-status-agent run-probe --server ${SERVER} &
     done
 
     wait

--- a/nym-node-status-api/nym-node-status-agent/src/cli/mod.rs
+++ b/nym-node-status-api/nym-node-status-agent/src/cli/mod.rs
@@ -50,7 +50,7 @@ pub(crate) struct Args {
 #[derive(Subcommand, Debug)]
 pub(crate) enum Command {
     RunProbe {
-        /// Server configurations in format "address:port:auth_key"
+        /// Server configurations in format "address|port"
         /// Can be specified multiple times for multiple servers
         #[arg(short, long, required = true)]
         server: Vec<String>,

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -21,6 +21,7 @@ celes = { workspace = true }
 clap = { workspace = true, features = ["cargo", "derive", "env", "string"] }
 cosmwasm-std = { workspace = true }
 futures-util = { workspace = true }
+humantime = { workspace = true }
 itertools = { workspace = true }
 moka = { workspace = true, features = ["future"] }
 

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-node-status-api"
-version = "3.2.2"
+version = "3.3.0"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-node-status-api/nym-node-status-api/launch_node_status_api.sh
+++ b/nym-node-status-api/nym-node-status-api/launch_node_status_api.sh
@@ -23,7 +23,7 @@ function run_bare() {
     echo "RUST_LOG=${RUST_LOG}"
 
     # --conection-url is provided in build.rs
-    cargo run --package nym-node-status-api
+    cargo run --package nym-node-status-api --no-default-features --features sqlite 
 }
 
 function run_docker() {

--- a/nym-node-status-api/nym-node-status-api/src/cli/mod.rs
+++ b/nym-node-status-api/nym-node-status-api/src/cli/mod.rs
@@ -38,7 +38,7 @@ pub(crate) struct Cli {
 
     /// Nym api client timeout.
     #[clap(long, default_value = "15", env = "NYM_API_CLIENT_TIMEOUT")]
-    #[arg(value_parser = parse_duration)]
+    #[arg(value_parser = parse_duration_std)]
     pub(crate) nym_api_client_timeout: Duration,
 
     /// Connection url for the database.
@@ -46,7 +46,7 @@ pub(crate) struct Cli {
     pub(crate) database_url: String,
 
     #[clap(long, default_value = "5", env = "SQLX_BUSY_TIMEOUT_S")]
-    #[arg(value_parser = parse_duration)]
+    #[arg(value_parser = parse_duration_std)]
     pub(crate) sqlx_busy_timeout_s: Duration,
 
     #[clap(
@@ -54,7 +54,7 @@ pub(crate) struct Cli {
         default_value = "300",
         env = "NODE_STATUS_API_MONITOR_REFRESH_INTERVAL"
     )]
-    #[arg(value_parser = parse_duration)]
+    #[arg(value_parser = parse_duration_std)]
     pub(crate) monitor_refresh_interval: Duration,
 
     #[clap(
@@ -62,16 +62,20 @@ pub(crate) struct Cli {
         default_value = "300",
         env = "NODE_STATUS_API_TESTRUN_REFRESH_INTERVAL"
     )]
-    #[arg(value_parser = parse_duration)]
+    #[arg(value_parser = parse_duration_std)]
     pub(crate) testruns_refresh_interval: Duration,
 
     #[clap(long, default_value = "86400", env = "NODE_STATUS_API_GEODATA_TTL")]
-    #[arg(value_parser = parse_duration)]
+    #[arg(value_parser = parse_duration_std)]
     pub(crate) geodata_ttl: Duration,
 
     #[clap(env = "NODE_STATUS_API_AGENT_KEY_LIST")]
     #[arg(value_delimiter = ',')]
     pub(crate) agent_key_list: Vec<String>,
+
+    #[clap(long, default_value = "120", env = "AGENT_REQUEST_FRESHNESS")]
+    #[arg(value_parser = parse_duration_time)]
+    pub(crate) agent_request_freshness: time::Duration,
 
     #[clap(
         long,
@@ -92,7 +96,12 @@ pub(crate) struct Cli {
     pub(crate) max_agent_count: i64,
 }
 
-fn parse_duration(arg: &str) -> Result<std::time::Duration, std::num::ParseIntError> {
+fn parse_duration_std(arg: &str) -> Result<std::time::Duration, std::num::ParseIntError> {
     let seconds = arg.parse()?;
     Ok(std::time::Duration::from_secs(seconds))
+}
+
+fn parse_duration_time(arg: &str) -> Result<time::Duration, std::num::ParseIntError> {
+    let seconds = arg.parse()?;
+    Ok(time::Duration::new(seconds, 0))
 }

--- a/nym-node-status-api/nym-node-status-api/src/http/api/testruns.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/api/testruns.rs
@@ -190,7 +190,6 @@ async fn submit_testrun_v2(
     Json(submission): Json<submit_results_v2::SubmitResultsV2>,
 ) -> HttpResult<StatusCode> {
     authenticate(&submission, &state)?;
-    is_fresh(&submission.payload.assigned_at_utc)?;
 
     let db = state.db_pool();
     let mut conn = db

--- a/nym-node-status-api/nym-node-status-api/src/http/api/testruns.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/api/testruns.rs
@@ -244,8 +244,6 @@ async fn submit_testrun_v2(
     }
 }
 
-// static AGENT_REQUEST_FRESHNESS_CUTOFF: OnceCell<time::Duration>  = OnceCell::new();
-
 fn get_result_from_log(log: &str) -> String {
     static RE: std::sync::LazyLock<regex::Regex> =
         std::sync::LazyLock::new(|| regex::Regex::new(r"\n\{\s").expect("Invalid regex pattern"));

--- a/nym-node-status-api/nym-node-status-api/src/http/server.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/server.rs
@@ -13,12 +13,14 @@ use crate::{
 
 /// Return handles that allow for graceful shutdown of server + awaiting its
 /// background tokio task
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn start_http_api(
     db_pool: DbPool,
     http_port: u16,
     nym_http_cache_ttl: u64,
     agent_key_list: Vec<PublicKey>,
     agent_max_count: i64,
+    agent_request_freshness_requirement: time::Duration,
     node_geocache: NodeGeoCache,
     node_delegations: Arc<RwLock<DelegationsCache>>,
 ) -> anyhow::Result<ShutdownHandles> {
@@ -29,6 +31,7 @@ pub(crate) async fn start_http_api(
         nym_http_cache_ttl,
         agent_key_list,
         agent_max_count,
+        agent_request_freshness_requirement,
         node_geocache,
         node_delegations,
     )

--- a/nym-node-status-api/nym-node-status-api/src/http/state.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/state.rs
@@ -107,7 +107,7 @@ impl AppState {
         &self,
         request: &impl VerifiableRequest,
     ) -> HttpResult<()> {
-        if self.is_registered(request.public_key()) {
+        if !self.is_registered(request.public_key()) {
             tracing::warn!("Public key not registered with NS API, rejecting");
             return Err(HttpError::unauthorized());
         };

--- a/nym-node-status-api/nym-node-status-api/src/main.rs
+++ b/nym-node-status-api/nym-node-status-api/src/main.rs
@@ -98,6 +98,7 @@ async fn main() -> anyhow::Result<()> {
         args.nym_http_cache_ttl,
         agent_key_list.to_owned(),
         args.max_agent_count,
+        args.agent_request_freshness,
         geocache,
         delegations_cache,
     )

--- a/nym-node-status-api/nym-node-status-client/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-client/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-node-status-client"
-version = "0.1.2"
+version = "0.2.0"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
- freshness is enforced by a background task that marks testruns as stale after a configured amount of time
- make existing freshness period configurable to avoid code changes in the future
- added `humantime` for parsing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5977)
<!-- Reviewable:end -->
