### PR TITLE
bugfix: Recipient deserialisation for deserialisers missing bytes specialisation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,8 +2130,8 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "defguard_wireguard_rs"
-version = "0.7.5"
-source = "git+https://github.com/DefGuard/wireguard-rs.git?rev=v0.7.5#d090d2249e5bb3d4154f07de098387e2ab69bfdc"
+version = "0.4.7"
+source = "git+https://github.com/DefGuard/wireguard-rs.git?rev=v0.4.7#ef1cf3714629bf5016fb38cbb7320451dc69fb09"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -2142,10 +2142,9 @@ dependencies = [
  "netlink-packet-utils",
  "netlink-packet-wireguard",
  "netlink-sys",
- "nix 0.30.1",
+ "nix 0.29.0",
  "serde",
- "thiserror 2.0.12",
- "x25519-dalek",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4588,9 +4587,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.22.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0e7987b28514adf555dc1f9a5c30dfc3e50750bbaffb1aec41ca7b23dcd8e4"
+checksum = "55e5bda7ca0f9ac5e75b5debac3b75e29a8ac8e2171106a2c3bb466389a8dd83"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -4669,18 +4668,6 @@ name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -6835,10 +6822,12 @@ dependencies = [
 name = "nym-sphinx-addressing"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "nym-crypto",
  "nym-sphinx-types",
  "rand 0.8.5",
  "serde",
+ "serde_json",
  "thiserror 2.0.12",
 ]
 

--- a/common/nymsphinx/addressing/Cargo.toml
+++ b/common/nymsphinx/addressing/Cargo.toml
@@ -16,3 +16,6 @@ thiserror = { workspace = true }
 [dev-dependencies]
 rand = { workspace = true }
 nym-crypto = { path = "../../crypto", features = ["rand"] }
+bincode = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true, features = ["derive"] }

--- a/common/nymsphinx/addressing/src/clients.rs
+++ b/common/nymsphinx/addressing/src/clients.rs
@@ -105,6 +105,8 @@ impl<'de> Deserialize<'de> for Recipient {
 
                 let mut recipient_bytes = [0u8; Recipient::LEN];
 
+                // clippy's suggestion is completely wrong and it iterates wrong sequence
+                #[allow(clippy::needless_range_loop)]
                 for i in 0..Recipient::LEN {
                     let Some(elem) = seq.next_element::<u8>()? else {
                         return Err(SerdeError::invalid_length(i + 1, &self));

--- a/common/nymsphinx/addressing/src/clients.rs
+++ b/common/nymsphinx/addressing/src/clients.rs
@@ -7,7 +7,7 @@
 use crate::nodes::{NodeIdentity, NODE_IDENTITY_SIZE};
 use nym_crypto::asymmetric::{ed25519, x25519};
 use nym_sphinx_types::Destination;
-use serde::de::{Error as SerdeError, Unexpected, Visitor};
+use serde::de::{Error as SerdeError, SeqAccess, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{self, Formatter};
 use std::str::FromStr;
@@ -64,7 +64,7 @@ impl<'de> Deserialize<'de> for Recipient {
     {
         struct RecipientVisitor;
 
-        impl Visitor<'_> for RecipientVisitor {
+        impl<'de> Visitor<'de> for RecipientVisitor {
             type Value = Recipient;
 
             fn expecting(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
@@ -82,6 +82,40 @@ impl<'de> Deserialize<'de> for Recipient {
                 let mut recipient_bytes = [0u8; Recipient::LEN];
                 // this shouldn't panic as we just checked for length
                 recipient_bytes.copy_from_slice(bytes);
+
+                Recipient::try_from_bytes(recipient_bytes).map_err(|_| {
+                    SerdeError::invalid_value(
+                        Unexpected::Other("At least one of the curve points was malformed"),
+                        &self,
+                    )
+                })
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                // if we know the size hint, check if it matches expectation,
+                // otherwise return an error
+                if let Some(size_hint) = seq.size_hint() {
+                    if size_hint != Recipient::LEN {
+                        return Err(SerdeError::invalid_length(size_hint, &self));
+                    }
+                }
+
+                let mut recipient_bytes = [0u8; Recipient::LEN];
+
+                for i in 0..Recipient::LEN {
+                    let Some(elem) = seq.next_element::<u8>()? else {
+                        return Err(SerdeError::invalid_length(i + 1, &self));
+                    };
+                    recipient_bytes[i] = elem;
+                }
+
+                // make sure there are no trailing bytes
+                if seq.next_element::<u8>()?.is_some() {
+                    return Err(SerdeError::invalid_length(Recipient::LEN + 1, &self));
+                }
 
                 Recipient::try_from_bytes(recipient_bytes).map_err(|_| {
                     SerdeError::invalid_value(
@@ -245,6 +279,18 @@ impl FromStr for Recipient {
 mod tests {
     use super::*;
 
+    fn mock_recipient() -> Recipient {
+        Recipient::try_from_bytes([
+            67, 5, 132, 146, 3, 236, 116, 89, 254, 57, 131, 159, 69, 181, 55, 208, 12, 108, 136,
+            83, 58, 76, 171, 195, 31, 98, 92, 64, 68, 53, 156, 184, 100, 189, 73, 3, 238, 103, 156,
+            108, 124, 199, 42, 79, 172, 98, 81, 177, 182, 100, 167, 164, 74, 183, 199, 213, 162,
+            173, 102, 112, 30, 159, 148, 66, 44, 75, 230, 182, 138, 114, 170, 163, 209, 82, 204,
+            100, 118, 91, 57, 150, 212, 147, 151, 135, 148, 16, 213, 223, 182, 164, 242, 37, 40,
+            73, 137, 228,
+        ])
+        .unwrap()
+    }
+
     #[test]
     fn string_conversion_works() {
         let mut rng = rand::thread_rng();
@@ -307,5 +353,41 @@ mod tests {
             recipient.gateway.to_bytes(),
             recovered_recipient.gateway.to_bytes()
         );
+    }
+
+    // calls `visit_bytes`
+    #[test]
+    fn bincode_serialisation_works() {
+        let recipient = mock_recipient();
+
+        #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+        struct MyStruct {
+            recipient: Recipient,
+        }
+        let a = MyStruct { recipient };
+        let s = bincode::serialize(&a).unwrap();
+
+        let b = bincode::deserialize(&s).unwrap();
+
+        assert_eq!(a, b);
+    }
+
+    // calls `visit_seq`
+    #[test]
+    fn json_serialisation_works() {
+        use serde::{Deserialize, Serialize};
+
+        let recipient = mock_recipient();
+
+        #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+        struct MyStruct {
+            recipient: Recipient,
+        }
+        let a = MyStruct { recipient };
+        let s = serde_json::to_string(&a).unwrap();
+
+        let b = serde_json::from_str(&s).unwrap();
+
+        assert_eq!(a, b);
     }
 }

--- a/common/nymsphinx/types/src/lib.rs
+++ b/common/nymsphinx/types/src/lib.rs
@@ -180,6 +180,7 @@ impl NymPacket {
     }
 
     #[cfg(feature = "sphinx")]
+    #[allow(unreachable_patterns)]
     pub fn sphinx_packet_ref(&self) -> Option<&SphinxPacket> {
         match self {
             NymPacket::Sphinx(packet) => Some(packet),
@@ -188,6 +189,7 @@ impl NymPacket {
     }
 
     #[cfg(feature = "sphinx")]
+    #[allow(unreachable_patterns)]
     pub fn to_sphinx_packet(self) -> Option<SphinxPacket> {
         match self {
             NymPacket::Sphinx(packet) => Some(packet),

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -3051,7 +3051,7 @@ dependencies = [
  "httpdate",
  "itoa 1.0.15",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -3140,7 +3140,7 @@ dependencies = [
  "hyper 1.6.0",
  "libc",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -3385,12 +3385,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.9",
  "widestring",
  "windows-sys 0.48.0",
  "winreg 0.50.0",
@@ -3631,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -5493,7 +5504,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.25",
- "socket2",
+ "socket2 0.5.9",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5529,7 +5540,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.9",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -6523,6 +6534,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "softbuffer"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7435,20 +7456,22 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
for example toml or json will just default to visit_seq ignoring bytes related optimisations

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/5991)
<!-- Reviewable:end -->
