### PR TITLE
Use default value for the ports until api is deployed

### DIFF
--- a/nym-api/nym-api-requests/src/models/described.rs
+++ b/nym-api/nym-api-requests/src/models/described.rs
@@ -8,7 +8,9 @@ use nym_crypto::asymmetric::x25519::serde_helpers::bs58_x25519_pubkey;
 use nym_crypto::asymmetric::{ed25519, x25519};
 use nym_mixnet_contract_common::reward_params::Performance;
 use nym_mixnet_contract_common::NodeId;
-use nym_network_defaults::{DEFAULT_MIX_LISTENING_PORT, DEFAULT_VERLOC_LISTENING_PORT};
+use nym_network_defaults::{
+    DEFAULT_MIX_LISTENING_PORT, DEFAULT_VERLOC_LISTENING_PORT, WG_METADATA_PORT, WG_TUNNEL_PORT,
+};
 use nym_node_requests::api::v1::authenticator::models::Authenticator;
 use nym_node_requests::api::v1::gateway::models::Wireguard;
 use nym_node_requests::api::v1::ip_packet_router::models::IpPacketRouter;
@@ -313,9 +315,18 @@ impl From<Authenticator> for AuthenticatorDetails {
 pub struct WireguardDetails {
     // NOTE: the port field is deprecated in favour of tunnel_port
     pub port: u16,
+    #[serde(default = "default_tunnel_port")]
     pub tunnel_port: u16,
+    #[serde(default = "default_metadata_port")]
     pub metadata_port: u16,
     pub public_key: String,
+}
+
+fn default_tunnel_port() -> u16 {
+    WG_TUNNEL_PORT
+}
+fn default_metadata_port() -> u16 {
+    WG_METADATA_PORT
 }
 
 // works for current simple case.


### PR DESCRIPTION
This fixes the vpn querying mainnet for the API and not finding (for now) some of the newly added values

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6007)
<!-- Reviewable:end -->
