### PR TITLE
Convenience for ShutdownTracker

### DIFF
--- a/common/task/src/cancellation/token.rs
+++ b/common/task/src/cancellation/token.rs
@@ -33,6 +33,13 @@ impl ShutdownToken {
         }
     }
 
+    /// Creates a new ShutdownToken given a tokio `CancellationToken`.
+    pub fn new_from_tokio_token(cancellation_token: CancellationToken) -> Self {
+        ShutdownToken {
+            inner: cancellation_token,
+        }
+    }
+
     /// Gets reference to the underlying [CancellationToken](tokio_util::sync::CancellationToken).
     pub fn inner(&self) -> &CancellationToken {
         &self.inner

--- a/sdk/rust/nym-sdk/src/lib.rs
+++ b/sdk/rust/nym-sdk/src/lib.rs
@@ -26,5 +26,5 @@ pub use nym_network_defaults::{
     ChainDetails, DenomDetails, DenomDetailsOwned, NymContracts, NymNetworkDetails,
     ValidatorDetails,
 };
-pub use nym_task::ShutdownToken;
+pub use nym_task::{ShutdownToken, ShutdownTracker};
 pub use nym_validator_client::UserAgent;


### PR DESCRIPTION
Add a method to create a `ShutdownToken` from an existing `CancellationToken`.

Expose `ShutdownTracker` in the sdk, since it's in its API

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6038)
<!-- Reviewable:end -->
