### PR TITLE
ns-api: filter out gateways with less than 75% performance from dvpn endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6508,7 +6508,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node-status-api"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-node-status-api"
-version = "4.0.3"
+version = "4.0.4"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -85,10 +85,10 @@ pub enum ScoreValue {
 
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub struct DVpnGatewayPerformance {
-    last_updated_utc: String,
-    score: ScoreValue,
-    load: ScoreValue,
-    uptime_percentage_last_24_hours: f32,
+    pub last_updated_utc: String,
+    pub score: ScoreValue,
+    pub load: ScoreValue,
+    pub uptime_percentage_last_24_hours: f32,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]

--- a/nym-node-status-api/nym-node-status-api/src/http/state.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/state.rs
@@ -357,6 +357,10 @@ impl HttpCache {
                             false
                         }
                     })
+                    .filter(|gw| {
+                        // filter out gateways with less than 75% uptime
+                        gw.performance_v2.clone().map(|p| p.uptime_percentage_last_24_hours >= 0.75).unwrap_or(false)
+                    })
                     // sort by country, then by identity key
                     .sorted_by_key(|item| {
                         (


### PR DESCRIPTION
Filter out gateways with less than 75% performance for the dVPN endpoint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6061)
<!-- Reviewable:end -->
