### PR TITLE
NS API: clamp `load` to `offline` when score is `offline` and add `mixnet_score` field to preformance_v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6433,7 +6433,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node-status-api"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-node-status-api"
-version = "4.0.5"
+version = "4.0.6"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
- when the `load` field of `offline`, make the `score` become `offline` because the gateway should be avoided by users
- add a `mixnet_score` field `high/med/low/offline` to make the same as `score`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6076)
<!-- Reviewable:end -->
