### PR TITLE
feat: expose obtaining reference to Mnemonic from DirectSecp256k1HdWallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5372,7 +5372,7 @@ dependencies = [
 
 [[package]]
 name = "nym-credential-proxy"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/common/client-libs/validator-client/src/signing/direct_wallet.rs
+++ b/common/client-libs/validator-client/src/signing/direct_wallet.rs
@@ -10,7 +10,7 @@ use cosmrs::tx;
 use cosmrs::tx::SignDoc;
 use nym_config::defaults;
 use thiserror::Error;
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 type Secp256k1Keypair = (SigningKey, PublicKey);
 
@@ -132,8 +132,15 @@ impl DirectSecp256k1HdWallet {
         &self.secret
     }
 
+    #[deprecated(
+        note = "use either .secret() for obtaining &bip39::Mnemonic or .mnemonic_string() for Zeroizing wrapper around the String"
+    )]
     pub fn mnemonic(&self) -> String {
         self.secret.to_string()
+    }
+
+    pub fn mnemonic_string(&self) -> Zeroizing<String> {
+        Zeroizing::new(self.secret.to_string())
     }
 }
 

--- a/common/client-libs/validator-client/src/signing/direct_wallet.rs
+++ b/common/client-libs/validator-client/src/signing/direct_wallet.rs
@@ -128,6 +128,10 @@ impl DirectSecp256k1HdWallet {
         Ok(accounts)
     }
 
+    pub fn secret(&self) -> &bip39::Mnemonic {
+        &self.secret
+    }
+
     pub fn mnemonic(&self) -> String {
         self.secret.to_string()
     }

--- a/common/commands/src/validator/account/create.rs
+++ b/common/commands/src/validator/account/create.rs
@@ -18,6 +18,6 @@ pub fn create_account(args: Args, prefix: &str) {
     let wallet = DirectSecp256k1HdWallet::from_mnemonic(prefix, mnemonic);
 
     // Output address and mnemonics into separate lines for easier parsing
-    println!("{}", wallet.mnemonic());
+    println!("{}", wallet.mnemonic_string().as_str());
     println!("{}", wallet.try_derive_accounts().unwrap()[0].address());
 }


### PR DESCRIPTION
inspired by constant cloning of the stringified mnemonic coming from the vpn and then parsing it afterwards. eventually some of those calls could be replaced by this method instead.

# Changes:

## Added:
- `fn secret(&self) -> &bip39::Mnemonic` method to return reference to the actual parsed bip39 mnemonic
- `fn mnemonic_string(&self) -> Zeroizing<String>` method as a safer replacement for `fn mnemonic(&self) -> String`

## Deprecated
- `fn mnemonic(&self) -> String` - all calls should be replaced by safer alternatives that guarantee value will be zeroed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6083)
<!-- Reviewable:end -->
