### PR TITLE
ns-api: add new fields for probe output for query_metadata and download file size and duration in ms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6455,7 +6455,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node-status-api"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-node-status-api"
-version = "4.0.6"
+version = "4.0.7"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -215,6 +215,7 @@ pub mod wg_outcome_versions {
         pub ping_hosts_performance: Option<f32>,
         pub ping_ips_performance: Option<f32>,
 
+        pub can_query_metadata_v4: Option<bool>,
         pub can_handshake_v4: bool,
         pub can_resolve_dns_v4: bool,
         pub ping_hosts_performance_v4: f32,
@@ -226,10 +227,14 @@ pub mod wg_outcome_versions {
         pub ping_ips_performance_v6: f32,
 
         pub download_duration_sec_v4: u64,
+        pub download_duration_milliseconds_v4: Option<u64>,
+        pub downloaded_file_size_bytes_v4: Option<u64>,
         pub downloaded_file_v4: String,
         pub download_error_v4: String,
 
         pub download_duration_sec_v6: u64,
+        pub download_duration_milliseconds_v6: Option<u64>,
+        pub downloaded_file_size_bytes_v6: Option<u64>,
         pub downloaded_file_v6: String,
         pub download_error_v6: String,
     }


### PR DESCRIPTION
This PR adds new fields:

```json
{
  "node": "ByxGq9hpDQu6Wc8augEh22w7CRWJHPNfDshB1b8nfWkh",
  "used_entry": "ByxGq9hpDQu6Wc8augEh22w7CRWJHPNfDshB1b8nfWkh",
  "outcome": {
    "as_entry": {
      "can_connect": true,
      "can_route": true
    },
    "as_exit": {
      "can_connect": true,
      "can_route_ip_v4": true,
      "can_route_ip_external_v4": true,
      "can_route_ip_v6": true,
      "can_route_ip_external_v6": true
    },
    "wg": {
      "can_register": true,
      "can_query_metadata_v4": true, // <--------------------------------
      "can_handshake_v4": true,
      "can_resolve_dns_v4": true,
      "ping_hosts_performance_v4": 1.0,
      "ping_ips_performance_v4": 1.0,
      "can_handshake_v6": true,
      "can_resolve_dns_v6": true,
      "ping_hosts_performance_v6": 1.0,
      "ping_ips_performance_v6": 0.93333334,
      "download_duration_sec_v4": 2,
      "download_duration_milliseconds_v4": 2034, // <--------------------------------
      "downloaded_file_size_bytes_v4": 1048576, // <--------------------------------
      "downloaded_file_v4": "https://nym-bandwidth-monitoring.ops-d86.workers.dev/1mb.dat",
      "download_error_v4": "",
      "download_duration_sec_v6": 5,
      "downloaded_file_size_bytes_v6": 1048576,
      "download_duration_milliseconds_v6": 5501,
      "downloaded_file_v6": "https://proof.ovh.net/files/1Mb.dat",
      "download_error_v6": ""
    }
  }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6091)
<!-- Reviewable:end -->
