### PR TITLE
ns-api: use download files size from probes instead of parsing filenames

### DIFF
--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -396,15 +396,11 @@ fn calculate_score(gateway: &Gateway, probe_outcome: &LastProbeResult) -> ScoreV
             let ping_ips_performance = p.ping_ips_performance_v4 as f64;
 
             let duration = p.download_duration_sec_v4 as f64;
-            let file_size_mb = if p.downloaded_file_v4.contains("1Mb") {
-                1024.0
-            } else if p.downloaded_file_v4.contains("10Mb") {
-                10240.0
-            } else if p.downloaded_file_v4.contains("100Mb") {
-                102400.0
-            } else {
-                1.0
-            };
+
+            // get the file size downloaded in bytes and convert to MB, or default to 1MB
+            let file_size_mb = p.downloaded_file_size_bytes_v4.unwrap_or_else(|| 1048576) as f64
+                / 1024f64
+                / 1024f64;
             let speed_mbps = file_size_mb / duration;
 
             let file_download_score = if speed_mbps > 100.0 {


### PR DESCRIPTION
This PR uses the new field in the probe results that says how many bytes were downloaded to calculate the speed of download.

It only uses downloads on ipv4 and ignores ipv6 for now. This might change in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6095)
<!-- Reviewable:end -->
