### PR TITLE
NS API: use new probe download filesize and milliseconds field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6598,7 +6598,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node-status-api"
-version = "4.0.7"
+version = "4.0.8"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-node-status-api"
-version = "4.0.7"
+version = "4.0.8"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -406,13 +406,13 @@ fn calculate_score(gateway: &Gateway, probe_outcome: &LastProbeResult) -> ScoreV
                 / 1024f64;
             let speed_mbps = file_size_mb / duration_sec;
 
-            let file_download_score = if speed_mbps > 100.0 {
+            let file_download_score = if speed_mbps > 10.0 {
                 1.0
-            } else if speed_mbps > 50.0 {
+            } else if speed_mbps > 5.0 {
                 0.75
-            } else if speed_mbps > 20.0 {
+            } else if speed_mbps > 2.0 {
                 0.5
-            } else if speed_mbps > 10.0 {
+            } else if speed_mbps > 1.0 {
                 0.25
             } else {
                 0.1

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -406,13 +406,13 @@ fn calculate_score(gateway: &Gateway, probe_outcome: &LastProbeResult) -> ScoreV
                 / 1024f64;
             let speed_mbps = file_size_mb / duration_sec;
 
-            let file_download_score = if speed_mbps > 10.0 {
+            let file_download_score = if speed_mbps > 5.0 {
                 1.0
-            } else if speed_mbps > 5.0 {
-                0.75
             } else if speed_mbps > 2.0 {
-                0.5
+                0.75
             } else if speed_mbps > 1.0 {
+                0.5
+            } else if speed_mbps > 0.5 {
                 0.25
             } else {
                 0.1

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -395,12 +395,16 @@ fn calculate_score(gateway: &Gateway, probe_outcome: &LastProbeResult) -> ScoreV
         .map(|p| {
             let ping_ips_performance = p.ping_ips_performance_v4 as f64;
 
-            let duration = p.download_duration_sec_v4 as f64;
+            let duration_sec =
+                p.download_duration_milliseconds_v4
+                    .unwrap_or_else(|| p.download_duration_sec_v4 * 1000) as f64
+                    / 1000f64;
 
             // get the file size downloaded in bytes and convert to MB, or default to 1MB
-            let file_size_mb =
-                p.downloaded_file_size_bytes_v4.unwrap_or(1048576) as f64 / 1024f64 / 1024f64;
-            let speed_mbps = file_size_mb / duration;
+            let file_size_mb = p.downloaded_file_size_bytes_v4.unwrap_or_else(|| 1048576) as f64
+                / 1024f64
+                / 1024f64;
+            let speed_mbps = file_size_mb / duration_sec;
 
             let file_download_score = if speed_mbps > 100.0 {
                 1.0


### PR DESCRIPTION
This PR uses the new fields in mainnet to calculate the probe download score

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6097)
<!-- Reviewable:end -->
