### PR TITLE
ns-api: add descriptions to dVPN gateway responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6598,7 +6598,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node-status-api"
-version = "4.0.8"
+version = "4.0.9"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/nym-node-status-api/nym-node-status-api/Cargo.toml
+++ b/nym-node-status-api/nym-node-status-api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "nym-node-status-api"
-version = "4.0.8"
+version = "4.0.9"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -99,6 +99,7 @@ pub struct DVpnGatewayPerformance {
 pub struct DVpnGateway {
     pub identity_key: String,
     pub name: String,
+    pub description: Option<String>,
     pub ip_packet_router: Option<IpPacketRouterDetails>,
     pub authenticator: Option<AuthenticatorDetails>,
     pub location: Location,
@@ -326,6 +327,7 @@ impl DVpnGateway {
         Ok(Self {
             identity_key: gateway.gateway_identity_key,
             name: gateway.description.moniker,
+            description: Some(gateway.description.details),
             ip_packet_router: self_described.ip_packet_router,
             authenticator: self_described.authenticator,
             location: Location {

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -403,7 +403,7 @@ fn calculate_score(gateway: &Gateway, probe_outcome: &LastProbeResult) -> ScoreV
                     / 1000f64;
 
             // get the file size downloaded in bytes and convert to MB, or default to 1MB
-            let file_size_mb = p.downloaded_file_size_bytes_v4.unwrap_or_else(|| 1048576) as f64
+            let file_size_mb = p.downloaded_file_size_bytes_v4.unwrap_or(1048576) as f64
                 / 1024f64
                 / 1024f64;
             let speed_mbps = file_size_mb / duration_sec;

--- a/nym-node-status-api/nym-node-status-api/src/http/models.rs
+++ b/nym-node-status-api/nym-node-status-api/src/http/models.rs
@@ -403,9 +403,8 @@ fn calculate_score(gateway: &Gateway, probe_outcome: &LastProbeResult) -> ScoreV
                     / 1000f64;
 
             // get the file size downloaded in bytes and convert to MB, or default to 1MB
-            let file_size_mb = p.downloaded_file_size_bytes_v4.unwrap_or(1048576) as f64
-                / 1024f64
-                / 1024f64;
+            let file_size_mb =
+                p.downloaded_file_size_bytes_v4.unwrap_or(1048576) as f64 / 1024f64 / 1024f64;
             let speed_mbps = file_size_mb / duration_sec;
 
             let file_download_score = if speed_mbps > 5.0 {


### PR DESCRIPTION
This PR adds the `description` field to dVPN gateways in `/dvpn/v1/directory/gateways`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6102)
<!-- Reviewable:end -->
