### PR TITLE
Add connect timeout

### DIFF
--- a/common/client-core/src/cli_helpers/client_add_gateway.rs
+++ b/common/client-core/src/cli_helpers/client_add_gateway.rs
@@ -140,6 +140,7 @@ where
         available_gateways,
         #[cfg(unix)]
         connection_fd_callback: None,
+        connect_timeout: None,
     };
 
     let init_details =

--- a/common/client-core/src/cli_helpers/client_init.rs
+++ b/common/client-core/src/cli_helpers/client_init.rs
@@ -188,6 +188,7 @@ where
         available_gateways,
         #[cfg(unix)]
         connection_fd_callback: None,
+        connect_timeout: None,
     };
 
     let init_details =

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -359,6 +359,11 @@ where
         self
     }
 
+    pub fn with_connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = Some(timeout);
+        self
+    }
+
     // note: do **NOT** make this method public as its only valid usage is from within `start_base`
     // because it relies on the crypto keys being already loaded
     fn mix_address(details: &InitialisationResult) -> Recipient {

--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -382,6 +382,7 @@ pub(super) async fn register_with_gateway(
     gateway_listener: Url,
     our_identity: Arc<ed25519::KeyPair>,
     #[cfg(unix)] connection_fd_callback: Option<Arc<dyn Fn(RawFd) + Send + Sync>>,
+    connect_timeout: Option<Duration>,
 ) -> Result<RegistrationResult, ClientCoreError> {
     let mut gateway_client = GatewayClient::new_init(
         gateway_listener,
@@ -389,6 +390,7 @@ pub(super) async fn register_with_gateway(
         our_identity.clone(),
         #[cfg(unix)]
         connection_fd_callback,
+        connect_timeout,
     );
 
     gateway_client.establish_connection().await.map_err(|err| {

--- a/common/client-core/src/init/mod.rs
+++ b/common/client-core/src/init/mod.rs
@@ -23,6 +23,7 @@ use nym_topology::node::RoutingNode;
 use rand::rngs::OsRng;
 use rand::{CryptoRng, RngCore};
 use serde::Serialize;
+use std::time::Duration;
 #[cfg(unix)]
 use std::{os::fd::RawFd, sync::Arc};
 
@@ -56,6 +57,7 @@ async fn setup_new_gateway<K, D>(
     selection_specification: GatewaySelectionSpecification,
     available_gateways: Vec<RoutingNode>,
     #[cfg(unix)] connection_fd_callback: Option<Arc<dyn Fn(RawFd) + Send + Sync>>,
+    connect_timeout: Option<Duration>,
 ) -> Result<InitialisationResult, ClientCoreError>
 where
     K: KeyStore,
@@ -117,6 +119,7 @@ where
                 our_identity,
                 #[cfg(unix)]
                 connection_fd_callback,
+                connect_timeout,
             )
             .await?;
             (
@@ -213,6 +216,7 @@ where
             available_gateways,
             #[cfg(unix)]
             connection_fd_callback,
+            connect_timeout,
         } => {
             tracing::debug!("GatewaySetup::New with spec: {specification:?}");
             setup_new_gateway(
@@ -222,6 +226,7 @@ where
                 available_gateways,
                 #[cfg(unix)]
                 connection_fd_callback,
+                connect_timeout,
             )
             .await
         }

--- a/common/client-core/src/init/types.rs
+++ b/common/client-core/src/init/types.rs
@@ -21,6 +21,7 @@ use std::fmt::{Debug, Display};
 #[cfg(unix)]
 use std::os::fd::RawFd;
 use std::sync::Arc;
+use std::time::Duration;
 use time::OffsetDateTime;
 use url::Url;
 
@@ -214,6 +215,9 @@ pub enum GatewaySetup {
         /// Callback useful for allowing initial connection to gateway
         #[cfg(unix)]
         connection_fd_callback: Option<Arc<dyn Fn(RawFd) + Send + Sync>>,
+
+        /// Timeout for establishing connection
+        connect_timeout: Option<Duration>,
     },
 
     ReuseConnection {
@@ -239,6 +243,7 @@ impl Debug for GatewaySetup {
                 available_gateways,
                 #[cfg(unix)]
                     connection_fd_callback: _,
+                connect_timeout: _,
             } => f
                 .debug_struct("GatewaySetup::New")
                 .field("specification", specification)
@@ -280,6 +285,7 @@ impl GatewaySetup {
             available_gateways: vec![],
             #[cfg(unix)]
             connection_fd_callback: None,
+            connect_timeout: None,
         }
     }
 

--- a/common/client-libs/gateway-client/src/error.rs
+++ b/common/client-libs/gateway-client/src/error.rs
@@ -4,6 +4,7 @@
 use nym_gateway_requests::registration::handshake::error::HandshakeError;
 use nym_gateway_requests::{GatewayRequestsError, SimpleGatewayRequestsError};
 use std::io;
+use std::time::Duration;
 use thiserror::Error;
 use tungstenite::Error as WsError;
 
@@ -45,6 +46,9 @@ pub enum GatewayClientError {
         address: String,
         source: Box<WsError>,
     },
+
+    #[error("timeout when establishing connection: {address}, timeout: {timeout:?}")]
+    NetworkConnectionTimeout { address: String, timeout: Duration },
 
     #[error("no socket address for endpoint: {address}")]
     NoEndpointForConnection { address: String },

--- a/nym-api/src/network_monitor/monitor/sender.rs
+++ b/nym-api/src/network_monitor/monitor/sender.rs
@@ -190,6 +190,7 @@ impl PacketSender {
             ),
             #[cfg(unix)]
             None,
+            None,
             fresh_gateway_client_data.shutdown_token.clone(),
         );
 

--- a/nym-registration-client/src/builder/config.rs
+++ b/nym-registration-client/src/builder/config.rs
@@ -38,6 +38,7 @@ pub struct BuilderConfig {
     pub cancel_token: CancellationToken,
     #[cfg(unix)]
     pub connection_fd_callback: Arc<dyn Fn(RawFd) + Send + Sync>,
+    pub connect_timeout: Option<Duration>,
 }
 
 #[derive(Clone, Default, Debug, Eq, PartialEq)]
@@ -71,6 +72,7 @@ impl BuilderConfig {
         network_env: NymNetworkDetails,
         cancel_token: CancellationToken,
         #[cfg(unix)] connection_fd_callback: Arc<dyn Fn(RawFd) + Send + Sync>,
+        connect_timeout: Option<Duration>,
     ) -> Self {
         Self {
             entry_node,
@@ -84,6 +86,7 @@ impl BuilderConfig {
             cancel_token,
             #[cfg(unix)]
             connection_fd_callback,
+            connect_timeout,
         }
     }
 
@@ -294,6 +297,7 @@ pub struct BuilderConfigBuilder {
     cancel_token: Option<CancellationToken>,
     #[cfg(unix)]
     connection_fd_callback: Option<Arc<dyn Fn(RawFd) + Send + Sync>>,
+    connect_timeout: Option<Duration>,
 }
 
 impl BuilderConfigBuilder {
@@ -358,6 +362,11 @@ impl BuilderConfigBuilder {
         self
     }
 
+    pub fn with_connect_timeout(mut self, connect_timeout: Duration) -> Self {
+        self.connect_timeout = Some(connect_timeout);
+        self
+    }
+
     /// Builds the `BuilderConfig`.
     ///
     /// Returns an error if any required field is missing.
@@ -388,6 +397,7 @@ impl BuilderConfigBuilder {
             connection_fd_callback: self
                 .connection_fd_callback
                 .ok_or(BuilderConfigError::MissingConnectionFdCallback)?,
+            connect_timeout: self.connect_timeout,
         })
     }
 }

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -764,6 +764,10 @@ where
             base_builder = base_builder.with_connection_fd_callback(connection_fd_callback);
         }
 
+        if let Some(connect_timeout) = self.connect_timeout {
+            base_builder = base_builder.with_connect_timeout(connect_timeout);
+        }
+
         let started_client = base_builder.start_base().await?;
         self.state = BuilderState::Registered {};
         let nym_address = started_client.address;

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -38,6 +38,7 @@ use std::path::Path;
 use std::path::PathBuf;
 #[cfg(unix)]
 use std::sync::Arc;
+use std::time::Duration;
 use url::Url;
 use zeroize::Zeroizing;
 
@@ -405,6 +406,9 @@ where
     #[cfg(unix)]
     connection_fd_callback: Option<Arc<dyn Fn(std::os::fd::RawFd) + Send + Sync>>,
 
+    /// Timeout for establishing a connection
+    connect_timeout: Option<Duration>,
+
     forget_me: ForgetMe,
 
     remember_me: RememberMe,
@@ -466,6 +470,7 @@ where
             user_agent: None,
             #[cfg(unix)]
             connection_fd_callback: None,
+            connect_timeout: None,
             forget_me,
             remember_me,
             derivation_material: None,
@@ -589,6 +594,7 @@ where
             available_gateways,
             #[cfg(unix)]
             connection_fd_callback: self.connection_fd_callback.clone(),
+            connect_timeout: self.connect_timeout,
         })
     }
 

--- a/wasm/client/src/client.rs
+++ b/wasm/client/src/client.rs
@@ -222,6 +222,7 @@ impl NymClientBuilder {
                 self.config.base.debug.topology.minimum_gateway_performance,
                 self.config.base.debug.topology.ignore_ingress_epoch_role,
                 &client_store,
+                None,
             )
             .await?;
         }

--- a/wasm/mix-fetch/src/client.rs
+++ b/wasm/mix-fetch/src/client.rs
@@ -158,6 +158,7 @@ impl MixFetchClientBuilder {
                 self.config.base.debug.topology.minimum_gateway_performance,
                 self.config.base.debug.topology.ignore_ingress_epoch_role,
                 &client_store,
+                None,
             )
             .await?;
         }

--- a/wasm/node-tester/src/tester.rs
+++ b/wasm/node-tester/src/tester.rs
@@ -153,6 +153,7 @@ impl NymNodeTesterBuilder {
                 false,
                 &self.base_topology,
                 client_store,
+                None,
             )
             .await?)
         }
@@ -211,6 +212,7 @@ impl NymNodeTesterBuilder {
                     packet_router,
                     self.bandwidth_controller.take(),
                     ClientStatsSender::new(None, stats_sender_task),
+                    None,
                     gateway_task,
                 )
             };


### PR DESCRIPTION
This is a draft PR that adds connect timeout for websocket. Since `tokio::net::TcpSocket` does not support `connect_timeout()` from std, the next close alternative using `tokio::time::timeout()` is used instead.

Connect timeout only limits how much time the call to `TcpSocket::connect()` may take before giving up.

A few notes:
- The structure of project seems to be very vertical which results into dragging variables all the way down 
- I don't understand how to pass connect_timeout in wasm client. It's not that vpn-client needs wasm, but for consistency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6110)
<!-- Reviewable:end -->
