### PR TITLE
Revert "Propagate cancel token to mixnet client"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5746,6 +5746,7 @@ dependencies = [
  "criterion",
  "ff",
  "group",
+ "lazy_static",
  "nym-contracts-common",
  "nym-pemstore",
  "rand 0.8.5",

--- a/nym-registration-client/src/builder/config.rs
+++ b/nym-registration-client/src/builder/config.rs
@@ -4,8 +4,7 @@
 use nym_credential_storage::persistent_storage::PersistentStorage;
 use nym_registration_common::NymNode;
 use nym_sdk::{
-    DebugConfig, NymNetworkDetails, RememberMe, ShutdownToken, ShutdownTracker, TopologyProvider,
-    UserAgent,
+    DebugConfig, NymNetworkDetails, RememberMe, TopologyProvider, UserAgent,
     mixnet::{
         CredentialStorage, GatewaysDetailsStore, KeyStore, MixnetClient, MixnetClientBuilder,
         MixnetClientStorage, OnDiskPersistent, ReplyStorageBackend, StoragePaths, x25519::KeyPair,
@@ -116,10 +115,7 @@ impl BuilderConfig {
             .debug_config(debug_config)
             .credentials_mode(true)
             .with_remember_me(remember_me)
-            .custom_topology_provider(self.custom_topology_provider)
-            .custom_shutdown(ShutdownTracker::new_from_external_shutdown_token(
-                ShutdownToken::from(self.cancel_token),
-            ));
+            .custom_topology_provider(self.custom_topology_provider);
 
         #[cfg(unix)]
         let builder = builder.with_connection_fd_callback(self.connection_fd_callback);


### PR DESCRIPTION
This reverts commit 50a259d454dd0142a4d7593240fe7124cf78680d. Given that we spotted some issues related to mixnet exiting too soon before sending forget-me and no easy way to postpone it, we shall perhaps revert this change for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6115)
<!-- Reviewable:end -->
