### PR TITLE
Skip ipv6 metadata endpoint request

### DIFF
--- a/nym-gateway-probe/netstack_ping/lib.go
+++ b/nym-gateway-probe/netstack_ping/lib.go
@@ -192,14 +192,20 @@ func ping(req NetstackRequestGo) (NetstackResponse, error) {
 
 	response.CanHandshake = true
 
-	version, duration, err := queryMetadata(req.MetadataEndpoint, req.MetadataTimeoutSec, tnet)
-	if err != nil {
-		log.Printf("Failed to query metadata URLs: %v\n", err)
-		response.CanQueryMetadata = false
+	// Skip metadata query if endpoint is empty (e.g., for IPv6 where the IPv4 metadata endpoint is not reachable)
+	if req.MetadataEndpoint != "" {
+		version, duration, err := queryMetadata(req.MetadataEndpoint, req.MetadataTimeoutSec, tnet)
+		if err != nil {
+			log.Printf("Failed to query metadata URLs: %v\n", err)
+			response.CanQueryMetadata = false
+		} else {
+			log.Printf("Queried metadata endpoint with version: %v\n", version)
+			log.Printf("Query duration: %v\n", duration)
+			response.CanQueryMetadata = true
+		}
 	} else {
-		log.Printf("Queried metadata endpoint with version: %v\n", version)
-		log.Printf("Query duration: %v\n", duration)
-		response.CanQueryMetadata = true
+		log.Printf("Skipping metadata query (no endpoint provided)")
+		response.CanQueryMetadata = false
 	}
 
 	for _, host := range req.PingHosts {
@@ -540,25 +546,25 @@ func queryMetadata(url string, timeoutSecs uint64, tnet *netstack.Net) (int, tim
 func main() {
 	// uncomment the lines below to run locally and see README.md for how to get the Wireguard config
 	/*	var _, err = ping(NetstackRequestGo{
-			WgIp:             "10.1.155.153",
-			PrivateKey:       "...",
-			PublicKey:        "...",
-			Endpoint:         "13.245.9.123:51822",
-			MetadataEndpoint: "http://10.1.0.1:51830",
-			Dns:              "1.1.1.1",
-			IpVersion:        4,
-			//PingHosts:          nil,
-			//PingIps:            nil,
-			//NumPing:            0,
-			//SendTimeoutSec:     0,
-			//RecvTimeoutSec:     0,
-			//DownloadTimeoutSec: 0,
-			MetadataTimeoutSec: 5,
-			//AwgArgs:            "",
-		})
+			 WgIp:             "10.1.155.153",
+			 PrivateKey:       "...",
+			 PublicKey:        "...",
+			 Endpoint:         "13.245.9.123:51822",
+			 MetadataEndpoint: "http://10.1.0.1:51830",
+			 Dns:              "1.1.1.1",
+			 IpVersion:        4,
+			 //PingHosts:          nil,
+			 //PingIps:            nil,
+			 //NumPing:            0,
+			 //SendTimeoutSec:     0,
+			 //RecvTimeoutSec:     0,
+			 //DownloadTimeoutSec: 0,
+			 MetadataTimeoutSec: 5,
+			 //AwgArgs:            "",
+		 })
 
-		if err != nil {
-			log.Fatal(err)
-		}
+		 if err != nil {
+			 log.Fatal(err)
+		 }
 	*/
 }

--- a/nym-gateway-probe/netstack_ping/lib_test.go
+++ b/nym-gateway-probe/netstack_ping/lib_test.go
@@ -215,8 +215,8 @@ func TestPingFunction(t *testing.T) {
 	// Create a request with valid IP but will fail due to network setup
 	req := NetstackRequestGo{
 		WgIp:               "10.0.0.1",
-		PrivateKey:         "test-key",
-		PublicKey:          "test-pub-key",
+		PrivateKey:         "0000000000000000000000000000000000000000000000000000000000000000",
+		PublicKey:          "0000000000000000000000000000000000000000000000000000000000000000",
 		Endpoint:           "1.1.1.1:51820",
 		Dns:                "1.1.1.1",
 		IpVersion:          4,
@@ -275,10 +275,11 @@ func TestResultStructs(t *testing.T) {
 // TestConsecutiveFailureExit validates that the ping loop exits cleanly after consecutive failures
 func TestConsecutiveFailureExit(t *testing.T) {
 	// Create a test request that will trigger consecutive failures
+	// Using valid hex-encoded keys (32 bytes = 64 hex chars)
 	req := NetstackRequestGo{
 		WgIp:               "10.0.0.1",
-		PrivateKey:         "test-key",
-		PublicKey:          "test-pub-key",
+		PrivateKey:         "0000000000000000000000000000000000000000000000000000000000000000",
+		PublicKey:          "0000000000000000000000000000000000000000000000000000000000000000",
 		Endpoint:           "1.1.1.1:51820",
 		Dns:                "1.1.1.1",
 		IpVersion:          4,

--- a/nym-gateway-probe/src/netstack.rs
+++ b/nym-gateway-probe/src/netstack.rs
@@ -145,7 +145,8 @@ impl NetstackRequestGo {
             private_key: req.private_key.clone(),
             public_key: req.public_key.clone(),
             endpoint: req.endpoint.clone(),
-            metadata_endpoint: req.metadata_endpoint.clone(),
+            // Skip metadata endpoint for IPv6 as it's an IPv4-only address (10.1.0.1)
+            metadata_endpoint: String::new(),
             dns: req.v6_ping_config.dns.clone(),
             ip_version: 6,
             ping_hosts: req.v6_ping_config.ping_hosts.clone(),


### PR DESCRIPTION
Probing with IPv6, it's still trying to query the metadata endpoint at 10.1.0.1:51830 (an IPv4 address), which fails with "no route to host"

Fix tests too

Now we skip that for the ipv6 part of the probe test:

IP version: 4
2025/10/14 11:10:50 Querying metadata encoding: url = http://10.1.0.1:51830/v1/bandwidth/version
2025/10/14 11:10:51 Metadata Content-Type: application/json

Now
WireGuard IP: fc01::6278
IP version: 6
2025/10/14 11:11:27 Skipping metadata query (no endpoint provided)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6118)
<!-- Reviewable:end -->
