### PR TITLE
VPN-4262: Update `Url` to return `url` and `front` fields.

### DIFF
--- a/common/http-api-client/src/url.rs
+++ b/common/http-api-client/src/url.rs
@@ -183,6 +183,11 @@ impl Url {
         })
     }
 
+    /// Returns the underlying URL
+    pub fn inner_url(&self) -> &url::Url {
+        &self.url
+    }
+
     /// Returns true if the URL has a front domain set
     pub fn has_front(&self) -> bool {
         if let Some(fronts) = &self.fronts {
@@ -199,6 +204,11 @@ impl Url {
             .as_ref()
             .and_then(|fronts| fronts.get(current))
             .and_then(|url| url.host_str())
+    }
+
+    /// Returns the fronts
+    pub fn fronts(&self) -> Option<&[url::Url]> {
+        self.fronts.as_deref()
     }
 
     /// Return the string representation of the host (domain or IP address) for this URL, if any.


### PR DESCRIPTION
The VPN client is using the `Url` type alot now and in order to avoid double URL-parsing we would like the content of the `Url` type exposed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6130)
<!-- Reviewable:end -->
