### PR TITLE
Bugfix: Add circuit breaker

### DIFF
--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -801,7 +801,7 @@ where
             event_tx,
         );
 
-        let mix_tx = mix_traffic_controller.mix_rx();
+        let mix_tx = mix_traffic_controller.mix_tx();
         let client_tx = mix_traffic_controller.client_tx();
 
         shutdown_tracker.try_spawn_named(

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -1005,7 +1005,7 @@ where
         // or get one from the registry
         let shutdown_tracker = match self.shutdown {
             Some(parent_tracker) => parent_tracker.clone(),
-            None => nym_task::get_sdk_shutdown_tracker()?,
+            None => nym_task::create_sdk_shutdown_tracker()?,
         };
 
         Self::start_event_control(self.event_tx, event_receiver, &shutdown_tracker);

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -1004,7 +1004,7 @@ where
         // Create a shutdown tracker for this client - either as a child of provided tracker
         // or get one from the registry
         let shutdown_tracker = match self.shutdown {
-            Some(parent_tracker) => parent_tracker.child_tracker(),
+            Some(parent_tracker) => parent_tracker.clone(),
             None => nym_task::get_sdk_shutdown_tracker()?,
         };
 
@@ -1044,7 +1044,7 @@ where
             self.user_agent.clone(),
             generate_client_stats_id(*self_address.identity()),
             input_sender.clone(),
-            &shutdown_tracker.child_tracker(),
+            &shutdown_tracker.clone(),
         );
 
         // needs to be started as the first thing to block if required waiting for the gateway
@@ -1054,7 +1054,7 @@ where
             shared_topology_accessor.clone(),
             self_address.gateway(),
             self.wait_for_gateway,
-            &shutdown_tracker.child_tracker(),
+            &shutdown_tracker.clone(),
         )
         .await?;
 
@@ -1074,7 +1074,7 @@ where
             stats_reporter.clone(),
             #[cfg(unix)]
             self.connection_fd_callback,
-            &shutdown_tracker.child_tracker(),
+            &shutdown_tracker.clone(),
         )
         .await?;
         let gateway_ws_fd = gateway_transceiver.ws_fd();
@@ -1082,7 +1082,7 @@ where
         let reply_storage = Self::setup_persistent_reply_storage(
             reply_storage_backend,
             key_rotation_config,
-            &shutdown_tracker.child_tracker(),
+            &shutdown_tracker.clone(),
         )
         .await?;
 
@@ -1093,7 +1093,7 @@ where
             reply_storage.key_storage(),
             reply_controller_sender.clone(),
             stats_reporter.clone(),
-            &shutdown_tracker.child_tracker(),
+            &shutdown_tracker.clone(),
         );
 
         // The message_sender is the transmitter for any component generating sphinx packets
@@ -1103,7 +1103,7 @@ where
 
         let (message_sender, client_request_sender) = Self::start_mix_traffic_controller(
             gateway_transceiver,
-            &shutdown_tracker.child_tracker(),
+            &shutdown_tracker.clone(),
             EventSender(event_sender),
         );
 
@@ -1134,7 +1134,7 @@ where
             shared_lane_queue_lengths.clone(),
             client_connection_rx,
             stats_reporter.clone(),
-            &shutdown_tracker.child_tracker(),
+            &shutdown_tracker.clone(),
         );
 
         if !self
@@ -1150,7 +1150,7 @@ where
                 shared_topology_accessor.clone(),
                 message_sender,
                 stats_reporter.clone(),
-                &shutdown_tracker.child_tracker(),
+                &shutdown_tracker.clone(),
             );
         }
 

--- a/common/client-core/src/client/cover_traffic_stream.rs
+++ b/common/client-core/src/client/cover_traffic_stream.rs
@@ -205,7 +205,7 @@ impl LoopCoverTrafficStream<OsRng> {
                 TrySendError::Full(_) => {
                     // This isn't a problem, if the channel is full means we're already sending the
                     // max amount of messages downstream can handle.
-                    tracing::debug!("Failed to send cover message - channel full");
+                    tracing::trace!("Failed to send cover message - channel full");
                 }
                 TrySendError::Closed(_) => {
                     tracing::warn!("Failed to send cover message - channel closed");

--- a/common/client-core/src/client/mix_traffic/mod.rs
+++ b/common/client-core/src/client/mix_traffic/mod.rs
@@ -20,7 +20,10 @@ pub mod transceiver;
 
 // We remind ourselves that 32 x 32kb = 1024kb, a reasonable size for a network buffer.
 pub const MIX_MESSAGE_RECEIVER_BUFFER_SIZE: usize = 32;
-const MAX_FAILURE_COUNT: usize = 100;
+
+/// Reduced from 100 to 20 to fail fast (~1-2 seconds instead of ~6 seconds).
+/// If we can't send 20 packets in a row, the gateway is unreachable.
+const MAX_FAILURE_COUNT: usize = 20;
 
 // that's also disgusting.
 pub struct Empty;

--- a/common/client-core/src/client/mix_traffic/mod.rs
+++ b/common/client-core/src/client/mix_traffic/mod.rs
@@ -87,7 +87,7 @@ impl MixTrafficController {
         self.client_tx.clone()
     }
 
-    pub fn mix_rx(&self) -> BatchMixMessageSender {
+    pub fn mix_tx(&self) -> BatchMixMessageSender {
         self.mix_tx.clone()
     }
 
@@ -159,6 +159,11 @@ impl MixTrafficController {
                             // Do we need to handle the embedded mixnet client case
                             // separately?
                             self.event_tx.send(MixnetClientEvent::Traffic(MixTrafficEvent::FailedSendingSphinx));
+                            // IMO it shouldn't be signalled from there but it is how it is
+                            // TODO : report the failure upwards and shutdown from upwards
+                            // Gateway is dead, we have to shut down currently
+                            error!("Signalling shutdown from the MixTrafficController");
+                            self.shutdown_token.cancel();
                             break;
                         }
                     }

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -301,8 +301,7 @@ where
                     tracing::error!(
                         "failed to send mixnet packet due to closed channel (outside of shutdown!)"
                     );
-                    // This prevents an infinite loop where we keep trying to send
-                    // packets through a closed channel
+                    // This prevents a loop where we keep trying to send packets through a closed channel
                     self.mix_tx_closed = true;
                 }
                 // Early return to avoid further processing when channel is closed
@@ -611,7 +610,7 @@ where
                     next_message = self.next() => if let Some(next_message) = next_message {
                         self.on_message(next_message).await;
                         // Check if mix_tx channel was closed during on_message
-                        // and break immediately to prevent infinite loop
+                        // and break immediately to prevent loop
                         if self.mix_tx_closed {
                             tracing::error!("OutQueueControl: mix_tx channel closed, stopping traffic stream");
                             break;
@@ -636,7 +635,7 @@ where
                     next_message = self.next() => if let Some(next_message) = next_message {
                         self.on_message(next_message).await;
                         // Check if mix_tx channel was closed during on_message
-                        // and break immediately to prevent infinite loop
+                        // and break immediately to prevent loop
                         if self.mix_tx_closed {
                             tracing::error!("OutQueueControl: mix_tx channel closed, stopping traffic stream");
                             break;

--- a/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
+++ b/common/client-core/src/client/real_messages_control/real_traffic_stream.rs
@@ -615,7 +615,7 @@ where
         {
             loop {
                 tokio::select! {
-                        biased;
+                    biased;
                     _ = shutdown_token.cancelled() => {
                         tracing::trace!("OutQueueControl: Received shutdown");
                         break;

--- a/common/task/src/lib.rs
+++ b/common/task/src/lib.rs
@@ -24,6 +24,6 @@ pub use crate::runtime_registry::RegistryAccessError;
 
 /// Get or create a ShutdownTracker for SDK use.
 /// This provides automatic task management without requiring manual setup.
-pub fn get_sdk_shutdown_tracker() -> Result<ShutdownTracker, RegistryAccessError> {
-    Ok(runtime_registry::RuntimeRegistry::get_or_create_sdk()?.shutdown_tracker_owned())
+pub fn create_sdk_shutdown_tracker() -> Result<ShutdownTracker, RegistryAccessError> {
+    Ok(runtime_registry::RuntimeRegistry::create_sdk()?.shutdown_tracker_owned())
 }

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -736,15 +736,11 @@ where
             base_builder = base_builder.with_topology_provider(topology_provider);
         }
 
-        // Use custom shutdown if provided, otherwise get from registry
-        let shutdown_tracker = match self.custom_shutdown {
-            Some(custom) => custom,
-            None => {
-                // Auto-create from registry for SDK use
-                nym_task::get_sdk_shutdown_tracker()?
-            }
-        };
-        base_builder = base_builder.with_shutdown(shutdown_tracker);
+        // Use custom shutdown if provided, otherwise the sdk one will be used later down the line
+        if let Some(shutdown_tracker) = self.custom_shutdown {
+            base_builder = base_builder.with_shutdown(shutdown_tracker);
+        }
+
         if let Some(event_tx) = self.event_tx {
             base_builder = base_builder.with_event_tx(event_tx);
         }

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -809,7 +809,7 @@ where
             client_output,
             client_state.clone(),
             nym_address,
-            started_client.shutdown_handle.child_tracker(),
+            started_client.shutdown_handle.clone(),
             packet_type,
         );
 


### PR DESCRIPTION
When the mixnet client's mix_tx channel closes during network drops, `OutQueueControl`
would retry sending packets through the closed channel, flooding logs and 
hanging the daemon. This affects all clients (VPN, SOCKS5, native clients), not just VPN.

Solution

Cancelling the root token from the MixTrafficController

Additionally, reduced `MAX_FAILURE_COUNT` from 100 → 20 to detect dead gateways faster 
(~1-2s instead of ~6s), improving reconnection speed during mobile network drops and 
sleep/wake cycles.

Example Logs (Before Fix)
```
2025-10-23T14:18:26.772232Z ERROR nym_client_core::client::mix_traffic: Failed to send sphinx packet to the gateway 100 times in a row - assuming the gateway is dead
2025-10-23T14:18:26.772239Z DEBUG nym_client_core::client::mix_traffic: MixTrafficController: Exiting
2025-10-23T14:18:26.773309Z ERROR nym_client_core::client::real_messages_control::real_traffic_stream: failed to send mixnet packet due to closed channel (outside of shutdown!)
2025-10-23T14:18:26.773382Z ERROR nym_client_core::client::real_messages_control::real_traffic_stream: failed to send mixnet packet due to closed channel (outside of shutdown!)
2025-10-23T14:18:26.774273Z ERROR nym_client_core::client::real_messages_control::real_traffic_stream: failed to send mixnet packet due to closed channel (outside of shutdown!)
... (continues infinitely)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6143)
<!-- Reviewable:end -->
