### PR TITLE
Max/tweak ts sdk actions

### DIFF
--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          
+
       - name: Setup yarn
         run: npm install -g yarn
 
@@ -43,6 +43,9 @@ jobs:
         with:
           go-version: "1.24.6"
 
+      - name: Install CPU Limit package
+        run: sudo apt-get update && sudo apt-get install -y cpulimit
+
       - name: Install
         run: yarn
 
@@ -53,7 +56,7 @@ jobs:
         run: yarn
 
       - name: Lint
-        run: yarn lint
-        
+        run: cpulimit -l 400 yarn lint
+
       - name: Typecheck with tsc
         run: yarn tsc

--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -43,9 +43,6 @@ jobs:
         with:
           go-version: "1.24.6"
 
-      - name: Install CPU Limit package
-        run: sudo apt-get update && sudo apt-get install -y cpulimit
-
       - name: Install
         run: yarn
 
@@ -56,7 +53,7 @@ jobs:
         run: yarn
 
       - name: Lint
-        run: cpulimit -l 400 yarn lint
+        run: yarn lint
 
       - name: Typecheck with tsc
         run: yarn tsc

--- a/wasm/client/Makefile
+++ b/wasm/client/Makefile
@@ -4,15 +4,15 @@ all: build build-node
 build: test build-wasm
 
 build-wasm:
-	taskset -c 0-7 wasm-pack build --scope nymproject --target web --out-dir ../../dist/wasm/client
-	taskset -c 0-7 wasm-opt -Oz -o ../../dist/wasm/client/nym_client_wasm_bg.wasm ../../dist/wasm/client/nym_client_wasm_bg.wasm
+	taskset -c 0-11 wasm-pack build --scope nymproject --target web --out-dir ../../dist/wasm/client
+	taskset -c 0-11 wasm-opt -Oz -o ../../dist/wasm/client/nym_client_wasm_bg.wasm ../../dist/wasm/client/nym_client_wasm_bg.wasm
 
 build-debug-dev:
 	wasm-pack build --debug --scope nymproject --target no-modules
 
 build-rust-node:
-	taskset -c 0-7 wasm-pack build --scope nymproject --target nodejs --out-dir ../../dist/node/wasm/client
-	taskset -c 0-7 wasm-opt -Oz -o ../../dist/node/wasm/client/nym_client_wasm_bg.wasm ../../dist/node/wasm/client/nym_client_wasm_bg.wasm
+	taskset -c 0-11 wasm-pack build --scope nymproject --target nodejs --out-dir ../../dist/node/wasm/client
+	taskset -c 0-11 wasm-opt -Oz -o ../../dist/node/wasm/client/nym_client_wasm_bg.wasm ../../dist/node/wasm/client/nym_client_wasm_bg.wasm
 
 build-package-json-node:
 	node build-node.mjs

--- a/wasm/client/Makefile
+++ b/wasm/client/Makefile
@@ -4,15 +4,15 @@ all: build build-node
 build: test build-wasm
 
 build-wasm:
-	wasm-pack build --scope nymproject --target web --out-dir ../../dist/wasm/client
-	wasm-opt -Oz -o ../../dist/wasm/client/nym_client_wasm_bg.wasm ../../dist/wasm/client/nym_client_wasm_bg.wasm
+	taskset -c 0-7 wasm-pack build --scope nymproject --target web --out-dir ../../dist/wasm/client
+	taskset -c 0-7 wasm-opt -Oz -o ../../dist/wasm/client/nym_client_wasm_bg.wasm ../../dist/wasm/client/nym_client_wasm_bg.wasm
 
 build-debug-dev:
 	wasm-pack build --debug --scope nymproject --target no-modules
 
 build-rust-node:
-	wasm-pack build --scope nymproject --target nodejs --out-dir ../../dist/node/wasm/client
-	wasm-opt -Oz -o ../../dist/node/wasm/client/nym_client_wasm_bg.wasm ../../dist/node/wasm/client/nym_client_wasm_bg.wasm
+	taskset -c 0-7 wasm-pack build --scope nymproject --target nodejs --out-dir ../../dist/node/wasm/client
+	taskset -c 0-7 wasm-opt -Oz -o ../../dist/node/wasm/client/nym_client_wasm_bg.wasm ../../dist/node/wasm/client/nym_client_wasm_bg.wasm
 
 build-package-json-node:
 	node build-node.mjs

--- a/wasm/full-nym-wasm/Makefile
+++ b/wasm/full-nym-wasm/Makefile
@@ -1,5 +1,5 @@
 all: build-full
 
 build-full:
-	wasm-pack build --all-features --scope nymproject --target web --out-dir ../../dist/wasm/full-nym-wasm
-	wasm-opt -Oz -o ../../dist/wasm/full-nym-wasm/nym_wasm_sdk_bg.wasm ../../dist/wasm/full-nym-wasm/nym_wasm_sdk_bg.wasm
+	taskset -c 0-7 wasm-pack build --all-features --scope nymproject --target web --out-dir ../../dist/wasm/full-nym-wasm
+	taskset -c 0-7 wasm-opt -Oz -o ../../dist/wasm/full-nym-wasm/nym_wasm_sdk_bg.wasm ../../dist/wasm/full-nym-wasm/nym_wasm_sdk_bg.wasm

--- a/wasm/full-nym-wasm/Makefile
+++ b/wasm/full-nym-wasm/Makefile
@@ -1,5 +1,5 @@
 all: build-full
 
 build-full:
-	taskset -c 0-7 wasm-pack build --all-features --scope nymproject --target web --out-dir ../../dist/wasm/full-nym-wasm
-	taskset -c 0-7 wasm-opt -Oz -o ../../dist/wasm/full-nym-wasm/nym_wasm_sdk_bg.wasm ../../dist/wasm/full-nym-wasm/nym_wasm_sdk_bg.wasm
+	taskset -c 0-11 wasm-pack build --all-features --scope nymproject --target web --out-dir ../../dist/wasm/full-nym-wasm
+	taskset -c 0-11 wasm-opt -Oz -o ../../dist/wasm/full-nym-wasm/nym_wasm_sdk_bg.wasm ../../dist/wasm/full-nym-wasm/nym_wasm_sdk_bg.wasm

--- a/wasm/mix-fetch/Makefile
+++ b/wasm/mix-fetch/Makefile
@@ -9,8 +9,8 @@ build-go-opt:
 	$(MAKE) -C go-mix-conn build-go-opt
 
 build-rust:
-	taskset -c 0-7 wasm-pack build --scope nymproject --target web --out-dir ../../dist/wasm/mix-fetch
-	taskset -c 0-7 wasm-opt -Oz -o ../../dist/wasm/mix-fetch/mix_fetch_wasm_bg.wasm ../../dist/wasm/mix-fetch/mix_fetch_wasm_bg.wasm
+	taskset -c 0-11 wasm-pack build --scope nymproject --target web --out-dir ../../dist/wasm/mix-fetch
+	taskset -c 0-11 wasm-opt -Oz -o ../../dist/wasm/mix-fetch/mix_fetch_wasm_bg.wasm ../../dist/wasm/mix-fetch/mix_fetch_wasm_bg.wasm
 
 build-rust-debug:
 	wasm-pack build --debug --scope nymproject --target no-modules

--- a/wasm/mix-fetch/Makefile
+++ b/wasm/mix-fetch/Makefile
@@ -9,8 +9,8 @@ build-go-opt:
 	$(MAKE) -C go-mix-conn build-go-opt
 
 build-rust:
-	wasm-pack build --scope nymproject --target web --out-dir ../../dist/wasm/mix-fetch
-	wasm-opt -Oz -o ../../dist/wasm/mix-fetch/mix_fetch_wasm_bg.wasm ../../dist/wasm/mix-fetch/mix_fetch_wasm_bg.wasm
+	taskset -c 0-7 wasm-pack build --scope nymproject --target web --out-dir ../../dist/wasm/mix-fetch
+	taskset -c 0-7 wasm-opt -Oz -o ../../dist/wasm/mix-fetch/mix_fetch_wasm_bg.wasm ../../dist/wasm/mix-fetch/mix_fetch_wasm_bg.wasm
 
 build-rust-debug:
 	wasm-pack build --debug --scope nymproject --target no-modules


### PR DESCRIPTION
Using `taskset` to limit the # of CPUs used by `wasm-pack` and `wasm-opt` commands used by ts linting CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6185)
<!-- Reviewable:end -->
