### PR TITLE
Use hardcoded devrel gw for examples to get around CSP

### DIFF
--- a/documentation/docs/components/mix-fetch.tsx
+++ b/documentation/docs/components/mix-fetch.tsx
@@ -9,11 +9,12 @@ import Stack from "@mui/material/Stack";
 import Paper from "@mui/material/Paper";
 import type { SetupMixFetchOps } from "@nymproject/mix-fetch-full-fat";
 
-const defaultUrl = "https://nymtech.net/.wellknown/network-requester/exit-policy.txt";
+const defaultUrl =
+  "https://nymtech.net/.wellknown/network-requester/exit-policy.txt";
 const args = { mode: "unsafe-ignore-cors" };
 
 const mixFetchOptions: SetupMixFetchOps = {
-  preferredGateway: "2xU4CBE6QiiYt6EyBXSALwxkNvM7gqJfjHXaMkjiFmYW", // with WSS
+  preferredGateway: "q2A2cbooyC16YJzvdYaSMH9X3cSiieZNtfBr8cE8Fi1", // with WSS
   // preferredNetworkRequester:
   //   "CTDxrcXgrZHWyCWnuCgjpJPghQUcEVz1HkhUr5mGdFnT.3UAww1YWNyVNYNWFQL1LaHYouQtDiXBGK5GiDZgpXkTK@2RFtU5BwxvJJXagAWAEuaPgb5ZVPRoy2542TT93Edw6v",
   mixFetchOverride: {

--- a/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
+++ b/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
@@ -1,1 +1,1 @@
-Monday, November 10th 2025, 13:30:27 UTC
+Tuesday, November 11th 2025, 13:59:52 UTC

--- a/documentation/docs/components/outputs/command-outputs/node-api-check-query-help.md
+++ b/documentation/docs/components/outputs/command-outputs/node-api-check-query-help.md
@@ -11,7 +11,7 @@ options:
   --no_routing_history  Display node stats without routing history
   --no_verloc_metrics   Display node stats without verloc metrics
   -m, --markdown        Display results in markdown format
-  -o [OUTPUT], --output [OUTPUT]
+  -o, --output [OUTPUT]
                         Save results to file (in current dir or supply with
                         path without filename)
 ```

--- a/documentation/docs/components/traffic.tsx
+++ b/documentation/docs/components/traffic.tsx
@@ -13,6 +13,7 @@ import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 
 const nymApiUrl = "https://validator.nymtech.net/api";
+const preferredGateway = "q2A2cbooyC16YJzvdYaSMH9X3cSiieZNtfBr8cE8Fi1";
 
 export const Traffic = () => {
   const [nym, setNym] = useState<NymMixnetClient>();
@@ -23,6 +24,7 @@ export const Traffic = () => {
   const [buttonEnabled, setButtonEnabled] = useState<boolean>(false);
 
   const init = async () => {
+    // TODO HOW TO SET PREFERRED GATEWAY? Can't find newWithConfig in import
     const client = await createNymMixnetClient();
     setNym(client);
 
@@ -31,6 +33,7 @@ export const Traffic = () => {
       clientId: crypto.randomUUID(),
       nymApiUrl,
       forceTls: true, // force WSS
+      preferredGateway,
     });
 
     // check when is connected and set the self address

--- a/documentation/docs/components/traffic.tsx
+++ b/documentation/docs/components/traffic.tsx
@@ -24,7 +24,6 @@ export const Traffic = () => {
   const [buttonEnabled, setButtonEnabled] = useState<boolean>(false);
 
   const init = async () => {
-    // TODO HOW TO SET PREFERRED GATEWAY? Can't find newWithConfig in import
     const client = await createNymMixnetClient();
     setNym(client);
 

--- a/documentation/docs/next.config.js
+++ b/documentation/docs/next.config.js
@@ -1108,7 +1108,7 @@ const config = {
         form-action 'self';
         frame-ancestors 'none';
         upgrade-insecure-requests;
-        connect-src 'self' wss: https://github.com *.vercel.app *.nymtech.net *.nymvpn.com *.nymte.ch *.nyx.network *.nym.com https://nym.com nymvpn.com https://nymvpn.com *.nymtech.cc;
+        connect-src 'self' wss://nym-node-cli.devrel.nymte.ch:9001 https://github.com *.vercel.app *.nymtech.net *.nymvpn.com *.nymte.ch *.nyx.network *.nym.com https://nym.com nymvpn.com https://nymvpn.com *.nymtech.cc;
         frame-src 'self' https://vercel.live *.vercel.app *.nym.com https://nym.com;
         worker-src 'self' blob: https://vercel.live *.vercel.app *.nym.com https://nym.com;
       `;

--- a/documentation/docs/pages/developers/typescript/examples/mix-fetch.mdx
+++ b/documentation/docs/pages/developers/typescript/examples/mix-fetch.mdx
@@ -18,7 +18,7 @@ Sounds great, are there any catches? Well, there are a few (for now):
 <Callout type="info" emoji="ℹ️">
   Right now Gateways are not required to run a Secure Websocket (WSS) listener, so only a subset of nodes running in Gateway mode have configured their nodes to do so.
 
-For the moment you have to select a Gateway that has WSS enabled and Network Requester from [Harbourmaster Gateways for mixFetch list](https://harbourmaster.nymtech.net/).
+For the moment you have to select a Gateway that has WSS from [Harbourmaster Gateways for mixFetch list](https://harbourmaster.nymtech.net/).
 
 ```
 curl -X 'GET' \
@@ -33,9 +33,7 @@ curl -X 'GET' \
 import type { SetupMixFetchOps } from '@nymproject/mix-fetch';
 
 const mixFetchOptions: SetupMixFetchOps = {
-  preferredGateway: '23A7CSaBSA2L67PWuFTPXUnYrCdyVcB7ATYsjUsfdftb', // with WSS
-  preferredNetworkRequester:
-    'HuNL1pFprNSKW6jdqppibXP5KNKCNJxDh7ivpYcoULN9.C62NahRTUf6kqpNtDVHXoVriQr6yyaU5LtxdgpbsGrtA@23A7CSaBSA2L67PWuFTPXUnYrCdyVcB7ATYsjUsfdftb',
+  preferredGateway: "q2A2cbooyC16YJzvdYaSMH9X3cSiieZNtfBr8cE8Fi1", // with WSS
   mixFetchOverride: {
     requestTimeoutMs: 60_000,
   },

--- a/documentation/docs/pages/developers/typescript/playground/mixfetch.mdx
+++ b/documentation/docs/pages/developers/typescript/playground/mixfetch.mdx
@@ -10,4 +10,9 @@ import { Callout } from 'nextra/components'
 
 
 <MixFetch />
+
+<Callout type="info">
+    Open your browser's console to see the connection and send/receive logging for this example.
+</Callout>
+
 <FormattedMixFetchExampleCode />

--- a/documentation/docs/pages/developers/typescript/playground/traffic.mdx
+++ b/documentation/docs/pages/developers/typescript/playground/traffic.mdx
@@ -7,5 +7,9 @@ import FormattedTrafficExampleCode from '../../../../code-examples/sdk/typescrip
 
 Use this tool to experiment with the mixnet: send and receive messages!
 
+<Callout type="info">
+    Open your browser's console to see the connection and send/receive logging for this example.
+</Callout>
+
 <Traffic />
 <FormattedTrafficExampleCode />


### PR DESCRIPTION
Hardcoding the GW ID key and WSS hostname for TS SDK examples in the docs. Will follow up with the same for the main nym.com site

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6187)
<!-- Reviewable:end -->
