### PR TITLE
HTTP API resilience enable & domain rotation conditions

### DIFF
--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -88,6 +88,13 @@ pub enum ResolveError {
     StaticLookupMiss,
 }
 
+impl ResolveError {
+    /// Returns true if the error is a timeout.
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, ResolveError::Timeout)
+    }
+}
+
 /// Wrapper around an `AsyncResolver`, which implements the `Resolve` trait.
 ///
 /// Typical use involves instantiating using the `Default` implementation and then resolving using

--- a/common/http-api-client/src/fronted.rs
+++ b/common/http-api-client/src/fronted.rs
@@ -121,4 +121,89 @@ mod tests {
         // println!("{response:?}");
         assert_eq!(response.status(), 200);
     }
+
+    #[tokio::test]
+    async fn fallback_on_failure() {
+        let url1 = Url::new(
+            "https://fake-domain.nymtech.net",
+            Some(vec![
+                "https://fake-front-1.nymtech.net",
+                "https://fake-front-2.nymtech.net",
+            ]),
+        )
+        .unwrap();
+        let url2 = Url::new(
+            "https://validator.global.ssl.fastly.net",
+            Some(vec!["https://yelp.global.ssl.fastly.net"]),
+        )
+        .unwrap(); // fastly
+
+        let client = ClientBuilder::new_with_urls(vec![url1, url2])
+            .expect("bad url")
+            .with_fronting(FrontPolicy::Always)
+            .build()
+            .expect("failed to build client");
+
+        // Check that the initial configuration has the broken domain and front.
+        assert_eq!(
+            client.current_url().as_str(),
+            "https://fake-domain.nymtech.net/",
+        );
+        assert_eq!(
+            client.current_url().front_str(),
+            Some("fake-front-1.nymtech.net"),
+        );
+
+        let result = client
+            .send_request::<_, (), &str, &str>(
+                reqwest::Method::GET,
+                &["api", "v1", "network", "details"],
+                NO_PARAMS,
+                None,
+            )
+            .await;
+        assert!(result.is_err());
+
+        // Check that the host configuration updated the front on error.
+        assert_eq!(
+            client.current_url().as_str(),
+            "https://fake-domain.nymtech.net/",
+        );
+        assert_eq!(
+            client.current_url().front_str(),
+            Some("fake-front-2.nymtech.net"),
+        );
+
+        let result = client
+            .send_request::<_, (), &str, &str>(
+                reqwest::Method::GET,
+                &["api", "v1", "network", "details"],
+                NO_PARAMS,
+                None,
+            )
+            .await;
+        assert!(result.is_err());
+
+        // Check that the host configuration updated the domain and front on error.
+        assert_eq!(
+            client.current_url().as_str(),
+            "https://validator.global.ssl.fastly.net/",
+        );
+        assert_eq!(
+            client.current_url().front_str(),
+            Some("yelp.global.ssl.fastly.net"),
+        );
+
+        let response = client
+            .send_request::<_, (), &str, &str>(
+                reqwest::Method::GET,
+                &["api", "v1", "network", "details"],
+                NO_PARAMS,
+                None,
+            )
+            .await
+            .expect("failed get request");
+
+        assert_eq!(response.status(), 200);
+    }
 }

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1086,13 +1086,14 @@ impl ApiClientCore for Client {
                 .build()
                 .map_err(HttpClientError::reqwest_client_build_error)?;
             self.apply_hosts_to_req(&mut req);
-            let url = Url::parse(req.url().as_str()).unwrap();
+            let url: Url = req.url().clone().into();
 
             // try an explicit DNS resolution - if successful then it will be in cache when reqwest
             // goes to execute the request. If failure then we get to handle the DNS lookup error.
             #[cfg(not(target_arch = "wasm32"))]
             if self.using_secure_dns
                 && let Some(hostname) = req.url().domain()
+                // Default here will use a shared resolver instance
                 && let Err(err) = HickoryDnsResolver::default().resolve_str(hostname).await
             {
                 // on failure update host, but don't trigger fronting enable.

--- a/common/http-api-client/src/tests.rs
+++ b/common/http-api-client/src/tests.rs
@@ -123,7 +123,7 @@ fn host_updating() {
     assert_eq!(current_url.front_str(), None);
 
     // update the url
-    client.update_host();
+    client.update_host(None);
 
     // check that the url is still the same since there is one URL
     assert_eq!(client.current_url().as_str(), "http://nym-api1.test/");
@@ -138,13 +138,13 @@ fn host_updating() {
     client.change_base_urls(new_urls);
     assert_eq!(client.current_url().as_str(), "http://nym-api1.test/");
 
-    client.update_host();
+    client.update_host(None);
 
     // check that the url got updated now that there are multiple URLs
     assert_eq!(client.current_url().as_str(), "http://nym-api2.test/");
     assert_eq!(client.current_url().front_str(), None);
 
-    client.update_host();
+    client.update_host(None);
     assert_eq!(client.current_url().as_str(), "http://nym-api1.test/");
 
     // =======================================
@@ -162,9 +162,30 @@ fn host_updating() {
 
     assert_eq!(client.current_url().as_str(), "http://nym-api1.test/");
 
-    client.update_host();
+    client.update_host(None);
 
     // check that the url got updated now that there are multiple URLs
+    assert_eq!(client.current_url().as_str(), "http://nym-api2.test/");
+}
+
+#[test]
+fn host_updating_url_conditioned() {
+    let url1 = Url::new("http://nym-api1.test", None).unwrap();
+    let url2 = Url::new("http://nym-api2.test", None).unwrap();
+    let urls = vec![url1.clone(), url2.clone()];
+    let client = ClientBuilder::new_with_urls(urls).unwrap().build().unwrap();
+
+    assert_eq!(client.current_url().as_str(), "http://nym-api1.test/");
+
+    // Try to update with a URL that does NOT match current - should result in no change
+    client.update_host(Some(Url::parse("http://example.com").unwrap()));
+
+    // check that the url did NOT get updated
+    assert_eq!(client.current_url().as_str(), "http://nym-api1.test/");
+    assert_eq!(client.current_url().front_str(), None);
+
+    // Try to update with a URL that DOES match current - should result in no change
+    client.update_host(Some(url1));
     assert_eq!(client.current_url().as_str(), "http://nym-api2.test/");
 }
 
@@ -184,7 +205,7 @@ fn fronted_host_updating() {
     assert_eq!(current_url.front_str(), Some("cdn1.test"));
 
     // update the url
-    client.update_host();
+    client.update_host(None);
 
     // check that the url is still the same since there is one URL and one front
     let current_url = client.current_url();
@@ -209,7 +230,7 @@ fn fronted_host_updating() {
     assert_eq!(current_url.front_str(), Some("cdn1.test"));
 
     // update the url - this should keep the same host but change the front
-    client.update_host();
+    client.update_host(None);
 
     let current_url = client.current_url();
     // check that the url is still the same since there is one URL
@@ -217,7 +238,7 @@ fn fronted_host_updating() {
     assert_eq!(current_url.front_str(), Some("cdn2.test"));
 
     // update the url - this should wrap around to the first front as the second url is not fronted
-    client.update_host();
+    client.update_host(None);
 
     let current_url = client.current_url();
     assert_eq!(current_url.as_str(), "http://nym-api.test/");


### PR DESCRIPTION
Changes to make sure fallback domains are updated / enabled only for relevant errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6200)
<!-- Reviewable:end -->
