### PR TITLE
Allow for explicit DNS error Handling in HTTP client 

### DIFF
--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -88,6 +88,13 @@ pub enum ResolveError {
     StaticLookupMiss,
 }
 
+impl ResolveError {
+    /// Returns true if the error is a timeout.
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, ResolveError::Timeout)
+    }
+}
+
 /// Wrapper around an `AsyncResolver`, which implements the `Resolve` trait.
 ///
 /// Typical use involves instantiating using the `Default` implementation and then resolving using

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1090,7 +1090,9 @@ impl ApiClientCore for Client {
             if self.using_secure_dns
                 && let Some(hostname) = url.domain()
             {
-                let _ = HickoryDnsResolver::default().resolve_str(hostname).await?;
+                // on failure update host, but don't trigger fronting enable.
+                let _ = HickoryDnsResolver::default().resolve_str(hostname).await
+                    .inspect_err(|_| self.update_host())?;
             }
 
             #[cfg(target_arch = "wasm32")]

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1099,8 +1099,11 @@ impl ApiClientCore for Client {
                 self.update_host(Some(url.clone()));
 
                 if attempts < self.retry_limit {
-                    warn!("Retrying request due to http error: {err}");
                     attempts += 1;
+                    warn!(
+                        "Retrying request due to dns error on attempt ({attempts}/{}): {err}",
+                        self.retry_limit
+                    );
                     continue;
                 }
             }
@@ -1149,8 +1152,11 @@ impl ApiClientCore for Client {
                     }
 
                     if attempts < self.retry_limit {
-                        warn!("Retrying request due to http error: {err}");
                         attempts += 1;
+                        warn!(
+                            "Retrying request due to http error on attempt ({attempts}/{}): {err}",
+                            self.retry_limit
+                        );
                         continue;
                     }
 


### PR DESCRIPTION
when sending http reqs add manual DNS so we can handle errors directly

NET-732

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6201)
<!-- Reviewable:end -->
