### PR TITLE
chore: remove support for legacy mixnode within the performance contract

### DIFF
--- a/contracts/performance/src/helpers.rs
+++ b/contracts/performance/src/helpers.rs
@@ -3,7 +3,7 @@
 
 use cosmwasm_std::{from_json, Binary, CustomQuery, QuerierWrapper, StdError, StdResult};
 use cw_storage_plus::{Key, Namespace, Path, PrimaryKey};
-use nym_mixnet_contract_common::{Interval, MixNodeBond, NymNodeBond};
+use nym_mixnet_contract_common::{Interval, NymNodeBond};
 use nym_performance_contract_common::{EpochId, NodeId};
 use serde::de::DeserializeOwned;
 use std::ops::Deref;
@@ -51,15 +51,10 @@ pub(crate) trait MixnetContractQuerier {
     fn check_node_existence(&self, address: impl Into<String>, node_id: NodeId) -> StdResult<bool> {
         let mixnet_contract_address = address.into();
 
-        // 1. check if it's a nym-node
         if let Some(nym_node) = self.query_nymnode_bond(mixnet_contract_address.clone(), node_id)? {
             return Ok(!nym_node.is_unbonding);
         }
 
-        // 2. try a legacy mixnode
-        if let Some(nym_node) = self.query_mixnode_bond(mixnet_contract_address, node_id)? {
-            return Ok(!nym_node.is_unbonding);
-        }
         Ok(false)
     }
 
@@ -71,22 +66,6 @@ pub(crate) trait MixnetContractQuerier {
         // construct proper map key
         let pk_namespace = "nn";
         let path: Path<NymNodeBond> = Path::new(
-            Namespace::from_static_str(pk_namespace).as_slice(),
-            &node_id.key().iter().map(Key::as_ref).collect::<Vec<_>>(),
-        );
-        let storage_key = path.deref();
-
-        self.query_mixnet_contract_storage_value(address, storage_key)
-    }
-
-    fn query_mixnode_bond(
-        &self,
-        address: impl Into<String>,
-        node_id: NodeId,
-    ) -> StdResult<Option<MixNodeBond>> {
-        // construct proper map key
-        let pk_namespace = "mnn";
-        let path: Path<MixNodeBond> = Path::new(
             Namespace::from_static_str(pk_namespace).as_slice(),
             &node_id.key().iter().map(Key::as_ref).collect::<Vec<_>>(),
         );


### PR DESCRIPTION
given the rest of the network no longer supports those nodes, there's no point in having the "brand new" (kinda) contract support them either

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6205)
<!-- Reviewable:end -->
