### PR TITLE
Quick change to default dns config option

### DIFF
--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -337,8 +337,7 @@ fn configure_and_build_resolver(
     let mut resolver_builder =
         TokioResolver::builder_with_config(config, TokioConnectionProvider::default());
 
-    resolver_builder.options_mut().ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
-    resolver_builder.options_mut().server_ordering_strategy = ServerOrderingStrategy::RoundRobin;
+    resolver_builder.options_mut().ip_strategy = LookupIpStrategy::Ipv4thenIpv6;
     // Cache successful responses for queries received by this resolver for 30 min minimum.
     resolver_builder.options_mut().positive_min_ttl = Some(Duration::from_secs(1800));
 

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -39,7 +39,7 @@ use std::{
 
 use hickory_resolver::{
     TokioResolver,
-    config::{LookupIpStrategy, NameServerConfigGroup, ResolverConfig, ServerOrderingStrategy},
+    config::{LookupIpStrategy, NameServerConfigGroup, ResolverConfig},
     lookup_ip::LookupIpIntoIter,
     name_server::TokioConnectionProvider,
 };


### PR DESCRIPTION
This changes the configuration option for default DNS resolution to start by looking up `A` records and to only send requests for `AAAA` if no `A` record is available.

This should reduce the number of DNS requests that get created when doing parallel resolutions and help prevent the resource busy error related to the hickory buffer filling.

Also going back to the (default) statistics based nameserver ordering strategy should improve the success rate of queries in the case that one or more resolvers return errors or get overwhelmed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6208)
<!-- Reviewable:end -->
