### PR TITLE
chore: don't rederive wallet keys on every tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7398,6 +7398,7 @@ dependencies = [
 name = "nym-validator-client"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bip32",

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -75,6 +75,7 @@ workspace = true
 features = ["json", "rustls-tls"]
 
 [dev-dependencies]
+anyhow = { workspace = true }
 bip39 = { workspace = true }
 cosmrs = { workspace = true, features = ["bip32"] }
 ts-rs = { workspace = true }

--- a/common/client-libs/validator-client/src/client.rs
+++ b/common/client-libs/validator-client/src/client.rs
@@ -5,8 +5,7 @@ use crate::nyxd::{self, NyxdClient};
 use crate::signing::direct_wallet::DirectSecp256k1HdWallet;
 use crate::signing::signer::{NoSigner, OfflineSigner};
 use crate::{
-    DirectSigningReqwestRpcValidatorClient, QueryReqwestRpcValidatorClient, ReqwestRpcClient,
-    ValidatorClientError,
+    DirectSigningReqwestRpcValidatorClient, QueryReqwestRpcValidatorClient, ValidatorClientError,
 };
 use nym_api_requests::ecash::models::{
     AggregatedCoinIndicesSignatureResponse, AggregatedExpirationDateSignatureResponse,
@@ -164,7 +163,7 @@ impl Client<HttpRpcClient, DirectSecp256k1HdWallet> {
     ) -> Result<DirectSigningHttpRpcValidatorClient, ValidatorClientError> {
         let rpc_client = http_client(config.nyxd_url.as_str())?;
         let prefix = &config.nyxd_config.chain_details.bech32_account_prefix;
-        let wallet = DirectSecp256k1HdWallet::from_mnemonic(prefix, mnemonic);
+        let wallet = DirectSecp256k1HdWallet::checked_from_mnemonic(prefix, mnemonic)?;
 
         Ok(Self::new_signing_with_rpc_client(
             config, rpc_client, wallet,
@@ -177,12 +176,13 @@ impl Client<HttpRpcClient, DirectSecp256k1HdWallet> {
     }
 }
 
-impl Client<ReqwestRpcClient, DirectSecp256k1HdWallet> {
+#[allow(deprecated)]
+impl Client<crate::ReqwestRpcClient, DirectSecp256k1HdWallet> {
     pub fn new_reqwest_signing(
         config: Config,
         mnemonic: bip39::Mnemonic,
     ) -> DirectSigningReqwestRpcValidatorClient {
-        let rpc_client = ReqwestRpcClient::new(config.nyxd_url.clone());
+        let rpc_client = crate::ReqwestRpcClient::new(config.nyxd_url.clone());
         let prefix = &config.nyxd_config.chain_details.bech32_account_prefix;
         let wallet = DirectSecp256k1HdWallet::from_mnemonic(prefix, mnemonic);
 
@@ -203,9 +203,10 @@ impl Client<HttpRpcClient> {
     }
 }
 
-impl Client<ReqwestRpcClient> {
+#[allow(deprecated)]
+impl Client<crate::ReqwestRpcClient> {
     pub fn new_reqwest_query(config: Config) -> QueryReqwestRpcValidatorClient {
-        let rpc_client = ReqwestRpcClient::new(config.nyxd_url.clone());
+        let rpc_client = crate::ReqwestRpcClient::new(config.nyxd_url.clone());
         Self::new_with_rpc_client(config, rpc_client)
     }
 }

--- a/common/client-libs/validator-client/src/error.rs
+++ b/common/client-libs/validator-client/src/error.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::nym_api;
+use crate::signing::direct_wallet::DirectSecp256k1HdWalletError;
 pub use tendermint_rpc::error::Error as TendermintRpcError;
 use thiserror::Error;
 
@@ -26,6 +27,12 @@ pub enum ValidatorClientError {
 
     #[error("No validator API url has been provided")]
     NoAPIUrlAvailable,
+
+    #[error("failed to derive signing accounts: {source}")]
+    AccountDerivationFailure {
+        #[from]
+        source: DirectSecp256k1HdWalletError,
+    },
 }
 
 impl From<nym_api::error::NymAPIError> for ValidatorClientError {

--- a/common/client-libs/validator-client/src/lib.rs
+++ b/common/client-libs/validator-client/src/lib.rs
@@ -12,6 +12,7 @@ pub mod rpc;
 pub mod signing;
 
 pub use crate::error::ValidatorClientError;
+#[allow(deprecated)]
 pub use crate::rpc::reqwest::ReqwestRpcClient;
 pub use crate::signing::direct_wallet::DirectSecp256k1HdWallet;
 pub use client::{Client, Config, EcashApiClient};
@@ -38,9 +39,13 @@ pub type DirectSigningHttpRpcValidatorClient = Client<HttpRpcClient, DirectSecp2
 #[cfg(feature = "http-client")]
 pub type DirectSigningHttpRpcNyxdClient = nyxd::NyxdClient<HttpRpcClient, DirectSecp256k1HdWallet>;
 
+#[allow(deprecated)]
 pub type QueryReqwestRpcValidatorClient = Client<ReqwestRpcClient>;
+#[allow(deprecated)]
 pub type QueryReqwestRpcNyxdClient = nyxd::NyxdClient<ReqwestRpcClient>;
 
+#[allow(deprecated)]
 pub type DirectSigningReqwestRpcValidatorClient = Client<ReqwestRpcClient, DirectSecp256k1HdWallet>;
+#[allow(deprecated)]
 pub type DirectSigningReqwestRpcNyxdClient =
     nyxd::NyxdClient<ReqwestRpcClient, DirectSecp256k1HdWallet>;

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/dkg_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/dkg_signing_client.rs
@@ -178,7 +178,7 @@ where
             .ok_or_else(|| NyxdError::unavailable_contract_address("dkg contract"))?;
 
         let fee = fee.unwrap_or(Fee::Auto(Some(self.simulated_gas_multiplier())));
-        let signer_address = &self.signer_addresses()?[0];
+        let signer_address = &self.signer_addresses()[0];
 
         self.execute(signer_address, dkg_contract_address, &msg, fee, memo, funds)
             .await

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/ecash_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/ecash_signing_client.rs
@@ -99,7 +99,7 @@ where
             .ok_or_else(|| NyxdError::unavailable_contract_address("coconut bandwidth contract"))?;
 
         let fee = fee.unwrap_or(Fee::Auto(Some(self.simulated_gas_multiplier())));
-        let signer_address = &self.signer_addresses()?[0];
+        let signer_address = &self.signer_addresses()[0];
 
         self.execute(
             signer_address,

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/group_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/group_signing_client.rs
@@ -95,7 +95,7 @@ where
 
         let fee = fee.unwrap_or(Fee::Auto(Some(self.simulated_gas_multiplier())));
 
-        let signer_address = &self.signer_addresses()?[0];
+        let signer_address = &self.signer_addresses()[0];
         self.execute(
             signer_address,
             group_contract_address,

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/mixnet_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/mixnet_signing_client.rs
@@ -667,7 +667,7 @@ where
         let fee = fee.unwrap_or(Fee::Auto(Some(self.simulated_gas_multiplier())));
         let memo = msg.default_memo();
 
-        let signer_address = &self.signer_addresses()?[0];
+        let signer_address = &self.signer_addresses()[0];
         self.execute(
             signer_address,
             mixnet_contract_address,

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/multisig_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/multisig_signing_client.rs
@@ -133,7 +133,7 @@ where
 
         let fee = fee.unwrap_or(Fee::Auto(Some(self.simulated_gas_multiplier())));
 
-        let signer_address = &self.signer_addresses()?[0];
+        let signer_address = &self.signer_addresses()[0];
         self.execute(
             signer_address,
             multisig_contract_address,

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/performance_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/performance_signing_client.rs
@@ -165,7 +165,7 @@ where
 
         let fee = fee.unwrap_or(Fee::Auto(Some(self.simulated_gas_multiplier())));
 
-        let signer_address = &self.signer_addresses()?[0];
+        let signer_address = &self.signer_addresses()[0];
         self.execute(
             signer_address,
             performance_contract_address,

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/vesting_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/vesting_signing_client.rs
@@ -375,7 +375,7 @@ where
         let fee = fee.unwrap_or(Fee::Auto(Some(self.simulated_gas_multiplier())));
         let memo = msg.name().to_string();
 
-        let signer_address = &self.signer_addresses()?[0];
+        let signer_address = &self.signer_addresses()[0];
         self.execute(
             signer_address,
             vesting_contract_address,

--- a/common/client-libs/validator-client/src/nyxd/cosmwasm_client/mod.rs
+++ b/common/client-libs/validator-client/src/nyxd/cosmwasm_client/mod.rs
@@ -324,7 +324,7 @@ where
 {
     type Error = S::Error;
 
-    fn get_accounts(&self) -> Result<Vec<AccountData>, Self::Error> {
+    fn get_accounts(&self) -> &[AccountData] {
         self.signer.get_accounts()
     }
 

--- a/common/client-libs/validator-client/src/rpc/reqwest.rs
+++ b/common/client-libs/validator-client/src/rpc/reqwest.rs
@@ -42,12 +42,15 @@ macro_rules! perform_with_compat {
     }};
 }
 
+// the separate implementation is now completely redundant
+#[deprecated(note = "use HttpClient directly instead")]
 pub struct ReqwestRpcClient {
     compat: CompatMode,
     inner: reqwest::Client,
     url: Url,
 }
 
+#[allow(deprecated)]
 impl ReqwestRpcClient {
     pub fn new(url: Url) -> Self {
         ReqwestRpcClient {
@@ -131,6 +134,7 @@ impl TendermintRpcErrorMap for reqwest::Error {
     }
 }
 
+#[allow(deprecated)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl TendermintRpcClient for ReqwestRpcClient {

--- a/common/client-libs/validator-client/src/signing/mod.rs
+++ b/common/client-libs/validator-client/src/signing/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::signing::direct_wallet::DirectSecp256k1HdWalletError;
+use bip32::XPrv;
 use cosmrs::bip32::DerivationPath;
 use cosmrs::crypto::secp256k1::SigningKey;
 use cosmrs::crypto::PublicKey;
@@ -12,14 +14,64 @@ pub mod direct_wallet;
 pub mod signer;
 pub mod tx_signer;
 
+pub(crate) type Secp256k1Keypair = (SigningKey, PublicKey);
+
 /// Derivation information required to derive a keypair and an address from a mnemonic.
 #[derive(Debug, Clone)]
-struct Secp256k1Derivation {
+pub(crate) struct Secp256k1Derivation {
     hd_path: DerivationPath,
     prefix: String,
 }
 
-// TODO: is this struct going to be derivable with other signer types?
+impl Secp256k1Derivation {
+    pub(crate) fn try_derive_account<S>(
+        &self,
+        seed: S,
+    ) -> Result<AccountData, DirectSecp256k1HdWalletError>
+    where
+        S: AsRef<[u8]>,
+    {
+        let keypair = derive_keypair(seed, &self.hd_path)?;
+
+        // it seems this can only fail if the provided account prefix is invalid
+        let address = keypair
+            .1
+            .account_id(&self.prefix)
+            .map_err(|source| DirectSecp256k1HdWalletError::AccountDerivationError { source })?;
+
+        Ok(AccountData {
+            address,
+            public_key: keypair.1,
+            private_key: keypair.0,
+        })
+    }
+}
+
+fn derive_keypair<S>(
+    seed: S,
+    hd_path: &DerivationPath,
+) -> Result<Secp256k1Keypair, DirectSecp256k1HdWalletError>
+where
+    S: AsRef<[u8]>,
+{
+    let extended_private_key = derive_extended_private_key(seed, hd_path)?;
+
+    let private_key: SigningKey = extended_private_key.into();
+    let public_key = private_key.public_key();
+
+    Ok((private_key, public_key))
+}
+
+fn derive_extended_private_key<S>(
+    seed: S,
+    hd_path: &DerivationPath,
+) -> Result<XPrv, DirectSecp256k1HdWalletError>
+where
+    S: AsRef<[u8]>,
+{
+    Ok(XPrv::derive_from_path(seed, hd_path)?)
+}
+
 pub struct AccountData {
     pub address: AccountId,
 

--- a/common/client-libs/validator-client/src/signing/signer.rs
+++ b/common/client-libs/validator-client/src/signing/signer.rs
@@ -33,23 +33,18 @@ pub enum SignerType {
 pub trait OfflineSigner {
     type Error: From<SigningError>;
 
-    // I really dislike existence of this function because it makes you re-derive your key **twice** for each contract transaction
-    fn signer_addresses(&self) -> Result<Vec<AccountId>, Self::Error> {
-        let derived_addresses = self
-            .get_accounts()?
-            .into_iter()
-            .map(|account| account.address)
-            .collect();
-        Ok(derived_addresses)
+    fn signer_addresses(&self) -> Vec<AccountId> {
+        self.get_accounts()
+            .iter()
+            .map(|account| account.address.clone())
+            .collect()
     }
 
-    fn get_accounts(&self) -> Result<Vec<AccountData>, Self::Error>;
+    fn get_accounts(&self) -> &[AccountData];
 
-    fn find_account(&self, signer_address: &AccountId) -> Result<AccountData, Self::Error> {
-        // TODO: we could really use some zeroize action here
-        let accounts = self.get_accounts()?;
-        accounts
-            .into_iter()
+    fn find_account(&self, signer_address: &AccountId) -> Result<&AccountData, Self::Error> {
+        self.get_accounts()
+            .iter()
             .find(|account| &account.address == signer_address)
             .ok_or_else(|| {
                 SigningError::AccountNotFound {
@@ -76,7 +71,7 @@ pub trait OfflineSigner {
         message: M,
     ) -> Result<Signature, Self::Error> {
         let signer = self.find_account(signer_address)?;
-        self.sign_raw_with_account(&signer, message)
+        self.sign_raw_with_account(signer, message)
     }
 
     fn sign_direct(
@@ -85,7 +80,7 @@ pub trait OfflineSigner {
         sign_doc: SignDoc,
     ) -> Result<tx::Raw, Self::Error> {
         let signer = self.find_account(signer_address)?;
-        self.sign_direct_with_account(&signer, sign_doc)
+        self.sign_direct_with_account(signer, sign_doc)
     }
 
     // unless explicitly defined, each signing method is unsupported
@@ -122,7 +117,7 @@ pub struct NoSigner;
 // impl OfflineSigner for NoSigner {
 //     type Error = SignerUnavailable;
 //
-//     fn get_accounts(&self) -> Result<Vec<AccountData>, Self::Error> {
+//     fn get_accounts(&self) -> &[AccountData] {
 //         return Err(SignerUnavailable);
 //     }
 // }

--- a/common/client-libs/validator-client/src/signing/tx_signer.rs
+++ b/common/client-libs/validator-client/src/signing/tx_signer.rs
@@ -50,7 +50,7 @@ pub trait TxSigner: OfflineSigner {
         )
         .map_err(|source| SigningError::SignDocFailure { source })?;
 
-        self.sign_direct_with_account(&account_from_signer, sign_doc)
+        self.sign_direct_with_account(account_from_signer, sign_doc)
     }
 }
 

--- a/common/commands/src/validator/account/create.rs
+++ b/common/commands/src/validator/account/create.rs
@@ -3,6 +3,7 @@
 
 use clap::Parser;
 use nym_validator_client::signing::direct_wallet::DirectSecp256k1HdWallet;
+use nym_validator_client::signing::signer::OfflineSigner;
 
 #[derive(Debug, Parser)]
 pub struct Args {
@@ -15,9 +16,10 @@ pub fn create_account(args: Args, prefix: &str) {
     let word_count = args.word_count.unwrap_or(24);
     let mnemonic = bip39::Mnemonic::generate(word_count).expect("failed to generate mnemonic!");
 
-    let wallet = DirectSecp256k1HdWallet::from_mnemonic(prefix, mnemonic);
+    let wallet = DirectSecp256k1HdWallet::checked_from_mnemonic(prefix, mnemonic)
+        .expect("failed to derive accounts!");
 
     // Output address and mnemonics into separate lines for easier parsing
     println!("{}", wallet.mnemonic_string().as_str());
-    println!("{}", wallet.try_derive_accounts().unwrap()[0].address());
+    println!("{}", wallet.signer_addresses()[0]);
 }

--- a/common/types/src/error.rs
+++ b/common/types/src/error.rs
@@ -1,6 +1,7 @@
 use nym_mixnet_contract_common::ContractsCommonError;
 use nym_validator_client::error::TendermintRpcError;
 use nym_validator_client::nym_api::error::NymAPIError;
+use nym_validator_client::signing::direct_wallet::DirectSecp256k1HdWalletError;
 use nym_validator_client::{nyxd::error::NyxdError, ValidatorClientError};
 use serde::{Serialize, Serializer};
 use std::io;
@@ -59,6 +60,8 @@ pub enum TypesError {
         #[from]
         source: cosmwasm_std::DecimalRangeExceeded,
     },
+    #[error(transparent)]
+    AccountDerivationFailure(#[from] DirectSecp256k1HdWalletError),
     #[error("No nym API URL configured")]
     NoNymApiUrlConfigured,
     #[error("{0} is not a valid amount string")]
@@ -113,6 +116,7 @@ impl From<ValidatorClientError> for TypesError {
             ValidatorClientError::InconsistentPagedMetadata => {
                 TypesError::InconsistentPagedMetadata
             }
+            ValidatorClientError::AccountDerivationFailure { source } => source.into(),
         }
     }
 }

--- a/contracts/coconut-dkg/src/support/tests/fixtures.rs
+++ b/contracts/coconut-dkg/src/support/tests/fixtures.rs
@@ -17,7 +17,7 @@ pub fn vk_share_fixture(owner: &str, index: u64) -> ContractVKShare {
         node_index: index,
         owner: Addr::unchecked(owner),
         epoch_id: index,
-        verified: index % 2 == 0,
+        verified: index.is_multiple_of(2),
     }
 }
 

--- a/contracts/coconut-dkg/src/support/tests/fixtures.rs
+++ b/contracts/coconut-dkg/src/support/tests/fixtures.rs
@@ -17,7 +17,7 @@ pub fn vk_share_fixture(owner: &str, index: u64) -> ContractVKShare {
         node_index: index,
         owner: Addr::unchecked(owner),
         epoch_id: index,
-        verified: index.is_multiple_of(2),
+        verified: index % 2 == 0,
     }
 }
 

--- a/nym-wallet/src-tauri/src/operations/mixnet/account.rs
+++ b/nym-wallet/src-tauri/src/operations/mixnet/account.rs
@@ -11,7 +11,7 @@ use nym_config::defaults::{NymNetworkDetails, COSMOS_DERIVATION_PATH};
 use nym_types::account::{Account, AccountEntry, Balance};
 use nym_validator_client::nyxd::CosmWasmClient;
 use nym_validator_client::signing::direct_wallet::DirectSecp256k1HdWallet;
-use nym_validator_client::signing::AccountData;
+use nym_validator_client::signing::signer::OfflineSigner;
 use nym_validator_client::DirectSigningHttpRpcValidatorClient;
 use nym_wallet_types::network::Network as WalletNetwork;
 use std::collections::HashMap;
@@ -575,10 +575,10 @@ fn derive_address(
     prefix: &str,
 ) -> Result<cosmrs::AccountId, BackendError> {
     // note: the ephemeral wallet will zeroize the mnemonic on drop
-    DirectSecp256k1HdWallet::from_mnemonic(prefix, mnemonic)
-        .try_derive_accounts()?
+    DirectSecp256k1HdWallet::checked_from_mnemonic(prefix, mnemonic)
+        .map_err(|_| BackendError::FailedToDeriveAddress)?
+        .signer_addresses()
         .first()
-        .map(AccountData::address)
         .cloned()
         .ok_or(BackendError::FailedToDeriveAddress)
 }

--- a/nym-wallet/src-tauri/src/operations/signatures/sign.rs
+++ b/nym-wallet/src-tauri/src/operations/signatures/sign.rs
@@ -24,7 +24,7 @@ pub async fn sign(
 ) -> Result<String, BackendError> {
     let guard = state.read().await;
     let client = guard.current_client()?;
-    let derived_accounts = client.nyxd.get_accounts()?;
+    let derived_accounts = client.nyxd.get_accounts();
     let account = derived_accounts.first().ok_or_else(|| {
         log::error!(">>> Unable to derive account");
         BackendError::SignatureError("unable to derive account".to_string())

--- a/tools/internal/testnet-manager/src/manager/contract.rs
+++ b/tools/internal/testnet-manager/src/manager/contract.rs
@@ -7,6 +7,7 @@ use nym_validator_client::nyxd::cosmwasm_client::types::{
     ContractCodeId, InstantiateResult, MigrateResult, UploadResult,
 };
 use nym_validator_client::nyxd::{AccountId, Hash};
+use nym_validator_client::signing::signer::OfflineSigner;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -145,12 +146,9 @@ impl Account {
     pub(crate) fn new() -> Account {
         let mnemonic = bip39::Mnemonic::generate(24).unwrap();
         // sure, we're using hardcoded prefix, but realistically this will never change
-        let wallet = DirectSecp256k1HdWallet::from_mnemonic("n", mnemonic.clone());
-        let acc = wallet.try_derive_accounts().unwrap().pop().unwrap();
-        Account {
-            address: acc.address,
-            mnemonic,
-        }
+        let wallet = DirectSecp256k1HdWallet::checked_from_mnemonic("n", mnemonic.clone()).unwrap();
+        let address = wallet.signer_addresses().pop().unwrap();
+        Account { address, mnemonic }
     }
 
     pub(crate) fn address(&self) -> AccountId {


### PR DESCRIPTION
A small change I've been meaning to do for a while now. the cosmrs' trait bounds on `EcdsaSigner` got updated to include `Send` and `Sync`, meaning we no longer need to derive private keys on every transaction and instead we can just do it once, on construction.

note that I had to deprecate some builder methods as they're no longer safe (i.e. they can possibly panic). They were not removed so it wouldn't break compatibility with the library consumers (_looking at VPN-core_)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6213)
<!-- Reviewable:end -->
