### PR TITLE
[bugfix] Tunnel not waiting on MixnetClient to shut down cleanly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4825,7 +4825,7 @@ dependencies = [
 
 [[package]]
 name = "nym-api"
-version = "1.1.69"
+version = "1.1.70"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5051,7 +5051,7 @@ dependencies = [
 
 [[package]]
 name = "nym-cli"
-version = "1.1.66"
+version = "1.1.67"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "nym-client"
-version = "1.1.66"
+version = "1.1.67"
 dependencies = [
  "bs58",
  "clap",
@@ -6363,7 +6363,7 @@ dependencies = [
 
 [[package]]
 name = "nym-network-requester"
-version = "1.1.67"
+version = "1.1.68"
 dependencies = [
  "addr",
  "anyhow",
@@ -6413,7 +6413,7 @@ dependencies = [
 
 [[package]]
 name = "nym-node"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6940,7 +6940,7 @@ dependencies = [
 
 [[package]]
 name = "nym-socks5-client"
-version = "1.1.66"
+version = "1.1.67"
 dependencies = [
  "bs58",
  "clap",
@@ -7681,7 +7681,7 @@ dependencies = [
 
 [[package]]
 name = "nymvisor"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
When there is a wireguard registration error, the mixnet client is signalled to shut down, but the tunnel doesn't wait. 
Now on errors, the registration client doesn't return until everything is properly stopped

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6225)
<!-- Reviewable:end -->
