### PR TITLE
fix: fix assertion

### DIFF
--- a/nym-node/src/config/gateway_tasks.rs
+++ b/nym-node/src/config/gateway_tasks.rs
@@ -133,7 +133,7 @@ impl ZkNymTicketHandlerDebug {
     pub const DEFAULT_MINIMUM_API_QUORUM: f32 = 0.7;
     pub const DEFAULT_MINIMUM_REDEMPTION_TICKETS: usize = 100;
 
-    // use min(4/5 of max validity, validity - 1), but making sure it's no greater than 1 day
+    // use min(4/5 of max validity, validity - 1), but making sure it's no lower than 1 day
     // ASSUMPTION: our validity period is AT LEAST 2 days
     //
     // this could have been a constant, but it's more readable as a function

--- a/nym-node/src/config/gateway_tasks.rs
+++ b/nym-node/src/config/gateway_tasks.rs
@@ -149,7 +149,7 @@ impl ZkNymTicketHandlerDebug {
         };
 
         assert!(
-            target_secs > 86400,
+            target_secs >= 86400,
             "the maximum time between redemption can't be lower than 1 day!"
         );
         Duration::from_secs(target_secs as u64)

--- a/nym-node/src/config/old_configs/old_config_v10.rs
+++ b/nym-node/src/config/old_configs/old_config_v10.rs
@@ -598,7 +598,7 @@ impl ZkNymTicketHandlerDebugV10 {
         };
 
         assert!(
-            target_secs > 86400,
+            target_secs >= 86400,
             "the maximum time between redemption can't be lower than 1 day!"
         );
         Duration::from_secs(target_secs as u64)

--- a/nym-node/src/config/old_configs/old_config_v10.rs
+++ b/nym-node/src/config/old_configs/old_config_v10.rs
@@ -582,7 +582,7 @@ impl ZkNymTicketHandlerDebugV10 {
     pub const DEFAULT_MINIMUM_API_QUORUM: f32 = 0.8;
     pub const DEFAULT_MINIMUM_REDEMPTION_TICKETS: usize = 100;
 
-    // use min(4/5 of max validity, validity - 1), but making sure it's no greater than 1 day
+    // use min(4/5 of max validity, validity - 1), but making sure it's no lower than 1 day
     // ASSUMPTION: our validity period is AT LEAST 2 days
     //
     // this could have been a constant, but it's more readable as a function

--- a/nym-node/src/config/old_configs/old_config_v4.rs
+++ b/nym-node/src/config/old_configs/old_config_v4.rs
@@ -436,7 +436,7 @@ impl ZkNymTicketHandlerDebugV4 {
         };
 
         assert!(
-            target_secs > 86400,
+            target_secs >= 86400,
             "the maximum time between redemption can't be lower than 1 day!"
         );
         Duration::from_secs(target_secs as u64)

--- a/nym-node/src/config/old_configs/old_config_v4.rs
+++ b/nym-node/src/config/old_configs/old_config_v4.rs
@@ -420,7 +420,7 @@ impl ZkNymTicketHandlerDebugV4 {
     pub const DEFAULT_MINIMUM_API_QUORUM: f32 = 0.8;
     pub const DEFAULT_MINIMUM_REDEMPTION_TICKETS: usize = 100;
 
-    // use min(4/5 of max validity, validity - 1), but making sure it's no greater than 1 day
+    // use min(4/5 of max validity, validity - 1), but making sure it's no lower than 1 day
     // ASSUMPTION: our validity period is AT LEAST 2 days
     //
     // this could have been a constant, but it's more readable as a function

--- a/nym-node/src/config/old_configs/old_config_v5.rs
+++ b/nym-node/src/config/old_configs/old_config_v5.rs
@@ -422,7 +422,7 @@ impl ZkNymTicketHandlerDebugV5 {
     pub const DEFAULT_MINIMUM_API_QUORUM: f32 = 0.8;
     pub const DEFAULT_MINIMUM_REDEMPTION_TICKETS: usize = 100;
 
-    // use min(4/5 of max validity, validity - 1), but making sure it's no greater than 1 day
+    // use min(4/5 of max validity, validity - 1), but making sure it's no lower than 1 day
     // ASSUMPTION: our validity period is AT LEAST 2 days
     //
     // this could have been a constant, but it's more readable as a function

--- a/nym-node/src/config/old_configs/old_config_v5.rs
+++ b/nym-node/src/config/old_configs/old_config_v5.rs
@@ -438,7 +438,7 @@ impl ZkNymTicketHandlerDebugV5 {
         };
 
         assert!(
-            target_secs > 86400,
+            target_secs >= 86400,
             "the maximum time between redemption can't be lower than 1 day!"
         );
         Duration::from_secs(target_secs as u64)

--- a/nym-node/src/config/old_configs/old_config_v6.rs
+++ b/nym-node/src/config/old_configs/old_config_v6.rs
@@ -458,7 +458,7 @@ impl ZkNymTicketHandlerDebugV6 {
         };
 
         assert!(
-            target_secs > 86400,
+            target_secs >= 86400,
             "the maximum time between redemption can't be lower than 1 day!"
         );
         Duration::from_secs(target_secs as u64)

--- a/nym-node/src/config/old_configs/old_config_v6.rs
+++ b/nym-node/src/config/old_configs/old_config_v6.rs
@@ -442,7 +442,7 @@ impl ZkNymTicketHandlerDebugV6 {
     pub const DEFAULT_MINIMUM_API_QUORUM: f32 = 0.8;
     pub const DEFAULT_MINIMUM_REDEMPTION_TICKETS: usize = 100;
 
-    // use min(4/5 of max validity, validity - 1), but making sure it's no greater than 1 day
+    // use min(4/5 of max validity, validity - 1), but making sure it's no lower than 1 day
     // ASSUMPTION: our validity period is AT LEAST 2 days
     //
     // this could have been a constant, but it's more readable as a function

--- a/nym-node/src/config/old_configs/old_config_v7.rs
+++ b/nym-node/src/config/old_configs/old_config_v7.rs
@@ -516,7 +516,7 @@ impl ZkNymTicketHandlerDebugV7 {
         };
 
         assert!(
-            target_secs > 86400,
+            target_secs >= 86400,
             "the maximum time between redemption can't be lower than 1 day!"
         );
         Duration::from_secs(target_secs as u64)

--- a/nym-node/src/config/old_configs/old_config_v7.rs
+++ b/nym-node/src/config/old_configs/old_config_v7.rs
@@ -500,7 +500,7 @@ impl ZkNymTicketHandlerDebugV7 {
     pub const DEFAULT_MINIMUM_API_QUORUM: f32 = 0.8;
     pub const DEFAULT_MINIMUM_REDEMPTION_TICKETS: usize = 100;
 
-    // use min(4/5 of max validity, validity - 1), but making sure it's no greater than 1 day
+    // use min(4/5 of max validity, validity - 1), but making sure it's no lower than 1 day
     // ASSUMPTION: our validity period is AT LEAST 2 days
     //
     // this could have been a constant, but it's more readable as a function

--- a/nym-node/src/config/old_configs/old_config_v8.rs
+++ b/nym-node/src/config/old_configs/old_config_v8.rs
@@ -490,7 +490,7 @@ impl ZkNymTicketHandlerDebugV8 {
         };
 
         assert!(
-            target_secs > 86400,
+            target_secs >= 86400,
             "the maximum time between redemption can't be lower than 1 day!"
         );
         Duration::from_secs(target_secs as u64)

--- a/nym-node/src/config/old_configs/old_config_v8.rs
+++ b/nym-node/src/config/old_configs/old_config_v8.rs
@@ -474,7 +474,7 @@ impl ZkNymTicketHandlerDebugV8 {
     pub const DEFAULT_MINIMUM_API_QUORUM: f32 = 0.8;
     pub const DEFAULT_MINIMUM_REDEMPTION_TICKETS: usize = 100;
 
-    // use min(4/5 of max validity, validity - 1), but making sure it's no greater than 1 day
+    // use min(4/5 of max validity, validity - 1), but making sure it's no lower than 1 day
     // ASSUMPTION: our validity period is AT LEAST 2 days
     //
     // this could have been a constant, but it's more readable as a function

--- a/nym-node/src/config/old_configs/old_config_v9.rs
+++ b/nym-node/src/config/old_configs/old_config_v9.rs
@@ -591,7 +591,7 @@ impl ZkNymTicketHandlerDebugV9 {
         };
 
         assert!(
-            target_secs > 86400,
+            target_secs >= 86400,
             "the maximum time between redemption can't be lower than 1 day!"
         );
         Duration::from_secs(target_secs as u64)

--- a/nym-node/src/config/old_configs/old_config_v9.rs
+++ b/nym-node/src/config/old_configs/old_config_v9.rs
@@ -575,7 +575,7 @@ impl ZkNymTicketHandlerDebugV9 {
     pub const DEFAULT_MINIMUM_API_QUORUM: f32 = 0.8;
     pub const DEFAULT_MINIMUM_REDEMPTION_TICKETS: usize = 100;
 
-    // use min(4/5 of max validity, validity - 1), but making sure it's no greater than 1 day
+    // use min(4/5 of max validity, validity - 1), but making sure it's no lower than 1 day
     // ASSUMPTION: our validity period is AT LEAST 2 days
     //
     // this could have been a constant, but it's more readable as a function


### PR DESCRIPTION
The inconsistency among comment, code and assertion cause confusion here, which should be fixed.
The assumption("ASSUMPTION: our validity period is AT LEAST 2 days") indicates that TICKETBOOK_VALIDITY_DAYS >= 2 days, which indicates TICKETBOOK_VALIDITY_DAYS - 1 >= 1 day. So target_secs should be >= 86400.
The comment will cause the confusion("making sure it's no greater than 1 day"). It indicate that it should be <= 86400, which is wrong semantically and should be changed it into "no lower than 1 day". 
The assertion message requires target_secs >= 86400("no lower than"), while the predicate is target_secs > 86400, so I changed it into `assert!(target_secs >= 86400,"the maximum time between redemption can't be lower than 1 day!");`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6238)
<!-- Reviewable:end -->
