### PR TITLE
Support different ipv6 network device in network-tunnel-manager.sh

### DIFF
--- a/documentation/docs/components/outputs/command-outputs/nym-node-cli-install-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-node-cli-install-help.md
@@ -7,7 +7,8 @@ usage: nym-node-cli install [-h] [-V] [-d BRANCH] [-v]
                             [--description DESCRIPTION]
                             [--public-ip PUBLIC_IP]
                             [--nym-node-binary NYM_NODE_BINARY]
-                            [--uplink-dev UPLINK_DEV] [--env KEY=VALUE]
+                            [--uplink-dev-v4 IPV4_UPLINK_DEV]
+                            [--uplink-dev-v6 IPV6_UPLINK_DEV] [--env KEY=VALUE]
 
 options:
   -h, --help            show this help message and exit
@@ -30,8 +31,11 @@ options:
                         External IPv4 address (autodetected if omitted)
   --nym-node-binary NYM_NODE_BINARY
                         URL for nym-node binary (autodetected if omitted)
-  --uplink-dev UPLINK_DEV
-                        Override uplink interface used for NAT/FORWARD (e.g.,
+  --uplink-dev-v4 IPV4_UPLINK_DEV
+                        Override ipv4 uplink interface used for NAT/FORWARD (e.g.,
                         'eth0'; autodetected if omitted)
+  --uplink-dev-v6 IPV6_UPLINK_DEV
+                        Override ipv6 uplink interface used for NAT/FORWARD (e.g.,
+                        'eth0.1'; autodetected if omitted)
   --env KEY=VALUE       (Optional) Extra ENV VARS, e.g. --env CUSTOM_KEY=value
 ```

--- a/documentation/docs/components/outputs/command-outputs/nym-node-cli-install-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-node-cli-install-help.md
@@ -7,7 +7,7 @@ usage: nym-node-cli install [-h] [-V] [-d BRANCH] [-v]
                             [--description DESCRIPTION]
                             [--public-ip PUBLIC_IP]
                             [--nym-node-binary NYM_NODE_BINARY]
-                            [--uplink-dev-v4 IPV4_UPLINK_DEV]
+                            [--uplink-dev IPV4_UPLINK_DEV]
                             [--uplink-dev-v6 IPV6_UPLINK_DEV] [--env KEY=VALUE]
 
 options:
@@ -31,7 +31,7 @@ options:
                         External IPv4 address (autodetected if omitted)
   --nym-node-binary NYM_NODE_BINARY
                         URL for nym-node binary (autodetected if omitted)
-  --uplink-dev-v4 IPV4_UPLINK_DEV
+  --uplink-dev IPV4_UPLINK_DEV
                         Override ipv4 uplink interface used for NAT/FORWARD (e.g.,
                         'eth0'; autodetected if omitted)
   --uplink-dev-v6 IPV6_UPLINK_DEV

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -89,13 +89,15 @@ WG_INTERFACE="${WG_INTERFACE:-nymwg}"
 
 # Function to detect and validate uplink interface
 detect_uplink_interface() {
+  local aflag="$1"                  # -4 or -6
+  local etyp="ahosts${aflag//-/v}"  # ahostsv4 or ahostsv6
   local host="$2"
-  local ip
-  local dev
+  local ip dev
 
-  ip="$(getent ahosts${1//-/v} "$host" 2>/dev/null | awk '$2=="STREAM" {print $1}' | head -n1 || true)"
-  dev="$(ip $1 -o route get "$ip" 2>/dev/null | awk '{print $5}' || true)"
-
+  ip="$(getent "$etyp" "$host" 2>/dev/null | awk '$2=="STREAM" {print $1}' | head -n1 || true)"
+  if [[ -n "$ip" ]]; then
+    dev="$(ip "$aflag" -o route get "$ip" 2>/dev/null | awk '{print $5}' || true)"
+  fi
   if [[ -n "$dev" && "$dev" =~ ^[a-zA-Z0-9._-]+$ ]]; then
     echo "$dev"
   else

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -93,8 +93,8 @@ detect_uplink_interface() {
   local ip
   local dev
 
-  ip="$(getent ahostsv${1//-/} "$host" 2>/dev/null | awk '{print $1}' | head -n1 || true)"
-  dev="$(ip -$1 route get "$ip" 2>/dev/null | awk '{print $5}' | head -n1 || true)"
+  ip="$(getent ahosts${1//-/v} "$host" 2>/dev/null | awk '$2=="STREAM" {print $1}' | head -n1 || true)"
+  dev="$(ip $1 route get "$ip" 2>/dev/null | awk '{print $5}' | head -n1 || true)"
 
   if [[ -n "$dev" && "$dev" =~ ^[a-zA-Z0-9._-]+$ ]]; then
     echo "$dev"

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -94,7 +94,7 @@ detect_uplink_interface() {
   local dev
 
   ip="$(getent ahosts${1//-/v} "$host" 2>/dev/null | awk '$2=="STREAM" {print $1}' | head -n1 || true)"
-  dev="$(ip $1 route get "$ip" 2>/dev/null | awk '{print $5}' | head -n1 || true)"
+  dev="$(ip $1 -o route get "$ip" 2>/dev/null | awk '{print $5}' || true)"
 
   if [[ -n "$dev" && "$dev" =~ ^[a-zA-Z0-9._-]+$ ]]; then
     echo "$dev"
@@ -104,20 +104,20 @@ detect_uplink_interface() {
 }
 
 # uplink device detection, can be overridden
-NET4_DEVICE="${NET4_DEVICE:-}"
-if [[ -z "$NET4_DEVICE" ]]; then
-  NET4_DEVICE="$(detect_uplink_interface -4 "ifconfig.co")"
+IPV4_UPLINK_DEV="${IPV4_UPLINK_DEV:-}"
+if [[ -z "$IPV4_UPLINK_DEV" ]]; then
+  IPV4_UPLINK_DEV="$(detect_uplink_interface -4 "ifconfig.co")"
 fi
-if [[ -z "$NET4_DEVICE" ]]; then
-  error "cannot determine ipv4 uplink interface. set NET4_DEVICE or UPLINK_DEV"
+if [[ -z "$IPV4_UPLINK_DEV" ]]; then
+  error "cannot determine ipv4 uplink interface. set IPV4_UPLINK_DEV"
   exit 1
 fi
-NET6_DEVICE="${NET6_DEVICE:-}"
-if [[ -z "$NET6_DEVICE" ]]; then
-  NET6_DEVICE="$(detect_uplink_interface -6 "ifconfig.co")"
+IPV6_UPLINK_DEV="${IPV6_UPLINK_DEV:-}"
+if [[ -z "$IPV6_UPLINK_DEV" ]]; then
+  IPV6_UPLINK_DEV="$(detect_uplink_interface -6 "ifconfig.co")"
 fi
-if [[ -z "$NET6_DEVICE" ]]; then
-  error "cannot determine ipv6 uplink interface. set NET6_DEVICE or UPLINK_DEV"
+if [[ -z "$IPV6_UPLINK_DEV" ]]; then
+  error "cannot determine ipv6 uplink interface. set IPV6_UPLINK_DEV"
   exit 1
 fi
 
@@ -201,11 +201,11 @@ fetch_ipv6_address() {
 
 fetch_and_display_ipv6() {
   local ipv6_address
-  ipv6_address=$(ip -6 addr show "$NET6_DEVICE" scope global | awk '/inet6/ {print $2}')
+  ipv6_address=$(ip -6 addr show "$IPV6_UPLINK_DEV" scope global | awk '/inet6/ {print $2}')
   if [[ -z "$ipv6_address" ]]; then
-    error "no global ipv6 address found on $NET6_DEVICE"
+    error "no global ipv6 address found on $IPV6_UPLINK_DEV"
   else
-    ok "ipv6 address on $NET6_DEVICE: $ipv6_address"
+    ok "ipv6 address on $IPV6_UPLINK_DEV: $ipv6_address"
   fi
 }
 
@@ -350,29 +350,31 @@ remove_duplicate_rules() {
 
 apply_iptables_rules() {
   local interface=$1
-  info "applying iptables rules for $interface using uplink $NET4_DEVICE"
-  info "applying ip6tables rules for $interface using uplink $NET6_DEVICE"
+  info "applying iptables rules for $interface using uplink $IPV4_UPLINK_DEV"
   sleep 1
 
   # ipv4 nat and forwarding
-  iptables -t nat -C POSTROUTING -o "$NET4_DEVICE" -j MASQUERADE 2>/dev/null || \
-    iptables -t nat -A POSTROUTING -o "$NET4_DEVICE" -j MASQUERADE
+  iptables -t nat -C POSTROUTING -o "$IPV4_UPLINK_DEV" -j MASQUERADE 2>/dev/null || \
+    iptables -t nat -A POSTROUTING -o "$IPV4_UPLINK_DEV" -j MASQUERADE
 
-  iptables -C FORWARD -i "$interface" -o "$NET4_DEVICE" -j ACCEPT 2>/dev/null || \
-    iptables -I FORWARD 1 -i "$interface" -o "$NET4_DEVICE" -j ACCEPT
+  iptables -C FORWARD -i "$interface" -o "$IPV4_UPLINK_DEV" -j ACCEPT 2>/dev/null || \
+    iptables -I FORWARD 1 -i "$interface" -o "$IPV4_UPLINK_DEV" -j ACCEPT
 
-  iptables -C FORWARD -i "$NET4_DEVICE" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || \
-    iptables -I FORWARD 2 -i "$NET4_DEVICE" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
+  iptables -C FORWARD -i "$IPV4_UPLINK_DEV" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || \
+    iptables -I FORWARD 2 -i "$IPV4_UPLINK_DEV" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+  info "applying ip6tables rules for $interface using uplink $IPV6_UPLINK_DEV"
+  sleep 1
 
   # ipv6 nat and forwarding
-  ip6tables -t nat -C POSTROUTING -o "$NET6_DEVICE" -j MASQUERADE 2>/dev/null || \
-    ip6tables -t nat -A POSTROUTING -o "$NET6_DEVICE" -j MASQUERADE
+  ip6tables -t nat -C POSTROUTING -o "$IPV6_UPLINK_DEV" -j MASQUERADE 2>/dev/null || \
+    ip6tables -t nat -A POSTROUTING -o "$IPV6_UPLINK_DEV" -j MASQUERADE
 
-  ip6tables -C FORWARD -i "$interface" -o "$NET6_DEVICE" -j ACCEPT 2>/dev/null || \
-    ip6tables -I FORWARD 1 -i "$interface" -o "$NET6_DEVICE" -j ACCEPT
+  ip6tables -C FORWARD -i "$interface" -o "$IPV6_UPLINK_DEV" -j ACCEPT 2>/dev/null || \
+    ip6tables -I FORWARD 1 -i "$interface" -o "$IPV6_UPLINK_DEV" -j ACCEPT
 
-  ip6tables -C FORWARD -i "$NET6_DEVICE" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || \
-    ip6tables -I FORWARD 2 -i "$NET6_DEVICE" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
+  ip6tables -C FORWARD -i "$IPV6_UPLINK_DEV" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || \
+    ip6tables -I FORWARD 2 -i "$IPV6_UPLINK_DEV" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
 
   save_iptables_rules
 }
@@ -547,38 +549,40 @@ create_nym_chain() {
     ip6tables -N "$NYM_CHAIN"
   fi
 
-  if ! iptables -C FORWARD -i "$WG_INTERFACE" -o "$NET4_DEVICE" -j "$NYM_CHAIN" 2>/dev/null; then
-    iptables -I FORWARD 1 -i "$WG_INTERFACE" -o "$NET4_DEVICE" -j "$NYM_CHAIN"
+  if ! iptables -C FORWARD -i "$WG_INTERFACE" -o "$IPV4_UPLINK_DEV" -j "$NYM_CHAIN" 2>/dev/null; then
+    iptables -I FORWARD 1 -i "$WG_INTERFACE" -o "$IPV4_UPLINK_DEV" -j "$NYM_CHAIN"
   fi
 
-  if ! ip6tables -C FORWARD -i "$WG_INTERFACE" -o "$NET6_DEVICE" -j "$NYM_CHAIN" 2>/dev/null; then
-    ip6tables -I FORWARD 1 -i "$WG_INTERFACE" -o "$NET6_DEVICE" -j "$NYM_CHAIN"
+  if ! ip6tables -C FORWARD -i "$WG_INTERFACE" -o "$IPV6_UPLINK_DEV" -j "$NYM_CHAIN" 2>/dev/null; then
+    ip6tables -I FORWARD 1 -i "$WG_INTERFACE" -o "$IPV6_UPLINK_DEV" -j "$NYM_CHAIN"
   fi
 }
 
 setup_nat_rules() {
-  info "setting up ipv4 nat and forwarding rules for $WG_INTERFACE via $NET4_DEVICE"
-  info "setting up ipv6 nat and forwarding rules for $WG_INTERFACE via $NET6_DEVICE"
+  info "setting up ipv4 nat and forwarding rules for $WG_INTERFACE via $IPV4_UPLINK_DEV"
 
-  if ! iptables -t nat -C POSTROUTING -o "$NET4_DEVICE" -j MASQUERADE 2>/dev/null; then
-    iptables -t nat -A POSTROUTING -o "$NET4_DEVICE" -j MASQUERADE
-  fi
-  if ! ip6tables -t nat -C POSTROUTING -o "$NET6_DEVICE" -j MASQUERADE 2>/dev/null; then
-    ip6tables -t nat -A POSTROUTING -o "$NET6_DEVICE" -j MASQUERADE
+  if ! iptables -t nat -C POSTROUTING -o "$IPV4_UPLINK_DEV" -j MASQUERADE 2>/dev/null; then
+    iptables -t nat -A POSTROUTING -o "$IPV4_UPLINK_DEV" -j MASQUERADE
   fi
 
-  if ! iptables -C FORWARD -i "$WG_INTERFACE" -o "$NET4_DEVICE" -j ACCEPT 2>/dev/null; then
-    iptables -I FORWARD 1 -i "$WG_INTERFACE" -o "$NET4_DEVICE" -j ACCEPT
+  if ! iptables -C FORWARD -i "$WG_INTERFACE" -o "$IPV4_UPLINK_DEV" -j ACCEPT 2>/dev/null; then
+    iptables -I FORWARD 1 -i "$WG_INTERFACE" -o "$IPV4_UPLINK_DEV" -j ACCEPT
   fi
-  if ! iptables -C FORWARD -i "$NET4_DEVICE" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null; then
-    iptables -I FORWARD 2 -i "$NET4_DEVICE" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT
+  if ! iptables -C FORWARD -i "$IPV4_UPLINK_DEV" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null; then
+    iptables -I FORWARD 2 -i "$IPV4_UPLINK_DEV" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT
   fi
 
-  if ! ip6tables -C FORWARD -i "$WG_INTERFACE" -o "$NET6_DEVICE" -j ACCEPT 2>/dev/null; then
-    ip6tables -I FORWARD 1 -i "$WG_INTERFACE" -o "$NET6_DEVICE" -j ACCEPT
+  info "setting up ipv6 nat and forwarding rules for $WG_INTERFACE via $IPV6_UPLINK_DEV"
+
+  if ! ip6tables -t nat -C POSTROUTING -o "$IPV6_UPLINK_DEV" -j MASQUERADE 2>/dev/null; then
+    ip6tables -t nat -A POSTROUTING -o "$IPV6_UPLINK_DEV" -j MASQUERADE
   fi
-  if ! ip6tables -C FORWARD -i "$NET6_DEVICE" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null; then
-    ip6tables -I FORWARD 2 -i "$NET6_DEVICE" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+  if ! ip6tables -C FORWARD -i "$WG_INTERFACE" -o "$IPV6_UPLINK_DEV" -j ACCEPT 2>/dev/null; then
+    ip6tables -I FORWARD 1 -i "$WG_INTERFACE" -o "$IPV6_UPLINK_DEV" -j ACCEPT
+  fi
+  if ! ip6tables -C FORWARD -i "$IPV6_UPLINK_DEV" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null; then
+    ip6tables -I FORWARD 2 -i "$IPV6_UPLINK_DEV" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT
   fi
 }
 
@@ -781,8 +785,8 @@ clear_exit_policy_rules() {
   iptables -F "$NYM_CHAIN" 2>/dev/null || true
   ip6tables -F "$NYM_CHAIN" 2>/dev/null || true
 
-  iptables -D FORWARD -i "$WG_INTERFACE" -o "$NET4_DEVICE" -j "$NYM_CHAIN" 2>/dev/null || true
-  ip6tables -D FORWARD -i "$WG_INTERFACE" -o "$NET6_DEVICE" -j "$NYM_CHAIN" 2>/dev/null || true
+  iptables -D FORWARD -i "$WG_INTERFACE" -o "$IPV4_UPLINK_DEV" -j "$NYM_CHAIN" 2>/dev/null || true
+  ip6tables -D FORWARD -i "$WG_INTERFACE" -o "$IPV6_UPLINK_DEV" -j "$NYM_CHAIN" 2>/dev/null || true
 
   iptables -X "$NYM_CHAIN" 2>/dev/null || true
   ip6tables -X "$NYM_CHAIN" 2>/dev/null || true
@@ -790,8 +794,8 @@ clear_exit_policy_rules() {
 
 show_exit_policy_status() {
   info "nym exit policy status"
-  info "ipv4 network device: $NET4_DEVICE"
-  info "ipv6 network device: $NET6_DEVICE"
+  info "ipv4 uplink device: $IPV4_UPLINK_DEV"
+  info "ipv6 uplink device: $IPV6_UPLINK_DEV"
   info "wireguard interface: $WG_INTERFACE"
   echo
 
@@ -1073,15 +1077,15 @@ test_forward_chain_hook() {
 
   local failures=0
 
-  if iptables -C FORWARD -i "$WG_INTERFACE" -o "$NET4_DEVICE" -j "$NYM_CHAIN" 2>/dev/null; then
-    ok "ipv4 forward hook ok: -i $WG_INTERFACE -o $NET4_DEVICE -> $NYM_CHAIN"
+  if iptables -C FORWARD -i "$WG_INTERFACE" -o "$IPV4_UPLINK_DEV" -j "$NYM_CHAIN" 2>/dev/null; then
+    ok "ipv4 forward hook ok: -i $WG_INTERFACE -o $IPV4_UPLINK_DEV -> $NYM_CHAIN"
   else
     error "ipv4 forward hook missing or wrong"
     ((failures++))
   fi
 
-  if ip6tables -C FORWARD -i "$WG_INTERFACE" -o "$NET6_DEVICE" -j "$NYM_CHAIN" 2>/dev/null; then
-    ok "ipv6 forward hook ok: -i $WG_INTERFACE -o $NET6_DEVICE -> $NYM_CHAIN"
+  if ip6tables -C FORWARD -i "$WG_INTERFACE" -o "$IPV6_UPLINK_DEV" -j "$NYM_CHAIN" 2>/dev/null; then
+    ok "ipv6 forward hook ok: -i $WG_INTERFACE -o $IPV6_UPLINK_DEV -> $NYM_CHAIN"
   else
     error "ipv6 forward hook missing or wrong"
     ((failures++))
@@ -1177,8 +1181,8 @@ nym_tunnel_setup() {
 }
 
 exit_policy_install() {
-  info "installing nym wireguard ipv4 exit policy for ${WG_INTERFACE} via ${NET4_DEVICE}"
-  info "installing nym wireguard ipv6 exit policy for ${WG_INTERFACE} via ${NET6_DEVICE}"
+  info "installing nym wireguard ipv4 exit policy for ${WG_INTERFACE} via ${IPV4_UPLINK_DEV}"
+  info "installing nym wireguard ipv6 exit policy for ${WG_INTERFACE} via ${IPV6_UPLINK_DEV}"
   exit_policy_install_deps
   adjust_ip_forwarding
   create_nym_chain
@@ -1320,7 +1324,7 @@ tunnel and nat helpers:
   check_nym_wg_tun                  Inspect forward chain for ${WG_INTERFACE}
   check_nymtun_iptables             Inspect forward chain for ${TUNNEL_INTERFACE}
   configure_dns_and_icmp_wg         Allow ping and dns ports on this host
-  fetch_and_display_ipv6            Show ipv6 on uplink ${NET6_DEVICE}
+  fetch_and_display_ipv6            Show ipv6 on uplink ${IPV6_UPLINK_DEV}
   fetch_ipv6_address_nym_tun        Show global ipv6 address on ${TUNNEL_INTERFACE}
   joke_through_the_mixnet           Test via ${TUNNEL_INTERFACE} with joke
   joke_through_wg_tunnel            Test via ${WG_INTERFACE} with joke
@@ -1337,8 +1341,8 @@ exit policy manager:
                                     Run verification tests on exit policy (options: --skip-default-reject).
 
 environment overrides:
-  NET4_DEVICE                       Auto-detected ipv4 uplink (e.g., eth0). Set manually if detection fails.
-  NET6_DEVICE                       Auto-detected ipv6 uplink (e.g., eth0). Set manually if detection fails.
+  IPV4_UPLINK_DEV                   Auto-detected ipv4 uplink (e.g., eth0). Set manually if detection fails.
+  IPV6_UPLINK_DEV                   Auto-detected ipv6 uplink (e.g., eth0). Set manually if detection fails.
   TUNNEL_INTERFACE                  Default: nymtun0. Requires root privileges (sudo) to manage.
   WG_INTERFACE                      Default: nymwg - Must match your WireGuard interface name.
 

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -1342,7 +1342,7 @@ exit policy manager:
 
 environment overrides:
   IPV4_UPLINK_DEV                   Auto-detected ipv4 uplink (e.g., eth0). Set manually if detection fails.
-  IPV6_UPLINK_DEV                   Auto-detected ipv6 uplink (e.g., eth0). Set manually if detection fails.
+  IPV6_UPLINK_DEV                   Auto-detected ipv6 uplink (e.g., eth0.1). Set manually if detection fails.
   TUNNEL_INTERFACE                  Default: nymtun0. Requires root privileges (sudo) to manage.
   WG_INTERFACE                      Default: nymwg - Must match your WireGuard interface name.
 

--- a/scripts/nym-node-setup/nym-node-cli.py
+++ b/scripts/nym-node-setup/nym-node-cli.py
@@ -641,7 +641,7 @@ class ArgParser:
         install_parser.add_argument("--description", help="Short public description of the node")
         install_parser.add_argument("--public-ip", help="External IPv4 address (autodetected if omitted)")
         install_parser.add_argument("--nym-node-binary", help="URL for nym-node binary (autodetected if omitted)")
-        install_parser.add_argument("--uplink-dev-v4", help="Override ipv4 uplink interface used for NAT/FORWARD (e.g., 'eth0'; autodetected if omitted)")
+        install_parser.add_argument("--uplink-dev", help="Override ipv4 uplink interface used for NAT/FORWARD (e.g., 'eth0'; autodetected if omitted)")
         install_parser.add_argument("--uplink-dev-v6", help="Override ipv6 uplink interface used for NAT/FORWARD (e.g., 'eth0.1'; autodetected if omitted)")
         
         # generic fallback

--- a/scripts/nym-node-setup/nym-node-cli.py
+++ b/scripts/nym-node-setup/nym-node-cli.py
@@ -573,9 +573,10 @@ class NodeSetupCLI:
         """Main function called by argparser command install running full node install flow"""
         self.ensure_env_values(args)
         # Pass uplink override to all helper scripts if provided
-        if getattr(args, "uplink_dev", None):
-            os.environ["UPLINK_DEV"] = args.uplink_dev
-            os.environ["NETWORK_DEVICE"] = args.uplink_dev
+        if getattr(args, "uplink_dev_v4", None):
+            os.environ["IPV4_UPLINK_DEV"] = args.uplink_dev_v4
+        if getattr(args, "uplink_dev_v6", None):
+            os.environ["IPV6_UPLINK_DEV"] = args.uplink_dev_v6
         self.run_script(self.prereqs_install_sh)
         self.run_script(self.node_install_sh)
         self.run_script(self.service_config_sh)

--- a/scripts/nym-node-setup/nym-node-cli.py
+++ b/scripts/nym-node-setup/nym-node-cli.py
@@ -641,7 +641,8 @@ class ArgParser:
         install_parser.add_argument("--description", help="Short public description of the node")
         install_parser.add_argument("--public-ip", help="External IPv4 address (autodetected if omitted)")
         install_parser.add_argument("--nym-node-binary", help="URL for nym-node binary (autodetected if omitted)")
-        install_parser.add_argument("--uplink-dev", help="Override uplink interface used for NAT/FORWARD (e.g., 'eth0'; autodetected if omitted)")
+        install_parser.add_argument("--uplink-dev-v4", help="Override ipv4 uplink interface used for NAT/FORWARD (e.g., 'eth0'; autodetected if omitted)")
+        install_parser.add_argument("--uplink-dev-v6", help="Override ipv6 uplink interface used for NAT/FORWARD (e.g., 'eth0.1'; autodetected if omitted)")
         
         # generic fallback
         install_parser.add_argument(

--- a/scripts/nym-node-setup/quic_bridge_deployment.sh
+++ b/scripts/nym-node-setup/quic_bridge_deployment.sh
@@ -60,13 +60,13 @@ NYM_ETC_BRIDGES="$NYM_ETC_DIR/bridges.toml"
 NYM_ETC_CLIENT_PARAMS_DEFAULT="$NYM_ETC_DIR/client_bridge_params.json"
 SERVICE_FILE="/etc/systemd/system/nym-bridge.service"
 
-NET_DEV="${UPLINK_DEV:-}"
+NET_DEV="${IPV4_UPLINK_DEV:-}"
 if [[ -z "$NET_DEV" ]]; then
   NET_DEV="$(ip -o route show default 2>/dev/null | awk '{print $5}' | head -n1)"
   [[ -z "$NET_DEV" ]] && NET_DEV="$(ip -o route show default table all 2>/dev/null | awk '{print $5}' | head -n1)"
 fi
 if [[ -z "$NET_DEV" ]]; then
-  echo -e "${RED}Cannot determine uplink interface. Set UPLINK_DEV.${RESET}" | tee -a "$LOG_FILE"
+  echo -e "${RED}Cannot determine uplink interface. Set IPV4_UPLINK_DEV.${RESET}" | tee -a "$LOG_FILE"
   exit 1
 fi
 echo "Using uplink device: $NET_DEV"


### PR DESCRIPTION
On many VPS providers, the IPv4 uplink network interface is eth0, while the IPv6 uplink may be on a different interface (e.g., eth1 or another device).

This PR:
- [x] Improves automatic detection of the uplink network interface for both IPv4 and IPv6.
- [x] Adds support for configurations where the IPv4 and IPv6 uplinks are on different interfaces, while remaining fully compatible with setups where they share the same interface.
- [x] Change the expected environment variable name from `NETWORK_DEVICE` to `IPV4_UPLINK_DEV` and `IPV6_UPLINK_DEV`
- [x] Add CLI flag for `--uplink-dev-v6`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6255)
<!-- Reviewable:end -->
