### PR TITLE
tunnel-manager: add support for IPv6 uplink detection

### DIFF
--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -103,6 +103,7 @@ detect_uplink_interface() {
 
 # uplink device detection, can be overridden
 NETWORK_DEVICE="${NETWORK_DEVICE:-}"
+NETWORK_DEVICE_IPV6="${NETWORK_DEVICE_IPV6:-$NETWORK_DEVICE}"
 if [[ -z "$NETWORK_DEVICE" ]]; then
   NETWORK_DEVICE="$(detect_uplink_interface "ip -o route show default")"
 fi
@@ -112,6 +113,15 @@ fi
 if [[ -z "$NETWORK_DEVICE" ]]; then
   error "cannot determine uplink interface. set NETWORK_DEVICE or UPLINK_DEV"
   exit 1
+fi
+if [[ -z "$NETWORK_DEVICE_IPV6" ]]; then
+  NETWORK_DEVICE_IPV6=$(detect_uplink_interface "ip -6 -o route show default")
+fi
+if [[ -z "$NETWORK_DEVICE_IPV6" ]]; then
+  NETWORK_DEVICE_IPV6=$(detect_uplink_interface "ip -6 -o route show default table all")
+fi
+if [[ -z "$NETWORK_DEVICE_IPV6" ]]; then
+  NETWORK_DEVICE_IPV6="$NETWORK_DEVICE"
 fi
 
 ###############################################################################
@@ -194,11 +204,11 @@ fetch_ipv6_address() {
 
 fetch_and_display_ipv6() {
   local ipv6_address
-  ipv6_address=$(ip -6 addr show "$NETWORK_DEVICE" scope global | awk '/inet6/ {print $2}')
+  ipv6_address=$(ip -6 addr show "$NETWORK_DEVICE_IPV6" scope global | awk '/inet6/ {print $2}')
   if [[ -z "$ipv6_address" ]]; then
-    error "no global ipv6 address found on $NETWORK_DEVICE"
+    error "no global ipv6 address found on $NETWORK_DEVICE_IPV6"
   else
-    ok "ipv6 address on $NETWORK_DEVICE: $ipv6_address"
+    ok "ipv6 address on $NETWORK_DEVICE_IPV6: $ipv6_address"
   fi
 }
 
@@ -343,7 +353,7 @@ remove_duplicate_rules() {
 
 apply_iptables_rules() {
   local interface=$1
-  info "applying iptables rules for $interface using uplink $NETWORK_DEVICE"
+  info "applying iptables rules for $interface using uplink (v4:$NETWORK_DEVICE, v6:$NETWORK_DEVICE_IPV6)"
   sleep 1
 
   # ipv4 nat and forwarding
@@ -360,17 +370,17 @@ apply_iptables_rules() {
     iptables -I FORWARD 2 -i "$NETWORK_DEVICE" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
 
   # ipv6 nat and forwarding
-  ip6tables -t nat -C POSTROUTING -o "$NETWORK_DEVICE" -j MASQUERADE 2>/dev/null || \
-    ip6tables -t nat -A POSTROUTING -o "$NETWORK_DEVICE" -j MASQUERADE
+  ip6tables -t nat -C POSTROUTING -o "$NETWORK_DEVICE_IPV6" -j MASQUERADE 2>/dev/null || \
+    ip6tables -t nat -A POSTROUTING -o "$NETWORK_DEVICE_IPV6" -j MASQUERADE
 
   # governed by NYM-EXIT, do not add a broad FORWARD ACCEPT
-  if ! ip6tables -C FORWARD -i "$interface" -o "$NETWORK_DEVICE" -j "$NYM_CHAIN" 2>/dev/null; then
-    ip6tables -C FORWARD -i "$interface" -o "$NETWORK_DEVICE" -j ACCEPT 2>/dev/null || \
-      ip6tables -I FORWARD 1 -i "$interface" -o "$NETWORK_DEVICE" -j ACCEPT
+  if ! ip6tables -C FORWARD -i "$interface" -o "$NETWORK_DEVICE_IPV6" -j "$NYM_CHAIN" 2>/dev/null; then
+    ip6tables -C FORWARD -i "$interface" -o "$NETWORK_DEVICE_IPV6" -j ACCEPT 2>/dev/null || \
+      ip6tables -I FORWARD 1 -i "$interface" -o "$NETWORK_DEVICE_IPV6" -j ACCEPT
   fi
 
-  ip6tables -C FORWARD -i "$NETWORK_DEVICE" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || \
-    ip6tables -I FORWARD 2 -i "$NETWORK_DEVICE" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
+  ip6tables -C FORWARD -i "$NETWORK_DEVICE_IPV6" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || \
+    ip6tables -I FORWARD 2 -i "$NETWORK_DEVICE_IPV6" -o "$interface" -m state --state RELATED,ESTABLISHED -j ACCEPT
 
   save_iptables_rules
 }
@@ -579,36 +589,36 @@ create_nym_chain() {
   # remove broad ACCEPT rules for wg + tun outbound so NYM-EXIT is authoritative
   iptables -D FORWARD -i "$WG_INTERFACE" -o "$NETWORK_DEVICE" -j ACCEPT 2>/dev/null || true
   iptables -D FORWARD -i "$TUNNEL_INTERFACE" -o "$NETWORK_DEVICE" -j ACCEPT 2>/dev/null || true
-  ip6tables -D FORWARD -i "$WG_INTERFACE" -o "$NETWORK_DEVICE" -j ACCEPT 2>/dev/null || true
-  ip6tables -D FORWARD -i "$TUNNEL_INTERFACE" -o "$NETWORK_DEVICE" -j ACCEPT 2>/dev/null || true
+  ip6tables -D FORWARD -i "$WG_INTERFACE" -o "$NETWORK_DEVICE_IPV6" -j ACCEPT 2>/dev/null || true
+  ip6tables -D FORWARD -i "$TUNNEL_INTERFACE" -o "$NETWORK_DEVICE_IPV6" -j ACCEPT 2>/dev/null || true
 
   # install the correct hook for both wg + tun
   iptables  -I FORWARD 1 -i "$WG_INTERFACE" -o "$NETWORK_DEVICE" -j "$NYM_CHAIN"
   iptables  -I FORWARD 1 -i "$TUNNEL_INTERFACE" -o "$NETWORK_DEVICE" -j "$NYM_CHAIN"
 
-  ip6tables -I FORWARD 1 -i "$WG_INTERFACE" -o "$NETWORK_DEVICE" -j "$NYM_CHAIN"
-  ip6tables -I FORWARD 1 -i "$TUNNEL_INTERFACE" -o "$NETWORK_DEVICE" -j "$NYM_CHAIN"
+  ip6tables -I FORWARD 1 -i "$WG_INTERFACE" -o "$NETWORK_DEVICE_IPV6" -j "$NYM_CHAIN"
+  ip6tables -I FORWARD 1 -i "$TUNNEL_INTERFACE" -o "$NETWORK_DEVICE_IPV6" -j "$NYM_CHAIN"
 
   ok "NYM-EXIT chain ready + FORWARD hooks installed for $WG_INTERFACE and $TUNNEL_INTERFACE"
 }
 
 
 setup_nat_rules() {
-  info "setting up nat and forwarding rules for $WG_INTERFACE via $NETWORK_DEVICE"
+  info "setting up nat and forwarding rules for $WG_INTERFACE via (v4:$NETWORK_DEVICE, v6:$NETWORK_DEVICE_IPV6)"
 
   if ! iptables -t nat -C POSTROUTING -o "$NETWORK_DEVICE" -j MASQUERADE 2>/dev/null; then
     iptables -t nat -A POSTROUTING -o "$NETWORK_DEVICE" -j MASQUERADE
   fi
-  if ! ip6tables -t nat -C POSTROUTING -o "$NETWORK_DEVICE" -j MASQUERADE 2>/dev/null; then
-    ip6tables -t nat -A POSTROUTING -o "$NETWORK_DEVICE" -j MASQUERADE
+  if ! ip6tables -t nat -C POSTROUTING -o "$NETWORK_DEVICE_IPV6" -j MASQUERADE 2>/dev/null; then
+    ip6tables -t nat -A POSTROUTING -o "$NETWORK_DEVICE_IPV6" -j MASQUERADE
   fi
 
   # keep reverse RELATED,ESTABLISHED in FORWARD for return traffic.
   if ! iptables -C FORWARD -i "$NETWORK_DEVICE" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null; then
     iptables -I FORWARD 2 -i "$NETWORK_DEVICE" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT
   fi
-  if ! ip6tables -C FORWARD -i "$NETWORK_DEVICE" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null; then
-    ip6tables -I FORWARD 2 -i "$NETWORK_DEVICE" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT
+  if ! ip6tables -C FORWARD -i "$NETWORK_DEVICE_IPV6" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT 2>/dev/null; then
+    ip6tables -I FORWARD 2 -i "$NETWORK_DEVICE_IPV6" -o "$WG_INTERFACE" -m state --state RELATED,ESTABLISHED -j ACCEPT
   fi
 }
 
@@ -826,8 +836,8 @@ clear_exit_policy_rules() {
   # remove hooks for BOTH wg + tun
   iptables -D FORWARD -i "$WG_INTERFACE" -o "$NETWORK_DEVICE" -j "$NYM_CHAIN" 2>/dev/null || true
   iptables -D FORWARD -i "$TUNNEL_INTERFACE" -o "$NETWORK_DEVICE" -j "$NYM_CHAIN" 2>/dev/null || true
-  ip6tables -D FORWARD -i "$WG_INTERFACE" -o "$NETWORK_DEVICE" -j "$NYM_CHAIN" 2>/dev/null || true
-  ip6tables -D FORWARD -i "$TUNNEL_INTERFACE" -o "$NETWORK_DEVICE" -j "$NYM_CHAIN" 2>/dev/null || true
+  ip6tables -D FORWARD -i "$WG_INTERFACE" -o "$NETWORK_DEVICE_IPV6" -j "$NYM_CHAIN" 2>/dev/null || true
+  ip6tables -D FORWARD -i "$TUNNEL_INTERFACE" -o "$NETWORK_DEVICE_IPV6" -j "$NYM_CHAIN" 2>/dev/null || true
 
   iptables -X "$NYM_CHAIN" 2>/dev/null || true
   ip6tables -X "$NYM_CHAIN" 2>/dev/null || true
@@ -835,7 +845,7 @@ clear_exit_policy_rules() {
 
 show_exit_policy_status() {
   info "nym exit policy status"
-  info "network device: $NETWORK_DEVICE"
+  info "network device: (v4:$NETWORK_DEVICE, v6:$NETWORK_DEVICE_IPV6)"
   info "wireguard interface: $WG_INTERFACE"
   info "tunnel interface: $TUNNEL_INTERFACE"
   echo
@@ -1150,15 +1160,15 @@ test_forward_chain_hook() {
     ((failures++))
   fi
 
-  if ip6tables -C FORWARD -i "$WG_INTERFACE" -o "$NETWORK_DEVICE" -j "$NYM_CHAIN" 2>/dev/null; then
-    ok "ipv6 forward hook ok (wg): -i $WG_INTERFACE -o $NETWORK_DEVICE -> $NYM_CHAIN"
+  if ip6tables -C FORWARD -i "$WG_INTERFACE" -o "$NETWORK_DEVICE_IPV6" -j "$NYM_CHAIN" 2>/dev/null; then
+    ok "ipv6 forward hook ok (wg): -i $WG_INTERFACE -o $NETWORK_DEVICE_IPV6 -> $NYM_CHAIN"
   else
     error "ipv6 forward hook missing or wrong (wg)"
     ((failures++))
   fi
 
-  if ip6tables -C FORWARD -i "$TUNNEL_INTERFACE" -o "$NETWORK_DEVICE" -j "$NYM_CHAIN" 2>/dev/null; then
-    ok "ipv6 forward hook ok (tun): -i $TUNNEL_INTERFACE -o $NETWORK_DEVICE -> $NYM_CHAIN"
+  if ip6tables -C FORWARD -i "$TUNNEL_INTERFACE" -o "$NETWORK_DEVICE_IPV6" -j "$NYM_CHAIN" 2>/dev/null; then
+    ok "ipv6 forward hook ok (tun): -i $TUNNEL_INTERFACE -o $NETWORK_DEVICE_IPV6 -> $NYM_CHAIN"
   else
     error "ipv6 forward hook missing or wrong (tun)"
     ((failures++))
@@ -1253,7 +1263,7 @@ nym_tunnel_setup() {
 }
 
 exit_policy_install() {
-  info "installing nym wireguard exit policy for ${WG_INTERFACE} via ${NETWORK_DEVICE}"
+  info "installing nym wireguard exit policy for ${WG_INTERFACE} via (v4:${NETWORK_DEVICE}, v6:${NETWORK_DEVICE_IPV6})"
   exit_policy_install_deps
   adjust_ip_forwarding
   create_nym_chain
@@ -1396,7 +1406,7 @@ tunnel and nat helpers:
   check_nym_wg_tun                  Inspect forward chain for ${WG_INTERFACE}
   check_nymtun_iptables             Inspect forward chain for ${TUNNEL_INTERFACE}
   configure_dns_and_icmp_wg         Allow ping and dns ports on this host
-  fetch_and_display_ipv6            Show ipv6 on uplink ${NETWORK_DEVICE}
+  fetch_and_display_ipv6            Show ipv6 on uplink ${NETWORK_DEVICE_IPV6}
   fetch_ipv6_address_nym_tun        Show global ipv6 address on ${TUNNEL_INTERFACE}
   joke_through_the_mixnet           Test via ${TUNNEL_INTERFACE} with joke
   joke_through_wg_tunnel            Test via ${WG_INTERFACE} with joke
@@ -1414,7 +1424,7 @@ exit policy manager:
 
 environment overrides:
   NETWORK_DEVICE                    Auto-detected uplink (e.g., eth0). Set manually if detection fails.
-  TUNNEL_INTERFACE                  Default: nymtun0. Requires root privileges (sudo) to manage.
+  NETWORK_DEVICE_IPV6               Auto-detected uplink for IPv6 (e.g., eth0). Defaults to NETWORK_DEVICE if not set.
   WG_INTERFACE                      Default: nymwg - Must match your WireGuard interface name.
 
 EOF


### PR DESCRIPTION
Add IPv6 uplink interface detection to network tunnel manager, supporting environments where IPv4 and IPv6 traffic routes through different interfaces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6256)
<!-- Reviewable:end -->
