### PR TITLE
QoL features for the HickoryDnsResolver

### DIFF
--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -229,6 +229,7 @@ impl From<NameServerConfigGroup> for NsConfigGroupWithStatus {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(unused)]
 enum NsStatus {
     Untested,
     Working(Instant),
@@ -593,7 +594,6 @@ impl HickoryDnsResolver {
     pub fn set_name_servers(&mut self, name_servers: impl AsRef<[NameServerConfig]>) {
         self.default_nameserver_config_group =
             NsConfigGroupWithStatus::from(name_servers.as_ref().to_vec());
-        self.force_primary_rebuild();
 
         if !self.dont_use_shared {
             SHARED_RESOLVER
@@ -601,6 +601,7 @@ impl HickoryDnsResolver {
                 .unwrap()
                 .set_name_servers(name_servers);
         }
+        self.force_primary_rebuild();
     }
 
     fn default_options() -> ResolverOpts {
@@ -615,12 +616,7 @@ impl HickoryDnsResolver {
     fn force_primary_rebuild(&mut self) {
         if !self.dont_use_shared {
             let mut resolver = SHARED_RESOLVER.write().unwrap();
-            // *resolver = HickoryDnsResolver {
-            //     dont_use_shared: true,
-            //     current_options: resolver.,
-            //     ..Default::default()
-            // }
-            (*resolver).state = Arc::new(OnceCell::new());
+            resolver.state = Arc::new(OnceCell::new());
         }
         self.state = Arc::new(OnceCell::new());
     }


### PR DESCRIPTION
Add in some quality of life public functionality to the `nym-http-api-client::dns::HickoryDnsResolver`. This makes it easier to both get information about the nameservers currently in use by the resolver and set those nameservers. 

Adds the following to the public interface for `HickoryDnsResolver`

```rust
/// Get the list of currently available nameserver configs. This includes nameservers that are
/// available, but unused because of a filter function -- for example [`Self::set_ipv4_only`]
/// would cause available IPv6 nameservers to be unused, but this function WOULD
/// include them in the returned value anyways.
pub fn all_configured_name_servers(&self) -> Vec<NameServerConfig> 

/// Get the list of currently used nameserver configs. This excludes nameservers that are
/// available, but unused because of a filter function -- for example [`Self::set_ipv4_only`]
/// would cause available IPv6 nameservers to be unused meaning that this function would NOT
/// include them in the returned value.
pub fn active_name_servers(&self) -> Vec<NameServerConfig>

/// Sets the available nameservers for use by this resolver to the provided list
///
/// NOTE: Calling this function will rebuild the inner resolver which means that the
/// cached dns lookups will not carry over and will go to network to resolve again.
pub fn set_name_servers(&mut self, name_servers: impl AsRef<[NameServerConfig]>)
```


Example usage in the VPN library for getting the set of available nameservers.

```rust
/// Default DNS servers.
static DEFAULT_DNS_SERVERS_CONFIG: LazyLock<NameServerConfigGroup> = LazyLock::new(|| {
    HickoryDnsResolver::default().all_configured_name_servers().into()
});
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6263)
<!-- Reviewable:end -->
