### PR TITLE
Feature: Add ports for SMTP, Whatsup and Session

### DIFF
--- a/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
+++ b/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
@@ -1,1 +1,1 @@
-Tuesday, December 9th 2025, 12:54:38 UTC
+Thursday, December 11th 2025, 11:24:33 UTC

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -49,6 +49,72 @@ This page displays a full list of all the changes during our release cycle from 
 
 <VarInfo />
 
+## Last Update of 2025
+
+We are not going to do a platform release this year anymore, but we have two important updates to share.
+
+### Governance decisions
+
+During December operators were active in voting about new ports and changes in the quorum. 
+
+**As agreed in [NIP-4](https://forum.nym.com/t/nip-4-nym-exit-policy-update-opening-port-587/2029/2) and [NIP-6](https://forum.nym.com/t/nip-6-nym-exit-policy-update-opening-ports-for-whatsapp-and-session/2042/1), we are opening these ports on [Nym exit policy](https://nymtech.net/.wellknown/network-requester/exit-policy.txt):**
+```ini
+*:587 (SMTP)
+*:22021(Session)
+*:3478 (WhatsApp)
+*:3480 (WhatsApp)
+*:3484 (WhatsApp)
+```
+
+**Node operators requirements**
+
+In order for these changes to become active, Nym node operators need to update their WireGuard and Mixnet exit policy, by following these simple steps:
+
+<Steps>
+
+###### 1. Update WireGuard exit policy
+
+- WireGuard exit policy is managed by `iptables rules` of each server hosting a `nym-node`
+- To simplify the flow, [`network-tunnel-manager.sh` (NTM)](https://github.com/nymtech/nym/blob/develop/scripts/nym-node-setup/network-tunnel-manager.sh) takes care of this
+- Please get the new NTM by SSH to your node and running:
+```sh
+curl -L https://raw.githubusercontent.com/nymtech/nym/refs/heads/develop/scripts/nym-node-setup/network-tunnel-manager.sh -o network-tunnel-manager.sh && \
+chmod +x network-tunnel-manager.sh && \
+./network-tunnel-manager.sh --help
+```
+- Then run either:
+```sh
+./network-tunnel-manager.sh complete_networking_configuration
+```
+- Or in case that you are sure that you did `complete_networking_configuration` since the latest release, you can just run the commands needed for the exit policy:
+```sh
+./network-tunnel-manager.sh exit_policy_clear
+./network-tunnel-manager.sh exit_policy_install
+./network-tunnel-manager.sh  exit_policy_status
+./network-tunnel-manager.sh exit_policy_tests
+```
+
+
+###### 2. Update Mixnet exit policy
+
+- Mixnet exit policy is being pulled with `nym-node run` command from this source: [nymtech.net/.wellknown/network-requester/exit-policy.txt](https://nymtech.net/.wellknown/network-requester/exit-policy.txt)
+- All you need to do is to restart your node:
+```sh
+service nym-node restart 
+```
+</Steps>
+
+
+### Orchestration with Ansible
+
+Finally we release our initial version [**Ansible playbooks](/operators/orchestration) for orchestrating multiple Nym nodes** from local shell. For now we have playbooks to perform these tasks:
+
+- Deploy
+- Upgrade
+- Bond
+
+Checkout the [docs](/operators/orchestration/ansible) and the [Ansible template](https://github.com/nymtech/nym/tree/develop/ansible/nym-node) and let us know how this flag ship worked for you. 
+
 ## `v2025.21-mozzarella`
 
 - [Release Binaries](https://github.com/nymtech/nym/releases/tag/nym-binaries-v2025.21-mozzarella)

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -107,7 +107,7 @@ service nym-node restart
 
 ### Orchestration with Ansible
 
-Finally we release our initial version [**Ansible playbooks](/operators/orchestration) for orchestrating multiple Nym nodes** from local shell. For now we have playbooks to perform these tasks:
+Finally we release our initial version **[Ansible playbooks](/operators/orchestration) for orchestrating multiple Nym nodes** from local shell. For now we have playbooks to perform these tasks:
 
 - Deploy
 - Upgrade

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -59,7 +59,8 @@ During December operators were active in voting about new ports and changes in t
 
 **As agreed in [NIP-4](https://forum.nym.com/t/nip-4-nym-exit-policy-update-opening-port-587/2029/2) and [NIP-6](https://forum.nym.com/t/nip-6-nym-exit-policy-update-opening-ports-for-whatsapp-and-session/2042/1), we are opening these ports on [Nym exit policy](https://nymtech.net/.wellknown/network-requester/exit-policy.txt):**
 ```ini
-*:587 (SMTP)
+*:465 (SMTPTLS)
+*:587 (SMTPSubmission)
 *:22021(Session)
 *:3478 (WhatsApp)
 *:3480 (WhatsApp)

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -90,7 +90,7 @@ chmod +x network-tunnel-manager.sh && \
 ```sh
 ./network-tunnel-manager.sh exit_policy_clear
 ./network-tunnel-manager.sh exit_policy_install
-./network-tunnel-manager.sh  exit_policy_status
+./network-tunnel-manager.sh exit_policy_status
 ./network-tunnel-manager.sh exit_policy_tests
 ```
 

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -59,7 +59,6 @@ During December operators were active in voting about new ports and changes in t
 
 **As agreed in [NIP-4](https://forum.nym.com/t/nip-4-nym-exit-policy-update-opening-port-587/2029/2) and [NIP-6](https://forum.nym.com/t/nip-6-nym-exit-policy-update-opening-ports-for-whatsapp-and-session/2042/1), we are opening these ports on [Nym exit policy](https://nymtech.net/.wellknown/network-requester/exit-policy.txt):**
 ```ini
-*:465 (SMTPTLS)
 *:587 (SMTPSubmission)
 *:22021(Session)
 *:3478 (WhatsApp)
@@ -4795,7 +4794,6 @@ For Entry Gateway:
 22 # SSH
 123 # NTP
 445 # SMB file share Windows
-465 # URD for SSM
 587 # SMTP
 853 # DNS over TLS
 1433 # databases

--- a/documentation/docs/pages/operators/orchestration/ansible.mdx
+++ b/documentation/docs/pages/operators/orchestration/ansible.mdx
@@ -82,7 +82,7 @@ Now you have the template of Ansible playbook for `nym-node` remote administrati
 
 ## Configuration
 
-After [getting the ansible Nym node playbpook](#ansible-installation) to your location, it's time to configure it for your own needs. 
+After [getting the ansible Nym node playbbook](#ansible-installation) to your location, it's time to configure it for your own needs. 
 
 > Mind that *idempotency* is an essential character when dealing with orchestration. A playbook, even when run many times should ensure that state of your targeted system will not change from what you intended. Therefore, it is important to make sure that all tasks in your playbook do not change the system in any way if the change you required has already been applied.
 

--- a/documentation/docs/pages/operators/orchestration/ansible.mdx
+++ b/documentation/docs/pages/operators/orchestration/ansible.mdx
@@ -82,7 +82,7 @@ Now you have the template of Ansible playbook for `nym-node` remote administrati
 
 ## Configuration
 
-After [getting the ansible Nym node playbbook](#ansible-installation) to your location, it's time to configure it for your own needs. 
+After [getting the ansible Nym node playbook](#ansible-installation) to your location, it's time to configure it for your own needs. 
 
 > Mind that *idempotency* is an essential character when dealing with orchestration. A playbook, even when run many times should ensure that state of your targeted system will not change from what you intended. Therefore, it is important to make sure that all tasks in your playbook do not change the system in any way if the change you required has already been applied.
 

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -685,9 +685,7 @@ apply_port_allowlist() {
     ["Minecraft"]="25565"
     ["DarkFi"]="26661"
     ["Steam"]="27000-27050"
-    ["WhatsAppSTUN"]="3478"
-    ["WhatsAppMedia1"]="3480"
-    ["WhatsAppMedia2"]="3484"
+    ["WhatsAppRange"]="3478-3484"
     ["ElectrumSSL"]="50002"
     ["MOSH"]="60000-61000"
     ["Mumble"]="64738"
@@ -1007,7 +1005,7 @@ test_port_range_rules() {
     "8232-8233:tcp:zcash"
     "8332-8333:tcp:bitcoin"
     "18080-18081:tcp:monero"
-    "3478-3484:tcp:whatsup"
+    "3478-3484:tcp:whatsapp"
   )
 
   local failures=0

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -617,6 +617,7 @@ apply_port_allowlist() {
     ["SMBWindowsFileShare"]="445"
     ["Kpasswd"]="464"
     ["RTSP"]="554"
+    ["SMTPSubmission"]="587"
     ["LDAPS"]="636"
     ["SILC"]="706"
     ["KerberosAdmin"]="749"
@@ -679,10 +680,14 @@ apply_port_allowlist() {
     ["MoneroRPC"]="18089"
     ["GoogleVoice"]="19294"
     ["EnsimControlPanel"]="19638"
+    ["Session"]="22021"
     ["DarkFiTor"]="25551"
     ["Minecraft"]="25565"
     ["DarkFi"]="26661"
     ["Steam"]="27000-27050"
+    ["WhatsAppSTUN"]="3478"
+    ["WhatsAppMedia1"]="3480"
+    ["WhatsAppMedia2"]="3484"
     ["ElectrumSSL"]="50002"
     ["MOSH"]="60000-61000"
     ["Mumble"]="64738"
@@ -1002,6 +1007,7 @@ test_port_range_rules() {
     "8232-8233:tcp:zcash"
     "8332-8333:tcp:bitcoin"
     "18080-18081:tcp:monero"
+    "3478-3484:tcp:whatsup"
   )
 
   local failures=0

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -690,6 +690,7 @@ apply_port_allowlist() {
     ["MOSH"]="60000-61000"
     ["Mumble"]="64738"
     ["Metadata"]="51830"
+    ["TESTING"]="465"
   )
 
   local port

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -616,6 +616,7 @@ apply_port_allowlist() {
     ["HTTPS"]="443"
     ["SMBWindowsFileShare"]="445"
     ["Kpasswd"]="464"
+    ["SMTPTLS"]="465"
     ["RTSP"]="554"
     ["SMTPSubmission"]="587"
     ["LDAPS"]="636"
@@ -690,7 +691,7 @@ apply_port_allowlist() {
     ["MOSH"]="60000-61000"
     ["Mumble"]="64738"
     ["Metadata"]="51830"
-    ["TESTING"]="465"
+    
   )
 
   local port

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -616,7 +616,6 @@ apply_port_allowlist() {
     ["HTTPS"]="443"
     ["SMBWindowsFileShare"]="445"
     ["Kpasswd"]="464"
-    ["SMTPTLS"]="465"
     ["RTSP"]="554"
     ["SMTPSubmission"]="587"
     ["LDAPS"]="636"


### PR DESCRIPTION
Adding new ports to NTM to expand wireguard exit policy according to NIP-4 and NIP-6, alongside needed documentation for steps required from the operators.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6280)
<!-- Reviewable:end -->
