### PR TITLE
HTTP client without default features

### DIFF
--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -895,18 +895,20 @@ impl Client {
         self.retry_limit = limit;
     }
 
+    #[cfg(feature = "tunneling")]
     fn matches_current_host(&self, url: &Url) -> bool {
-        if cfg!(feature = "tunneling") {
-            if let Some(ref front) = self.front
-                && front.is_enabled()
-            {
-                url.host_str() == self.current_url().front_str()
-            } else {
-                url.host_str() == self.current_url().host_str()
-            }
+        if let Some(ref front) = self.front
+            && front.is_enabled()
+        {
+            url.host_str() == self.current_url().front_str()
         } else {
             url.host_str() == self.current_url().host_str()
         }
+    }
+
+    #[cfg(not(feature = "tunneling"))]
+    fn matches_current_host(&self, url: &Url) -> bool {
+        url.host_str() == self.current_url().host_str()
     }
 
     /// If multiple base urls are available rotate to next (e.g. when the current one resulted in an error)

--- a/common/upgrade-mode-check/src/attestation.rs
+++ b/common/upgrade-mode-check/src/attestation.rs
@@ -97,6 +97,7 @@ pub async fn attempt_retrieve_attestation(
     let attestation = reqwest::ClientBuilder::new()
         .user_agent(user_agent.unwrap_or_else(|| nym_http_api_client::generate_user_agent!()))
         .timeout(std::time::Duration::from_secs(5))
+        .no_hickory_dns()
         .build()
         .map_err(retrieval_failure)?
         .get(url)


### PR DESCRIPTION
Fix compile issue caused when using the http client using `default-features=false`

Also make it so that the HTTP client used in `nym-upgrade-mode-check` uses the default reqwest resolver instead of the DoT / DoH resolver intended for client lib use.

pre-fix the issue can be triggered with
```
cargo test  -p nym-http-api-client --no-default-features
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6281)
<!-- Reviewable:end -->
