### PR TITLE
Minor DNS improvements

### DIFF
--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -65,8 +65,8 @@ mod static_resolver;
 pub(crate) use static_resolver::*;
 
 pub(crate) const DEFAULT_POSITIVE_LOOKUP_CACHE_TTL: Duration = Duration::from_secs(1800);
-pub(crate) const DEFAULT_OVERALL_LOOKUP_TIMEOUT: Duration = Duration::from_secs(6);
-pub(crate) const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(3);
+pub(crate) const DEFAULT_OVERALL_LOOKUP_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl ClientBuilder {
     /// Override the DNS resolver implementation used by the underlying http client.

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -962,6 +962,10 @@ impl Client {
             }
 
             self.current_idx.store(next, Ordering::Relaxed);
+            debug!(
+                "http client rotating host {} -> {}",
+                self.base_urls[orig], self.base_urls[next]
+            );
         }
     }
 
@@ -1089,27 +1093,6 @@ impl ApiClientCore for Client {
                 .map_err(HttpClientError::reqwest_client_build_error)?;
             self.apply_hosts_to_req(&mut req);
             let url: Url = req.url().clone().into();
-
-            // try an explicit DNS resolution - if successful then it will be in cache when reqwest
-            // goes to execute the request. If failure then we get to handle the DNS lookup error.
-            #[cfg(not(target_arch = "wasm32"))]
-            if self.using_secure_dns
-                && let Some(hostname) = req.url().domain()
-                // Default here will use a shared resolver instance
-                && let Err(err) = HickoryDnsResolver::default().resolve_str(hostname).await
-            {
-                // on failure update host, but don't trigger fronting enable.
-                self.update_host(Some(url.clone()));
-
-                if attempts < self.retry_limit {
-                    attempts += 1;
-                    warn!(
-                        "Retrying request due to dns error on attempt ({attempts}/{}): {err}",
-                        self.retry_limit
-                    );
-                    continue;
-                }
-            }
 
             #[cfg(target_arch = "wasm32")]
             let response: Result<Response, HttpClientError> = {

--- a/common/http-api-client/src/tests.rs
+++ b/common/http-api-client/src/tests.rs
@@ -89,13 +89,14 @@ fn sanitizing_urls() {
 // - on error without retries is where we have multiple urls, is the url updated?
 
 #[tokio::test]
+#[ignore] // test relies on external services being available and behaving in a specific way.
 async fn api_client_retry() -> Result<(), Box<dyn std::error::Error>> {
     let client = ClientBuilder::new_with_urls(vec![
         "http://broken.nym.test".parse()?, // This should fail because of DNS NXDomain (rotate)
         "http://127.0.0.1:9".parse()?,     // This will fail because of TCP refused (rotate)
         "https://httpbin.org/status/200".parse()?, // This should succeed
     ])?
-    .with_retries(3)
+    .with_retries(2)
     .build()?;
 
     let req = client.create_get_request(&[], NO_PARAMS).unwrap();


### PR DESCRIPTION
* Increase timeouts back to 10 seconds for overall lookup and 5 seconds per query.

* ignore unreliable test

* remove JIT resolution in http client as it is at best not useful, and at worst increasing timeout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6283)
<!-- Reviewable:end -->
