### PR TITLE
[chore] clippy fixes and use fixed rust version from REQUIRED_RUSTC_VERSION

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install Rust stable
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
       - name: Build all binaries
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci-binary-config-checker.yml
+++ b/.github/workflows/ci-binary-config-checker.yml
@@ -43,10 +43,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install jq vim libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev libudev-dev squashfs-tools
         continue-on-error: true
 
-      - name: Install Rust stable
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
 
       - name: Branch name
         run: echo running on branch ${GITHUB_REF##*/}

--- a/.github/workflows/ci-build-upload-binaries.yml
+++ b/.github/workflows/ci-build-upload-binaries.yml
@@ -46,10 +46,10 @@ jobs:
         run: |
           echo "RUSTFLAGS=--cfg tokio_unstable" >> $GITHUB_ENV
           echo "CARGO_FEATURES=--features tokio-console" >> $GITHUB_ENV
-      - name: Install Rust stable
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
 
       - name: Build all binaries
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci-build-vpn-api-wasm.yml
+++ b/.github/workflows/ci-build-vpn-api-wasm.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           target: wasm32-unknown-unknown
           override: true
           components: rustfmt, clippy

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/ci-contracts-schema.yml
+++ b/.github/workflows/ci-contracts-schema.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
 
       - name: Generate the schema
         run: make contract-schema

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -34,10 +34,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install Rust stable
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
       - name: Build all binaries
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci-lint-typescript.yml
+++ b/.github/workflows/ci-lint-typescript.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Setup yarn
         run: npm install -g yarn
 
-      - name: Install Rust stable
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/ci-nym-wallet-rust.yml
+++ b/.github/workflows/ci-nym-wallet-rust.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/ci-nym-wallet-storybook.yml
+++ b/.github/workflows/ci-nym-wallet-storybook.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-linux-dind
+    runs-on: arc-linux-latest-dind
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-nym-wallet-storybook.yml
+++ b/.github/workflows/ci-nym-wallet-storybook.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Setup yarn
         run: npm install -g yarn
 
-      - name: Install Rust stable
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/ci-nym-wallet-storybook.yml
+++ b/.github/workflows/ci-nym-wallet-storybook.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-linux-latest
+    runs-on: arc-linux-dind
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-sdk-wasm.yml
+++ b/.github/workflows/ci-sdk-wasm.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           target: wasm32-unknown-unknown
           override: true
           components: rustfmt, clippy

--- a/.github/workflows/nightly-nym-wallet-build.yml
+++ b/.github/workflows/nightly-nym-wallet-build.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/nightly-security-audit.yml
+++ b/.github/workflows/nightly-security-audit.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
       - name: Install cargo deny
         run: cargo install --locked cargo-deny
       - name: Run cargo deny

--- a/.github/workflows/nym-api-integration-tests.yml
+++ b/.github/workflows/nym-api-integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           override: true
 
       - name: Install dependencies

--- a/.github/workflows/publish-nym-binaries.yml
+++ b/.github/workflows/publish-nym-binaries.yml
@@ -53,10 +53,10 @@ jobs:
           echo 'RUSTFLAGS="--cfg tokio_unstable"' >> $GITHUB_ENV
         if: github.event_name == 'workflow_dispatch' && inputs.add_tokio_unstable == true
 
-      - name: Install Rust stable
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88.0
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           override: true
 
       - name: Build all binaries

--- a/.github/workflows/publish-nym-contracts.yml
+++ b/.github/workflows/publish-nym-contracts.yml
@@ -11,9 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust stable
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           target: wasm32-unknown-unknown
           override: true
 

--- a/.github/workflows/publish-nym-wallet-macos.yml
+++ b/.github/workflows/publish-nym-wallet-macos.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           node-version: 21
           
-      - name: Install Rust stable
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           
       - name: Add Rust target for x86_64-apple-darwin
         run: rustup target add x86_64-apple-darwin

--- a/.github/workflows/publish-nym-wallet-ubuntu.yml
+++ b/.github/workflows/publish-nym-wallet-ubuntu.yml
@@ -33,10 +33,10 @@ jobs:
           node-version: 21
           cache: 'yarn'
       
-      - name: Install Rust stable
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
       
       - name: Install project dependencies
         shell: bash

--- a/.github/workflows/publish-nym-wallet-win11.yml
+++ b/.github/workflows/publish-nym-wallet-win11.yml
@@ -29,10 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust stable
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
 
       - name: Setup MSBuild.exe
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/publish-sdk-npm.yml
+++ b/.github/workflows/publish-sdk-npm.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ vars.REQUIRED_RUSTC_VERSION }}
           override: true
           components: rustfmt, clippy
 

--- a/common/client-core/src/client/mix_traffic/transceiver.rs
+++ b/common/client-core/src/client/mix_traffic/transceiver.rs
@@ -13,7 +13,7 @@ use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
 use std::fmt::Debug;
 use std::os::raw::c_int as RawFd;
 use thiserror::Error;
-use tracing::{debug, error};
+use tracing::debug;
 
 #[cfg(not(target_arch = "wasm32"))]
 use futures::channel::oneshot;

--- a/common/client-core/src/client/replies/reply_controller/requests.rs
+++ b/common/client-core/src/client/replies/reply_controller/requests.rs
@@ -8,7 +8,6 @@ use nym_sphinx::anonymous_replies::requests::AnonymousSenderTag;
 use nym_sphinx::anonymous_replies::ReplySurbWithKeyRotation;
 use nym_task::connections::{ConnectionId, TransmissionLane};
 use std::sync::Weak;
-use tracing::error;
 
 pub(crate) fn new_control_channels() -> (ReplyControllerSender, ReplyControllerReceiver) {
     let (tx, rx) = mpsc::unbounded();

--- a/common/nymsphinx/framing/src/processing.rs
+++ b/common/nymsphinx/framing/src/processing.rs
@@ -14,7 +14,7 @@ use nym_sphinx_types::{
 };
 use std::fmt::Display;
 use thiserror::Error;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, info, trace};
 
 #[derive(Debug)]
 pub enum MixProcessingResultData {

--- a/documentation/autodoc/src/main.rs
+++ b/documentation/autodoc/src/main.rs
@@ -272,13 +272,13 @@ fn execute_command(
     subsubcommand: Option<&str>,
 ) -> io::Result<()> {
     // checking for the nym-cli subsubcommands
-    if subsubcommand.is_some() {
-        writeln!(file, "\n## `{} {}`", subcommand, subsubcommand.unwrap())?;
+    if let Some(subsubcommand) = subsubcommand {
+        writeln!(file, "\n## `{} {}`", subcommand, subsubcommand)?;
 
         info!("executing {main_command} {subcommand} --help ");
         let output = Command::new(main_command)
             .arg(subcommand)
-            .arg(subsubcommand.unwrap())
+            .arg(subsubcommand)
             .arg("--help")
             .output()?;
         if !output.stdout.is_empty() {

--- a/gateway/src/node/client_handling/bandwidth.rs
+++ b/gateway/src/node/client_handling/bandwidth.rs
@@ -3,7 +3,6 @@
 
 use std::num::ParseIntError;
 use thiserror::Error;
-use tracing::error;
 
 #[derive(Debug, Error)]
 pub enum BandwidthError {

--- a/nym-api/src/network_monitor/monitor/processor.rs
+++ b/nym-api/src/network_monitor/monitor/processor.rs
@@ -17,7 +17,7 @@ use std::ops::Deref;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use thiserror::Error;
-use tracing::{error, trace, warn};
+use tracing::{trace, warn};
 
 pub(crate) type ReceivedProcessorSender = mpsc::UnboundedSender<GatewayMessages>;
 pub(crate) type ReceivedProcessorReceiver = mpsc::UnboundedReceiver<GatewayMessages>;

--- a/nym-api/src/node_performance/provider/mod.rs
+++ b/nym-api/src/node_performance/provider/mod.rs
@@ -8,7 +8,7 @@ use nym_api_requests::models::RoutingScore;
 use nym_mixnet_contract_common::{EpochId, NodeId};
 use std::collections::HashMap;
 use thiserror::Error;
-use tracing::{debug, error};
+use tracing::debug;
 
 pub(crate) mod contract_provider;
 pub(crate) mod legacy_storage_provider;

--- a/nym-api/src/unstable_routes/v1/account/models.rs
+++ b/nym-api/src/unstable_routes/v1/account/models.rs
@@ -4,7 +4,6 @@
 use cosmwasm_std::{Addr, Coin};
 use nym_topology::NodeId;
 use serde::{Deserialize, Serialize};
-use utoipa::schema;
 
 #[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema, utoipa::ToResponse)]
 #[schema(title = "Coin")]


### PR DESCRIPTION
Rust stable currently has a bug on `#[zeroize(skip)]` fields : 
https://github.com/rust-lang/rust/issues/147648

Changing CI to use a rust version defined in REQUIRED_RUSTC_VERSION instead of stable, like the vpn-client repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6295)
<!-- Reviewable:end -->
