### PR TITLE
[bugfix] Sqlite transaction escalation was causing errors 

### DIFF
--- a/common/credential-storage/src/backends/sqlite.rs
+++ b/common/credential-storage/src/backends/sqlite.rs
@@ -41,7 +41,7 @@ impl SqliteEcashTicketbookManager {
     }
 
     pub(crate) async fn begin_storage_tx(&self) -> Result<Transaction<'_, Sqlite>, sqlx::Error> {
-        self.connection_pool.begin().await
+        self.connection_pool.begin_with("BEGIN IMMEDIATE").await
     }
 
     pub(crate) async fn insert_pending_ticketbook(

--- a/common/credential-storage/src/backends/sqlite.rs
+++ b/common/credential-storage/src/backends/sqlite.rs
@@ -40,7 +40,10 @@ impl SqliteEcashTicketbookManager {
         Ok(())
     }
 
-    pub(crate) async fn begin_storage_tx(&self) -> Result<Transaction<'_, Sqlite>, sqlx::Error> {
+    /// Starts a write (IMMEDIATE) transaction, to prevent issue when upgrading from a read one to a write one
+    pub(crate) async fn begin_storage_write_tx(
+        &self,
+    ) -> Result<Transaction<'_, Sqlite>, sqlx::Error> {
         self.connection_pool.begin_with("BEGIN IMMEDIATE").await
     }
 

--- a/common/credential-storage/src/persistent_storage/mod.rs
+++ b/common/credential-storage/src/persistent_storage/mod.rs
@@ -244,7 +244,7 @@ impl Storage for PersistentStorage {
         tickets: u32,
     ) -> Result<Option<RetrievedTicketbook>, Self::StorageError> {
         let deadline = ecash_today().ecash_date();
-        let mut tx = self.storage_manager.begin_storage_tx().await?;
+        let mut tx = self.storage_manager.begin_storage_write_tx().await?;
 
         // we don't want ticketbooks with expiration in the past
         let Some(raw) =


### PR DESCRIPTION
Getting tickets from credential storage requires a transaction doing a read and then a write. 
Running registration in parallel was causing sqlite to return errors, because it can't escalate two transactions, only one.

Fix : Declare said transaction as a write from the start, and the second one will wait for the first to complete

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6299)
<!-- Reviewable:end -->
