### PR TITLE
feat: introduce on-disk cache persistance for major nym-api caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6383,6 +6383,7 @@ dependencies = [
  "nym-network-defaults",
  "nym-validator-client",
  "semver 1.0.27",
+ "serde",
  "thiserror 2.0.17",
  "tokio",
  "tracing",

--- a/common/ecash-signer-check/Cargo.toml
+++ b/common/ecash-signer-check/Cargo.toml
@@ -15,6 +15,7 @@ description = "Functions to interact with zknym signers, checking their status a
 futures = { workspace = true }
 thiserror = { workspace = true }
 semver = { workspace = true }
+serde = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/common/ecash-signer-check/src/lib.rs
+++ b/common/ecash-signer-check/src/lib.rs
@@ -3,14 +3,9 @@
 
 use crate::client_check::check_client;
 use futures::stream::{FuturesUnordered, StreamExt};
+use nym_ecash_signer_check_types::status::{SignerResult, Status};
 use nym_network_defaults::NymNetworkDetails;
 use nym_validator_client::QueryHttpRpcNyxdClient;
-use nym_validator_client::nyxd::contract_traits::{DkgQueryClient, PagedDkgQueryClient};
-use std::collections::HashMap;
-use url::Url;
-
-pub use error::SignerCheckError;
-use nym_ecash_signer_check_types::status::{SignerResult, Status};
 use nym_validator_client::ecash::models::EcashSignerStatusResponse;
 use nym_validator_client::models::{
     ChainBlocksStatusResponse, ChainStatusResponse, SignerInformationResponse,
@@ -18,6 +13,12 @@ use nym_validator_client::models::{
 use nym_validator_client::nyxd::contract_traits::dkg_query_client::{
     ContractVKShare, DealerDetails, Epoch,
 };
+use nym_validator_client::nyxd::contract_traits::{DkgQueryClient, PagedDkgQueryClient};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use url::Url;
+
+pub use error::SignerCheckError;
 
 mod client_check;
 pub mod error;
@@ -31,6 +32,7 @@ pub type TypedSignerResult = SignerResult<
 pub type LocalChainStatus = Status<ChainStatusResponse, ChainBlocksStatusResponse>;
 pub type SigningStatus = Status<SignerInformationResponse, EcashSignerStatusResponse>;
 
+#[derive(Serialize, Deserialize)]
 pub struct SignersTestResult {
     pub threshold: Option<u64>,
     pub results: Vec<TypedSignerResult>,

--- a/nym-api/src/ecash/tests/mod.rs
+++ b/nym-api/src/ecash/tests/mod.rs
@@ -5,11 +5,9 @@ use crate::ecash::api_routes::handlers::ecash_routes;
 use crate::ecash::error::{EcashError, Result};
 use crate::ecash::keys::KeyPairWithEpoch;
 use crate::ecash::state::EcashState;
-use crate::mixnet_contract_cache::cache::MixnetContractCache;
 use crate::network::models::NetworkDetails;
 use crate::node_describe_cache::cache::DescribedNodes;
 use crate::node_status_api::handlers::unstable;
-use crate::node_status_api::NodeStatusCache;
 use crate::status::ApiStatusState;
 use crate::support::caching::cache::SharedCache;
 use crate::support::config;
@@ -1284,8 +1282,8 @@ impl TestFixture {
             ecash_signers_cache: Default::default(),
             address_info_cache: AddressInfoCache::new(Duration::from_secs(42), 1000),
             forced_refresh: ForcedRefresh::new(true),
-            mixnet_contract_cache: MixnetContractCache::new(),
-            node_status_cache: NodeStatusCache::new(),
+            mixnet_contract_cache: SharedCache::new().into(),
+            node_status_cache: SharedCache::new().into(),
             storage,
             described_nodes_cache: SharedCache::<DescribedNodes>::new(),
             network_details: NetworkDetails::new(

--- a/nym-api/src/epoch_operations/rewarded_set_assignment.rs
+++ b/nym-api/src/epoch_operations/rewarded_set_assignment.rs
@@ -214,7 +214,7 @@ impl EpochAdvancer {
         #[allow(clippy::unwrap_used)]
         let described_cache = self.described_cache.get().await.unwrap();
 
-        let Some(status_cache) = self.status_cache.node_annotations().await else {
+        let Ok(status_cache) = self.status_cache.node_annotations().await else {
             warn!("there are no node annotations available");
             return Vec::new();
         };

--- a/nym-api/src/mixnet_contract_cache/cache/data.rs
+++ b/nym-api/src/mixnet_contract_cache/cache/data.rs
@@ -7,8 +7,9 @@ use nym_mixnet_contract_common::{
     NymNodeDetails, RewardingParams,
 };
 use nym_topology::CachedEpochRewardedSet;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct ConfigScoreData {
     pub(crate) config_score_params: ConfigScoreParams,
     pub(crate) nym_node_version_history: Vec<HistoricalNymNodeVersionEntry>,
@@ -27,6 +28,7 @@ impl From<ConfigScoreData> for ConfigScoreDataResponse {
     }
 }
 
+#[derive(Serialize, Deserialize)]
 pub(crate) struct MixnetContractCacheData {
     pub(crate) rewarding_denom: String,
 

--- a/nym-api/src/mixnet_contract_cache/cache/mod.rs
+++ b/nym-api/src/mixnet_contract_cache/cache/mod.rs
@@ -14,6 +14,8 @@ use nym_mixnet_contract_common::{
 };
 use nym_topology::CachedEpochRewardedSet;
 use nym_validator_client::nyxd::Coin;
+use std::path::Path;
+use std::time::Duration;
 use time::OffsetDateTime;
 use tokio::sync::RwLockReadGuard;
 
@@ -27,10 +29,16 @@ pub struct MixnetContractCache {
     pub(crate) inner: SharedCache<MixnetContractCacheData>,
 }
 
+impl From<SharedCache<MixnetContractCacheData>> for MixnetContractCache {
+    fn from(inner: SharedCache<MixnetContractCacheData>) -> Self {
+        MixnetContractCache { inner }
+    }
+}
+
 impl MixnetContractCache {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new<P: AsRef<Path>>(store_path: P, max_cache_age: Duration) -> Self {
         MixnetContractCache {
-            inner: SharedCache::new(),
+            inner: SharedCache::new_with_persistent(store_path, max_cache_age, None),
         }
     }
 

--- a/nym-api/src/mixnet_contract_cache/mod.rs
+++ b/nym-api/src/mixnet_contract_cache/mod.rs
@@ -7,6 +7,7 @@ use crate::mixnet_contract_cache::cache::MixnetContractCache;
 use crate::support::caching::refresher::CacheRefresher;
 use crate::support::{config, nyxd};
 use nym_validator_client::nyxd::error::NyxdError;
+use std::path::PathBuf;
 
 pub(crate) mod cache;
 pub(crate) mod handlers;
@@ -15,6 +16,7 @@ pub(crate) fn build_refresher(
     config: &config::MixnetContractCache,
     nym_contract_cache_state: &MixnetContractCache,
     nyxd_client: nyxd::Client,
+    on_disk_file: PathBuf,
 ) -> CacheRefresher<MixnetContractCacheData, NyxdError> {
     CacheRefresher::new_with_initial_value(
         Box::new(MixnetContractDataProvider::new(nyxd_client)),
@@ -22,4 +24,5 @@ pub(crate) fn build_refresher(
         nym_contract_cache_state.inner(),
     )
     .named("mixnet-contract-cache-refresher")
+    .with_persistent_cache(on_disk_file)
 }

--- a/nym-api/src/network_monitor/monitor/preparer.rs
+++ b/nym-api/src/network_monitor/monitor/preparer.rs
@@ -233,7 +233,7 @@ impl PacketPreparer {
     // routes so that they wouldn't be reused
     pub(crate) async fn prepare_test_routes(&self, n: usize) -> Option<Vec<TestRoute>> {
         let descriptions = self.described_cache.get().await.ok()?;
-        let statuses = self.node_status_cache.node_annotations().await?;
+        let statuses = self.node_status_cache.node_annotations().await.ok()?;
 
         let mixing_nym_nodes = descriptions.mixing_nym_nodes();
         // last I checked `gatewaying` wasn't a word : )

--- a/nym-api/src/node_describe_cache/cache.rs
+++ b/nym-api/src/node_describe_cache/cache.rs
@@ -3,10 +3,11 @@
 
 use nym_api_requests::models::{DescribedNodeTypeV2, NymNodeDataV2, NymNodeDescriptionV2};
 use nym_mixnet_contract_common::NodeId;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::IpAddr;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DescribedNodes {
     pub(crate) nodes: HashMap<NodeId, NymNodeDescriptionV2>,
     pub(crate) addresses_cache: HashMap<IpAddr, NodeId>,

--- a/nym-api/src/node_describe_cache/provider.rs
+++ b/nym-api/src/node_describe_cache/provider.rs
@@ -12,6 +12,7 @@ use crate::support::config::DEFAULT_NODE_DESCRIBE_BATCH_SIZE;
 use async_trait::async_trait;
 use futures::{stream, StreamExt};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use tracing::{error, info};
 
 pub struct NodeDescriptionProvider {
@@ -90,23 +91,11 @@ impl CacheItemProvider for NodeDescriptionProvider {
     }
 }
 
-// currently dead code : (
-#[allow(dead_code)]
-pub(crate) fn new_refresher(
-    config: &config::DescribeCache,
-    contract_cache: MixnetContractCache,
-) -> CacheRefresher<DescribedNodes, NodeDescribeCacheError> {
-    CacheRefresher::new(
-        NodeDescriptionProvider::new(contract_cache, config.debug.allow_illegal_ips)
-            .with_batch_size(config.debug.batch_size),
-        config.debug.caching_interval,
-    )
-}
-
 pub(crate) fn new_provider_with_initial_value(
     config: &config::DescribeCache,
     contract_cache: MixnetContractCache,
     initial: SharedCache<DescribedNodes>,
+    on_disk_file: PathBuf,
 ) -> CacheRefresher<DescribedNodes, NodeDescribeCacheError> {
     CacheRefresher::new_with_initial_value(
         Box::new(
@@ -116,4 +105,6 @@ pub(crate) fn new_provider_with_initial_value(
         config.debug.caching_interval,
         initial,
     )
+    .named("node-self-described-data-refresher")
+    .with_persistent_cache(on_disk_file)
 }

--- a/nym-api/src/node_performance/contract_cache/data.rs
+++ b/nym-api/src/node_performance/contract_cache/data.rs
@@ -7,8 +7,10 @@ use nym_contracts_common::NaiveFloat;
 use nym_mixnet_contract_common::reward_params::Performance;
 use nym_mixnet_contract_common::{EpochId, NodeId};
 use nym_validator_client::nyxd::contract_traits::performance_query_client::NodePerformance;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
+#[derive(Serialize, Deserialize)]
 pub(crate) struct PerformanceContractEpochCacheData {
     pub(crate) epoch_id: EpochId,
     pub(crate) median_performance: HashMap<NodeId, Performance>,
@@ -30,6 +32,7 @@ impl PerformanceContractEpochCacheData {
     }
 }
 
+#[derive(Serialize, Deserialize)]
 pub(crate) struct PerformanceContractCacheData {
     pub(crate) epoch_performance: BTreeMap<EpochId, PerformanceContractEpochCacheData>,
 }

--- a/nym-api/src/node_status_api/cache/data.rs
+++ b/nym-api/src/node_status_api/cache/data.rs
@@ -1,20 +1,20 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::support::caching::Cache;
 use nym_api_requests::models::NodeAnnotation;
 use nym_mixnet_contract_common::NodeId;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Default)]
+#[derive(Default, Serialize, Deserialize)]
 #[allow(deprecated)]
 pub(crate) struct NodeStatusCacheData {
     /// Basic annotation for nym-nodes
-    pub(crate) node_annotations: Cache<HashMap<NodeId, NodeAnnotation>>,
+    pub(crate) node_annotations: HashMap<NodeId, NodeAnnotation>,
 }
 
-impl NodeStatusCacheData {
-    pub fn new() -> Self {
-        Self::default()
+impl From<HashMap<NodeId, NodeAnnotation>> for NodeStatusCacheData {
+    fn from(node_annotations: HashMap<NodeId, NodeAnnotation>) -> Self {
+        NodeStatusCacheData { node_annotations }
     }
 }

--- a/nym-api/src/node_status_api/cache/mod.rs
+++ b/nym-api/src/node_status_api/cache/mod.rs
@@ -3,18 +3,17 @@
 
 use self::data::NodeStatusCacheData;
 use crate::node_performance::provider::PerformanceRetrievalFailure;
-use crate::support::caching::cache::UninitialisedCache;
+use crate::support::caching::cache::{SharedCache, UninitialisedCache};
 use crate::support::caching::Cache;
 use nym_api_requests::models::NodeAnnotation;
 use nym_mixnet_contract_common::NodeId;
 use std::collections::HashMap;
-use std::{sync::Arc, time::Duration};
+use std::path::Path;
+use std::time::Duration;
 use thiserror::Error;
+use time::OffsetDateTime;
 use tokio::sync::RwLockReadGuard;
-use tokio::{sync::RwLock, time};
 use tracing::error;
-
-const CACHE_TIMEOUT_MS: u64 = 100;
 
 mod config_score;
 pub mod data;
@@ -44,43 +43,64 @@ impl From<UninitialisedCache> for NodeStatusCacheError {
 /// The cache can be triggered to update on contract cache changes, and/or periodically on a timer.
 #[derive(Clone)]
 pub struct NodeStatusCache {
-    inner: Arc<RwLock<NodeStatusCacheData>>,
+    inner: SharedCache<NodeStatusCacheData>,
+}
+
+impl From<SharedCache<NodeStatusCacheData>> for NodeStatusCache {
+    fn from(inner: SharedCache<NodeStatusCacheData>) -> Self {
+        NodeStatusCache { inner }
+    }
 }
 
 impl NodeStatusCache {
     /// Creates a new cache with no data.
-    pub(crate) fn new() -> NodeStatusCache {
+    pub(crate) fn new<P: AsRef<Path>>(store_path: P, max_cache_age: Duration) -> NodeStatusCache {
         NodeStatusCache {
-            inner: Arc::new(RwLock::new(NodeStatusCacheData::new())),
+            inner: SharedCache::new_with_persistent(
+                store_path,
+                max_cache_age,
+                Some(HashMap::new().into()),
+            ),
         }
+    }
+
+    pub async fn cache_timestamp(&self) -> OffsetDateTime {
+        let Ok(cache) = self.inner.get().await else {
+            return OffsetDateTime::UNIX_EPOCH;
+        };
+
+        cache.timestamp()
     }
 
     /// Updates the cache with the latest data.
     async fn update(&self, node_annotations: HashMap<NodeId, NodeAnnotation>) {
-        match time::timeout(Duration::from_millis(CACHE_TIMEOUT_MS), self.inner.write()).await {
-            Ok(mut cache) => {
-                cache.node_annotations.unchecked_update(node_annotations);
-            }
-            Err(e) => error!("{e}"),
+        if self
+            .inner
+            .try_overwrite_old_value(node_annotations, "node-status")
+            .await
+            .is_err()
+        {
+            error!("failed to update node status cache!")
         }
+    }
+
+    pub(crate) async fn cache(
+        &self,
+    ) -> Result<RwLockReadGuard<'_, Cache<NodeStatusCacheData>>, UninitialisedCache> {
+        self.inner.get().await
     }
 
     async fn get<'a, T: 'a>(
         &'a self,
-        fn_arg: impl FnOnce(&NodeStatusCacheData) -> &Cache<T>,
-    ) -> Option<RwLockReadGuard<'a, Cache<T>>> {
-        match time::timeout(Duration::from_millis(CACHE_TIMEOUT_MS), self.inner.read()).await {
-            Ok(cache) => Some(RwLockReadGuard::map(cache, |item| fn_arg(item))),
-            Err(e) => {
-                error!("{e}");
-                None
-            }
-        }
+        fn_arg: impl FnOnce(&Cache<NodeStatusCacheData>) -> &T,
+    ) -> Result<RwLockReadGuard<'a, T>, UninitialisedCache> {
+        let guard = self.inner.get().await?;
+        Ok(RwLockReadGuard::map(guard, fn_arg))
     }
 
     pub(crate) async fn node_annotations(
         &self,
-    ) -> Option<RwLockReadGuard<'_, Cache<HashMap<NodeId, NodeAnnotation>>>> {
+    ) -> Result<RwLockReadGuard<'_, HashMap<NodeId, NodeAnnotation>>, UninitialisedCache> {
         self.get(|c| &c.node_annotations).await
     }
 }

--- a/nym-api/src/node_status_api/mod.rs
+++ b/nym-api/src/node_status_api/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 pub(crate) use cache::NodeStatusCache;
 use nym_task::ShutdownManager;
+use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::watch;
 
@@ -39,6 +40,7 @@ pub(crate) fn start_cache_refresh(
     performance_provider: Box<dyn NodePerformanceProvider + Send + Sync>,
     nym_contract_cache_listener: watch::Receiver<support::caching::CacheNotification>,
     described_cache_cache_listener: watch::Receiver<support::caching::CacheNotification>,
+    on_disk_file: PathBuf,
     shutdown_manager: &ShutdownManager,
 ) {
     let mut nym_api_cache_refresher = NodeStatusCacheRefresher::new(
@@ -49,6 +51,7 @@ pub(crate) fn start_cache_refresh(
         nym_contract_cache_listener,
         described_cache_cache_listener,
         performance_provider,
+        on_disk_file,
     );
     let shutdown_listener = shutdown_manager.clone_shutdown_token();
     tokio::spawn(async move { nym_api_cache_refresher.run(shutdown_listener).await });

--- a/nym-api/src/node_status_api/models.rs
+++ b/nym-api/src/node_status_api/models.rs
@@ -346,13 +346,6 @@ impl AxumErrorResponse {
         }
     }
 
-    pub(crate) fn internal() -> Self {
-        Self {
-            message: RequestError::new("Internal server error"),
-            status: StatusCode::INTERNAL_SERVER_ERROR,
-        }
-    }
-
     pub(crate) fn not_implemented() -> Self {
         Self {
             message: RequestError::empty(),

--- a/nym-api/src/nym_nodes/handlers/v1.rs
+++ b/nym-api/src/nym_nodes/handlers/v1.rs
@@ -279,11 +279,7 @@ async fn get_node_annotation(
 ) -> AxumResult<FormattedResponse<AnnotationResponse>> {
     let output = output.output.unwrap_or_default();
 
-    let annotations = state
-        .node_status_cache
-        .node_annotations()
-        .await
-        .ok_or_else(AxumErrorResponse::internal)?;
+    let annotations = state.node_status_cache().node_annotations().await?;
 
     Ok(output.to_response(AnnotationResponse {
         node_id,
@@ -312,11 +308,7 @@ async fn get_current_node_performance(
 ) -> AxumResult<FormattedResponse<NodePerformanceResponse>> {
     let output = output.output.unwrap_or_default();
 
-    let annotations = state
-        .node_status_cache
-        .node_annotations()
-        .await
-        .ok_or_else(AxumErrorResponse::internal)?;
+    let annotations = state.node_status_cache().node_annotations().await?;
 
     Ok(output.to_response(NodePerformanceResponse {
         node_id,

--- a/nym-api/src/signers_cache/cache/mod.rs
+++ b/nym-api/src/signers_cache/cache/mod.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use nym_ecash_signer_check::SignersTestResult;
+use serde::{Deserialize, Serialize};
 
 pub(crate) mod data;
 pub(crate) mod refresher;
 
+#[derive(Serialize, Deserialize)]
 pub(crate) struct SignersCacheData {
     pub(crate) signers_results: SignersTestResult,
 }

--- a/nym-api/src/support/config/persistence.rs
+++ b/nym-api/src/support/config/persistence.rs
@@ -18,27 +18,9 @@ pub const DEFAULT_DKG_PUBLIC_KEY_WITH_PROOF_FILENAME: &str = "dkg_public_key_wit
 // don't want to be changing the defaults in case something breaks..., but it should be called ecash.pem instead
 pub const DEFAULT_ECASH_KEY_FILENAME: &str = "coconut.pem";
 
+pub const DEFAULT_CACHES_DIRECTORY: &str = ".cache";
 pub const DEFAULT_PRIVATE_IDENTITY_KEY_FILENAME: &str = "private_identity.pem";
 pub const DEFAULT_PUBLIC_IDENTITY_KEY_FILENAME: &str = "public_identity.pem";
-
-// #[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
-// pub struct NymApiPathfinder {
-//     pub network_monitor: NetworkMonitorPathfinder,
-//
-//     pub node_status_api: NodeStatusAPIPathfinder,
-//
-//     pub coconut: CoconutSignerPathfinder,
-// }
-//
-// impl NymApiPathfinder {
-//     pub fn new_default<P: AsRef<Path>>(id: P) -> Self {
-//         NymApiPathfinder {
-//             network_monitor: NetworkMonitorPathfinder::new_default(id.as_ref()),
-//             node_status_api: NodeStatusAPIPathfinder::new_default(id.as_ref()),
-//             coconut: CoconutSignerPathfinder::new_default(id.as_ref()),
-//         }
-//     }
-// }
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct NetworkMonitorPaths {
@@ -106,6 +88,11 @@ impl EcashSignerPaths {
 #[derive(Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default)]
 pub struct NymApiPaths {
+    /// Path to directory containing persistent caches of, for example,
+    /// the describe information, performance, etc.
+    /// It is used for restarting the nym-api and preserving the data
+    pub persistent_cache_directory: PathBuf,
+
     /// Path to file containing private identity key of the nym-api.
     pub private_identity_key_file: PathBuf,
 
@@ -118,9 +105,14 @@ impl NymApiPaths {
         let data_dir = default_data_directory(id);
 
         NymApiPaths {
+            persistent_cache_directory: data_dir.join(DEFAULT_CACHES_DIRECTORY),
             private_identity_key_file: data_dir.join(DEFAULT_PRIVATE_IDENTITY_KEY_FILENAME),
             public_identity_key_file: data_dir.join(DEFAULT_PUBLIC_IDENTITY_KEY_FILENAME),
         }
+    }
+
+    pub fn cache_file(&self, name: impl AsRef<Path>) -> PathBuf {
+        self.persistent_cache_directory.join(name)
     }
 
     pub fn load_identity(&self) -> anyhow::Result<ed25519::KeyPair> {

--- a/nym-api/src/support/config/template.rs
+++ b/nym-api/src/support/config/template.rs
@@ -22,6 +22,12 @@ bind_address = '{{ base.bind_address }}'
 mnemonic = '{{ base.mnemonic }}'
 
 [base.storage_paths]
+
+# Path to directory containing persistent caches of, for example,
+# the describe information, performance, etc.
+# It is used for restarting the nym-api and preserving the data
+persistent_cache_directory = '{{ base.storage_paths.persistent_cache_directory }}'
+
 # Path to file containing private identity key of the nym-api.
 private_identity_key_file = '{{ base.storage_paths.private_identity_key_file }}'
 

--- a/nym-api/src/support/http/state/mod.rs
+++ b/nym-api/src/support/http/state/mod.rs
@@ -20,11 +20,8 @@ use crate::support::storage;
 use crate::unstable_routes::v1::account::cache::AddressInfoCache;
 use crate::unstable_routes::v1::account::models::NyxAccountDetails;
 use axum::extract::FromRef;
-use nym_api_requests::models::NodeAnnotation;
 use nym_crypto::asymmetric::ed25519;
-use nym_mixnet_contract_common::NodeId;
 use nym_topology::CachedEpochRewardedSet;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLockReadGuard;
 
@@ -156,16 +153,6 @@ impl AppState {
         &self,
     ) -> Result<Cache<CachedEpochRewardedSet>, AxumErrorResponse> {
         Ok(self.nym_contract_cache().cached_rewarded_set().await?)
-    }
-
-    pub(crate) async fn node_annotations(
-        &self,
-    ) -> Result<RwLockReadGuard<'_, Cache<HashMap<NodeId, NodeAnnotation>>>, AxumErrorResponse>
-    {
-        self.node_status_cache()
-            .node_annotations()
-            .await
-            .ok_or_else(AxumErrorResponse::internal)
     }
 
     pub(crate) async fn get_address_info(

--- a/nym-api/src/unstable_routes/v2/nym_nodes/semi_skimmed/mod.rs
+++ b/nym-api/src/unstable_routes/v2/nym_nodes/semi_skimmed/mod.rs
@@ -90,7 +90,8 @@ pub(super) async fn nodes_expanded(
 
     let describe_cache = state.describe_nodes_cache_data().await?;
     let all_nym_nodes = describe_cache.all_nym_nodes();
-    let annotations = state.node_annotations().await?;
+    let status_cache = &state.node_status_cache();
+    let annotations = status_cache.node_annotations().await?;
 
     let contract_cache = state.nym_contract_cache();
     let current_key_rotation = contract_cache.current_key_rotation_id().await?;
@@ -107,7 +108,7 @@ pub(super) async fn nodes_expanded(
     // min of all caches
     let refreshed_at = refreshed_at([
         rewarded_set.timestamp(),
-        annotations.timestamp(),
+        status_cache.cache_timestamp().await,
         describe_cache.timestamp(),
     ]);
 

--- a/nym-api/src/unstable_routes/v2/nym_nodes/skimmed/helpers.rs
+++ b/nym-api/src/unstable_routes/v2/nym_nodes/skimmed/helpers.rs
@@ -101,7 +101,8 @@ where
     let rewarded_set = state.rewarded_set().await?;
 
     // 2. grab all annotations so that we could attach scores to the [nym] nodes
-    let annotations = state.node_annotations().await?;
+    let status_cache = &state.node_status_cache();
+    let annotations = status_cache.node_annotations().await?;
 
     // 3. implicitly grab the relevant described nodes
     // (ideally it'd be tied directly to the NI iterator, but I couldn't defeat the compiler)
@@ -138,7 +139,7 @@ where
         // min of all caches
         let refreshed_at = refreshed_at([
             rewarded_set.timestamp(),
-            annotations.timestamp(),
+            status_cache.cache_timestamp().await,
             describe_cache.timestamp(),
         ]);
 
@@ -155,7 +156,7 @@ where
     // min of all caches
     let refreshed_at = refreshed_at([
         rewarded_set.timestamp(),
-        annotations.timestamp(),
+        status_cache.cache_timestamp().await,
         describe_cache.timestamp(),
     ]);
 
@@ -183,7 +184,8 @@ pub(crate) async fn nodes_basic(
 
     let describe_cache = state.describe_nodes_cache_data().await?;
     let all_nym_nodes = describe_cache.all_nym_nodes();
-    let annotations = state.node_annotations().await?;
+    let status_cache = &state.node_status_cache();
+    let annotations = status_cache.node_annotations().await?;
 
     let interval = state.nym_contract_cache().current_interval().await?;
     let current_key_rotation = state.nym_contract_cache().current_key_rotation_id().await?;
@@ -199,7 +201,7 @@ pub(crate) async fn nodes_basic(
     // min of all caches
     let refreshed_at = refreshed_at([
         rewarded_set.timestamp(),
-        annotations.timestamp(),
+        status_cache.cache_timestamp().await,
         describe_cache.timestamp(),
     ]);
 


### PR DESCRIPTION
This includes:
- mixnet contract cache
- described nodes cache
- nodes annotations cache (performance)

those changes include taking some code developed for the purposes of #6277


Essentially whenever the aforementioned caches are refreshed, their contents are also written to disk so when the API restarts,  it could load them (assuming the data is not older than the corresponding refreshing interval) instead of starting with no data

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6302)
<!-- Reviewable:end -->
