### PR TITLE
Deriving Serialize for GatewayData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6867,6 +6867,7 @@ dependencies = [
  "nym-crypto",
  "nym-ip-packet-requests",
  "nym-sphinx",
+ "serde",
  "tokio-util",
 ]
 

--- a/common/registration/Cargo.toml
+++ b/common/registration/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 tokio-util.workspace = true
+serde.workspace = true
 
 nym-authenticator-requests = { path = "../authenticator-requests" }
 nym-crypto = { path = "../crypto" }

--- a/common/registration/src/lib.rs
+++ b/common/registration/src/lib.rs
@@ -1,10 +1,11 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use nym_authenticator_requests::AuthenticatorVersion;
-use nym_crypto::asymmetric::x25519::PublicKey;
+use nym_crypto::asymmetric::x25519::{PublicKey, serde_helpers::bs58_x25519_pubkey};
 use nym_ip_packet_requests::IpPair;
 use nym_sphinx::addressing::{NodeIdentity, Recipient};
 
@@ -16,9 +17,9 @@ pub struct NymNode {
     pub authenticator_address: Option<Recipient>,
     pub version: AuthenticatorVersion,
 }
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GatewayData {
+    #[serde(with = "bs58_x25519_pubkey")]
     pub public_key: PublicKey,
     pub endpoint: SocketAddr,
     pub private_ipv4: Ipv4Addr,


### PR DESCRIPTION
Deriving `Serialize` for gateway data, that will be used by the diagnostic tool in the vpn-client repo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6314)
<!-- Reviewable:end -->
