### PR TITLE
Topology fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix topology fetch failures during epoch transitions by accepting epoch differences of 1 between mixnodes and gateways API calls
+
 ## [2026.1-niolo] (2026-01-13)
 
 - bugfix: mozzarella -> niolo config migration ([#6259])

--- a/common/client-core/src/client/topology_control/nym_api_provider.rs
+++ b/common/client-core/src/client/topology_control/nym_api_provider.rs
@@ -154,9 +154,29 @@ impl NymApiTopologyProvider {
             let metadata = mixnodes_res.metadata;
             let mixnodes = mixnodes_res.nodes;
 
+            // Check for epoch consistency between mixnodes and gateways responses
             if !gateways_res.metadata.consistency_check(&metadata) {
-                warn!("inconsistent nodes metadata between mixnodes and gateways calls! {metadata:?} and {:?}", gateways_res.metadata);
-                return None;
+                warn!(
+                    "Inconsistent nodes metadata between mixnodes and gateways calls! \
+                    mixnodes epoch: {}, gateways epoch: {}. This can happen when requests span an epoch boundary.",
+                    metadata.absolute_epoch_id, gateways_res.metadata.absolute_epoch_id
+                );
+                
+                // Use the response with the higher (more recent) epoch to avoid stale data
+                let epoch_diff = metadata.absolute_epoch_id.abs_diff(gateways_res.metadata.absolute_epoch_id);
+                
+                if epoch_diff <= 1 {
+                    // If epochs are only 1 apart, this is expected during epoch transitions
+                    // Use the data anyway as it's still valid
+                    warn!("Epoch difference is 1, proceeding with topology fetch (this is normal during epoch transitions)");
+                } else {
+                    // If epochs are more than 1 apart, something is wrong
+                    error!(
+                        "Epoch difference is {}, which indicates a serious synchronization issue. Rejecting topology.",
+                        epoch_diff
+                    );
+                    return None;
+                }
             }
 
             let gateways = gateways_res.nodes;

--- a/common/client-core/src/client/topology_control/nym_api_provider.rs
+++ b/common/client-core/src/client/topology_control/nym_api_provider.rs
@@ -161,10 +161,12 @@ impl NymApiTopologyProvider {
                     mixnodes epoch: {}, gateways epoch: {}. This can happen when requests span an epoch boundary.",
                     metadata.absolute_epoch_id, gateways_res.metadata.absolute_epoch_id
                 );
-                
+
                 // Use the response with the higher (more recent) epoch to avoid stale data
-                let epoch_diff = metadata.absolute_epoch_id.abs_diff(gateways_res.metadata.absolute_epoch_id);
-                
+                let epoch_diff = metadata
+                    .absolute_epoch_id
+                    .abs_diff(gateways_res.metadata.absolute_epoch_id);
+
                 if epoch_diff <= 1 {
                     // If epochs are only 1 apart, this is expected during epoch transitions
                     // Use the data anyway as it's still valid


### PR DESCRIPTION
Fix topology fetch failures during epoch transitions by accepting epoch differences of 1 between mixnodes and gateways API calls.

This was seen regularly when invoking the vpn-client.

```
Some(Fresh(Interval { id: 38, epochs_in_interval: 720, current_epoch_start: 2026-01-23 13:26:19.0 +00:00:00, current_epoch_id: 596, epoch_length: 3600s, total_elapsed_epochs: 27956 })), absolute_epoch_id: 27956, rotation_id: 198, refreshed_at: OffsetDateTimeJsonSchemaWrapper(2026-01-23 14:25:02.46195034 +00:00:00) }
2026-01-23T14:37:09.828569Z ERROR nym_vpn_lib::mixnet::topology_service: Error: failed to fetch topology
Caused by: failed to fetch topology from network
2026-01-23T14:37:09.828584Z  INFO nym_vpn_lib::mixnet::topology_service: No fallback topology available
```