### PR TITLE
Better controls for global interaction w/ static DNS

### DIFF
--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -364,24 +364,13 @@ impl HickoryDnsResolver {
         }
     }
 
-    /// Set (or overwrite) the map of static addresses and mark these domains to be returned
-    /// WITHOUT attempting a lookup over the network resolver.
-    pub fn preresolve_to_addrs(&self, addrs: HashMap<String, Vec<IpAddr>>) {
-        debug!("setting pre-resolve entries for {:?}", addrs.keys());
-        if let Some(cell) = &self.static_base {
-            let static_base =
-                cell.get_or_init(|| HickoryDnsResolver::new_static_fallback(self.use_shared));
-            static_base.set_preresolve(addrs);
-        }
-    }
-
     /// Unset the map of static addresses returned in the pre-resolve stage.
     pub fn clear_preresolve(&self) {
         debug!("clearing pre-resolve table");
-        if let Some(cell) = &self.static_base {
-            if let Some(static_base) = cell.get() {
-                static_base.clear_preresolve()
-            }
+        if let Some(cell) = &self.static_base
+            && let Some(static_base) = cell.get()
+        {
+            static_base.clear_preresolve()
         }
     }
 
@@ -392,7 +381,8 @@ impl HickoryDnsResolver {
     }
 
     /// Set (or overwrite) the map of addresses used in the fallback static hostname lookup
-    pub fn set_static_fallbacks(&mut self, addrs: HashMap<String, Vec<IpAddr>>) {
+    pub fn set_fallback_addrs(&mut self, addrs: HashMap<String, Vec<IpAddr>>) {
+        debug!("setting fallback entries for {:?}", addrs.keys());
         if self.static_base.is_none() {
             let cell = OnceCell::new();
             self.static_base = Some(Arc::new(cell));
@@ -400,7 +390,7 @@ impl HickoryDnsResolver {
         self.static_base
             .as_ref()
             .unwrap()
-            .get_or_init(|| StaticResolver::new())
+            .get_or_init(|| Self::new_static_fallback(self.use_shared))
             .set_fallback(addrs);
     }
 
@@ -412,6 +402,7 @@ impl HickoryDnsResolver {
 
     /// Set (or overwrite) the map of addresses used in the preresolve static hostname lookup
     pub fn set_static_preresolve(&mut self, addrs: HashMap<String, Vec<IpAddr>>) {
+        debug!("setting pre-resolve entries for {:?}", addrs.keys());
         if self.static_base.is_none() {
             let cell = OnceCell::new();
             self.static_base = Some(Arc::new(cell));
@@ -419,7 +410,7 @@ impl HickoryDnsResolver {
         self.static_base
             .as_ref()
             .unwrap()
-            .get_or_init(|| StaticResolver::new())
+            .get_or_init(|| Self::new_static_fallback(self.use_shared))
             .set_preresolve(addrs);
     }
 
@@ -659,7 +650,7 @@ mod test {
         let example_ip6: IpAddr = "dead::beef".parse().unwrap();
         addr_map.insert(example_domain.to_string(), vec![example_ip4, example_ip6]);
 
-        resolver.set_static_fallbacks(addr_map);
+        resolver.set_fallback_addrs(addr_map);
 
         let mut addrs = resolver.resolve_str(example_domain).await?;
         assert!(addrs.contains(&example_ip4));

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -364,7 +364,13 @@ impl HickoryDnsResolver {
         }
     }
 
-    /// Unset the map of static addresses returned in the pre-resolve stage.
+    /// Clear entries from the static table that would return entries during the pre-resolve stage.
+    /// This means that all lookups will attempt to use the network resolver again before the static
+    /// table is consulted.
+    ///  
+    /// Entries elevated to pre-resolve from fallback (added from default or using
+    /// [`set_fallback`]`) will have their cache timeout cleared. Entries added directly to
+    /// pre-resolve (using [`Self::set_static_preresolve`]) will be removed.
     pub fn clear_preresolve(&self) {
         debug!("clearing pre-resolve table");
         if let Some(cell) = &self.static_base

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -792,17 +792,18 @@ mod test {
 
         #[tokio::test]
         #[ignore]
-        // this test is dependent of external network setup -- i.e. blocking all traffic to the default
-        // resolvers. Otherwise the default resolvers will succeed without using the static fallback,
-        // making the test pointless
+        // This test impacts the state of the shared resolver and as such is disabled to avoid
+        // interference with other tests.
+        //
+        // this test is dependent of external network setup -- i.e. blocking all traffic to the
+        // default resolvers. Otherwise the default resolvers will succeed without using the static
+        // fallback, making the test pointless
         async fn dns_lookup_failure_on_shared() -> Result<(), ResolveError> {
-            let time_start = Instant::now();
-            let r = OnceCell::new();
-            r.set(build_broken_resolver().expect("failed to build resolver"))
-                .expect("broken resolver init error");
+            let resolver1 = HickoryDnsResolver::shared();
 
-            // create a new resolver that won't mess with the shared resolver used by other tests
-            let resolver = HickoryDnsResolver::default();
+            let time_start = Instant::now();
+            // create a new resolver that uses the shared resolver
+            let resolver = HickoryDnsResolver::shared();
 
             // successful lookup using fallback to static resolver
             let domain = "rpc.nymtech.net";
@@ -811,9 +812,27 @@ mod test {
                 .await
                 .expect("failed to resolve address in static lookup");
 
-            println!(
-                "{}ms resolved {domain}",
-                (Instant::now() - time_start).as_millis()
+            let lookup_dur = Instant::now() - time_start;
+            assert!(
+                lookup_dur > resolver.overall_dns_timeout,
+                "expected lookup timeout - took {}ms",
+                (lookup_dur).as_millis()
+            );
+
+            let time_start = Instant::now();
+            // successful lookup using pre-resolve entry promoted from fallback
+            let domain = "rpc.nymtech.net";
+            let _ = resolver1
+                .resolve_str(domain)
+                .await
+                .expect("domain expected to be in pre-resolve");
+
+            // this lookup should basically be instant as we are using pre-resolve
+            let lookup_dur = Instant::now() - time_start;
+            assert!(
+                lookup_dur < Duration::from_millis(10),
+                "expected instant - took {}ms",
+                (lookup_dur).as_millis()
             );
 
             // unsuccessful lookup - primary times out, and not in static table
@@ -822,6 +841,63 @@ mod test {
             assert!(result.is_err());
             // assert!(result.is_err_and(|e| matches!(e, ResolveError::Timeout)));
             // assert!(result.is_err_and(|e| matches!(e, ResolveError::ResolveError(e) if e.is_nx_domain())));
+            Ok(())
+        }
+
+        #[tokio::test]
+        #[ignore]
+        // This test impacts the state of the shared resolver and as such is disabled to avoid
+        // interference with other tests.
+        async fn setting_dns_fallbacks_with_shared_resolver() -> Result<(), ResolveError> {
+            let resolver1 = HickoryDnsResolver::shared();
+
+            // create a new resolver that uses the shared resolver
+            let mut resolver = HickoryDnsResolver::shared();
+
+            let example_domains = [
+                String::from("static1.nymvpn.com"),
+                String::from("static2.nymvpn.com"),
+            ];
+            let mut addr_map1 = HashMap::new();
+            addr_map1.insert(
+                example_domains[0].clone(),
+                vec![Ipv4Addr::new(10, 10, 10, 10).into()],
+            );
+            addr_map1.insert(
+                example_domains[1].clone(),
+                vec![Ipv4Addr::new(1, 1, 1, 1).into()],
+            );
+
+            resolver.set_static_preresolve(addr_map1);
+
+            let time_start = Instant::now();
+            // successful lookup using pre-resolve entry promoted from fallback
+            let _ = resolver1
+                .resolve_str(&example_domains[0])
+                .await
+                .expect("domain expected to be in pre-resolve");
+
+            // this lookup should basically be instant as we are using pre-resolve
+            let lookup_dur = Instant::now() - time_start;
+            assert!(
+                lookup_dur < Duration::from_millis(10),
+                "expected instant - took {}ms",
+                (lookup_dur).as_millis()
+            );
+
+            // After clearing the pre-resolve in one instance of the shared resolver ...
+            resolver.clear_preresolve();
+
+            // ... other instances have their pre-resolve entries cleared.
+            let prereslve_lookup = resolver1
+                .static_base
+                .as_ref()
+                .unwrap()
+                .get()
+                .unwrap()
+                .pre_resolve(&example_domains[0]);
+            assert!(prereslve_lookup.is_none());
+
             Ok(())
         }
     }

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -371,12 +371,11 @@ impl HickoryDnsResolver {
         if let Some(cell) = &self.static_base {
             let static_base =
                 cell.get_or_init(|| HickoryDnsResolver::new_static_fallback(self.use_shared));
-            static_base.preresolve_to_addrs(addrs);
+            static_base.set_preresolve(addrs);
         }
     }
 
-    /// Set (or overwrite) the map of static addresses and mark these domains to be returned
-    /// WITHOUT attempting a lookup over the network resolver.
+    /// Unset the map of static addresses returned in the pre-resolve stage.
     pub fn clear_preresolve(&self) {
         debug!("clearing pre-resolve table");
         if let Some(cell) = &self.static_base {
@@ -386,18 +385,42 @@ impl HickoryDnsResolver {
         }
     }
 
-    /// Get the current map of hostname to address in use by the fallback static lookup if one
+    /// Get the current map of hostnames to addresses used in the fallback static lookup stage if one
     /// exists.
     pub fn get_static_fallbacks(&self) -> Option<HashMap<String, Vec<IpAddr>>> {
-        Some(self.static_base.as_ref()?.get()?.get_addrs())
+        Some(self.static_base.as_ref()?.get()?.get_fallback_addrs())
     }
 
     /// Set (or overwrite) the map of addresses used in the fallback static hostname lookup
     pub fn set_static_fallbacks(&mut self, addrs: HashMap<String, Vec<IpAddr>>) {
-        let cell = OnceCell::new();
-        cell.set(StaticResolver::new(addrs))
-            .expect("infallible assign");
-        self.static_base = Some(Arc::new(cell));
+        if self.static_base.is_none() {
+            let cell = OnceCell::new();
+            self.static_base = Some(Arc::new(cell));
+        }
+        self.static_base
+            .as_ref()
+            .unwrap()
+            .get_or_init(|| StaticResolver::new())
+            .set_fallback(addrs);
+    }
+
+    /// Get the current map of hostnames to addresses used in the preresolve static lookup stage
+    /// if one exists.
+    pub fn get_static_preresolve(&self) -> Option<HashMap<String, Vec<IpAddr>>> {
+        Some(self.static_base.as_ref()?.get()?.get_preresolve_addrs())
+    }
+
+    /// Set (or overwrite) the map of addresses used in the preresolve static hostname lookup
+    pub fn set_static_preresolve(&mut self, addrs: HashMap<String, Vec<IpAddr>>) {
+        if self.static_base.is_none() {
+            let cell = OnceCell::new();
+            self.static_base = Some(Arc::new(cell));
+        }
+        self.static_base
+            .as_ref()
+            .unwrap()
+            .get_or_init(|| StaticResolver::new())
+            .set_preresolve(addrs);
     }
 
     /// Successfully resolved addresses are cached for a minimum of 30 minutes
@@ -534,7 +557,7 @@ fn new_resolver_system() -> Result<TokioResolver, ResolveError> {
 }
 
 fn new_default_static_fallback() -> StaticResolver {
-    StaticResolver::new(constants::empty_static_addrs())
+    StaticResolver::new().with_fallback(constants::default_static_addrs())
 }
 
 /// Do a trial resolution using each nameserver individually to test which are working and which

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -359,6 +359,26 @@ impl HickoryDnsResolver {
         }
     }
 
+    /// Set (or overwrite) the map of static addresses and mark these domains to be returned
+    /// WITHOUT attempting a lookup over the network resolver.
+    pub fn preresolve_to_addrs(&self, addrs: HashMap<String, Vec<IpAddr>>) {
+        if let Some(cell) = &self.static_base {
+            let static_base =
+                cell.get_or_init(|| HickoryDnsResolver::new_static_fallback(self.use_shared));
+            static_base.preresolve_to_addrs(addrs);
+        }
+    }
+
+    /// Set (or overwrite) the map of static addresses and mark these domains to be returned
+    /// WITHOUT attempting a lookup over the network resolver.
+    pub fn clear_preresolve(&self) {
+        if let Some(cell) = &self.static_base {
+            if let Some(static_base) = cell.get() {
+                static_base.clear_preresolve()
+            }
+        }
+    }
+
     /// Get the current map of hostname to address in use by the fallback static lookup if one
     /// exists.
     pub fn get_static_fallbacks(&self) -> Option<HashMap<String, Vec<IpAddr>>> {

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -269,6 +269,11 @@ impl Iterator for SocketAddrs {
 }
 
 impl HickoryDnsResolver {
+    /// Returns an instance of the shared resolver.
+    pub fn shared() -> Self {
+        SHARED_RESOLVER.clone()
+    }
+
     /// Attempt to resolve a domain name to a set of ['IpAddr']s
     pub async fn resolve_str(
         &self,
@@ -362,6 +367,7 @@ impl HickoryDnsResolver {
     /// Set (or overwrite) the map of static addresses and mark these domains to be returned
     /// WITHOUT attempting a lookup over the network resolver.
     pub fn preresolve_to_addrs(&self, addrs: HashMap<String, Vec<IpAddr>>) {
+        debug!("setting pre-resolve entries for {:?}", addrs.keys());
         if let Some(cell) = &self.static_base {
             let static_base =
                 cell.get_or_init(|| HickoryDnsResolver::new_static_fallback(self.use_shared));
@@ -372,6 +378,7 @@ impl HickoryDnsResolver {
     /// Set (or overwrite) the map of static addresses and mark these domains to be returned
     /// WITHOUT attempting a lookup over the network resolver.
     pub fn clear_preresolve(&self) {
+        debug!("clearing pre-resolve table");
         if let Some(cell) = &self.static_base {
             if let Some(static_base) = cell.get() {
                 static_base.clear_preresolve()
@@ -527,7 +534,7 @@ fn new_resolver_system() -> Result<TokioResolver, ResolveError> {
 }
 
 fn new_default_static_fallback() -> StaticResolver {
-    StaticResolver::new(constants::default_static_addrs())
+    StaticResolver::new(constants::empty_static_addrs())
 }
 
 /// Do a trial resolution using each nameserver individually to test which are working and which

--- a/common/http-api-client/src/dns/constants.rs
+++ b/common/http-api-client/src/dns/constants.rs
@@ -69,10 +69,12 @@ pub const NYM_RPC_IPS: &[IpAddr] = &[
     )),
 ];
 
+#[allow(unused)]
 pub fn empty_static_addrs() -> HashMap<String, Vec<IpAddr>> {
     HashMap::new()
 }
 
+#[allow(unused)]
 pub fn default_static_addrs() -> HashMap<String, Vec<IpAddr>> {
     let mut m = HashMap::new();
     m.insert(NYM_API_DOMAIN.to_string(), NYM_API_IPS.to_vec());

--- a/common/http-api-client/src/dns/constants.rs
+++ b/common/http-api-client/src/dns/constants.rs
@@ -69,6 +69,10 @@ pub const NYM_RPC_IPS: &[IpAddr] = &[
     )),
 ];
 
+pub fn empty_static_addrs() -> HashMap<String, Vec<IpAddr>> {
+    HashMap::new()
+}
+
 pub fn default_static_addrs() -> HashMap<String, Vec<IpAddr>> {
     let mut m = HashMap::new();
     m.insert(NYM_API_DOMAIN.to_string(), NYM_API_IPS.to_vec());

--- a/common/http-api-client/src/dns/static_resolver.rs
+++ b/common/http-api-client/src/dns/static_resolver.rs
@@ -64,6 +64,8 @@ impl StaticResolver {
         }
     }
 
+    /// Initialize the contents of the pre-resolve table for this instance of the static resolver
+    #[allow(unused)]
     pub fn with_preresolve(mut self, entries: HashMap<String, Vec<IpAddr>>) -> Self {
         let entries = entries
             .into_iter()
@@ -73,12 +75,14 @@ impl StaticResolver {
         self
     }
 
+    /// Initialize the contenes of the fallback table for this instance of the static resolver
     pub fn with_fallback(mut self, entries: HashMap<String, Vec<IpAddr>>) -> Self {
         self.fallback_addr_map = Arc::new(Mutex::new(entries));
         self
     }
 
-    /// Return the full set of domain names and associated addresses stored in this static lookup table
+    /// Return the set of domain names and associated addresses stored in the pre-resolve static
+    /// lookup table
     pub fn get_preresolve_addrs(&self) -> HashMap<String, Vec<IpAddr>> {
         let mut out = HashMap::new();
         self.preresolve_addr_map
@@ -91,9 +95,16 @@ impl StaticResolver {
         out
     }
 
-    /// Return the full set of domain names and associated addresses stored in this static lookup table
+    /// Return the set of domain names and associated addresses stored in the fallback static lookup
+    /// table
     pub fn get_fallback_addrs(&self) -> HashMap<String, Vec<IpAddr>> {
         self.fallback_addr_map.lock().unwrap().clone()
+    }
+
+    /// Set (or overwrite) the map of static addresses to be returned only after attempting a lookup
+    /// over the network resolver.
+    pub fn set_fallback(&self, addrs: HashMap<String, Vec<IpAddr>>) {
+        self.fallback_addr_map.lock().unwrap().extend(addrs);
     }
 
     /// Clear entries from the static table that would return entries during the pre-resolve stage.
@@ -101,12 +112,8 @@ impl StaticResolver {
     /// table is consulted.
     ///  
     /// Entries elevated to pre-resolve from fallback (added from default or using
-    /// [`fallback_to_addrs`]`) will have their cache timeout cleared. Entries added directly to
+    /// [`set_fallback`]`) will have their cache timeout cleared. Entries added directly to
     /// pre-resolve (using [`Self::preresolve_to_addrs`]) will be removed.
-    ///
-    /// (Corner case) entries that were added first as fallback, then overwritten with pre-resolve
-    /// entries using [`Self::preresolve_to_addrs`] will not be downgraded back to fallback. They
-    /// will be removed like all other pre-resolve entries.
     pub fn clear_preresolve(&self) {
         *self.preresolve_addr_map.lock().unwrap() = HashMap::new();
     }
@@ -118,10 +125,6 @@ impl StaticResolver {
         for (domain, ips) in addrs.into_iter() {
             _ = current_map.insert(domain, Entry::new(ips))
         }
-    }
-
-    pub fn set_fallback(&self, addrs: HashMap<String, Vec<IpAddr>>) {
-        self.fallback_addr_map.lock().unwrap().extend(addrs);
     }
 
     /// Change the timeout for which domains can be pre-resolved after they are looked up in the
@@ -282,15 +285,14 @@ mod test {
         assert!(result.is_none());
 
         // resolving should now update the pre-resolve validity timeout for the entry
-        let entry = StaticResolver::resolve_inner(
-            resolver.fallback_addr_map.lock().unwrap(),
-            resolver.preresolve_addr_map.lock().unwrap(),
-            &example_domain,
-            Some(example_duration),
-        )
-        .expect("missing entry???!!!!");
-        // assert!(matches!(entry
-        //         .status, PreResolveStatus::ValidUntil(t) if t < Instant::now() + example_duration));
+        let _addrs = resolver
+            .resolve_str(&example_domain)
+            .expect("entry should exist");
+        assert!(matches!(
+            resolver.preresolve_status(&example_domain),
+            Some(PreResolveStatus::ValidUntil(t))
+                if t < Instant::now() + example_duration
+        ));
 
         // check that pre-resolve now returns the expected record
         let addrs = resolver
@@ -308,7 +310,7 @@ mod test {
     #[test]
     fn set_and_use_preresolve() {
         let example_duration = Duration::from_secs(3);
-        let example_domains = vec![
+        let example_domains = [
             String::from("static1.nymvpn.com"),
             String::from("static2.nymvpn.com"),
             String::from("preresolve.nymvpn.com"),
@@ -352,12 +354,91 @@ mod test {
         assert!(result.is_none());
 
         resolver.clear_preresolve();
-
-        println!("{:?}", resolver.get_preresolve_addrs());
     }
 
     #[test]
     fn preresolve_with_fallback() {
-        todo!()
+        let example_duration = Duration::from_secs(3);
+        let example_domains = [
+            String::from("static1.nymvpn.com"),
+            String::from("static2.nymvpn.com"),
+            String::from("preresolve.nymvpn.com"),
+        ];
+        let mut addr_map1 = HashMap::new();
+        addr_map1.insert(
+            example_domains[0].clone(),
+            vec![Ipv4Addr::new(10, 10, 10, 10).into()],
+        );
+        addr_map1.insert(
+            example_domains[1].clone(),
+            vec![Ipv4Addr::new(1, 1, 1, 1).into()],
+        );
+
+        let mut addr_map2 = HashMap::new();
+        addr_map2.insert(
+            example_domains[1].clone(),
+            vec![Ipv4Addr::new(1, 1, 1, 1).into()],
+        );
+        addr_map2.insert(
+            example_domains[2].clone(),
+            vec![Ipv4Addr::new(8, 8, 8, 8).into()],
+        );
+
+        let resolver = StaticResolver::new()
+            .with_fallback(addr_map1)
+            .with_preresolve(addr_map2)
+            .with_pre_resolve_timeout(example_duration);
+
+        // when using both pre-resolve and fallback elevating entries from fallback to pre-resolve
+        // leaves the entries as `Valid`.
+        assert!(matches!(
+            resolver.preresolve_status(&example_domains[1]),
+            Some(PreResolveStatus::Valid)
+        ));
+        let _addrs = resolver
+            .resolve_str(&example_domains[1])
+            .expect("entry should exist");
+        assert!(matches!(
+            resolver.preresolve_status(&example_domains[1]),
+            Some(PreResolveStatus::Valid)
+        ));
+
+        // entries not already in pre-resolve get elevated with a timeout.
+        assert!(!resolver.preresolve_contains(&example_domains[0]));
+        let _addrs = resolver
+            .resolve_str(&example_domains[0])
+            .expect("entry should exist");
+        assert!(resolver.preresolve_contains(&example_domains[0]));
+        assert!(matches!(
+            resolver.preresolve_status(&example_domains[0]),
+            Some(PreResolveStatus::ValidUntil(_))
+        ));
+
+        // clearing the pre-resolve table doesn't impact the fallback table.
+        resolver.clear_preresolve();
+        assert!(!resolver.preresolve_contains(&example_domains[0]));
+        assert!(!resolver.preresolve_contains(&example_domains[1]));
+        assert!(!resolver.preresolve_contains(&example_domains[2]));
+        assert!(!resolver.fallback_contains(&example_domains[0]));
+        assert!(!resolver.fallback_contains(&example_domains[1]));
+    }
+
+    /// convenience functions for testing
+    impl StaticResolver {
+        fn preresolve_status(&self, name: &str) -> Option<PreResolveStatus> {
+            self.preresolve_addr_map
+                .lock()
+                .unwrap()
+                .get(name)
+                .map(|e| e.status.clone())
+        }
+
+        fn preresolve_contains(&self, name: &str) -> bool {
+            self.preresolve_addr_map.lock().unwrap().contains_key(name)
+        }
+
+        fn fallback_contains(&self, name: &str) -> bool {
+            self.preresolve_addr_map.lock().unwrap().contains_key(name)
+        }
     }
 }

--- a/common/http-api-client/src/dns/static_resolver.rs
+++ b/common/http-api-client/src/dns/static_resolver.rs
@@ -131,16 +131,17 @@ impl StaticResolver {
     /// recently (within the configured timeout) looked it up previously in this static table using
     /// a regular resolve.
     pub fn pre_resolve(&self, name: &str) -> Option<Vec<IpAddr>> {
-        debug!("found {name:?} in pre-resolve static table resolver");
-
         self.pre_resolve_timeout?;
 
         self.static_addr_map
             .lock()
             .unwrap()
             .get(name)
-            .filter(|e| e.is_valid())
-            .map(|e| e.addrs.clone())
+            .filter(|entry| entry.is_valid())
+            .map(|entry| {
+                debug!("pre-resolve lookup hit for \"{name:?}\" in static table resolver");
+                entry.addrs.clone()
+            })
     }
 
     #[allow(unused)]
@@ -160,7 +161,7 @@ impl StaticResolver {
     ) -> Option<Entry> {
         let resolved = table.get_mut(name)?;
 
-        debug!("found {name:?} in static table resolver");
+        debug!("lookup hit for \"{name:?}\" in static table resolver");
 
         // We had to look this entry up and a pre-resolve duration is defined, so it will
         // trigger in pre-resolve lookups for the next _timeout_ window if it wasn't already

--- a/common/http-api-client/src/dns/static_resolver.rs
+++ b/common/http-api-client/src/dns/static_resolver.rs
@@ -14,16 +14,16 @@ const DEFAULT_PRE_RESOLVE_TIMEOUT: Duration = super::DEFAULT_POSITIVE_LOOKUP_CAC
 
 #[derive(Debug, Default, Clone)]
 pub struct StaticResolver {
-    static_addr_map: Arc<Mutex<HashMap<String, Entry>>>,
+    fallback_addr_map: Arc<Mutex<HashMap<String, Vec<IpAddr>>>>,
+    preresolve_addr_map: Arc<Mutex<HashMap<String, Entry>>>,
     pre_resolve_timeout: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Default)]
 enum PreResolveStatus {
+    #[default]
     Valid,
     ValidUntil(Instant),
-    #[default]
-    Invalid,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -35,14 +35,20 @@ struct Entry {
 impl Entry {
     fn new(addrs: Vec<IpAddr>) -> Self {
         Self {
-            status: PreResolveStatus::Invalid,
+            status: PreResolveStatus::Valid,
+            addrs,
+        }
+    }
+
+    fn new_timeout(addrs: Vec<IpAddr>, timeout: Duration) -> Self {
+        Self {
+            status: PreResolveStatus::ValidUntil(Instant::now() + timeout),
             addrs,
         }
     }
 
     fn is_valid(&self) -> bool {
         match self.status {
-            PreResolveStatus::Invalid => false,
             PreResolveStatus::Valid => true,
             PreResolveStatus::ValidUntil(t) => t > Instant::now(),
         }
@@ -50,22 +56,32 @@ impl Entry {
 }
 
 impl StaticResolver {
-    pub fn new(static_entries: HashMap<String, Vec<IpAddr>>) -> StaticResolver {
-        debug!("building static resolver");
-        let static_entries = static_entries
-            .into_iter()
-            .map(|(name, ips)| (name, Entry::new(ips)))
-            .collect();
+    pub fn new() -> StaticResolver {
         Self {
-            static_addr_map: Arc::new(Mutex::new(static_entries)),
+            fallback_addr_map: Arc::new(Mutex::new(HashMap::new())),
+            preresolve_addr_map: Arc::new(Mutex::new(HashMap::new())),
             pre_resolve_timeout: Some(DEFAULT_PRE_RESOLVE_TIMEOUT),
         }
     }
 
+    pub fn with_preresolve(mut self, entries: HashMap<String, Vec<IpAddr>>) -> Self {
+        let entries = entries
+            .into_iter()
+            .map(|(name, ips)| (name, Entry::new(ips)))
+            .collect();
+        self.preresolve_addr_map = Arc::new(Mutex::new(entries));
+        self
+    }
+
+    pub fn with_fallback(mut self, entries: HashMap<String, Vec<IpAddr>>) -> Self {
+        self.fallback_addr_map = Arc::new(Mutex::new(entries));
+        self
+    }
+
     /// Return the full set of domain names and associated addresses stored in this static lookup table
-    pub fn get_addrs(&self) -> HashMap<String, Vec<IpAddr>> {
+    pub fn get_preresolve_addrs(&self) -> HashMap<String, Vec<IpAddr>> {
         let mut out = HashMap::new();
-        self.static_addr_map
+        self.preresolve_addr_map
             .lock()
             .unwrap()
             .iter()
@@ -73,6 +89,11 @@ impl StaticResolver {
                 out.insert(name.clone(), entry.addrs.clone());
             });
         out
+    }
+
+    /// Return the full set of domain names and associated addresses stored in this static lookup table
+    pub fn get_fallback_addrs(&self) -> HashMap<String, Vec<IpAddr>> {
+        self.fallback_addr_map.lock().unwrap().clone()
     }
 
     /// Clear entries from the static table that would return entries during the pre-resolve stage.
@@ -87,36 +108,20 @@ impl StaticResolver {
     /// entries using [`Self::preresolve_to_addrs`] will not be downgraded back to fallback. They
     /// will be removed like all other pre-resolve entries.
     pub fn clear_preresolve(&self) {
-        let mut to_remove = Vec::new();
-        let mut current_map = self.static_addr_map.lock().unwrap();
-        for (domain, entry) in current_map.iter_mut() {
-            match entry.status {
-                // retain entries that are there for static fallback
-                PreResolveStatus::Invalid => {}
-                // clear pre-resolve cache timeout for entries elevated from fallback
-                PreResolveStatus::ValidUntil(_) => entry.status = PreResolveStatus::Invalid,
-                // remove entries added exclusively for pre-resolve
-                PreResolveStatus::Valid => to_remove.push(domain.clone()),
-            }
-        }
-        to_remove.iter().for_each(|k| {
-            _ = current_map.remove(k);
-        });
+        *self.preresolve_addr_map.lock().unwrap() = HashMap::new();
     }
 
     /// Set (or overwrite) the map of static addresses and mark these domains to be returned
     /// WITHOUT attempting a lookup over the network resolver.
-    pub fn preresolve_to_addrs(&self, addrs: HashMap<String, Vec<IpAddr>>) {
-        let mut current_map = self.static_addr_map.lock().unwrap();
+    pub fn set_preresolve(&self, addrs: HashMap<String, Vec<IpAddr>>) {
+        let mut current_map = self.preresolve_addr_map.lock().unwrap();
         for (domain, ips) in addrs.into_iter() {
-            _ = current_map.insert(
-                domain,
-                Entry {
-                    status: PreResolveStatus::Valid,
-                    addrs: ips,
-                },
-            )
+            _ = current_map.insert(domain, Entry::new(ips))
         }
+    }
+
+    pub fn set_fallback(&self, addrs: HashMap<String, Vec<IpAddr>>) {
+        self.fallback_addr_map.lock().unwrap().extend(addrs);
     }
 
     /// Change the timeout for which domains can be pre-resolved after they are looked up in the
@@ -131,9 +136,7 @@ impl StaticResolver {
     /// recently (within the configured timeout) looked it up previously in this static table using
     /// a regular resolve.
     pub fn pre_resolve(&self, name: &str) -> Option<Vec<IpAddr>> {
-        self.pre_resolve_timeout?;
-
-        self.static_addr_map
+        self.preresolve_addr_map
             .lock()
             .unwrap()
             .get(name)
@@ -147,19 +150,20 @@ impl StaticResolver {
     #[allow(unused)]
     pub fn resolve_str(&self, name: &str) -> Option<Vec<IpAddr>> {
         Self::resolve_inner(
-            self.static_addr_map.lock().unwrap(),
+            self.fallback_addr_map.lock().unwrap(),
+            self.preresolve_addr_map.lock().unwrap(),
             name,
             self.pre_resolve_timeout,
         )
-        .map(|e| e.addrs)
     }
 
     fn resolve_inner(
-        mut table: MutexGuard<'_, HashMap<String, Entry>>,
+        fallback_table: MutexGuard<'_, HashMap<String, Vec<IpAddr>>>,
+        mut preresolve_table: MutexGuard<'_, HashMap<String, Entry>>,
         name: &str,
         pre_resolve_cache_timeout: Option<Duration>,
-    ) -> Option<Entry> {
-        let resolved = table.get_mut(name)?;
+    ) -> Option<Vec<IpAddr>> {
+        let resolved = fallback_table.get(name)?;
 
         debug!("lookup hit for \"{name:?}\" in static table resolver");
 
@@ -167,17 +171,22 @@ impl StaticResolver {
         // trigger in pre-resolve lookups for the next _timeout_ window if it wasn't already
         // triggering.
         if let Some(pre_resolve_timeout) = pre_resolve_cache_timeout {
-            let timeout = Instant::now() + pre_resolve_timeout;
-            match resolved.status {
-                PreResolveStatus::Invalid => {
-                    resolved.status = PreResolveStatus::ValidUntil(timeout)
+            match preresolve_table.get_mut(name) {
+                None => {
+                    _ = preresolve_table.insert(
+                        name.to_string(),
+                        Entry::new_timeout(resolved.clone(), pre_resolve_timeout),
+                    );
                 }
-                PreResolveStatus::ValidUntil(t) => {
-                    if t < timeout {
-                        resolved.status = PreResolveStatus::ValidUntil(timeout)
-                    }
+                // Not sure how we would get cases where this is Some( ) -- it requires having a
+                // Valid entry in the preresolve table and still doing a lookup against fallback.
+                Some(entry) if matches!(entry.status, PreResolveStatus::ValidUntil(_)) => {
+                    _ = preresolve_table.insert(
+                        name.to_string(),
+                        Entry::new_timeout(resolved.clone(), pre_resolve_timeout),
+                    );
                 }
-                PreResolveStatus::Valid => {}
+                _ => {}
             }
         }
         Some(resolved.clone())
@@ -187,13 +196,23 @@ impl StaticResolver {
 impl Resolve for StaticResolver {
     fn resolve(&self, name: Name) -> Resolving {
         debug!("looking up {name:?} in static resolver");
-        let addr_map = self.static_addr_map.clone();
+        // these should clone arcs, not the actual tables
+        let fallback_addr_map = self.fallback_addr_map.clone();
+        let presesolve_addr_map = self.preresolve_addr_map.clone();
         let timeout = self.pre_resolve_timeout;
+        // Also the returned future doesn't try to take the lock on the tables until the
+        // future is awaited, so no blocking issues.
         Box::pin(async move {
-            let addr_map = addr_map.lock().unwrap();
-            let lookup = match Self::resolve_inner(addr_map, name.as_str(), timeout) {
+            let fallback_addr_map = fallback_addr_map.lock().unwrap();
+            let presesolve_addr_map = presesolve_addr_map.lock().unwrap();
+            let lookup = match Self::resolve_inner(
+                fallback_addr_map,
+                presesolve_addr_map,
+                name.as_str(),
+                timeout,
+            ) {
                 None => return Err(ResolveError::StaticLookupMiss.into()),
-                Some(entry) => entry.addrs,
+                Some(addrs) => addrs,
             };
             let addrs: Addrs = Box::new(
                 lookup
@@ -220,7 +239,7 @@ mod test {
         let example_domain = String::from("static.nymvpn.com");
 
         // lookup for domain for which there is no entry
-        let resolver = StaticResolver::new(HashMap::new());
+        let resolver = StaticResolver::new();
 
         let url = reqwest::dns::Name::from_str(&example_domain).unwrap();
         let result = resolver.resolve(url).await;
@@ -237,7 +256,7 @@ mod test {
         addr_map.insert(example_domain.clone(), vec![example_ip4, example_ip6]);
 
         let url = reqwest::dns::Name::from_str(&example_domain).unwrap();
-        let resolver = StaticResolver::new(addr_map);
+        let resolver = StaticResolver::new().with_fallback(addr_map);
         let mut addrs = resolver.resolve(url).await?;
         assert!(addrs.contains(&SocketAddr::new(example_ip4, 0)));
         assert!(addrs.contains(&SocketAddr::new(example_ip6, 0)));
@@ -254,7 +273,9 @@ mod test {
         let example_ip6: IpAddr = "dead::beef".parse().unwrap();
         addr_map.insert(example_domain.clone(), vec![example_ip4, example_ip6]);
 
-        let resolver = StaticResolver::new(addr_map).with_pre_resolve_timeout(example_duration);
+        let resolver = StaticResolver::new()
+            .with_fallback(addr_map)
+            .with_pre_resolve_timeout(example_duration);
 
         // ensure that attempting to pre-resolve without first resolving returns none
         let result = resolver.pre_resolve(&example_domain);
@@ -262,13 +283,14 @@ mod test {
 
         // resolving should now update the pre-resolve validity timeout for the entry
         let entry = StaticResolver::resolve_inner(
-            resolver.static_addr_map.lock().unwrap(),
+            resolver.fallback_addr_map.lock().unwrap(),
+            resolver.preresolve_addr_map.lock().unwrap(),
             &example_domain,
             Some(example_duration),
         )
         .expect("missing entry???!!!!");
-        assert!(matches!(entry
-                .status, PreResolveStatus::ValidUntil(t) if t < Instant::now() + example_duration));
+        // assert!(matches!(entry
+        //         .status, PreResolveStatus::ValidUntil(t) if t < Instant::now() + example_duration));
 
         // check that pre-resolve now returns the expected record
         let addrs = resolver
@@ -311,27 +333,31 @@ mod test {
             vec![Ipv4Addr::new(8, 8, 8, 8).into()],
         );
 
-        let resolver = StaticResolver::new(addr_map1).with_pre_resolve_timeout(example_duration);
+        let resolver = StaticResolver::new()
+            .with_fallback(addr_map1)
+            .with_pre_resolve_timeout(example_duration);
 
-        // ensure that attempting to pre-resolve without first resolving returns none
+        // Attempting to pre-resolve without setting the table returns none
         let result = resolver.pre_resolve(&example_domains[0]);
         assert!(result.is_none());
 
-        resolver.preresolve_to_addrs(addr_map2);
+        resolver.set_preresolve(addr_map2);
 
-        // ensure that attempting to pre-resolve without first resolving returns none
-        let result = resolver.pre_resolve(&example_domains[0]);
-        assert!(result.is_none());
-
-        // ensure that attempting to pre-resolve without first resolving returns none
+        // After setting the pre-resolve, addresses in the the table are returned
         let result = resolver.pre_resolve(&example_domains[1]);
         assert!(result.is_some());
 
-        let result = resolver.pre_resolve(&example_domains[2]);
-        assert!(result.is_some());
+        // If the domain wasn't in the pre-resolve table it returns none.
+        let result = resolver.pre_resolve(&example_domains[0]);
+        assert!(result.is_none());
 
         resolver.clear_preresolve();
 
-        println!("{:?}", resolver.get_addrs());
+        println!("{:?}", resolver.get_preresolve_addrs());
+    }
+
+    #[test]
+    fn preresolve_with_fallback() {
+        todo!()
     }
 }


### PR DESCRIPTION
Allow more streamlined interaction with the static DNS underpinning the HTTP client. This makes usage for the firewall. and for ensuring API availability more reliable.

In the VPN client we are already doing the manual DNS lookups for the firewall exceptions. We should just set those entries as pre-resolve until some further point controlled by the state machine where we are okay with DNS doing lookups using the network again. This process simplifies things that are already in place too, like forcing clients to use the resolved addresses which currently leverages a message passing system.

This change tries to:
- Add explicit controls for setting and unsetting the contents of both pre-resolve and fallback tables of a dns resolver.
- ensure changes applied to independent instances are associated with the independent instance.
- ensure that the static resolve entries (pre-resolve and fallback) are uniform for all clients using the default shared DNS resolver.

### Lib Changs

```rust
impl HickoryDnsResolver {
    /// Returns an instance of the shared resolver.
    pub fn shared() -> Self { /* ... */ }

    /// Clear entries from the static table that would return entries during the pre-resolve stage.
    /// This means that all lookups will attempt to use the network resolver again before the static
    /// table is consulted.
    ///  
    /// Entries elevated to pre-resolve from fallback (added from default or using
    /// [`set_fallback`]`) will have their cache timeout cleared. Entries added directly to
    /// pre-resolve (using [`Self::set_static_preresolve`]) will be removed.
    pub fn clear_preresolve(&self) { /* ... */ }

    /// Set (or overwrite) the map of addresses used in the fallback static hostname lookup
    pub fn set_fallback_addrs(&mut self, addrs: HashMap<String, Vec<IpAddr>>) { /* ... */ }

    /// Set (or overwrite) the map of addresses used in the preresolve static hostname lookup
    pub fn set_static_preresolve(&mut self, addrs: HashMap<String, Vec<IpAddr>>) { /* ... */ }

    /// Get the current map of hostnames to addresses used in the fallback static lookup stage if one
    /// exists.
    pub fn get_static_fallbacks(&self) -> Option<HashMap<String, Vec<IpAddr>>> { /* ... */ }

    /// Get the current map of hostnames to addresses used in the preresolve static lookup stage
    /// if one exists.
    pub fn get_static_preresolve(&self) -> Option<HashMap<String, Vec<IpAddr>>> { /* ... */ }

}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6374)
<!-- Reviewable:end -->
