### PR TITLE
Reduce the size of `HttpClientError`

### DIFF
--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -329,14 +329,14 @@ pub enum HttpClientError {
 
     #[error("failed to send request for {url}: {source}")]
     RequestSendFailure {
-        url: reqwest::Url,
+        url: Box<reqwest::Url>,
         #[source]
         source: ReqwestErrorWrapper,
     },
 
     #[error("failed to read response body from {url}: {source}")]
     ResponseReadFailure {
-        url: reqwest::Url,
+        url: Box<reqwest::Url>,
         headers: Box<HeaderMap>,
         status: StatusCode,
         #[source]
@@ -353,7 +353,7 @@ pub enum HttpClientError {
     },
 
     #[error("the requested resource could not be found at {url}")]
-    NotFound { url: reqwest::Url },
+    NotFound { url: Box<reqwest::Url> },
 
     #[error("attempted to use domain fronting and clone a request containing stream data")]
     AttemptedToCloneStreamRequest,
@@ -365,7 +365,7 @@ pub enum HttpClientError {
         "the request for {url} failed with status '{status}'. no additional error message provided. response headers: {headers:?}"
     )]
     RequestFailure {
-        url: reqwest::Url,
+        url: Box<reqwest::Url>,
         status: StatusCode,
         headers: Box<HeaderMap>,
     },
@@ -374,7 +374,7 @@ pub enum HttpClientError {
         "the returned response from {url} was empty. status: '{status}'. response headers: {headers:?}"
     )]
     EmptyResponse {
-        url: reqwest::Url,
+        url: Box<reqwest::Url>,
         status: StatusCode,
         headers: Box<HeaderMap>,
     },
@@ -383,7 +383,7 @@ pub enum HttpClientError {
         "failed to resolve request for {url}. status: '{status}'. response headers: {headers:?}. additional error message: {error}"
     )]
     EndpointFailure {
-        url: reqwest::Url,
+        url: Box<reqwest::Url>,
         status: StatusCode,
         headers: Box<HeaderMap>,
         error: String,
@@ -453,7 +453,7 @@ impl HttpClientError {
 
     pub fn request_send_error(url: reqwest::Url, source: reqwest::Error) -> Self {
         HttpClientError::RequestSendFailure {
-            url,
+            url: Box::new(url),
             source: ReqwestErrorWrapper(source),
         }
     }
@@ -1517,7 +1517,7 @@ where
 
     if !allow_empty && let Some(0) = res.content_length() {
         return Err(HttpClientError::EmptyResponse {
-            url,
+            url: Box::new(url),
             status,
             headers: Box::new(headers),
         });
@@ -1530,25 +1530,25 @@ where
             .bytes()
             .await
             .map_err(|source| HttpClientError::ResponseReadFailure {
-                url,
+                url: Box::new(url),
                 headers: Box::new(headers.clone()),
                 status,
                 source: ReqwestErrorWrapper(source),
             })?;
         decode_raw_response(&headers, full)
     } else if res.status() == StatusCode::NOT_FOUND {
-        Err(HttpClientError::NotFound { url })
+        Err(HttpClientError::NotFound { url: Box::new(url) })
     } else {
         let Ok(plaintext) = res.text().await else {
             return Err(HttpClientError::RequestFailure {
-                url,
+                url: Box::new(url),
                 status,
                 headers: Box::new(headers),
             });
         };
 
         Err(HttpClientError::EndpointFailure {
-            url,
+            url: Box::new(url),
             status,
             headers: Box::new(headers),
             error: plaintext,

--- a/nym-node-status-api/nym-node-status-api/src/metrics_scraper/error.rs
+++ b/nym-node-status-api/nym-node-status-api/src/metrics_scraper/error.rs
@@ -57,7 +57,9 @@ mod tests {
         let error = NodeScraperError::MalformedHost {
             host: "".to_string(),
             node_id: 0,
-            source: Box::new(NymNodeApiClientError::NotFound { url: dummy_url() }),
+            source: Box::new(NymNodeApiClientError::NotFound {
+                url: Box::new(dummy_url()),
+            }),
         };
 
         let error_msg = error.to_string();
@@ -112,7 +114,9 @@ mod tests {
     #[allow(deprecated)]
     fn test_error_different_sources() {
         // Test with different NymNodeApiClientError variants
-        let not_found_error = NymNodeApiClientError::NotFound { url: dummy_url() };
+        let not_found_error = NymNodeApiClientError::NotFound {
+            url: Box::new(dummy_url()),
+        };
         let error1 = NodeScraperError::MalformedHost {
             host: "host1".to_string(),
             node_id: 1,


### PR DESCRIPTION
Box `reqwest::Url` to keep `HttpClientError` below 128 byte size which triggers clippy