### PR TITLE
Update reqwest to v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9862,6 +9862,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "coarsetime"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1318,16 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1438,6 +1485,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1866,7 +1923,7 @@ checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
 dependencies = [
  "curl-sys",
  "libc",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
  "socket2 0.6.1",
@@ -2433,6 +2490,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,6 +2927,12 @@ checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -3701,7 +3770,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -4281,6 +4349,28 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -5374,7 +5464,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "schemars 0.8.22",
  "semver 1.0.27",
  "serde",
@@ -5982,7 +6072,7 @@ dependencies = [
  "nym-upgrade-mode-check",
  "nym-validator-client",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "sqlx",
@@ -6023,7 +6113,7 @@ dependencies = [
  "nym-network-defaults",
  "nym-validator-client",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "sqlx",
@@ -6051,7 +6141,7 @@ dependencies = [
  "nym-http-api-common",
  "nym-serde-helpers",
  "nym-upgrade-mode-check",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -6229,7 +6319,7 @@ dependencies = [
  "nym-validator-client",
  "nyxd-scraper-psql",
  "nyxd-scraper-shared",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -6326,7 +6416,7 @@ dependencies = [
 name = "nym-exit-policy"
 version = "1.20.1"
 dependencies = [
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -6489,7 +6579,7 @@ dependencies = [
  "nym-validator-client",
  "pnet_packet",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -6618,7 +6708,7 @@ dependencies = [
  "nym-http-api-common",
  "nym-network-defaults",
  "once_cell",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "serde_plain",
@@ -6639,7 +6729,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "syn 2.0.114",
  "uuid",
 ]
@@ -6767,7 +6857,7 @@ dependencies = [
  "nym-wireguard",
  "nym-wireguard-types",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -7045,7 +7135,7 @@ dependencies = [
  "petgraph",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "tokio",
@@ -7091,7 +7181,7 @@ dependencies = [
  "publicsuffix",
  "rand 0.8.5",
  "regex",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "sqlx",
@@ -7292,7 +7382,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -7324,7 +7414,7 @@ dependencies = [
  "bs58",
  "nym-credentials",
  "nym-crypto",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "time",
@@ -7578,7 +7668,7 @@ dependencies = [
  "nym-validator-client",
  "parking_lot",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "tap",
  "tempfile",
@@ -7708,7 +7798,7 @@ dependencies = [
  "nym-validator-client",
  "pin-project",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "schemars 0.8.22",
  "serde",
  "tap",
@@ -8055,7 +8145,7 @@ dependencies = [
  "nym-sphinx-types",
  "nym-wasm-utils",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -8093,7 +8183,7 @@ dependencies = [
  "nym-mixnet-contract-common",
  "nym-validator-client",
  "nym-vesting-contract-common",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -8117,7 +8207,7 @@ dependencies = [
  "nym-crypto",
  "nym-http-api-client",
  "nym-test-utils",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -8162,7 +8252,7 @@ dependencies = [
  "nym-serde-helpers",
  "nym-vesting-contract-common",
  "prost",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -8490,7 +8580,7 @@ dependencies = [
  "nym-bin-common",
  "nym-config",
  "nym-task",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -8517,7 +8607,7 @@ dependencies = [
  "nym-task",
  "nym-validator-client",
  "nyxd-scraper-sqlite",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "schemars 0.8.22",
  "serde",
  "sqlx",
@@ -8649,6 +8739,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -9481,6 +9577,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -9741,9 +9838,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -9762,9 +9859,9 @@ dependencies = [
  "quinn",
  "rustls 0.23.36",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -9777,7 +9874,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -9996,6 +10092,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -10011,10 +10108,10 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -10023,11 +10120,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -10059,6 +10168,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.36",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.8",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10085,6 +10221,7 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -10257,7 +10394,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -11224,7 +11374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -13114,6 +13264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13939,7 +14098,7 @@ dependencies = [
  "nym-http-api-client",
  "nym-wasm-utils",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -14003,7 +14162,7 @@ dependencies = [
  "itertools 0.14.0",
  "nym-bin-common",
  "nym-http-api-client",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "thiserror 2.0.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,7 +324,7 @@ rand_core = "0.6.3"
 rand_distr = "0.4"
 rayon = "1.5.1"
 regex = "1.10.6"
-reqwest = { version = "0.12.15", default-features = false }
+reqwest = { version = "0.13.1", default-features = false }
 rs_merkle = "1.5.0"
 schemars = "0.8.22"
 semver = "1.0.26"

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -76,7 +76,7 @@ features = ["json"]
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.reqwest]
 workspace = true
-features = ["json", "rustls-tls"]
+features = ["json", "rustls"]
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/common/credential-proxy/Cargo.toml
+++ b/common/credential-proxy/Cargo.toml
@@ -19,7 +19,7 @@ bs58 = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
 rand = { workspace = true }
-reqwest = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["rustls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 strum = { workspace = true, features = ["derive"] }

--- a/common/http-api-client/Cargo.toml
+++ b/common/http-api-client/Cargo.toml
@@ -21,7 +21,7 @@ debug-inventory = ["nym-http-api-client-macro/debug-inventory"]
 async-trait = { workspace = true }
 bincode = { workspace = true }
 cfg-if = { workspace = true}
-reqwest = { workspace = true, features = ["json", "gzip", "deflate", "brotli", "zstd", "rustls-tls"] }
+reqwest = { workspace = true, features = ["json", "gzip", "deflate", "brotli", "zstd", "rustls"] }
 http.workspace = true
 url = { workspace = true }
 once_cell = { workspace = true }

--- a/common/http-api-client/src/dns.rs
+++ b/common/http-api-client/src/dns.rs
@@ -552,7 +552,7 @@ mod test {
         let var_name = HickoryDnsResolver::default();
         let resolver = var_name;
         let client = reqwest::ClientBuilder::new()
-            .dns_resolver(resolver.into())
+            .dns_resolver(resolver)
             .build()
             .unwrap();
 

--- a/common/upgrade-mode-check/Cargo.toml
+++ b/common/upgrade-mode-check/Cargo.toml
@@ -13,7 +13,7 @@ description = "Functions and tests for checking Nym's Credential Proxy is being 
 
 [dependencies]
 jwt-simple = { workspace = true }
-reqwest = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["rustls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 time = { workspace = true, features = ["serde", "formatting", "parsing"] }

--- a/common/zulip-client/Cargo.toml
+++ b/common/zulip-client/Cargo.toml
@@ -21,7 +21,7 @@ zeroize = { workspace = true }
 
 nym-bin-common = { workspace = true }
 nym-http-api-client = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["form"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/nym-api/Cargo.toml
+++ b/nym-api/Cargo.toml
@@ -27,7 +27,7 @@ moka = { workspace = true }
 pin-project = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "query"] }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/nym-api/Cargo.toml
+++ b/nym-api/Cargo.toml
@@ -27,7 +27,6 @@ moka = { workspace = true }
 pin-project = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-reqwest = { workspace = true, features = ["json", "query"] }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -124,6 +123,7 @@ sqlx = { workspace = true, features = [
 
 [dev-dependencies]
 axum-test = { workspace = true }
+reqwest = { workspace = true, features = ["json", "query"] }
 tempfile = { workspace = true }
 cw3 = { workspace = true }
 cw-utils = { workspace = true }

--- a/nym-api/src/node_status_api/models.rs
+++ b/nym-api/src/node_status_api/models.rs
@@ -15,7 +15,7 @@ use nym_mixnet_contract_common::reward_params::Performance;
 use nym_mixnet_contract_common::{IdentityKey, NodeId};
 use nym_serde_helpers::date::DATE_FORMAT;
 use nym_validator_client::nyxd::error::NyxdError;
-use reqwest::StatusCode;
+use axum::http::StatusCode;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sqlx::Error;

--- a/nym-api/src/node_status_api/models.rs
+++ b/nym-api/src/node_status_api/models.rs
@@ -5,6 +5,7 @@ use crate::ecash::error::{EcashError, RedemptionError};
 use crate::node_status_api::utils::NodeUptimes;
 use crate::storage::models::NodeStatus;
 use crate::support::caching::cache::UninitialisedCache;
+use axum::http::StatusCode;
 use nym_api_requests::ecash::models::DepositId;
 use nym_api_requests::models::{
     HistoricalPerformanceResponse, HistoricalUptimeResponse, NodePerformance,
@@ -15,7 +16,6 @@ use nym_mixnet_contract_common::reward_params::Performance;
 use nym_mixnet_contract_common::{IdentityKey, NodeId};
 use nym_serde_helpers::date::DATE_FORMAT;
 use nym_validator_client::nyxd::error::NyxdError;
-use axum::http::StatusCode;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sqlx::Error;

--- a/nym-credential-proxy/nym-credential-proxy-requests/Cargo.toml
+++ b/nym-credential-proxy/nym-credential-proxy-requests/Cargo.toml
@@ -20,7 +20,7 @@ serde_json.workspace = true
 serde_with = { workspace = true }
 time = { workspace = true, features = ["serde", "formatting", "parsing"] }
 tsify = { workspace = true, optional = true }
-reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+reqwest = { workspace = true, features = ["json", "rustls"] }
 wasm-bindgen = { workspace = true, optional = true }
 
 ## openapi:

--- a/nym-credential-proxy/nym-credential-proxy/Cargo.toml
+++ b/nym-credential-proxy/nym-credential-proxy/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 futures.workspace = true
 humantime.workspace = true
 rand.workspace = true
-reqwest = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["rustls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sqlx = { workspace = true, features = [

--- a/nym-data-observatory/Cargo.toml
+++ b/nym-data-observatory/Cargo.toml
@@ -27,7 +27,7 @@ nym-task = { workspace = true }
 nym-validator-client = { workspace = true }
 nyxd-scraper-psql = { path = "../common/nyxd-scraper-psql" }
 nyxd-scraper-shared = { workspace = true }
-reqwest = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["rustls"] }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/nyx-chain-watcher/Cargo.toml
+++ b/nyx-chain-watcher/Cargo.toml
@@ -26,7 +26,7 @@ nym-network-defaults = { workspace = true }
 nym-task = { workspace = true }
 nym-validator-client = { workspace = true }
 nyxd-scraper-sqlite = { path = "../common/nyxd-scraper-sqlite" }
-reqwest = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["rustls"] }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite", "time"] }

--- a/tools/nymvisor/Cargo.toml
+++ b/tools/nymvisor/Cargo.toml
@@ -22,7 +22,7 @@ hex = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 nix = { workspace = true, features = ["signal", "fs"] }
-reqwest = { workspace = true, features = ["json", "stream", "rustls-tls"] }
+reqwest = { workspace = true, features = ["json", "stream", "rustls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }


### PR DESCRIPTION
Update reqwest to v0.13.1, switch to using rustls (default); ring is no longer available. We may need to setup NAND and some other stuff for aws-lc-sys to compile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6401)
<!-- Reviewable:end -->
