### PR TITLE
use local kem key instead of local x25519

### DIFF
--- a/common/nym-lp/src/state_machine.rs
+++ b/common/nym-lp/src/state_machine.rs
@@ -23,6 +23,7 @@ use crate::{
 };
 use bytes::{Buf, Bytes};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+use nym_kkt::ciphersuite::EncapsulationKey;
 use std::mem;
 use tracing::debug;
 
@@ -364,33 +365,44 @@ impl LpStateMachine {
                     result_action = Some(Err(LpError::UnknownSessionId(packet.header.receiver_idx())));
                     LpState::KKTExchange { session }
                 } else {
-                    use crate::message::LpMessage;
 
                     // Packet message is already parsed, match on it directly
                     match &packet.message {
                         LpMessage::KKTRequest(kkt_request) if !session.is_initiator() => {
                             // Responder processes KKT request
                             // Convert X25519 public key to KEM format for KKT response
-                            use nym_kkt::ciphersuite::EncapsulationKey;
 
-                            // Get local X25519 public key by deriving from private key
-                            let local_x25519_public = session.local_x25519_public();
+                            // Get local KEM key
+                            match session.get_kem_key_handle() {
+                                Err(err) => {
+                                    let reason = err.to_string();
+                                    result_action = Some(Err(err));
+                                    LpState::Closed { reason }
+                                }
+                                Ok(local_kem_psq_public) => {
+                                    // Convert to libcrux KEM public key
+                                    // V1 is X255519
+                                    match libcrux_kem::PublicKey::decode(
+                                        libcrux_kem::Algorithm::X25519,
+                                        local_kem_psq_public.as_bytes(),
+                                    ) {
+                                        Ok(libcrux_public_key) => {
+                                            let responder_kem_pk = EncapsulationKey::X25519(libcrux_public_key);
 
-                            // Convert to libcrux KEM public key
-                            match libcrux_kem::PublicKey::decode(
-                                libcrux_kem::Algorithm::X25519,
-                                local_x25519_public.as_bytes(),
-                            ) {
-                                Ok(libcrux_public_key) => {
-                                    let responder_kem_pk = EncapsulationKey::X25519(libcrux_public_key);
-
-                                    match session.process_kkt_request(&kkt_request.0, &responder_kem_pk) {
-                                        Ok(kkt_response_message) => {
-                                            match session.next_packet(kkt_response_message) {
-                                                Ok(response_packet) => {
-                                                    result_action = Some(Ok(LpAction::SendPacket(response_packet)));
-                                                    // After KKT exchange, move to Handshaking
-                                                    LpState::Handshaking { session }
+                                            match session.process_kkt_request(&kkt_request.0, &responder_kem_pk) {
+                                                Ok(kkt_response_message) => {
+                                                    match session.next_packet(kkt_response_message) {
+                                                        Ok(response_packet) => {
+                                                            result_action = Some(Ok(LpAction::SendPacket(response_packet)));
+                                                            // After KKT exchange, move to Handshaking
+                                                            LpState::Handshaking { session }
+                                                        }
+                                                        Err(e) => {
+                                                            let reason = e.to_string();
+                                                            result_action = Some(Err(e));
+                                                            LpState::Closed { reason }
+                                                        }
+                                                    }
                                                 }
                                                 Err(e) => {
                                                     let reason = e.to_string();
@@ -400,18 +412,13 @@ impl LpStateMachine {
                                             }
                                         }
                                         Err(e) => {
-                                            let reason = e.to_string();
-                                            result_action = Some(Err(e));
+                                            let reason = format!("Failed to convert X25519 to KEM: {:?}", e);
+                                            let err = LpError::Internal(reason.clone());
+                                            result_action = Some(Err(err));
                                             LpState::Closed { reason }
                                         }
                                     }
-                                }
-                                Err(e) => {
-                                    let reason = format!("Failed to convert X25519 to KEM: {:?}", e);
-                                    let err = LpError::Internal(reason.clone());
-                                    result_action = Some(Err(err));
-                                    LpState::Closed { reason }
-                                }
+                                },
                             }
                         }
                         LpMessage::KKTResponse(kkt_response) if session.is_initiator() => {


### PR DESCRIPTION
KKT exchange was using local x25519 public key, which is wrong.
It should use the local KEM key (which just so happens to be x25519 in V1)

Before bugfix : probe test says
```
2026-02-02T09:40:41.053756Z ERROR nym_gateway_probe::common::probe_tests: LP handshake failed: LP handshake failed: Internal error: KKT response handling failure: KEMError { info: "Hash of received encapsulation key does not match the value stored on the directory." }
```

After bugfix : probe test says
```
2026-02-02T09:43:11.757208Z  INFO nym_registration_client::lp_client::client: KKT exchange completed, starting Noise handshake
2026-02-02T09:43:11.852452Z  INFO nym_gateway_probe::common::probe_tests: LP handshake completed successfully
```


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6402)
<!-- Reviewable:end -->
