### PR TITLE
LP-fix : add LP x25519 key to the description

### DIFF
--- a/nym-api/nym-api-requests/src/models/described/type_translation.rs
+++ b/nym-api/nym-api-requests/src/models/described/type_translation.rs
@@ -210,6 +210,12 @@ pub struct LewesProtocolDetailsV1 {
     /// LP UDP data address (default: 51264) for Sphinx packets wrapped in LP
     pub data_port: u16,
 
+    #[serde(with = "bs58_x25519_pubkey")]
+    #[schemars(with = "String")]
+    #[schema(value_type = String)]
+    /// LP public key
+    pub x25519: x25519::PublicKey,
+
     /// Digests of the KEM keys available to this node alongside hashing algorithms used
     /// for their computation.
     /// note: digests are hex encoded
@@ -457,6 +463,7 @@ impl From<nym_node_requests::api::v1::lewes_protocol::models::LewesProtocol>
             enabled: value.enabled,
             control_port: value.control_port,
             data_port: value.data_port,
+            x25519: value.x25519,
             kem_keys: value
                 .kem_keys
                 .into_iter()

--- a/nym-api/nym-api-requests/src/models/described/v2.rs
+++ b/nym-api/nym-api-requests/src/models/described/v2.rs
@@ -343,6 +343,7 @@ pub fn mock_nym_node_description(seed: u64) -> NymNodeDescriptionV2 {
                 enabled: true,
                 control_port: 1234,
                 data_port: 2345,
+                x25519: *x25519.public_key(),
                 kem_keys: kem_hashes_wrapper,
                 signing_keys: signing_keys_hashes_wrapper,
             }),

--- a/nym-gateway-probe/src/common/nodes.rs
+++ b/nym-gateway-probe/src/common/nodes.rs
@@ -130,20 +130,16 @@ impl DirectoryNode {
             .copied()
             .ok_or_else(|| anyhow!("no ip address known"))?;
 
-        let lp_data = match (
-            description.lewes_protocol.clone(),
-            description.host_information.keys.x25519_versioned_noise,
-        ) {
-            (Some(lp_data), Some(noise_key)) => Some(TestedNodeLpDetails {
+        let lp_data = description.lewes_protocol.as_ref().and_then(|lp_data| {
+            Some(TestedNodeLpDetails {
                 address: SocketAddr::new(ip_address, lp_data.control_port),
-                expected_kem_key_hashes: lp_data.kem_keys()?,
-                expected_signing_key_hashes: lp_data.signing_keys()?,
-                x25519: noise_key.x25519_pubkey,
+                expected_kem_key_hashes: lp_data.kem_keys().ok()?,
+                expected_signing_key_hashes: lp_data.signing_keys().ok()?,
+                x25519: lp_data.x25519,
                 // \/ TODO: proper derivation from build version
                 lp_version: version::CURRENT,
-            }),
-            _ => None,
-        };
+            })
+        });
 
         Ok(TestedNodeDetails {
             identity: self.identity(),

--- a/nym-node/nym-node-requests/src/api/v1/lewes_protocol/models.rs
+++ b/nym-node/nym-node-requests/src/api/v1/lewes_protocol/models.rs
@@ -1,6 +1,8 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use nym_crypto::asymmetric::x25519;
+use nym_crypto::asymmetric::x25519::serde_helpers::bs58_x25519_pubkey;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -19,6 +21,12 @@ pub struct LewesProtocol {
     /// LP UDP data address (default: 51264) for Sphinx packets wrapped in LP
     pub data_port: u16,
 
+    #[serde(with = "bs58_x25519_pubkey")]
+    #[schemars(with = "String")]
+    #[schema(value_type = String)]
+    /// LP public key
+    pub x25519: x25519::PublicKey,
+
     /// Digests of the KEM keys available to this node alongside hashing algorithms used
     /// for their computation.
     /// note: digests are hex encoded
@@ -35,6 +43,7 @@ impl LewesProtocol {
         enabled: bool,
         control_port: u16,
         data_port: u16,
+        x25519: x25519::PublicKey,
         kem_keys: HashMap<LPKEM, HashMap<LPHashFunction, String>>,
         signing_keys: HashMap<LPSignatureScheme, HashMap<LPHashFunction, String>>,
     ) -> Self {
@@ -42,6 +51,7 @@ impl LewesProtocol {
             enabled,
             control_port,
             data_port,
+            x25519,
             kem_keys,
             signing_keys,
         }

--- a/nym-node/src/node/mod.rs
+++ b/nym-node/src/node/mod.rs
@@ -890,6 +890,7 @@ impl NymNode {
             self.modes().entry,
             self.config.gateway_tasks.lp.announced_control_port(),
             self.config.gateway_tasks.lp.announced_data_port(),
+            *self.x25519_noise_keys.public_key(),
             self.compute_kem_key_hashes(),
             self.compute_signing_key_hashes(),
         );


### PR DESCRIPTION
Add the x25519 key to the LP description. 
It is still technically the Noise key, but it allows future changes and client can have it easily

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6408)
<!-- Reviewable:end -->
