### PR TITLE
LP-fix : configurable LP timeouts

### DIFF
--- a/nym-registration-client/src/builder/config.rs
+++ b/nym-registration-client/src/builder/config.rs
@@ -17,8 +17,8 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio_util::sync::CancellationToken;
 use typed_builder::TypedBuilder;
 
-use crate::config::RegistrationMode;
 use crate::error::RegistrationClientError;
+use crate::{LpRegistrationConfig, config::RegistrationMode};
 
 const VPN_AVERAGE_PACKET_DELAY: Duration = Duration::from_millis(15);
 const MIXNET_CLIENT_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
@@ -44,6 +44,8 @@ pub struct BuilderConfig {
     pub cancel_token: CancellationToken,
     #[cfg(unix)]
     pub connection_fd_callback: Arc<dyn Fn(RawFd) + Send + Sync>,
+    #[builder(default)]
+    pub lp_registration_config: LpRegistrationConfig,
 }
 
 #[derive(Clone, Default, Debug, Eq, PartialEq)]

--- a/nym-registration-client/src/builder/mod.rs
+++ b/nym-registration-client/src/builder/mod.rs
@@ -33,6 +33,7 @@ impl RegistrationClientBuilder {
             entry: self.config.entry_node.clone(),
             exit: self.config.exit_node.clone(),
             mode: self.config.mode,
+            lp_registration_config: self.config.lp_registration_config,
         };
         let cancel_token = self.config.cancel_token.clone();
         let (event_tx, event_rx) = mpsc::unbounded();

--- a/nym-registration-client/src/config.rs
+++ b/nym-registration-client/src/config.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use crate::LpRegistrationConfig;
+
 use crate::builder::config::NymNodeWithKeys;
 
 /// Registration mode for the client
@@ -30,4 +32,5 @@ pub struct RegistrationClientConfig {
     pub(crate) entry: NymNodeWithKeys,
     pub(crate) exit: NymNodeWithKeys,
     pub(crate) mode: RegistrationMode,
+    pub(crate) lp_registration_config: LpRegistrationConfig,
 }

--- a/nym-registration-client/src/lib.rs
+++ b/nym-registration-client/src/lib.rs
@@ -22,7 +22,9 @@ pub use builder::config::{
 };
 pub use config::RegistrationMode;
 pub use error::RegistrationClientError;
-pub use lp_client::{LpConfig, LpRegistrationClient, NestedLpSession, error::LpClientError};
+pub use lp_client::{
+    LpRegistrationClient, LpRegistrationConfig, NestedLpSession, error::LpClientError,
+};
 use nym_crypto::aes::cipher::crypto_common::rand_core::{CryptoRng, RngCore};
 pub use types::{
     LpRegistrationResult, MixnetRegistrationResult, RegistrationResult, WireguardRegistrationResult,
@@ -196,11 +198,12 @@ impl RegistrationClient {
         // This creates the LP session that will be used to forward packets to exit.
         // Uses packet-per-connection model: each handshake packet on new TCP connection.
         tracing::info!("Establishing outer session with entry gateway");
-        let mut entry_client = LpRegistrationClient::new_with_default_config(
+        let mut entry_client = LpRegistrationClient::new(
             entry_lp_keypair.clone(),
             entry_peer,
             entry_address,
             entry_lp_protocol,
+            self.config.lp_registration_config,
         );
 
         // Perform handshake with entry gateway (outer session now established)

--- a/nym-registration-client/src/lp_client/client.rs
+++ b/nym-registration-client/src/lp_client/client.rs
@@ -3,7 +3,7 @@
 
 //! LP (Lewes Protocol) registration client for direct gateway connections.
 
-use super::config::LpConfig;
+use super::config::LpRegistrationConfig;
 use super::error::{LpClientError, Result};
 use crate::lp_client::helpers::{
     LpDataDeliverExt, LpDataSendExt, convert_forward_data, try_convert_forward_response,
@@ -66,7 +66,7 @@ pub struct LpRegistrationClient<S = TcpStream> {
     state_machine: Option<LpStateMachine>,
 
     /// Configuration for timeouts and TCP parameters.
-    config: LpConfig,
+    config: LpRegistrationConfig,
 
     /// Persistent TCP stream for the connection.
     /// Opened on first use, closed after registration.
@@ -93,7 +93,7 @@ where
         gateway_lp_peer: LpRemotePeer,
         gateway_lp_address: SocketAddr,
         gateway_supported_lp_protocol_version: u8,
-        config: LpConfig,
+        config: LpRegistrationConfig,
     ) -> Self {
         let lp_protocol = if gateway_supported_lp_protocol_version > version::CURRENT {
             warn!(
@@ -140,7 +140,7 @@ where
             gateway_lp_peer,
             gateway_lp_address,
             gateway_supported_lp_protocol_version,
-            LpConfig::default(),
+            LpRegistrationConfig::default(),
         )
     }
 
@@ -634,7 +634,7 @@ where
         packet: &LpPacket,
         send_key: Option<&OuterAeadKey>,
         recv_key: Option<&OuterAeadKey>,
-        config: &LpConfig,
+        config: &LpRegistrationConfig,
     ) -> Result<LpPacket> {
         // 1. Connect with timeout
         let mut stream = tokio::time::timeout(config.connect_timeout, S::connect(address))

--- a/nym-registration-client/src/lp_client/config.rs
+++ b/nym-registration-client/src/lp_client/config.rs
@@ -26,8 +26,8 @@ use std::time::Duration;
 /// - Fail fast enough for good UX (no indefinite hangs)
 /// - Allow sufficient time for real network conditions
 /// - Optimize for latency over throughput (small messages)
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LpConfig {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LpRegistrationConfig {
     /// TCP connection timeout (nym-102).
     ///
     /// Maximum time to wait for TCP connection establishment.
@@ -69,7 +69,7 @@ pub struct LpConfig {
     pub tcp_keepalive: Option<Duration>,
 }
 
-impl Default for LpConfig {
+impl Default for LpRegistrationConfig {
     fn default() -> Self {
         Self {
             // nym-102: Sane timeout defaults for real network conditions
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn test_default_config() {
-        let config = LpConfig::default();
+        let config = LpRegistrationConfig::default();
 
         assert_eq!(config.connect_timeout, Duration::from_secs(10));
         assert_eq!(config.handshake_timeout, Duration::from_secs(15));
@@ -99,13 +99,5 @@ mod tests {
         assert_eq!(config.forward_timeout, Duration::from_secs(30));
         assert!(config.tcp_nodelay);
         assert_eq!(config.tcp_keepalive, None);
-    }
-
-    #[test]
-    fn test_config_clone() {
-        let config = LpConfig::default();
-        let cloned = config.clone();
-
-        assert_eq!(config, cloned);
     }
 }

--- a/nym-registration-client/src/lp_client/mod.rs
+++ b/nym-registration-client/src/lp_client/mod.rs
@@ -39,6 +39,6 @@ mod nested_session;
 mod state_machine_helpers;
 
 pub use client::LpRegistrationClient;
-pub use config::LpConfig;
+pub use config::LpRegistrationConfig;
 pub use error::LpClientError;
 pub use nested_session::NestedLpSession;


### PR DESCRIPTION
Allow bubbling up of LP timeout config as per :
https://nymtech.atlassian.net/browse/NYM-218

Vpn-client needs no changes as there is a default value

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6409)
<!-- Reviewable:end -->
