### PR TITLE
bugfix: restore 'latest_measurement' field for nym-node /verloc endpoint

### DIFF
--- a/nym-node/nym-node-requests/src/api/v1/metrics/models.rs
+++ b/nym-node/nym-node-requests/src/api/v1/metrics/models.rs
@@ -106,6 +106,8 @@ pub mod verloc {
         #[serde(with = "bs58_ed25519_pubkey")]
         #[cfg_attr(feature = "openapi", schema(value_type = String))]
         pub node_identity: ed25519::PublicKey,
+
+        pub latest_measurement: Option<VerlocMeasurement>,
     }
 
     #[derive(Serialize, Deserialize, Default, Debug, Clone)]

--- a/nym-node/src/node/http/router/api/v1/metrics/verloc.rs
+++ b/nym-node/src/node/http/router/api/v1/metrics/verloc.rs
@@ -4,7 +4,7 @@
 use axum::extract::{Query, State};
 use nym_http_api_common::{FormattedResponse, OutputParams};
 use nym_node_requests::api::v1::metrics::models::{
-    VerlocNodeResult, VerlocResult, VerlocResultData, VerlocStats,
+    VerlocMeasurement, VerlocNodeResult, VerlocResult, VerlocResultData, VerlocStats,
 };
 use nym_verloc::measurements::SharedVerlocStats;
 
@@ -43,6 +43,12 @@ async fn build_response(verloc_stats: &SharedVerlocStats) -> VerlocStats {
                 .iter()
                 .map(|r| VerlocNodeResult {
                     node_identity: r.node_identity,
+                    latest_measurement: r.latest_measurement.map(|m| VerlocMeasurement {
+                        minimum: m.minimum,
+                        mean: m.mean,
+                        maximum: m.maximum,
+                        standard_deviation: m.standard_deviation,
+                    }),
                 })
                 .collect(),
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6452)
<!-- Reviewable:end -->
