### PR TITLE
fix: gate mix-fetch debug logs behind a build-time flag

### DIFF
--- a/sdk/typescript/packages/mix-fetch/package.json
+++ b/sdk/typescript/packages/mix-fetch/package.json
@@ -13,9 +13,9 @@
   "browser": "dist/esm/index.js",
   "scripts": {
     "build": "scripts/build-prod.sh",
-    "build:dev": "scripts/build.sh",
-    "build:dev:esm": "MIX_FETCH_DEV_MODE=true scripts/build-dev-esm.sh",
-    "build:dev:esm-no-inline": "scripts/build-dev-esm.sh",
+    "build:dev": "MIX_FETCH_DEBUG=true scripts/build.sh",
+    "build:dev:esm": "MIX_FETCH_DEV_MODE=true MIX_FETCH_DEBUG=true scripts/build-dev-esm.sh",
+    "build:dev:esm-no-inline": "MIX_FETCH_DEBUG=true scripts/build-dev-esm.sh",
     "build:worker": "rollup -c rollup-worker.config.mjs",
     "build:worker:full-fat": "rollup -c rollup-worker-full-fat.config.mjs",
     "clean": "rimraf dist",

--- a/sdk/typescript/packages/mix-fetch/rollup/cjs.mjs
+++ b/sdk/typescript/packages/mix-fetch/rollup/cjs.mjs
@@ -2,8 +2,10 @@ import typescript from '@rollup/plugin-typescript';
 import resolve from '@rollup/plugin-node-resolve';
 import { wasm } from '@rollup/plugin-wasm';
 import webWorkerLoader from 'rollup-plugin-web-worker-loader';
+import replace from '@rollup/plugin-replace';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
+const isDebugEnabled = process.env.MIX_FETCH_DEBUG === 'true';
 
 /**
  * Gets the config for bundling the package as a CommonJS module.
@@ -20,6 +22,13 @@ export const getConfig = (opts) => ({
   },
   plugins: [
     webWorkerLoader({ targetPlatform: 'browser', inline: opts.inline }), // the inline param is used here
+    replace({
+      values: {
+        'globalThis.__MIX_FETCH_DEBUG__': JSON.stringify(opts?.debug ?? isDebugEnabled),
+      },
+      delimiters: ['', ''],
+      preventAssignment: true,
+    }),
     resolve({ extensions }),
     wasm({ maxFileSize: 10000000, targetEnv: 'browser' }),
     typescript({

--- a/sdk/typescript/packages/mix-fetch/rollup/esm.mjs
+++ b/sdk/typescript/packages/mix-fetch/rollup/esm.mjs
@@ -4,6 +4,7 @@ import webWorkerLoader from 'rollup-plugin-web-worker-loader';
 import replace from '@rollup/plugin-replace';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
+const isDebugEnabled = process.env.MIX_FETCH_DEBUG === 'true';
 
 /**
  * Gets the config for bundling the package as an ES Module.
@@ -32,6 +33,7 @@ export const getConfig = (opts) => ({
       values: {
         "createURLWorkerFactory('web-worker-0.js')":
           "createURLWorkerFactory(new URL('web-worker-0.js', import.meta.url))",
+        'globalThis.__MIX_FETCH_DEBUG__': JSON.stringify(opts?.debug ?? isDebugEnabled),
       },
       delimiters: ['', ''],
       preventAssignment: true,

--- a/sdk/typescript/packages/mix-fetch/rollup/worker.mjs
+++ b/sdk/typescript/packages/mix-fetch/rollup/worker.mjs
@@ -4,6 +4,7 @@ import { wasm } from '@rollup/plugin-wasm';
 import replace from '@rollup/plugin-replace';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
+const isDebugEnabled = process.env.MIX_FETCH_DEBUG === 'true';
 
 /**
  * Configure worker output
@@ -23,7 +24,10 @@ export const getConfig = (opts) => ({
     resolve({ extensions }),
     // this is some nasty monkey patching that removes the WASM URL (because it is handled by the `wasm` plugin)
     replace({
-      values: { "input = new URL('mix_fetch_wasm_bg.wasm', import.meta.url);": 'input = undefined;' },
+      values: {
+        "input = new URL('mix_fetch_wasm_bg.wasm', import.meta.url);": 'input = undefined;',
+        'globalThis.__MIX_FETCH_DEBUG__': JSON.stringify(opts?.debug ?? isDebugEnabled),
+      },
       delimiters: ['', ''],
       preventAssignment: true,
     }),

--- a/sdk/typescript/packages/mix-fetch/scripts/build-prod.sh
+++ b/sdk/typescript/packages/mix-fetch/scripts/build-prod.sh
@@ -7,8 +7,8 @@ set -o pipefail
 rm -rf dist || true
 rm -rf ../../../../dist/ts/sdk/mix-fetch || true
 
-# run the build
-scripts/build.sh
+# run the build with debug logging disabled
+MIX_FETCH_DEBUG=false scripts/build.sh
 node scripts/buildPackageJson.mjs
 
 # move the output outside of the yarn/npm workspaces

--- a/sdk/typescript/packages/mix-fetch/src/create-mix-fetch.ts
+++ b/sdk/typescript/packages/mix-fetch/src/create-mix-fetch.ts
@@ -1,5 +1,6 @@
 import InlineWasmWebWorker from 'web-worker:./worker/worker';
 import * as Comlink from 'comlink';
+import { runIfDebugEnabled } from './debug';
 import type { IMixFetchWebWorker } from './types';
 import { EventKinds, IMixFetch } from './types';
 
@@ -53,6 +54,7 @@ export const createMixFetch = async (): Promise<IMixFetch> => {
       if (!workerResponse) {
         throw new Error('No response received');
       }
+      runIfDebugEnabled(() => console.log('[mixFetch]', { workerResponse }));
       const { headers: headersRaw, status, statusText } = workerResponse;
 
       // reconstruct the Headers object instance from a plain object

--- a/sdk/typescript/packages/mix-fetch/src/create-mix-fetch.ts
+++ b/sdk/typescript/packages/mix-fetch/src/create-mix-fetch.ts
@@ -53,7 +53,6 @@ export const createMixFetch = async (): Promise<IMixFetch> => {
       if (!workerResponse) {
         throw new Error('No response received');
       }
-      console.log({ workerResponse });
       const { headers: headersRaw, status, statusText } = workerResponse;
 
       // reconstruct the Headers object instance from a plain object

--- a/sdk/typescript/packages/mix-fetch/src/debug.test.ts
+++ b/sdk/typescript/packages/mix-fetch/src/debug.test.ts
@@ -1,0 +1,41 @@
+import { isMixFetchDebugEnabled, runIfDebugEnabled } from './debug';
+
+describe('runIfDebugEnabled', () => {
+  let originalDebugFlag: boolean | undefined;
+
+  beforeEach(() => {
+    originalDebugFlag = globalThis.__MIX_FETCH_DEBUG__;
+  });
+
+  afterEach(() => {
+    if (originalDebugFlag === undefined) {
+      delete globalThis.__MIX_FETCH_DEBUG__;
+    } else {
+      globalThis.__MIX_FETCH_DEBUG__ = originalDebugFlag;
+    }
+  });
+
+  test('is disabled by default', () => {
+    delete globalThis.__MIX_FETCH_DEBUG__;
+
+    expect(isMixFetchDebugEnabled()).toBe(false);
+  });
+
+  test('does not run the callback when the debug flag is disabled', () => {
+    globalThis.__MIX_FETCH_DEBUG__ = false;
+    const callback = jest.fn();
+
+    runIfDebugEnabled(callback);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test('runs the callback when the debug flag is enabled', () => {
+    globalThis.__MIX_FETCH_DEBUG__ = true;
+    const callback = jest.fn();
+
+    runIfDebugEnabled(callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/sdk/typescript/packages/mix-fetch/src/debug.ts
+++ b/sdk/typescript/packages/mix-fetch/src/debug.ts
@@ -1,0 +1,21 @@
+declare global {
+  var __MIX_FETCH_DEBUG__: boolean | undefined;
+}
+
+/**
+ * Rollup replaces `globalThis.__MIX_FETCH_DEBUG__` at build time.
+ */
+export const isMixFetchDebugEnabled = () => globalThis.__MIX_FETCH_DEBUG__ === true;
+
+/**
+ * Use a callback so debug-only work stays behind the flag.
+ */
+export const runIfDebugEnabled = (fn: () => void) => {
+  if (!isMixFetchDebugEnabled()) {
+    return;
+  }
+
+  fn();
+};
+
+export {};

--- a/sdk/typescript/packages/mix-fetch/src/worker/main.ts
+++ b/sdk/typescript/packages/mix-fetch/src/worker/main.ts
@@ -17,14 +17,9 @@ export async function run() {
 
   const mixFetchWebWorker: IMixFetchWebWorker = {
     mixFetch: async (url, args) => {
-      console.log('[Worker] --- mixFetch ---', { url, args });
-
       const response: Response = await mixFetch(url, args);
 
-      console.log('[Worker]', { response, json: JSON.stringify(response, null, 2) });
-
       const bodyResponse = await handleResponseMimeTypes(response, responseBodyConfigMap);
-      console.log('[Worker]', { bodyResponse });
 
       const headers: any = {};
       response.headers.forEach((value, key) => {
@@ -42,20 +37,15 @@ export async function run() {
         redirected: response.redirected,
       };
 
-      console.log('[Worker]', { output });
-
       return output;
     },
     setupMixFetch: async (opts) => {
-      console.log('[Worker] --- setupMixFetch ---', { opts });
       if (opts?.responseBodyConfigMap) {
         responseBodyConfigMap = opts.responseBodyConfigMap;
       }
       await setupMixFetch(opts || {});
     },
     disconnectMixFetch: async () => {
-      console.log('[Worker] --- disconnectMixFetch ---');
-
       await disconnectMixFetch();
     },
   };

--- a/sdk/typescript/packages/mix-fetch/src/worker/main.ts
+++ b/sdk/typescript/packages/mix-fetch/src/worker/main.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-globals */
 import { setupMixFetch, disconnectMixFetch } from '@nymproject/mix-fetch-wasm';
 import * as Comlink from 'comlink';
+import { runIfDebugEnabled } from '../debug';
 import type { IMixFetchWebWorker, LoadedEvent } from '../types';
 import { EventKinds, ResponseBodyConfigMap, ResponseBodyConfigMapDefaults } from '../types';
 import { handleResponseMimeTypes } from './handle-response-mime-types';
@@ -17,9 +18,20 @@ export async function run() {
 
   const mixFetchWebWorker: IMixFetchWebWorker = {
     mixFetch: async (url, args) => {
+      runIfDebugEnabled(() => {
+        console.log('[Worker] --- mixFetch ---', { url, args });
+      });
+
       const response: Response = await mixFetch(url, args);
 
+      runIfDebugEnabled(() => {
+        console.log('[Worker]', { response, json: JSON.stringify(response, null, 2) });
+      });
+
       const bodyResponse = await handleResponseMimeTypes(response, responseBodyConfigMap);
+      runIfDebugEnabled(() => {
+        console.log('[Worker]', { bodyResponse });
+      });
 
       const headers: any = {};
       response.headers.forEach((value, key) => {
@@ -37,15 +49,25 @@ export async function run() {
         redirected: response.redirected,
       };
 
+      runIfDebugEnabled(() => {
+        console.log('[Worker]', { output });
+      });
+
       return output;
     },
     setupMixFetch: async (opts) => {
+      runIfDebugEnabled(() => {
+        console.log('[Worker] --- setupMixFetch ---', { opts });
+      });
       if (opts?.responseBodyConfigMap) {
         responseBodyConfigMap = opts.responseBodyConfigMap;
       }
       await setupMixFetch(opts || {});
     },
     disconnectMixFetch: async () => {
+      runIfDebugEnabled(() => {
+        console.log('[Worker] --- disconnectMixFetch ---');
+      });
       await disconnectMixFetch();
     },
   };

--- a/sdk/typescript/packages/mix-fetch/src/worker/wasm-loading.ts
+++ b/sdk/typescript/packages/mix-fetch/src/worker/wasm-loading.ts
@@ -36,6 +36,7 @@ import init, {
   mix_fetch_initialised,
   finish_mixnet_connection,
 } from '@nymproject/mix-fetch-wasm';
+import { runIfDebugEnabled } from '../debug';
 
 // see `typings/wasm_exec.d.ts` for the defintion of the `class Go` in global scope
 import '@nymproject/mix-fetch-wasm/wasm_exec';
@@ -72,9 +73,11 @@ export async function loadWasm() {
 
   // load rust WASM package
   await init(bytes);
+  runIfDebugEnabled(() => console.log('[Worker] Loaded RUST WASM'));
 
   // load go WASM package
   await loadGoWasm();
+  runIfDebugEnabled(() => console.log('[Worker] Loaded GO WASM'));
 
   // sets up better stack traces in case of in-rust panics
   set_panic_hook();

--- a/sdk/typescript/packages/mix-fetch/src/worker/wasm-loading.ts
+++ b/sdk/typescript/packages/mix-fetch/src/worker/wasm-loading.ts
@@ -72,11 +72,9 @@ export async function loadWasm() {
 
   // load rust WASM package
   await init(bytes);
-  console.log('Loaded RUST WASM');
 
   // load go WASM package
   await loadGoWasm();
-  console.log('Loaded GO WASM');
 
   // sets up better stack traces in case of in-rust panics
   set_panic_hook();


### PR DESCRIPTION
Keeps the existing mix-fetch debug logs available for local development, but removes them from production builds.

As raised in #6397, mix-fetch is a library and should not write debug output to the consumer's console in production. At the same time, the existing logs are useful when working on the package locally. This change gates those logs behind a build-time `MIX_FETCH_DEBUG` flag.

`build:dev`, `build:dev:esm`, and `build:dev:esm-no-inline` now enable debug logging. The production build path explicitly disables it, so release artifacts stay quiet even if `MIX_FETCH_DEBUG` is set in the shell.

Changes:
- add a small debug helper and test coverage for the flag behavior
- gate the existing logs in `create-mix-fetch.ts`, `worker/main.ts`, and `worker/wasm-loading.ts`
- thread `MIX_FETCH_DEBUG` through the ESM, CJS, and worker Rollup configs
- force `build-prod.sh` to compile with debug logging disabled

No API changes. The `console.error` for unhandled worker exceptions in `worker/index.ts` is unchanged.

Closes #6397

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6503)
<!-- Reviewable:end -->
