### PR TITLE
fix(ecash): verification fails on 32-bit platforms

### DIFF
--- a/common/nym_offline_compact_ecash/src/scheme/keygen.rs
+++ b/common/nym_offline_compact_ecash/src/scheme/keygen.rs
@@ -112,7 +112,7 @@ impl SecretKeyAuth {
         let ys_len = self.ys.len();
         let mut bytes = Vec::with_capacity(8 + (ys_len + 1) * 32);
         bytes.extend_from_slice(&self.x.to_bytes());
-        bytes.extend_from_slice(&ys_len.to_le_bytes());
+        bytes.extend_from_slice(&(ys_len as u64).to_le_bytes());
         for y in self.ys.iter() {
             bytes.extend_from_slice(&y.to_bytes())
         }
@@ -337,7 +337,7 @@ impl VerificationKeyAuth {
 
         bytes.extend_from_slice(&self.alpha.to_affine().to_compressed());
 
-        bytes.extend_from_slice(&beta_g1_len.to_le_bytes());
+        bytes.extend_from_slice(&(beta_g1_len as u64).to_le_bytes());
 
         for beta_g1 in self.beta_g1.iter() {
             bytes.extend_from_slice(&beta_g1.to_affine().to_compressed())


### PR DESCRIPTION
## Summary

`VerificationKeyAuth::to_bytes()` and `SecretKeyAuth::to_bytes()` in `nym_offline_compact_ecash` use `usize::to_le_bytes()` to serialize vector lengths. This produces 4 bytes on 32-bit platforms and 8 bytes on 64-bit platforms.

This causes ecash ticket verification to fail on all 32-bit targets because `VerificationKeyAuth::to_bytes()` is called in the ZK proof challenge hash computation (src/proofs/proof_spend.rs lines 227 and 381). The 32-bit client computes a different challenge than the 64-bit gateway, so the proof never verifies.

The corresponding `from_bytes()` implementations read 8 bytes via `u64::from_le_bytes()`, so `to_bytes()` should match.

## Fix

Cast `usize` to `u64` before calling `to_le_bytes()`.
No behavioral change on 64-bit where `usize` is already 8 bytes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6528)
<!-- Reviewable:end -->
