### PR TITLE
critical bugfix

### DIFF
--- a/common/nym-lp/src/packet/utils.rs
+++ b/common/nym-lp/src/packet/utils.rs
@@ -8,7 +8,7 @@ pub fn format_debug_bytes(bytes: &[u8]) -> Result<String, fmt::Error> {
         write!(out, "{line_prefix:12}")?;
         let mut line = String::new();
         for b in chunk {
-            line.push_str(format!("{:02x} ", b).as_str());
+            line.push_str(format!("{:02X} ", b).as_str());
         }
         write!(
             out,


### PR DESCRIPTION
Debug bytes should use uppercase for hexadecimal digits

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6558)
<!-- Reviewable:end -->
