### PR TITLE
HTTP domain rotation conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3589,7 +3589,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.2",
  "ring",
- "rustls 0.23.29",
+ "rustls 0.23.37",
  "thiserror 2.0.12",
  "tinyvec",
  "tokio",
@@ -3614,7 +3614,7 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "resolv-conf",
- "rustls 0.23.29",
+ "rustls 0.23.37",
  "smallvec",
  "thiserror 2.0.12",
  "tokio",
@@ -3871,7 +3871,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.29",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
@@ -5448,7 +5448,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6849,6 +6849,7 @@ dependencies = [
  "nym-network-defaults",
  "once_cell",
  "reqwest 0.13.1",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "serde_plain",
@@ -9651,7 +9652,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.29",
+ "rustls 0.23.37",
  "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
@@ -9672,7 +9673,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.29",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -9939,7 +9940,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.29",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -9980,7 +9981,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.29",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -10240,16 +10241,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.4",
+ "rustls-webpki 0.103.9",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -10330,14 +10331,14 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.29",
+ "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.4",
+ "rustls-webpki 0.103.9",
  "security-framework 3.6.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10369,9 +10370,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -11202,7 +11203,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.29",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -12024,7 +12025,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.29",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -12842,7 +12843,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.8.23",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_internal_macros 0.31.0",
  "uniffi_meta 0.31.0",
  "uniffi_pipeline 0.31.0",
@@ -12951,7 +12952,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.106",
- "toml 0.8.23",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_meta 0.31.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,7 +334,7 @@ rayon = "1.5.1"
 regex = "1.10.6"
 reqwest = { version = "0.13.1", default-features = false }
 rs_merkle = "1.5.0"
-rustls = "0.23.37"
+rustls = { version = "0.23.37", default-features = false }
 schemars = "0.8.22"
 semver = "1.0.26"
 serde = "1.0.219"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,6 +334,7 @@ rayon = "1.5.1"
 regex = "1.10.6"
 reqwest = { version = "0.13.1", default-features = false }
 rs_merkle = "1.5.0"
+rustls = "0.23.37"
 schemars = "0.8.22"
 semver = "1.0.26"
 serde = "1.0.219"

--- a/common/http-api-client/Cargo.toml
+++ b/common/http-api-client/Cargo.toml
@@ -34,6 +34,7 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 inventory = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
+rustls = { workspace=true }
 # used for decoding text responses (they were already implicitly included)
 bytes = { workspace = true }
 encoding_rs = { workspace = true }

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1214,6 +1214,8 @@ impl ApiClientCore for Client {
     }
 }
 
+const MAX_ERR_SOURCE_ITERATIONS: usize = 4;
+
 /// only if there was a network issue should we consider updating the host info
 pub(crate) fn is_network_error(err: &reqwest::Error) -> bool {
     if err.is_timeout() {
@@ -1225,31 +1227,32 @@ pub(crate) fn is_network_error(err: &reqwest::Error) -> bool {
         return false;
     }
 
-    // reqwest::Error -> hyper_util::Error
-    if let Some(inner1) = err.source() {
-        // hyper_util::Error -> hyper_util::ClientError
-        if let Some(inner2) = inner1.source() {
-            // hyper_util::ClientError -> io::Error
-            if let Some(inner3) = inner2.source() {
-                // downcase from dyn
-                if let Some(io_err) = inner3.downcast_ref::<std::io::Error>() {
-                    match io_err.kind() {
-                        // device not connected to the internet
-                        ErrorKind::NetworkUnreachable | ErrorKind::NetworkDown => return false,
-                        // custom errors may be case by case, but in general not DF related
-                        // -- includes DNS errors for hyper_util
-                        ErrorKind::Other => return false,
-                        // timeouts can indicate packet drops or adress blocklisting
-                        // -- this should hit the timeout conditional above
-                        ErrorKind::TimedOut => return true,
-                        // connection errors can indicate connection interference
-                        ErrorKind::ConnectionReset
-                        | ErrorKind::HostUnreachable
-                        | ErrorKind::ConnectionRefused => return true,
-                        _ => return false,
-                    }
+    // The io::Error source is several layers deep, for clarity this is done as a loop
+    // * reqwest::Error -> hyper_util::Error
+    // * hyper_util::Error -> hyper_util::ClientError
+    // * hyper_util::ClientError -> io::Error
+    let mut inner = err.source();
+    for _ in 0..MAX_ERR_SOURCE_ITERATIONS {
+        if let Some(e) = inner {
+            // try downcast to io::Error from <dyn std::error:Error>
+            if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+                match io_err.kind() {
+                    // device not connected to the internet
+                    ErrorKind::NetworkUnreachable | ErrorKind::NetworkDown => return false,
+                    // custom errors may be case by case, but in general not DF related
+                    // -- includes DNS errors for hyper_util
+                    ErrorKind::Other => return false,
+                    // connection errors can indicate connection interference
+                    ErrorKind::ConnectionReset
+                    | ErrorKind::HostUnreachable
+                    | ErrorKind::ConnectionRefused => return true,
+                    _ => return false,
                 }
+            } else {
+                inner = e.source();
             }
+        } else {
+            break;
         }
     }
 

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -161,6 +161,7 @@ use reqwest::{RequestBuilder, Response};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+use std::io::ErrorKind;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use thiserror::Error;
@@ -1167,16 +1168,7 @@ impl ApiClientCore for Client {
             match response {
                 Ok(resp) => return Ok(resp),
                 Err(err) => {
-                    // only if there was a network issue should we consider updating the host info
-                    //
-                    // note: for now this includes DNS resolution failure, I am not sure how I would go about
-                    // segregating that based on the interface provided by request for errors.
-                    #[cfg(target_arch = "wasm32")]
-                    let is_network_err = err.is_timeout();
-                    #[cfg(not(target_arch = "wasm32"))]
-                    let is_network_err = err.is_timeout() || err.is_connect();
-
-                    if is_network_err {
+                    if network_error(&err) {
                         // if we have multiple urls, update to the next
                         self.maybe_rotate_hosts(Some(url.clone()));
 
@@ -1220,6 +1212,48 @@ impl ApiClientCore for Client {
             tracing::debug!("Domain fronting activated after failure: {context:?}",);
         }
     }
+}
+
+/// only if there was a network issue should we consider updating the host info
+pub(crate) fn network_error(err: &reqwest::Error) -> bool {
+    if err.is_timeout() {
+        return true;
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    if !(err.is_connect() || err.is_request()) {
+        return false;
+    }
+
+    // reqwest::Error -> hyper_util::Error
+    if let Some(inner1) = err.source() {
+        // hyper_util::Error -> hyper_util::ClientError
+        if let Some(inner2) = inner1.source() {
+            // hyper_util::ClientError -> io::Error
+            if let Some(inner3) = inner2.source() {
+                // downcase from dyn
+                if let Some(io_err) = inner3.downcast_ref::<std::io::Error>() {
+                    match io_err.kind() {
+                        // device not connected to the internet
+                        ErrorKind::NetworkUnreachable | ErrorKind::NetworkDown => return false,
+                        // custom errors may be case by case, but in general not DF related
+                        // -- includes DNS errors for hyper_util
+                        ErrorKind::Other => return false,
+                        // timeouts can indicate packet drops or adress blocklisting
+                        // -- this should hit the timeout conditional above
+                        ErrorKind::TimedOut => return true,
+                        // connection errors can indicate connection interference
+                        ErrorKind::ConnectionReset
+                        | ErrorKind::HostUnreachable
+                        | ErrorKind::ConnectionRefused => return true,
+                        _ => return false,
+                    }
+                }
+            }
+        }
+    }
+
+    false
 }
 
 /// Common usage functionality for the http client.

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1168,7 +1168,7 @@ impl ApiClientCore for Client {
             match response {
                 Ok(resp) => return Ok(resp),
                 Err(err) => {
-                    if network_error(&err) {
+                    if is_network_error(&err) {
                         // if we have multiple urls, update to the next
                         self.maybe_rotate_hosts(Some(url.clone()));
 
@@ -1215,7 +1215,7 @@ impl ApiClientCore for Client {
 }
 
 /// only if there was a network issue should we consider updating the host info
-pub(crate) fn network_error(err: &reqwest::Error) -> bool {
+pub(crate) fn is_network_error(err: &reqwest::Error) -> bool {
     if err.is_timeout() {
         return true;
     }

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -161,6 +161,7 @@ use reqwest::{RequestBuilder, Response};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+#[cfg(not(target_arch = "wasm32"))]
 use std::io::ErrorKind;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -1229,7 +1230,6 @@ pub(crate) fn is_network_error(err: &reqwest::Error) -> bool {
         return true;
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     if !(err.is_connect() || err.is_request()) {
         return false;
     }

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1168,7 +1168,12 @@ impl ApiClientCore for Client {
             match response {
                 Ok(resp) => return Ok(resp),
                 Err(err) => {
-                    if is_network_error(&err) {
+                    #[cfg(target_arch = "wasm32")]
+                    let is_network_err = err.is_timeout();
+                    #[cfg(not(target_arch = "wasm32"))]
+                    let is_network_err = is_network_error(&err);
+
+                    if is_network_err {
                         // if we have multiple urls, update to the next
                         self.maybe_rotate_hosts(Some(url.clone()));
 

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1172,7 +1172,7 @@ impl ApiClientCore for Client {
                     #[cfg(target_arch = "wasm32")]
                     let is_network_err = err.is_timeout();
                     #[cfg(not(target_arch = "wasm32"))]
-                    let is_network_err = is_network_error(&err);
+                    let is_network_err = might_be_network_interference(&err);
 
                     if is_network_err {
                         // if we have multiple urls, update to the next
@@ -1223,9 +1223,16 @@ impl ApiClientCore for Client {
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_ERR_SOURCE_ITERATIONS: usize = 4;
 
-/// only if there was a network issue should we consider updating the host info
+/// This functions attempts to check the error returned by reqwest to see if
+/// rotating host informtion (for clients with mutliple hosts defined) could be
+/// helpful. This looks for situations where the error could plausibly be caused
+/// by a network adversary, or where rotating to an equival hostname might help.
+///
+/// For example --> NetworkUnreachable will not be helped by rotating domains,
+/// but ConnectionReset might be caused by a network adversary blocking by SNI
+/// which could possibly benefit from rotating domains.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn is_network_error(err: &reqwest::Error) -> bool {
+pub(crate) fn might_be_network_interference(err: &reqwest::Error) -> bool {
     if err.is_timeout() {
         return true;
     }

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1241,20 +1241,29 @@ pub(crate) fn is_network_error(err: &reqwest::Error) -> bool {
     let mut inner = err.source();
     for _ in 0..MAX_ERR_SOURCE_ITERATIONS {
         if let Some(e) = inner {
-            // try downcast to io::Error from <dyn std::error:Error>
             if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+                // try downcast to io::Error from <dyn std::error:Error>
                 match io_err.kind() {
                     // device not connected to the internet
                     ErrorKind::NetworkUnreachable | ErrorKind::NetworkDown => return false,
-                    // custom errors may be case by case, but in general not DF related
-                    // -- includes DNS errors for hyper_util
-                    ErrorKind::Other => return false,
                     // connection errors can indicate connection interference
                     ErrorKind::ConnectionReset
                     | ErrorKind::HostUnreachable
                     | ErrorKind::ConnectionRefused => return true,
+                    // TLS errors get wrapped in custom io::Errors
+                    ErrorKind::Other | ErrorKind::InvalidData => {
+                        // io::Error get_ref works while source doesn't here -_-
+                        //   if you don't like it take it up with the rust devs https://users.rust-lang.org/t/question-about-implementation-of-std-source/121117
+                        inner = io_err.get_ref().map(|e| e as &dyn std::error::Error);
+                    }
                     _ => return false,
                 }
+            } else if let Some(_tls_err) = e.downcast_ref::<rustls::Error>() {
+                // try downcast to TLS error
+                return true;
+            } else if let Some(resolve_err) = e.downcast_ref::<hickory_resolver::ResolveError>() {
+                // try downcast to DNS error
+                return resolve_err.is_nx_domain();
             } else {
                 inner = e.source();
             }

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1219,9 +1219,11 @@ impl ApiClientCore for Client {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 const MAX_ERR_SOURCE_ITERATIONS: usize = 4;
 
 /// only if there was a network issue should we consider updating the host info
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn is_network_error(err: &reqwest::Error) -> bool {
     if err.is_timeout() {
         return true;


### PR DESCRIPTION
This is a relatively small changeto add more explicit handling for df enable and domain rotation.  Mostly I wanted to make sure that requests that fail because the network is unreachable are not triggering domain rotation as it will not help and might confuse things. In general though I think specificity in the handling here is a good thing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6570)
<!-- Reviewable:end -->
