### PR TITLE
[feat] propagate NM agent noise keys to nym-node routing

### DIFF
--- a/common/client-libs/validator-client/src/nyxd/contract_traits/network_monitors_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/network_monitors_signing_client.rs
@@ -69,9 +69,15 @@ pub trait NetworkMonitorsSigningClient {
     async fn authorise_network_monitor(
         &self,
         address: IpAddr,
+        bs58_x25519_noise: String,
+        noise_version: u8,
         fee: Option<Fee>,
     ) -> Result<ExecuteResult, NyxdError> {
-        let msg = NetworkMonitorsExecuteMsg::AuthoriseNetworkMonitor { address };
+        let msg = NetworkMonitorsExecuteMsg::AuthoriseNetworkMonitor {
+            address,
+            bs58_x25519_noise,
+            noise_version,
+        };
         self.execute_network_monitors_contract(
             fee,
             msg,
@@ -159,9 +165,13 @@ mod tests {
             ExecuteMsg::RevokeNetworkMonitorOrchestrator { address } => client
                 .revoke_network_monitor_orchestrator(address, None)
                 .ignore(),
-            ExecuteMsg::AuthoriseNetworkMonitor { address } => {
-                client.authorise_network_monitor(address, None).ignore()
-            }
+            ExecuteMsg::AuthoriseNetworkMonitor {
+                address,
+                bs58_x25519_noise,
+                noise_version,
+            } => client
+                .authorise_network_monitor(address, bs58_x25519_noise, noise_version, None)
+                .ignore(),
             ExecuteMsg::RevokeNetworkMonitor { address } => {
                 client.revoke_network_monitor(address, None).ignore()
             }

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/network_monitors_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/network_monitors_signing_client.rs
@@ -8,7 +8,7 @@ use crate::nyxd::{Coin, Fee, SigningCosmWasmClient};
 use crate::signing::signer::OfflineSigner;
 use async_trait::async_trait;
 use nym_network_monitors_contract_common::ExecuteMsg as NetworkMonitorsExecuteMsg;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -68,13 +68,13 @@ pub trait NetworkMonitorsSigningClient {
 
     async fn authorise_network_monitor(
         &self,
-        address: IpAddr,
+        mixnet_address: SocketAddr,
         bs58_x25519_noise: String,
         noise_version: u8,
         fee: Option<Fee>,
     ) -> Result<ExecuteResult, NyxdError> {
         let msg = NetworkMonitorsExecuteMsg::AuthoriseNetworkMonitor {
-            address,
+            mixnet_address,
             bs58_x25519_noise,
             noise_version,
         };
@@ -166,7 +166,7 @@ mod tests {
                 .revoke_network_monitor_orchestrator(address, None)
                 .ignore(),
             ExecuteMsg::AuthoriseNetworkMonitor {
-                address,
+                mixnet_address: address,
                 bs58_x25519_noise,
                 noise_version,
             } => client

--- a/common/cosmwasm-smart-contracts/network-monitors-contract/src/error.rs
+++ b/common/cosmwasm-smart-contracts/network-monitors-contract/src/error.rs
@@ -19,6 +19,9 @@ pub enum NetworkMonitorsContractError {
     #[error("address {addr} is not an authorised orchestrator")]
     NotAnOrchestrator { addr: Addr },
 
+    #[error("Failed to recover x25519 public key from its base58 representation: {0}")]
+    MalformedX25519AgentNoiseKey(String),
+
     #[error(transparent)]
     StdErr(#[from] cosmwasm_std::StdError),
 }

--- a/common/cosmwasm-smart-contracts/network-monitors-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/network-monitors-contract/src/msg.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use cosmwasm_schema::cw_serde;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 
 #[cfg(feature = "schema")]
 use crate::{
@@ -29,8 +29,10 @@ pub enum ExecuteMsg {
     /// Authorise new network monitor (or renew authorisation)
     /// granting additional privileges when sending mixnet packets to Nym nodes.
     AuthoriseNetworkMonitor {
-        /// Ip address of the agent
-        address: IpAddr,
+        /// Mixnet address of the agent.
+        /// The underlying ip address is going to be used as ingress to the nodes,
+        /// and the full socket address announces the egress and the association with the noise key
+        mixnet_address: SocketAddr,
 
         /// Base-58 encoded noise key of the agent.
         bs58_x25519_noise: String,

--- a/common/cosmwasm-smart-contracts/network-monitors-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/network-monitors-contract/src/msg.rs
@@ -28,7 +28,16 @@ pub enum ExecuteMsg {
 
     /// Authorise new network monitor (or renew authorisation)
     /// granting additional privileges when sending mixnet packets to Nym nodes.
-    AuthoriseNetworkMonitor { address: IpAddr },
+    AuthoriseNetworkMonitor {
+        /// Ip address of the agent
+        address: IpAddr,
+
+        /// Base-58 encoded noise key of the agent.
+        bs58_x25519_noise: String,
+
+        /// Version of the noise protocol used by the agent.
+        noise_version: u8,
+    },
 
     /// Revoke network monitor authorisation.
     RevokeNetworkMonitor { address: IpAddr },

--- a/common/cosmwasm-smart-contracts/network-monitors-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/network-monitors-contract/src/types.rs
@@ -29,6 +29,12 @@ pub struct AuthorisedNetworkMonitor {
 
     /// Timestamp of when the network monitor was authorised or the authorisation was renewed.
     pub authorised_at: Timestamp,
+
+    /// Base-58 encoded noise key of the agent.
+    pub bs58_x25519_noise: String,
+
+    /// Version of the noise protocol used by the agent.
+    pub noise_version: u8,
 }
 
 #[cw_serde]

--- a/common/cosmwasm-smart-contracts/network-monitors-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/network-monitors-contract/src/types.rs
@@ -29,6 +29,12 @@ pub struct AuthorisedNetworkMonitor {
 
     /// Timestamp of when the network monitor was authorised.
     pub authorised_at: Timestamp,
+
+    /// Base-58 encoded noise key of the agent.
+    pub bs58_x25519_noise: String,
+
+    /// Version of the noise protocol used by the agent.
+    pub noise_version: u8,
 }
 
 #[cw_serde]

--- a/common/cosmwasm-smart-contracts/network-monitors-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/network-monitors-contract/src/types.rs
@@ -3,12 +3,9 @@
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Timestamp};
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 
 pub type OrchestratorAddress = Addr;
-
-// Unfortunately `IpAddr` does not implement `PrimaryKey`, so we store its stringified representation instead
-pub type NetworkMonitorAddress = String;
 
 #[cw_serde]
 pub struct AuthorisedNetworkMonitorOrchestrator {
@@ -21,8 +18,10 @@ pub struct AuthorisedNetworkMonitorOrchestrator {
 
 #[cw_serde]
 pub struct AuthorisedNetworkMonitor {
-    /// The Ip address associated with the network monitor agent.
-    pub address: IpAddr,
+    /// Mixnet address of the agent.
+    /// The underlying ip address is going to be used as ingress to the nodes,
+    /// and the full socket address announces the egress and the association with the noise key
+    pub mixnet_address: SocketAddr,
 
     /// The address of the orchestrator that authorised the network monitor agent.
     pub authorised_by: OrchestratorAddress,

--- a/common/nymnoise/src/config.rs
+++ b/common/nymnoise/src/config.rs
@@ -53,6 +53,14 @@ pub struct NoiseNetworkView {
     inner: Arc<NoiseNetworkViewInner>,
 }
 
+/// Inner state of [`NoiseNetworkView`], shared behind an `Arc`.
+///
+/// # Concurrency model
+///
+/// Reads (on the packet-processing hot path) use `ArcSwap` and are fully lock-free.
+/// Writers must first acquire `update_lock` to serialise concurrent updates, then call
+/// `swap_view` to atomically publish the new map.  The lock is intentionally *not* wrapping
+/// the map itself so that readers are never blocked.
 #[derive(Debug)]
 struct NoiseNetworkViewInner {
     update_lock: Mutex<()>,
@@ -63,7 +71,11 @@ struct NoiseNetworkViewInner {
 pub struct NoiseNode {
     key: VersionedNoiseKeyV1,
 
-    // flag indicating whether this node is a nym node or a network monitor agent
+    // Distinguishes nym-node entries (sourced from nym-api topology refreshes) from
+    // network-monitor agent entries (sourced from blockchain events).
+    // This is needed because the two sources have independent lifecycles:
+    // `revoked_all_agents` must wipe NM entries while preserving nym-node entries,
+    // and `refresh_network_nodes` must rebuild nym-node entries without touching NM entries.
     is_nym_node: bool,
 }
 
@@ -101,9 +113,14 @@ impl NoiseNetworkView {
         self.inner.update_lock.lock().await
     }
 
-    // this MUST not be called without obtaining the permit first.
-    // the reason the data is not wrapped in mutex itself is to reduce the overhead
-    // for the reading tasks performing packet routing
+    /// Atomically replace the noise key map.
+    ///
+    /// # Precondition
+    ///
+    /// The caller **must** hold the permit returned by [`NoiseNetworkView::get_update_permit`].
+    /// Passing the `MutexGuard` by value enforces this at the type level — the guard is dropped
+    /// (releasing the lock) only after the swap completes, preventing torn writes from concurrent
+    /// update calls.
     pub fn swap_view(&self, _permit: MutexGuard<'_, ()>, new: HashMap<IpAddr, NoiseNode>) {
         self.inner.nodes.store(Arc::new(new));
     }
@@ -152,9 +169,11 @@ impl NoiseConfig {
     }
 
     pub(crate) fn get_noise_key(&self, address: IpAddr) -> Option<VersionedNoiseKeyV1> {
-        // with the default bind address being `[::]:1789`,
-        // it can happen that a responder sees the ipv6-mapped address of the initiator,
-        // this checks for that
+        // When a nym-node binds on `[::]:1789` (the default), it will accept connections on both
+        // IPv4 and IPv6.  If an IPv4 initiator connects, the kernel may present its address to the
+        // responder as an IPv4-mapped IPv6 address (e.g. `::ffff:1.2.3.4`) rather than the plain
+        // IPv4 address (`1.2.3.4`) that was registered in the noise map.
+        // `to_canonical()` strips that mapping so we can find the entry either way.
         let base_ip = address;
         let canonical_ip = base_ip.to_canonical();
 

--- a/common/nymnoise/src/config.rs
+++ b/common/nymnoise/src/config.rs
@@ -1,19 +1,14 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::HashMap,
-    net::{IpAddr, SocketAddr},
-    sync::Arc,
-    time::Duration,
-};
-
 use arc_swap::ArcSwap;
 use nym_crypto::asymmetric::x25519;
-use nym_noise_keys::{NoiseVersion, VersionedNoiseKeyV1};
+use nym_noise_keys::VersionedNoiseKeyV1;
 use snow::params::NoiseParams;
+use std::{collections::HashMap, net::IpAddr, sync::Arc, time::Duration};
 
 use strum_macros::{EnumIter, FromRepr};
+use tokio::sync::{Mutex, MutexGuard};
 
 #[derive(Default, Debug, Clone, Copy, EnumIter, FromRepr, Eq, PartialEq)]
 #[repr(u8)]
@@ -53,38 +48,68 @@ impl NoisePattern {
     }
 }
 
-#[derive(Debug, Default)]
-struct SocketAddrToKey {
-    inner: ArcSwap<HashMap<SocketAddr, VersionedNoiseKeyV1>>,
-}
-
-// SW NOTE : Only for phased upgrade. To remove once we decide all nodes have to support Noise
-#[derive(Debug, Default)]
-struct IpAddrToVersion {
-    inner: ArcSwap<HashMap<IpAddr, NoiseVersion>>,
-}
-
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct NoiseNetworkView {
-    keys: Arc<SocketAddrToKey>,
-    support: Arc<IpAddrToVersion>,
+    inner: Arc<NoiseNetworkViewInner>,
+}
+
+#[derive(Debug)]
+struct NoiseNetworkViewInner {
+    update_lock: Mutex<()>,
+    nodes: ArcSwap<HashMap<IpAddr, NoiseNode>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NoiseNode {
+    key: VersionedNoiseKeyV1,
+
+    // flag indicating whether this node is a nym node or a network monitor agent
+    is_nym_node: bool,
+}
+
+impl NoiseNode {
+    pub fn new_nym_node(key: VersionedNoiseKeyV1) -> Self {
+        NoiseNode {
+            key,
+            is_nym_node: true,
+        }
+    }
+
+    pub fn new_network_monitor_agent(key: VersionedNoiseKeyV1) -> Self {
+        NoiseNode {
+            key,
+            is_nym_node: false,
+        }
+    }
+
+    pub fn is_nym_node(&self) -> bool {
+        self.is_nym_node
+    }
 }
 
 impl NoiseNetworkView {
     pub fn new_empty() -> Self {
         NoiseNetworkView {
-            keys: Default::default(),
-            support: Default::default(),
+            inner: Arc::new(NoiseNetworkViewInner {
+                update_lock: Mutex::new(()),
+                nodes: Default::default(),
+            }),
         }
     }
 
-    pub fn swap_view(&self, new: HashMap<SocketAddr, VersionedNoiseKeyV1>) {
-        let noise_support = new
-            .iter()
-            .map(|(s_addr, key)| (s_addr.ip(), key.supported_version))
-            .collect::<HashMap<_, _>>();
-        self.keys.inner.store(Arc::new(new));
-        self.support.inner.store(Arc::new(noise_support));
+    pub async fn get_update_permit(&self) -> MutexGuard<'_, ()> {
+        self.inner.update_lock.lock().await
+    }
+
+    // this MUST not be called without obtaining the permit first.
+    // the reason the data is not wrapped in mutex itself is to reduce the overhead
+    // for the reading tasks performing packet routing
+    pub fn swap_view(&self, _permit: MutexGuard<'_, ()>, new: HashMap<IpAddr, NoiseNode>) {
+        self.inner.nodes.store(Arc::new(new));
+    }
+
+    pub fn all_nodes(&self) -> HashMap<IpAddr, NoiseNode> {
+        self.inner.nodes.load().as_ref().clone()
     }
 }
 
@@ -126,20 +151,22 @@ impl NoiseConfig {
         self
     }
 
-    pub(crate) fn get_noise_key(&self, s_address: &SocketAddr) -> Option<VersionedNoiseKeyV1> {
-        self.network.keys.inner.load().get(s_address).copied()
+    pub(crate) fn get_noise_key(&self, address: IpAddr) -> Option<VersionedNoiseKeyV1> {
+        // with the default bind address being `[::]:1789`,
+        // it can happen that a responder sees the ipv6-mapped address of the initiator,
+        // this checks for that
+        let base_ip = address;
+        let canonical_ip = base_ip.to_canonical();
+
+        if let Some(node) = self.network.inner.nodes.load().get(&base_ip) {
+            return Some(node.key);
+        }
+
+        Some(self.network.inner.nodes.load().get(&canonical_ip)?.key)
     }
 
-    // Only for phased update
-    //SW This can lead to some troubles if two nodes share the same IP and one support Noise but not the other.
-    // This in only for the progressive update though and there is no workaround
-    pub(crate) fn get_noise_support(&self, ip_addr: IpAddr) -> Option<NoiseVersion> {
-        let plain_ip_support = self.network.support.inner.load().get(&ip_addr).copied();
-
-        // SW default bind address being [::]:1789, it can happen that a responder sees the ipv6-mapped address of the initiator, this check for that
-        let canonical_ip = &ip_addr.to_canonical();
-        let canonical_ip_support = self.network.support.inner.load().get(canonical_ip).copied();
-        plain_ip_support.or(canonical_ip_support)
+    pub(crate) fn supports_noise(&self, ip_addr: IpAddr) -> bool {
+        self.get_noise_key(ip_addr).is_some()
     }
 }
 

--- a/common/nymnoise/src/lib.rs
+++ b/common/nymnoise/src/lib.rs
@@ -66,7 +66,7 @@ pub async fn upgrade_noise_initiator(
         Error::Prereq(Prerequisite::RemotePublicKey)
     })?;
 
-    let Some(key) = config.get_noise_key(&responder_addr) else {
+    let Some(key) = config.get_noise_key(responder_addr.ip()) else {
         warn!("{responder_addr} can't speak Noise yet, falling back to TCP");
         return Ok(Connection::Raw(conn));
     };
@@ -106,7 +106,7 @@ pub async fn upgrade_noise_responder(
     };
 
     // if responder doesn't announce noise support, we fallback to tcp
-    if config.get_noise_support(initiator_addr.ip()).is_none() {
+    if !config.supports_noise(initiator_addr.ip()) {
         warn!("{initiator_addr} can't speak Noise yet, falling back to TCP",);
         return Ok(Connection::Raw(conn));
     };

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1185,6 +1185,7 @@ name = "network-monitors"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bs58",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers",

--- a/contracts/network-monitors/Cargo.toml
+++ b/contracts/network-monitors/Cargo.toml
@@ -21,6 +21,7 @@ name = "network_monitors_contract"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+bs58 = { workspace = true }
 cosmwasm-std = { workspace = true }
 cw2 = { workspace = true }
 cw-storage-plus = { workspace = true }

--- a/contracts/network-monitors/src/contract.rs
+++ b/contracts/network-monitors/src/contract.rs
@@ -52,9 +52,11 @@ pub fn execute(
         ExecuteMsg::RevokeNetworkMonitorOrchestrator { address } => {
             try_revoke_network_monitor_orchestrator(deps, info, address)
         }
-        ExecuteMsg::AuthoriseNetworkMonitor { address } => {
-            try_authorise_network_monitor(deps, env, info, address)
-        }
+        ExecuteMsg::AuthoriseNetworkMonitor {
+            address,
+            bs58_x25519_noise,
+            noise_version,
+        } => try_authorise_network_monitor(deps, env, info, address, bs58_x25519_noise, noise_version),
         ExecuteMsg::RevokeNetworkMonitor { address } => {
             try_revoke_network_monitor(deps, info, address)
         }

--- a/contracts/network-monitors/src/contract.rs
+++ b/contracts/network-monitors/src/contract.rs
@@ -53,10 +53,17 @@ pub fn execute(
             try_revoke_network_monitor_orchestrator(deps, info, address)
         }
         ExecuteMsg::AuthoriseNetworkMonitor {
+            mixnet_address: address,
+            bs58_x25519_noise,
+            noise_version,
+        } => try_authorise_network_monitor(
+            deps,
+            env,
+            info,
             address,
             bs58_x25519_noise,
             noise_version,
-        } => try_authorise_network_monitor(deps, env, info, address, bs58_x25519_noise, noise_version),
+        ),
         ExecuteMsg::RevokeNetworkMonitor { address } => {
             try_revoke_network_monitor(deps, info, address)
         }

--- a/contracts/network-monitors/src/queries.rs
+++ b/contracts/network-monitors/src/queries.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::storage::{retrieval_limits, NETWORK_MONITORS_CONTRACT_STORAGE};
+use crate::storage::{retrieval_limits, AgentStorageKey, NETWORK_MONITORS_CONTRACT_STORAGE};
 use cosmwasm_std::{Deps, StdResult};
 use cw_controllers::AdminResponse;
 use cw_storage_plus::Bound;
@@ -40,7 +40,7 @@ pub fn query_network_monitor_agents(
         .unwrap_or(retrieval_limits::AGENTS_DEFAULT_LIMIT)
         .min(retrieval_limits::AGENTS_MAX_LIMIT) as usize;
 
-    let start = start_after.map(|addr| Bound::exclusive(addr.to_string()));
+    let start = start_after.map(|addr| Bound::exclusive(AgentStorageKey::from(addr)));
 
     let authorised = NETWORK_MONITORS_CONTRACT_STORAGE
         .authorised_agents
@@ -49,7 +49,7 @@ pub fn query_network_monitor_agents(
         .map(|record| record.map(|(_, details)| details))
         .collect::<StdResult<Vec<_>>>()?;
 
-    let start_next_after = authorised.last().map(|last| last.address);
+    let start_next_after = authorised.last().map(|last| last.mixnet_address.ip());
 
     Ok(AuthorisedNetworkMonitorsPagedResponse {
         authorised,
@@ -187,22 +187,24 @@ mod tests {
     mod network_monitor_agents_query {
         use super::*;
         use crate::testing::{
-            init_contract_tester, NetworkMonitorsContract, NetworkMonitorsContractTesterExt,
+            init_contract_tester, storage_ip_comp, NetworkMonitorsContract,
+            NetworkMonitorsContractTesterExt,
         };
         use nym_contracts_common_testing::{ContractOpts, ContractTester};
-        use nym_network_monitors_contract_common::ExecuteMsg;
+        use std::net::SocketAddr;
 
-        fn string_sorted_ips(
+        fn storage_sorted_addresses(
             test: &mut ContractTester<NetworkMonitorsContract>,
             n: usize,
-        ) -> Vec<IpAddr> {
+        ) -> Vec<SocketAddr> {
             let mut ips = Vec::new();
             for _ in 0..n {
-                ips.push(test.random_ip().to_string());
+                ips.push(test.random_socket());
             }
 
-            ips.sort_unstable();
-            ips.into_iter().map(|ip| ip.parse().unwrap()).collect()
+            ips.sort_by(|a, b| storage_ip_comp(a.ip(), b.ip()));
+            // ips.into_iter().map(|ip| ip.parse().unwrap()).collect()
+            ips
         }
 
         #[test]
@@ -220,23 +222,19 @@ mod tests {
         #[test]
         fn returns_all_authorised_agents_below_default_limit() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
-            let agents = string_sorted_ips(&mut test, 5);
+            let agents = storage_sorted_addresses(&mut test, 5);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
             let res = query_network_monitor_agents(test.deps(), None, None)?;
 
             assert_eq!(res.authorised.len(), agents.len());
-            assert_eq!(res.start_next_after, agents.last().copied());
+            assert_eq!(res.start_next_after, agents.last().map(|a| a.ip()));
 
             for agent in &agents {
-                assert!(res.authorised.iter().any(|a| a.address == *agent));
+                assert!(res.authorised.iter().any(|a| a.mixnet_address == *agent));
             }
 
             Ok(())
@@ -245,22 +243,18 @@ mod tests {
         #[test]
         fn respects_explicit_limit() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
-            let agents = string_sorted_ips(&mut test, 5);
+            let agents = storage_sorted_addresses(&mut test, 5);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
             let res = query_network_monitor_agents(test.deps(), None, Some(2))?;
 
             assert_eq!(res.authorised.len(), 2);
-            assert_eq!(res.authorised[0].address, agents[0]);
-            assert_eq!(res.authorised[1].address, agents[1]);
-            assert_eq!(res.start_next_after, Some(agents[1]));
+            assert_eq!(res.authorised[0].mixnet_address, agents[0]);
+            assert_eq!(res.authorised[1].mixnet_address, agents[1]);
+            assert_eq!(res.start_next_after, Some(agents[1].ip()));
 
             Ok(())
         }
@@ -268,22 +262,18 @@ mod tests {
         #[test]
         fn respects_start_after_for_pagination() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
-            let agents = string_sorted_ips(&mut test, 5);
+            let agents = storage_sorted_addresses(&mut test, 5);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
-            let res = query_network_monitor_agents(test.deps(), Some(agents[1]), Some(2))?;
+            let res = query_network_monitor_agents(test.deps(), Some(agents[1].ip()), Some(2))?;
 
             assert_eq!(res.authorised.len(), 2);
-            assert_eq!(res.authorised[0].address, agents[2]);
-            assert_eq!(res.authorised[1].address, agents[3]);
-            assert_eq!(res.start_next_after, Some(agents[3]));
+            assert_eq!(res.authorised[0].mixnet_address, agents[2]);
+            assert_eq!(res.authorised[1].mixnet_address, agents[3]);
+            assert_eq!(res.start_next_after, Some(agents[3].ip()));
 
             Ok(())
         }
@@ -291,15 +281,11 @@ mod tests {
         #[test]
         fn caps_limit_at_maximum() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
             let total = retrieval_limits::AGENTS_MAX_LIMIT as usize + 20;
-            let agents = string_sorted_ips(&mut test, total);
+            let agents = storage_sorted_addresses(&mut test, total);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
             let res = query_network_monitor_agents(
@@ -314,7 +300,7 @@ mod tests {
             );
             assert_eq!(
                 res.start_next_after,
-                Some(agents[retrieval_limits::AGENTS_MAX_LIMIT as usize - 1])
+                Some(agents[retrieval_limits::AGENTS_MAX_LIMIT as usize - 1].ip())
             );
 
             Ok(())
@@ -323,17 +309,13 @@ mod tests {
         #[test]
         fn start_next_after_is_none_for_empty_page() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
-            let agents = string_sorted_ips(&mut test, 3);
+            let agents = storage_sorted_addresses(&mut test, 3);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
-            let res = query_network_monitor_agents(test.deps(), Some(agents[2]), Some(10))?;
+            let res = query_network_monitor_agents(test.deps(), Some(agents[2].ip()), Some(10))?;
 
             assert!(res.authorised.is_empty());
             assert_eq!(res.start_next_after, None);
@@ -344,22 +326,19 @@ mod tests {
         #[test]
         fn returns_entries_in_ascending_order() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
-            let agents = string_sorted_ips(&mut test, 6);
+            let agents = storage_sorted_addresses(&mut test, 6);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
             let res = query_network_monitor_agents(test.deps(), None, None)?;
 
-            assert!(res
-                .authorised
-                .windows(2)
-                .all(|window| window[0].address.to_string() <= window[1].address.to_string()));
+            assert!(res.authorised.windows(2).all(|window| storage_ip_comp(
+                window[0].mixnet_address.ip(),
+                window[1].mixnet_address.ip()
+            )
+            .is_le()));
 
             Ok(())
         }

--- a/contracts/network-monitors/src/queries.rs
+++ b/contracts/network-monitors/src/queries.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::storage::{retrieval_limits, NETWORK_MONITORS_CONTRACT_STORAGE};
+use crate::storage::{retrieval_limits, AgentStorageKey, NETWORK_MONITORS_CONTRACT_STORAGE};
 use cosmwasm_std::{Deps, StdResult};
 use cw_controllers::AdminResponse;
 use cw_storage_plus::Bound;
@@ -40,7 +40,7 @@ pub fn query_network_monitor_agents(
         .unwrap_or(retrieval_limits::AGENTS_DEFAULT_LIMIT)
         .min(retrieval_limits::AGENTS_MAX_LIMIT) as usize;
 
-    let start = start_after.map(|addr| Bound::exclusive(addr.to_string()));
+    let start = start_after.map(|addr| Bound::exclusive(AgentStorageKey::from(addr)));
 
     let authorised = NETWORK_MONITORS_CONTRACT_STORAGE
         .authorised_agents
@@ -49,7 +49,7 @@ pub fn query_network_monitor_agents(
         .map(|record| record.map(|(_, details)| details))
         .collect::<StdResult<Vec<_>>>()?;
 
-    let start_next_after = authorised.last().map(|last| last.address);
+    let start_next_after = authorised.last().map(|last| last.mixnet_address.ip());
 
     Ok(AuthorisedNetworkMonitorsPagedResponse {
         authorised,
@@ -187,22 +187,24 @@ mod tests {
     mod network_monitor_agents_query {
         use super::*;
         use crate::testing::{
-            init_contract_tester, NetworkMonitorsContract, NetworkMonitorsContractTesterExt,
+            init_contract_tester, storage_ip_comp, NetworkMonitorsContract,
+            NetworkMonitorsContractTesterExt,
         };
         use nym_contracts_common_testing::{ContractOpts, ContractTester};
-        use nym_network_monitors_contract_common::ExecuteMsg;
+        use std::net::SocketAddr;
 
-        fn string_sorted_ips(
+        fn storage_sorted_addresses(
             test: &mut ContractTester<NetworkMonitorsContract>,
             n: usize,
-        ) -> Vec<IpAddr> {
+        ) -> Vec<SocketAddr> {
             let mut ips = Vec::new();
             for _ in 0..n {
-                ips.push(test.random_ip().to_string());
+                ips.push(test.random_socket());
             }
 
-            ips.sort_unstable();
-            ips.into_iter().map(|ip| ip.parse().unwrap()).collect()
+            ips.sort_by(|a, b| storage_ip_comp(a.ip(), b.ip()));
+            // ips.into_iter().map(|ip| ip.parse().unwrap()).collect()
+            ips
         }
 
         #[test]
@@ -220,23 +222,19 @@ mod tests {
         #[test]
         fn returns_all_authorised_agents_below_default_limit() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
-            let agents = string_sorted_ips(&mut test, 5);
+            let agents = storage_sorted_addresses(&mut test, 5);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
             let res = query_network_monitor_agents(test.deps(), None, None)?;
 
             assert_eq!(res.authorised.len(), agents.len());
-            assert_eq!(res.start_next_after, agents.last().copied());
+            assert_eq!(res.start_next_after, agents.last().map(|a| a.ip()));
 
             for agent in &agents {
-                assert!(res.authorised.iter().any(|a| a.address == *agent));
+                assert!(res.authorised.iter().any(|a| a.mixnet_address == *agent));
             }
 
             Ok(())
@@ -245,22 +243,18 @@ mod tests {
         #[test]
         fn respects_explicit_limit() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
-            let agents = string_sorted_ips(&mut test, 5);
+            let agents = storage_sorted_addresses(&mut test, 5);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
             let res = query_network_monitor_agents(test.deps(), None, Some(2))?;
 
             assert_eq!(res.authorised.len(), 2);
-            assert_eq!(res.authorised[0].address, agents[0]);
-            assert_eq!(res.authorised[1].address, agents[1]);
-            assert_eq!(res.start_next_after, Some(agents[1]));
+            assert_eq!(res.authorised[0].mixnet_address, agents[0]);
+            assert_eq!(res.authorised[1].mixnet_address, agents[1]);
+            assert_eq!(res.start_next_after, Some(agents[1].ip()));
 
             Ok(())
         }
@@ -268,22 +262,18 @@ mod tests {
         #[test]
         fn respects_start_after_for_pagination() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
-            let agents = string_sorted_ips(&mut test, 5);
+            let agents = storage_sorted_addresses(&mut test, 5);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
-            let res = query_network_monitor_agents(test.deps(), Some(agents[1]), Some(2))?;
+            let res = query_network_monitor_agents(test.deps(), Some(agents[1].ip()), Some(2))?;
 
             assert_eq!(res.authorised.len(), 2);
-            assert_eq!(res.authorised[0].address, agents[2]);
-            assert_eq!(res.authorised[1].address, agents[3]);
-            assert_eq!(res.start_next_after, Some(agents[3]));
+            assert_eq!(res.authorised[0].mixnet_address, agents[2]);
+            assert_eq!(res.authorised[1].mixnet_address, agents[3]);
+            assert_eq!(res.start_next_after, Some(agents[3].ip()));
 
             Ok(())
         }
@@ -291,15 +281,11 @@ mod tests {
         #[test]
         fn caps_limit_at_maximum() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
             let total = retrieval_limits::AGENTS_MAX_LIMIT as usize + 20;
-            let agents = string_sorted_ips(&mut test, total);
+            let agents = storage_sorted_addresses(&mut test, total);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
             let res = query_network_monitor_agents(
@@ -314,7 +300,7 @@ mod tests {
             );
             assert_eq!(
                 res.start_next_after,
-                Some(agents[retrieval_limits::AGENTS_MAX_LIMIT as usize - 1])
+                Some(agents[retrieval_limits::AGENTS_MAX_LIMIT as usize - 1].ip())
             );
 
             Ok(())
@@ -323,17 +309,13 @@ mod tests {
         #[test]
         fn start_next_after_is_none_for_empty_page() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
-            let agents = string_sorted_ips(&mut test, 3);
+            let agents = storage_sorted_addresses(&mut test, 3);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
-            let res = query_network_monitor_agents(test.deps(), Some(agents[2]), Some(10))?;
+            let res = query_network_monitor_agents(test.deps(), Some(agents[2].ip()), Some(10))?;
 
             assert!(res.authorised.is_empty());
             assert_eq!(res.start_next_after, None);
@@ -344,22 +326,19 @@ mod tests {
         #[test]
         fn returns_entries_in_ascending_order() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
-            let orchestrator = test.add_orchestrator()?;
-            let agents = string_sorted_ips(&mut test, 6);
+            let agents = storage_sorted_addresses(&mut test, 6);
 
             for agent in &agents {
-                test.execute_raw(
-                    orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: *agent },
-                )?;
+                test.add_dummy_agent(*agent)
             }
 
             let res = query_network_monitor_agents(test.deps(), None, None)?;
 
-            assert!(res
-                .authorised
-                .windows(2)
-                .all(|window| window[0].address.to_string() <= window[1].address.to_string()));
+            assert!(res.authorised.windows(2).all(|window| storage_ip_comp(
+                window[0].mixnet_address.ip(),
+                window[1].mixnet_address.ip()
+            )
+            .is_le()));
 
             Ok(())
         }

--- a/contracts/network-monitors/src/storage.rs
+++ b/contracts/network-monitors/src/storage.rs
@@ -153,6 +153,8 @@ impl NetworkMonitorsStorage {
         env: &Env,
         sender: &Addr,
         monitor_address: IpAddr,
+        bs58_x25519_noise: String,
+        noise_version: u8,
     ) -> Result<(), NetworkMonitorsContractError> {
         // only orchestrators can authorise new monitors
         self.ensure_is_orchestrator(deps.as_ref(), sender)?;
@@ -164,6 +166,8 @@ impl NetworkMonitorsStorage {
                 address: monitor_address,
                 authorised_by: sender.clone(),
                 authorised_at: env.block.time,
+                bs58_x25519_noise,
+                noise_version,
             },
         )?;
         Ok(())
@@ -645,7 +649,7 @@ mod tests {
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 let res = storage
-                    .authorise_monitor(deps, &env, &non_orchestrator, agent)
+                    .authorise_monitor(deps, &env, &non_orchestrator, agent, "test_noise_key".to_string(), 1)
                     .unwrap_err();
                 assert_eq!(
                     NetworkMonitorsContractError::NotAnOrchestrator {
@@ -656,7 +660,7 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                let res2 = storage.authorise_monitor(deps, &env, &orchestrator, agent);
+                let res2 = storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1);
                 assert_eq!(res2, Ok(()));
 
                 Ok(())
@@ -677,7 +681,7 @@ mod tests {
                     .authorised_agents
                     .may_load(deps.storage, agent.to_string())?
                     .is_none());
-                storage.authorise_monitor(deps, &env, &orchestrator, agent)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
 
                 let info = storage.authorised_agents.load(&tester, agent.to_string())?;
 
@@ -699,7 +703,7 @@ mod tests {
                 let env = tester.env();
                 let deps = tester.deps_mut();
 
-                storage.authorise_monitor(deps, &env, &orchestrator, agent)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
 
                 let initial_time = env.block.time;
                 tester.advance_day_of_blocks();
@@ -707,7 +711,7 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
 
                 let updated_info = storage.authorised_agents.load(&tester, agent.to_string())?;
 
@@ -738,7 +742,7 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
 
                 let deps = tester.deps_mut();
                 let res = storage
@@ -787,7 +791,7 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
 
                 assert!(storage
                     .authorised_agents
@@ -854,19 +858,19 @@ mod tests {
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent1)
+                    .authorise_monitor(deps, &env, &orchestrator, agent1, "test_noise_key".to_string(), 1)
                     .unwrap();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent2)
+                    .authorise_monitor(deps, &env, &orchestrator, agent2, "test_noise_key".to_string(), 1)
                     .unwrap();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent3)
+                    .authorise_monitor(deps, &env, &orchestrator, agent3, "test_noise_key".to_string(), 1)
                     .unwrap();
 
                 // sanity check to make sure all agents got added
@@ -990,19 +994,19 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent1)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent1, "test_noise_key".to_string(), 1)?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent2)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent2, "test_noise_key".to_string(), 1)?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent3)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent3, "test_noise_key".to_string(), 1)?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent4)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent4, "test_noise_key".to_string(), 1)?;
 
                 // Verify agents are present
                 assert!(storage

--- a/contracts/network-monitors/src/storage.rs
+++ b/contracts/network-monitors/src/storage.rs
@@ -1,15 +1,15 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use cosmwasm_std::{Addr, Deps, DepsMut, Env};
+use cosmwasm_std::{Addr, Deps, DepsMut, Env, StdError, StdResult};
 use cw_controllers::Admin;
-use cw_storage_plus::Map;
+use cw_storage_plus::{Key, KeyDeserialize, Map, PrimaryKey};
 use nym_network_monitors_contract_common::constants::storage_keys;
 use nym_network_monitors_contract_common::{
-    AuthorisedNetworkMonitor, AuthorisedNetworkMonitorOrchestrator, NetworkMonitorAddress,
-    NetworkMonitorsContractError, OrchestratorAddress,
+    AuthorisedNetworkMonitor, AuthorisedNetworkMonitorOrchestrator, NetworkMonitorsContractError,
+    OrchestratorAddress,
 };
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 pub const NETWORK_MONITORS_CONTRACT_STORAGE: NetworkMonitorsStorage = NetworkMonitorsStorage::new();
 
@@ -22,7 +22,54 @@ pub struct NetworkMonitorsStorage {
     pub(crate) contract_admin: Admin,
     pub(crate) authorised_orchestrators:
         Map<&'static OrchestratorAddress, AuthorisedNetworkMonitorOrchestrator>,
-    pub(crate) authorised_agents: Map<NetworkMonitorAddress, AuthorisedNetworkMonitor>,
+    pub(crate) authorised_agents: Map<AgentStorageKey, AuthorisedNetworkMonitor>,
+}
+
+// implement explicit wrapper for the storage key rather than use string representation
+// to make use of type safety and avoid accidentally mixing up `IpAddr` and `SocketAddr`
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AgentStorageKey(IpAddr);
+
+impl<'a> PrimaryKey<'a> for AgentStorageKey {
+    type Prefix = ();
+    type SubPrefix = ();
+    type Suffix = Self;
+    type SuperSuffix = Self;
+
+    fn key(&'_ self) -> Vec<Key<'_>> {
+        match self.0 {
+            IpAddr::V4(ipv4) => vec![Key::Val32(ipv4.octets())],
+            IpAddr::V6(ipv6) => vec![Key::Val128(ipv6.octets())],
+        }
+    }
+}
+
+impl KeyDeserialize for AgentStorageKey {
+    type Output = AgentStorageKey;
+    const KEY_ELEMS: u16 = 1;
+
+    fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+        // SAFETY: we're using correct number of bytes for the conversion
+        #[allow(clippy::unwrap_used)]
+        let ip = match value.len() {
+            4 => IpAddr::V4(Ipv4Addr::from_octets(value.try_into().unwrap())),
+            16 => IpAddr::V6(Ipv6Addr::from_octets(value.try_into().unwrap())),
+            _ => return Err(StdError::generic_err("invalid IP address length")),
+        };
+        Ok(AgentStorageKey(ip))
+    }
+}
+
+impl From<IpAddr> for AgentStorageKey {
+    fn from(ip: IpAddr) -> Self {
+        Self(ip)
+    }
+}
+
+impl From<SocketAddr> for AgentStorageKey {
+    fn from(addr: SocketAddr) -> Self {
+        Self(addr.ip())
+    }
 }
 
 impl NetworkMonitorsStorage {
@@ -152,7 +199,7 @@ impl NetworkMonitorsStorage {
         deps: DepsMut,
         env: &Env,
         sender: &Addr,
-        monitor_address: IpAddr,
+        monitor_address: SocketAddr,
         bs58_x25519_noise: String,
         noise_version: u8,
     ) -> Result<(), NetworkMonitorsContractError> {
@@ -161,9 +208,9 @@ impl NetworkMonitorsStorage {
 
         self.authorised_agents.save(
             deps.storage,
-            monitor_address.to_string(),
+            monitor_address.into(),
             &AuthorisedNetworkMonitor {
-                address: monitor_address,
+                mixnet_address: monitor_address,
                 authorised_by: sender.clone(),
                 authorised_at: env.block.time,
                 bs58_x25519_noise,
@@ -185,7 +232,7 @@ impl NetworkMonitorsStorage {
         }
 
         self.authorised_agents
-            .remove(deps.storage, monitor_address.to_string());
+            .remove(deps.storage, monitor_address.into());
         Ok(())
     }
 
@@ -541,8 +588,8 @@ mod tests {
                 let admin = tester.admin_unchecked();
                 let orchestrator = tester.add_orchestrator()?;
 
-                let agent1 = tester.random_ip();
-                let agent2 = tester.random_ip();
+                let agent1 = tester.random_socket();
+                let agent2 = tester.random_socket();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
@@ -555,11 +602,11 @@ mod tests {
                 // sanity: both agents present
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent1.to_string())?
+                    .may_load(&tester, agent1.into())?
                     .is_some());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent2.to_string())?
+                    .may_load(&tester, agent2.into())?
                     .is_some());
 
                 let deps = tester.deps_mut();
@@ -574,11 +621,11 @@ mod tests {
                 // its agents are cascade-removed
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent1.to_string())?
+                    .may_load(&tester, agent1.into())?
                     .is_none());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent2.to_string())?
+                    .may_load(&tester, agent2.into())?
                     .is_none());
 
                 Ok(())
@@ -593,8 +640,8 @@ mod tests {
                 let orchestrator_a = tester.add_orchestrator()?;
                 let orchestrator_b = tester.add_orchestrator()?;
 
-                let agent_a = tester.random_ip();
-                let agent_b = tester.random_ip();
+                let agent_a = tester.random_socket();
+                let agent_b = tester.random_socket();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
@@ -610,14 +657,14 @@ mod tests {
                 // orchestrator_a's agent is gone
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent_a.to_string())?
+                    .may_load(&tester, agent_a.into())?
                     .is_none());
 
                 // orchestrator_b's agent is untouched
                 let remaining = storage
                     .authorised_agents
-                    .load(&tester, agent_b.to_string())?;
-                assert_eq!(remaining.address, agent_b);
+                    .load(&tester, agent_b.into())?;
+                assert_eq!(remaining.mixnet_address, agent_b);
                 assert_eq!(remaining.authorised_by, orchestrator_b);
 
                 // orchestrator_b itself is untouched
@@ -644,12 +691,19 @@ mod tests {
 
                 let orchestrator = tester.add_orchestrator()?;
                 let non_orchestrator = tester.generate_account();
-                let agent = tester.random_ip();
+                let agent = tester.random_socket();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 let res = storage
-                    .authorise_monitor(deps, &env, &non_orchestrator, agent, "test_noise_key".to_string(), 1)
+                    .authorise_monitor(
+                        deps,
+                        &env,
+                        &non_orchestrator,
+                        agent,
+                        "test_noise_key".to_string(),
+                        1,
+                    )
                     .unwrap_err();
                 assert_eq!(
                     NetworkMonitorsContractError::NotAnOrchestrator {
@@ -660,7 +714,14 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                let res2 = storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1);
+                let res2 = storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                );
                 assert_eq!(res2, Ok(()));
 
                 Ok(())
@@ -671,21 +732,56 @@ mod tests {
                 let mut tester = init_contract_tester();
                 let storage = NetworkMonitorsStorage::new();
 
+                // IPV4:
                 let orchestrator = tester.add_orchestrator()?;
-                let agent = tester.random_ip();
+                let agent = tester.random_socket_ipv4();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
 
                 assert!(storage
                     .authorised_agents
-                    .may_load(deps.storage, agent.to_string())?
+                    .may_load(deps.storage, agent.into())?
                     .is_none());
-                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
-                let info = storage.authorised_agents.load(&tester, agent.to_string())?;
+                let info = storage.authorised_agents.load(&tester, agent.into())?;
 
-                assert_eq!(info.address, agent);
+                assert_eq!(info.mixnet_address, agent);
+                assert_eq!(info.authorised_by, orchestrator);
+                assert_eq!(info.authorised_at, env.block.time);
+
+                tester.advance_day_of_blocks();
+
+                // IPV6:
+                let agent = tester.random_socket_ipv6();
+
+                let env = tester.env();
+                let deps = tester.deps_mut();
+
+                assert!(storage
+                    .authorised_agents
+                    .may_load(deps.storage, agent.into())?
+                    .is_none());
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
+
+                let info = storage.authorised_agents.load(&tester, agent.into())?;
+
+                assert_eq!(info.mixnet_address, agent);
                 assert_eq!(info.authorised_by, orchestrator);
                 assert_eq!(info.authorised_at, env.block.time);
 
@@ -697,13 +793,21 @@ mod tests {
                 let mut tester = init_contract_tester();
                 let storage = NetworkMonitorsStorage::new();
 
+                // IPV4:
                 let orchestrator = tester.add_orchestrator()?;
-                let agent = tester.random_ip();
+                let agent = tester.random_socket_ipv4();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
 
-                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let initial_time = env.block.time;
                 tester.advance_day_of_blocks();
@@ -711,11 +815,57 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
-                let updated_info = storage.authorised_agents.load(&tester, agent.to_string())?;
+                let updated_info = storage.authorised_agents.load(&tester, agent.into())?;
 
-                assert_eq!(updated_info.address, agent);
+                assert_eq!(updated_info.mixnet_address, agent);
+                assert_eq!(updated_info.authorised_by, orchestrator);
+                assert_ne!(updated_info.authorised_at, initial_time);
+                assert_eq!(updated_info.authorised_at, new_expected_time);
+
+                tester.advance_day_of_blocks();
+
+                // IPV6:
+                let agent = tester.random_socket_ipv6();
+
+                let env = tester.env();
+                let deps = tester.deps_mut();
+
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
+
+                let initial_time = env.block.time;
+                tester.advance_day_of_blocks();
+                let new_expected_time = tester.env().block.time;
+
+                let env = tester.env();
+                let deps = tester.deps_mut();
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
+
+                let updated_info = storage.authorised_agents.load(&tester, agent.into())?;
+
+                assert_eq!(updated_info.mixnet_address, agent);
                 assert_eq!(updated_info.authorised_by, orchestrator);
                 assert_ne!(updated_info.authorised_at, initial_time);
                 assert_eq!(updated_info.authorised_at, new_expected_time);
@@ -728,7 +878,7 @@ mod tests {
         mod removing_monitor_authorisation {
             use super::*;
             use crate::testing::{init_contract_tester, NetworkMonitorsContractTesterExt};
-            use nym_contracts_common_testing::{AdminExt, ContractOpts, RandExt};
+            use nym_contracts_common_testing::{AdminExt, ChainOpts, ContractOpts, RandExt};
             use nym_network_monitors_contract_common::NetworkMonitorsContractError;
 
             #[test]
@@ -738,20 +888,27 @@ mod tests {
 
                 let orchestrator = tester.add_orchestrator()?;
                 let non_privileged = tester.generate_account();
-                let agent = tester.random_ip();
+                let agent = tester.random_socket();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let deps = tester.deps_mut();
                 let res = storage
-                    .remove_monitor_authorisation(deps, &non_privileged, agent)
+                    .remove_monitor_authorisation(deps, &non_privileged, agent.ip())
                     .unwrap_err();
                 assert_eq!(NetworkMonitorsContractError::Unauthorized, res);
 
                 let deps = tester.deps_mut();
-                let res2 = storage.remove_monitor_authorisation(deps, &orchestrator, agent);
+                let res2 = storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip());
                 assert_eq!(res2, Ok(()));
 
                 Ok(())
@@ -764,7 +921,7 @@ mod tests {
 
                 let admin = tester.admin_unchecked();
                 let orchestrator = tester.add_orchestrator()?;
-                let agent = tester.random_ip();
+                let agent = tester.random_socket();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
@@ -775,7 +932,7 @@ mod tests {
 
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent.to_string())?
+                    .may_load(&tester, agent.into())?
                     .is_none());
 
                 Ok(())
@@ -786,24 +943,61 @@ mod tests {
                 let mut tester = init_contract_tester();
                 let storage = NetworkMonitorsStorage::new();
 
+                // IPV4:
                 let orchestrator = tester.add_orchestrator()?;
-                let agent = tester.random_ip();
+                let agent = tester.random_socket_ipv4();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent.to_string())?
+                    .may_load(&tester, agent.into())?
                     .is_some());
 
                 let deps = tester.deps_mut();
-                storage.remove_monitor_authorisation(deps, &orchestrator, agent)?;
+                storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip())?;
 
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent.to_string())?
+                    .may_load(&tester, agent.into())?
+                    .is_none());
+
+                tester.advance_day_of_blocks();
+
+                // IPV6:
+                let agent = tester.random_socket_ipv6();
+
+                let env = tester.env();
+                let deps = tester.deps_mut();
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
+
+                assert!(storage
+                    .authorised_agents
+                    .may_load(&tester, agent.into())?
+                    .is_some());
+
+                let deps = tester.deps_mut();
+                storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip())?;
+
+                assert!(storage
+                    .authorised_agents
+                    .may_load(&tester, agent.into())?
                     .is_none());
 
                 Ok(())
@@ -815,20 +1009,20 @@ mod tests {
                 let storage = NetworkMonitorsStorage::new();
 
                 let orchestrator = tester.add_orchestrator()?;
-                let agent = tester.random_ip();
+                let agent = tester.random_socket();
 
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent.to_string())?
+                    .may_load(&tester, agent.into())?
                     .is_none());
 
                 let deps = tester.deps_mut();
-                let res = storage.remove_monitor_authorisation(deps, &orchestrator, agent);
+                let res = storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip());
                 assert_eq!(res, Ok(()));
 
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent.to_string())?
+                    .may_load(&tester, agent.into())?
                     .is_none());
 
                 Ok(())
@@ -851,26 +1045,47 @@ mod tests {
                 let orchestrator = tester.add_orchestrator().unwrap();
 
                 // Prepopulate with several agents
-                let agent1 = tester.random_ip();
-                let agent2 = tester.random_ip();
-                let agent3 = tester.random_ip();
+                let agent1 = tester.random_socket();
+                let agent2 = tester.random_socket();
+                let agent3 = tester.random_socket();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent1, "test_noise_key".to_string(), 1)
+                    .authorise_monitor(
+                        deps,
+                        &env,
+                        &orchestrator,
+                        agent1,
+                        "test_noise_key".to_string(),
+                        1,
+                    )
                     .unwrap();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent2, "test_noise_key".to_string(), 1)
+                    .authorise_monitor(
+                        deps,
+                        &env,
+                        &orchestrator,
+                        agent2,
+                        "test_noise_key".to_string(),
+                        1,
+                    )
                     .unwrap();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent3, "test_noise_key".to_string(), 1)
+                    .authorise_monitor(
+                        deps,
+                        &env,
+                        &orchestrator,
+                        agent3,
+                        "test_noise_key".to_string(),
+                        1,
+                    )
                     .unwrap();
 
                 // sanity check to make sure all agents got added
@@ -900,7 +1115,7 @@ mod tests {
                 for agent in all_agents {
                     assert!(storage
                         .authorised_agents
-                        .may_load(&tester, agent.to_string())?
+                        .may_load(&tester, agent.into())?
                         .is_none());
                 }
 
@@ -923,7 +1138,7 @@ mod tests {
                 for agent in all_agents {
                     assert!(storage
                         .authorised_agents
-                        .may_load(&tester, agent.to_string())?
+                        .may_load(&tester, agent.into())?
                         .is_none());
                 }
 
@@ -987,43 +1202,71 @@ mod tests {
                 let orchestrator = tester.add_orchestrator()?;
 
                 // Prepopulate with multiple agents
-                let agent1 = tester.random_ip();
-                let agent2 = tester.random_ip();
-                let agent3 = tester.random_ip();
-                let agent4 = tester.random_ip();
+                let agent1 = tester.random_socket();
+                let agent2 = tester.random_socket();
+                let agent3 = tester.random_socket();
+                let agent4 = tester.random_socket();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent1, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent1,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent2, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent2,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent3, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent3,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent4, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent4,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 // Verify agents are present
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent1.to_string())?
+                    .may_load(&tester, agent1.into())?
                     .is_some());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent2.to_string())?
+                    .may_load(&tester, agent2.into())?
                     .is_some());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent3.to_string())?
+                    .may_load(&tester, agent3.into())?
                     .is_some());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent4.to_string())?
+                    .may_load(&tester, agent4.into())?
                     .is_some());
 
                 // Remove all monitors
@@ -1033,19 +1276,19 @@ mod tests {
                 // Verify all agents are cleared
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent1.to_string())?
+                    .may_load(&tester, agent1.into())?
                     .is_none());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent2.to_string())?
+                    .may_load(&tester, agent2.into())?
                     .is_none());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent3.to_string())?
+                    .may_load(&tester, agent3.into())?
                     .is_none());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent4.to_string())?
+                    .may_load(&tester, agent4.into())?
                     .is_none());
 
                 Ok(())

--- a/contracts/network-monitors/src/storage.rs
+++ b/contracts/network-monitors/src/storage.rs
@@ -595,11 +595,25 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent1,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent2)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent2,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 // sanity: both agents present
                 assert!(storage
@@ -647,11 +661,25 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator_a, agent_a)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator_a,
+                    agent_a,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator_b, agent_b)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator_b,
+                    agent_b,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let deps = tester.deps_mut();
                 storage.remove_orchestrator_authorisation(deps, &admin, orchestrator_a.clone())?;
@@ -927,10 +955,17 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let deps = tester.deps_mut();
-                storage.remove_monitor_authorisation(deps, &admin, agent)?;
+                storage.remove_monitor_authorisation(deps, &admin, agent.ip())?;
 
                 assert!(storage
                     .authorised_agents

--- a/contracts/network-monitors/src/storage.rs
+++ b/contracts/network-monitors/src/storage.rs
@@ -136,6 +136,8 @@ impl NetworkMonitorsStorage {
         env: &Env,
         sender: &Addr,
         monitor_address: IpAddr,
+        bs58_x25519_noise: String,
+        noise_version: u8,
     ) -> Result<(), NetworkMonitorsContractError> {
         // only orchestrators can authorise new monitors
         self.ensure_is_orchestrator(deps.as_ref(), sender)?;
@@ -147,6 +149,8 @@ impl NetworkMonitorsStorage {
                 address: monitor_address,
                 authorised_by: sender.clone(),
                 authorised_at: env.block.time,
+                bs58_x25519_noise,
+                noise_version,
             },
         )?;
         Ok(())
@@ -528,7 +532,7 @@ mod tests {
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 let res = storage
-                    .authorise_monitor(deps, &env, &non_orchestrator, agent)
+                    .authorise_monitor(deps, &env, &non_orchestrator, agent, "test_noise_key".to_string(), 1)
                     .unwrap_err();
                 assert_eq!(
                     NetworkMonitorsContractError::NotAnOrchestrator {
@@ -539,7 +543,7 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                let res2 = storage.authorise_monitor(deps, &env, &orchestrator, agent);
+                let res2 = storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1);
                 assert_eq!(res2, Ok(()));
 
                 Ok(())
@@ -560,7 +564,7 @@ mod tests {
                     .authorised_agents
                     .may_load(deps.storage, agent.to_string())?
                     .is_none());
-                storage.authorise_monitor(deps, &env, &orchestrator, agent)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
 
                 let info = storage.authorised_agents.load(&tester, agent.to_string())?;
 
@@ -582,7 +586,7 @@ mod tests {
                 let env = tester.env();
                 let deps = tester.deps_mut();
 
-                storage.authorise_monitor(deps, &env, &orchestrator, agent)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
 
                 let initial_time = env.block.time;
                 tester.advance_day_of_blocks();
@@ -590,7 +594,7 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
 
                 let updated_info = storage.authorised_agents.load(&tester, agent.to_string())?;
 
@@ -621,7 +625,7 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
 
                 let deps = tester.deps_mut();
                 let res = storage
@@ -651,7 +655,7 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
 
                 assert!(storage
                     .authorised_agents
@@ -718,19 +722,19 @@ mod tests {
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent1)
+                    .authorise_monitor(deps, &env, &orchestrator, agent1, "test_noise_key".to_string(), 1)
                     .unwrap();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent2)
+                    .authorise_monitor(deps, &env, &orchestrator, agent2, "test_noise_key".to_string(), 1)
                     .unwrap();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent3)
+                    .authorise_monitor(deps, &env, &orchestrator, agent3, "test_noise_key".to_string(), 1)
                     .unwrap();
 
                 // sanity check to make sure all agents got added
@@ -851,19 +855,19 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent1)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent1, "test_noise_key".to_string(), 1)?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent2)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent2, "test_noise_key".to_string(), 1)?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent3)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent3, "test_noise_key".to_string(), 1)?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent4)?;
+                storage.authorise_monitor(deps, &env, &orchestrator, agent4, "test_noise_key".to_string(), 1)?;
 
                 // Verify agents are present
                 assert!(storage

--- a/contracts/network-monitors/src/storage.rs
+++ b/contracts/network-monitors/src/storage.rs
@@ -52,8 +52,10 @@ impl KeyDeserialize for AgentStorageKey {
         // SAFETY: we're using the correct number of bytes for the conversion
         #[allow(clippy::unwrap_used)]
         let ip = match value.len() {
-            4 => IpAddr::V4(Ipv4Addr::from_octets(value.try_into().unwrap())),
-            16 => IpAddr::V6(Ipv6Addr::from_octets(value.try_into().unwrap())),
+            4 => IpAddr::V4(Ipv4Addr::from(TryInto::<[u8; 4]>::try_into(value).unwrap())),
+            16 => IpAddr::V6(Ipv6Addr::from(
+                TryInto::<[u8; 16]>::try_into(value).unwrap(),
+            )),
             _ => return Err(StdError::generic_err("invalid IP address length")),
         };
         Ok(AgentStorageKey(ip))

--- a/contracts/network-monitors/src/storage.rs
+++ b/contracts/network-monitors/src/storage.rs
@@ -49,7 +49,7 @@ impl KeyDeserialize for AgentStorageKey {
     const KEY_ELEMS: u16 = 1;
 
     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
-        // SAFETY: we're using correct number of bytes for the conversion
+        // SAFETY: we're using the correct number of bytes for the conversion
         #[allow(clippy::unwrap_used)]
         let ip = match value.len() {
             4 => IpAddr::V4(Ipv4Addr::from_octets(value.try_into().unwrap())),

--- a/contracts/network-monitors/src/storage.rs
+++ b/contracts/network-monitors/src/storage.rs
@@ -1,15 +1,15 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use cosmwasm_std::{Addr, Deps, DepsMut, Env};
+use cosmwasm_std::{Addr, Deps, DepsMut, Env, StdError, StdResult};
 use cw_controllers::Admin;
-use cw_storage_plus::Map;
+use cw_storage_plus::{Key, KeyDeserialize, Map, PrimaryKey};
 use nym_network_monitors_contract_common::constants::storage_keys;
 use nym_network_monitors_contract_common::{
-    AuthorisedNetworkMonitor, AuthorisedNetworkMonitorOrchestrator, NetworkMonitorAddress,
-    NetworkMonitorsContractError, OrchestratorAddress,
+    AuthorisedNetworkMonitor, AuthorisedNetworkMonitorOrchestrator, NetworkMonitorsContractError,
+    OrchestratorAddress,
 };
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 pub const NETWORK_MONITORS_CONTRACT_STORAGE: NetworkMonitorsStorage = NetworkMonitorsStorage::new();
 
@@ -22,7 +22,54 @@ pub struct NetworkMonitorsStorage {
     pub(crate) contract_admin: Admin,
     pub(crate) authorised_orchestrators:
         Map<&'static OrchestratorAddress, AuthorisedNetworkMonitorOrchestrator>,
-    pub(crate) authorised_agents: Map<NetworkMonitorAddress, AuthorisedNetworkMonitor>,
+    pub(crate) authorised_agents: Map<AgentStorageKey, AuthorisedNetworkMonitor>,
+}
+
+// implement explicit wrapper for the storage key rather than use string representation
+// to make use of type safety and avoid accidentally mixing up `IpAddr` and `SocketAddr`
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AgentStorageKey(IpAddr);
+
+impl<'a> PrimaryKey<'a> for AgentStorageKey {
+    type Prefix = ();
+    type SubPrefix = ();
+    type Suffix = Self;
+    type SuperSuffix = Self;
+
+    fn key(&'_ self) -> Vec<Key<'_>> {
+        match self.0 {
+            IpAddr::V4(ipv4) => vec![Key::Val32(ipv4.octets())],
+            IpAddr::V6(ipv6) => vec![Key::Val128(ipv6.octets())],
+        }
+    }
+}
+
+impl KeyDeserialize for AgentStorageKey {
+    type Output = AgentStorageKey;
+    const KEY_ELEMS: u16 = 1;
+
+    fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+        // SAFETY: we're using correct number of bytes for the conversion
+        #[allow(clippy::unwrap_used)]
+        let ip = match value.len() {
+            4 => IpAddr::V4(Ipv4Addr::from_octets(value.try_into().unwrap())),
+            16 => IpAddr::V6(Ipv6Addr::from_octets(value.try_into().unwrap())),
+            _ => return Err(StdError::generic_err("invalid IP address length")),
+        };
+        Ok(AgentStorageKey(ip))
+    }
+}
+
+impl From<IpAddr> for AgentStorageKey {
+    fn from(ip: IpAddr) -> Self {
+        Self(ip)
+    }
+}
+
+impl From<SocketAddr> for AgentStorageKey {
+    fn from(addr: SocketAddr) -> Self {
+        Self(addr.ip())
+    }
 }
 
 impl NetworkMonitorsStorage {
@@ -135,7 +182,7 @@ impl NetworkMonitorsStorage {
         deps: DepsMut,
         env: &Env,
         sender: &Addr,
-        monitor_address: IpAddr,
+        monitor_address: SocketAddr,
         bs58_x25519_noise: String,
         noise_version: u8,
     ) -> Result<(), NetworkMonitorsContractError> {
@@ -144,9 +191,9 @@ impl NetworkMonitorsStorage {
 
         self.authorised_agents.save(
             deps.storage,
-            monitor_address.to_string(),
+            monitor_address.into(),
             &AuthorisedNetworkMonitor {
-                address: monitor_address,
+                mixnet_address: monitor_address,
                 authorised_by: sender.clone(),
                 authorised_at: env.block.time,
                 bs58_x25519_noise,
@@ -164,7 +211,7 @@ impl NetworkMonitorsStorage {
     ) -> Result<(), NetworkMonitorsContractError> {
         self.ensure_is_orchestrator(deps.as_ref(), sender)?;
         self.authorised_agents
-            .remove(deps.storage, monitor_address.to_string());
+            .remove(deps.storage, monitor_address.into());
         Ok(())
     }
 
@@ -527,12 +574,19 @@ mod tests {
 
                 let orchestrator = tester.add_orchestrator()?;
                 let non_orchestrator = tester.generate_account();
-                let agent = tester.random_ip();
+                let agent = tester.random_socket();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 let res = storage
-                    .authorise_monitor(deps, &env, &non_orchestrator, agent, "test_noise_key".to_string(), 1)
+                    .authorise_monitor(
+                        deps,
+                        &env,
+                        &non_orchestrator,
+                        agent,
+                        "test_noise_key".to_string(),
+                        1,
+                    )
                     .unwrap_err();
                 assert_eq!(
                     NetworkMonitorsContractError::NotAnOrchestrator {
@@ -543,7 +597,14 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                let res2 = storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1);
+                let res2 = storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                );
                 assert_eq!(res2, Ok(()));
 
                 Ok(())
@@ -554,21 +615,56 @@ mod tests {
                 let mut tester = init_contract_tester();
                 let storage = NetworkMonitorsStorage::new();
 
+                // IPV4:
                 let orchestrator = tester.add_orchestrator()?;
-                let agent = tester.random_ip();
+                let agent = tester.random_socket_ipv4();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
 
                 assert!(storage
                     .authorised_agents
-                    .may_load(deps.storage, agent.to_string())?
+                    .may_load(deps.storage, agent.into())?
                     .is_none());
-                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
-                let info = storage.authorised_agents.load(&tester, agent.to_string())?;
+                let info = storage.authorised_agents.load(&tester, agent.into())?;
 
-                assert_eq!(info.address, agent);
+                assert_eq!(info.mixnet_address, agent);
+                assert_eq!(info.authorised_by, orchestrator);
+                assert_eq!(info.authorised_at, env.block.time);
+
+                tester.advance_day_of_blocks();
+
+                // IPV6:
+                let agent = tester.random_socket_ipv6();
+
+                let env = tester.env();
+                let deps = tester.deps_mut();
+
+                assert!(storage
+                    .authorised_agents
+                    .may_load(deps.storage, agent.into())?
+                    .is_none());
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
+
+                let info = storage.authorised_agents.load(&tester, agent.into())?;
+
+                assert_eq!(info.mixnet_address, agent);
                 assert_eq!(info.authorised_by, orchestrator);
                 assert_eq!(info.authorised_at, env.block.time);
 
@@ -580,13 +676,21 @@ mod tests {
                 let mut tester = init_contract_tester();
                 let storage = NetworkMonitorsStorage::new();
 
+                // IPV4:
                 let orchestrator = tester.add_orchestrator()?;
-                let agent = tester.random_ip();
+                let agent = tester.random_socket_ipv4();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
 
-                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let initial_time = env.block.time;
                 tester.advance_day_of_blocks();
@@ -594,11 +698,57 @@ mod tests {
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
-                let updated_info = storage.authorised_agents.load(&tester, agent.to_string())?;
+                let updated_info = storage.authorised_agents.load(&tester, agent.into())?;
 
-                assert_eq!(updated_info.address, agent);
+                assert_eq!(updated_info.mixnet_address, agent);
+                assert_eq!(updated_info.authorised_by, orchestrator);
+                assert_ne!(updated_info.authorised_at, initial_time);
+                assert_eq!(updated_info.authorised_at, new_expected_time);
+
+                tester.advance_day_of_blocks();
+
+                // IPV6:
+                let agent = tester.random_socket_ipv6();
+
+                let env = tester.env();
+                let deps = tester.deps_mut();
+
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
+
+                let initial_time = env.block.time;
+                tester.advance_day_of_blocks();
+                let new_expected_time = tester.env().block.time;
+
+                let env = tester.env();
+                let deps = tester.deps_mut();
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
+
+                let updated_info = storage.authorised_agents.load(&tester, agent.into())?;
+
+                assert_eq!(updated_info.mixnet_address, agent);
                 assert_eq!(updated_info.authorised_by, orchestrator);
                 assert_ne!(updated_info.authorised_at, initial_time);
                 assert_eq!(updated_info.authorised_at, new_expected_time);
@@ -611,7 +761,7 @@ mod tests {
         mod removing_monitor_authorisation {
             use super::*;
             use crate::testing::{init_contract_tester, NetworkMonitorsContractTesterExt};
-            use nym_contracts_common_testing::{ContractOpts, RandExt};
+            use nym_contracts_common_testing::{ChainOpts, ContractOpts, RandExt};
             use nym_network_monitors_contract_common::NetworkMonitorsContractError;
 
             #[test]
@@ -621,15 +771,22 @@ mod tests {
 
                 let orchestrator = tester.add_orchestrator()?;
                 let non_orchestrator = tester.generate_account();
-                let agent = tester.random_ip();
+                let agent = tester.random_socket();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let deps = tester.deps_mut();
                 let res = storage
-                    .remove_monitor_authorisation(deps, &non_orchestrator, agent)
+                    .remove_monitor_authorisation(deps, &non_orchestrator, agent.ip())
                     .unwrap_err();
                 assert_eq!(
                     NetworkMonitorsContractError::NotAnOrchestrator {
@@ -639,7 +796,7 @@ mod tests {
                 );
 
                 let deps = tester.deps_mut();
-                let res2 = storage.remove_monitor_authorisation(deps, &orchestrator, agent);
+                let res2 = storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip());
                 assert_eq!(res2, Ok(()));
 
                 Ok(())
@@ -650,24 +807,61 @@ mod tests {
                 let mut tester = init_contract_tester();
                 let storage = NetworkMonitorsStorage::new();
 
+                // IPV4:
                 let orchestrator = tester.add_orchestrator()?;
-                let agent = tester.random_ip();
+                let agent = tester.random_socket_ipv4();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent.to_string())?
+                    .may_load(&tester, agent.into())?
                     .is_some());
 
                 let deps = tester.deps_mut();
-                storage.remove_monitor_authorisation(deps, &orchestrator, agent)?;
+                storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip())?;
 
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent.to_string())?
+                    .may_load(&tester, agent.into())?
+                    .is_none());
+
+                tester.advance_day_of_blocks();
+
+                // IPV6:
+                let agent = tester.random_socket_ipv6();
+
+                let env = tester.env();
+                let deps = tester.deps_mut();
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
+
+                assert!(storage
+                    .authorised_agents
+                    .may_load(&tester, agent.into())?
+                    .is_some());
+
+                let deps = tester.deps_mut();
+                storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip())?;
+
+                assert!(storage
+                    .authorised_agents
+                    .may_load(&tester, agent.into())?
                     .is_none());
 
                 Ok(())
@@ -679,20 +873,20 @@ mod tests {
                 let storage = NetworkMonitorsStorage::new();
 
                 let orchestrator = tester.add_orchestrator()?;
-                let agent = tester.random_ip();
+                let agent = tester.random_socket();
 
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent.to_string())?
+                    .may_load(&tester, agent.into())?
                     .is_none());
 
                 let deps = tester.deps_mut();
-                let res = storage.remove_monitor_authorisation(deps, &orchestrator, agent);
+                let res = storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip());
                 assert_eq!(res, Ok(()));
 
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent.to_string())?
+                    .may_load(&tester, agent.into())?
                     .is_none());
 
                 Ok(())
@@ -715,26 +909,47 @@ mod tests {
                 let orchestrator = tester.add_orchestrator().unwrap();
 
                 // Prepopulate with several agents
-                let agent1 = tester.random_ip();
-                let agent2 = tester.random_ip();
-                let agent3 = tester.random_ip();
+                let agent1 = tester.random_socket();
+                let agent2 = tester.random_socket();
+                let agent3 = tester.random_socket();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent1, "test_noise_key".to_string(), 1)
+                    .authorise_monitor(
+                        deps,
+                        &env,
+                        &orchestrator,
+                        agent1,
+                        "test_noise_key".to_string(),
+                        1,
+                    )
                     .unwrap();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent2, "test_noise_key".to_string(), 1)
+                    .authorise_monitor(
+                        deps,
+                        &env,
+                        &orchestrator,
+                        agent2,
+                        "test_noise_key".to_string(),
+                        1,
+                    )
                     .unwrap();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
                 storage
-                    .authorise_monitor(deps, &env, &orchestrator, agent3, "test_noise_key".to_string(), 1)
+                    .authorise_monitor(
+                        deps,
+                        &env,
+                        &orchestrator,
+                        agent3,
+                        "test_noise_key".to_string(),
+                        1,
+                    )
                     .unwrap();
 
                 // sanity check to make sure all agents got added
@@ -764,7 +979,7 @@ mod tests {
                 for agent in all_agents {
                     assert!(storage
                         .authorised_agents
-                        .may_load(&tester, agent.to_string())?
+                        .may_load(&tester, agent.into())?
                         .is_none());
                 }
 
@@ -787,7 +1002,7 @@ mod tests {
                 for agent in all_agents {
                     assert!(storage
                         .authorised_agents
-                        .may_load(&tester, agent.to_string())?
+                        .may_load(&tester, agent.into())?
                         .is_none());
                 }
 
@@ -848,43 +1063,71 @@ mod tests {
                 let orchestrator = tester.add_orchestrator()?;
 
                 // Prepopulate with multiple agents
-                let agent1 = tester.random_ip();
-                let agent2 = tester.random_ip();
-                let agent3 = tester.random_ip();
-                let agent4 = tester.random_ip();
+                let agent1 = tester.random_socket();
+                let agent2 = tester.random_socket();
+                let agent3 = tester.random_socket();
+                let agent4 = tester.random_socket();
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent1, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent1,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent2, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent2,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent3, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent3,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 let env = tester.env();
                 let deps = tester.deps_mut();
-                storage.authorise_monitor(deps, &env, &orchestrator, agent4, "test_noise_key".to_string(), 1)?;
+                storage.authorise_monitor(
+                    deps,
+                    &env,
+                    &orchestrator,
+                    agent4,
+                    "test_noise_key".to_string(),
+                    1,
+                )?;
 
                 // Verify agents are present
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent1.to_string())?
+                    .may_load(&tester, agent1.into())?
                     .is_some());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent2.to_string())?
+                    .may_load(&tester, agent2.into())?
                     .is_some());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent3.to_string())?
+                    .may_load(&tester, agent3.into())?
                     .is_some());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent4.to_string())?
+                    .may_load(&tester, agent4.into())?
                     .is_some());
 
                 // Remove all monitors
@@ -894,19 +1137,19 @@ mod tests {
                 // Verify all agents are cleared
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent1.to_string())?
+                    .may_load(&tester, agent1.into())?
                     .is_none());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent2.to_string())?
+                    .may_load(&tester, agent2.into())?
                     .is_none());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent3.to_string())?
+                    .may_load(&tester, agent3.into())?
                     .is_none());
                 assert!(storage
                     .authorised_agents
-                    .may_load(&tester, agent4.to_string())?
+                    .may_load(&tester, agent4.into())?
                     .is_none());
 
                 Ok(())

--- a/contracts/network-monitors/src/storage.rs
+++ b/contracts/network-monitors/src/storage.rs
@@ -30,7 +30,7 @@ pub struct NetworkMonitorsStorage {
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct AgentStorageKey(IpAddr);
 
-impl<'a> PrimaryKey<'a> for AgentStorageKey {
+impl PrimaryKey<'_> for AgentStorageKey {
     type Prefix = ();
     type SubPrefix = ();
     type Suffix = Self;

--- a/contracts/network-monitors/src/testing/mod.rs
+++ b/contracts/network-monitors/src/testing/mod.rs
@@ -100,7 +100,7 @@ pub trait NetworkMonitorsContractTesterExt:
             orchestrator,
             ExecuteMsg::AuthoriseNetworkMonitor {
                 mixnet_address: agent,
-                bs58_x25519_noise: "noise123".to_string(),
+                bs58_x25519_noise: "11111111111111111111111111111111".to_string(),
                 noise_version: 1,
             },
         )

--- a/contracts/network-monitors/src/testing/mod.rs
+++ b/contracts/network-monitors/src/testing/mod.rs
@@ -130,7 +130,7 @@ pub trait NetworkMonitorsContractTesterExt:
         let rng = self.raw_rng();
 
         // toss a coin, if even => ipv4, if odd => ipv6
-        if rng.next_u32().is_multiple_of(2) {
+        if rng.next_u32() % 2 == 0 {
             self.random_ipv4()
         } else {
             self.random_ipv6()

--- a/contracts/network-monitors/src/testing/mod.rs
+++ b/contracts/network-monitors/src/testing/mod.rs
@@ -5,9 +5,9 @@ use crate::contract::{execute, instantiate, migrate, query};
 use cosmwasm_std::{Addr, Order};
 use nym_contracts_common_testing::{
     mock_dependencies, AdminExt, ChainOpts, CommonStorageKeys, ContractFn, ContractOpts,
-    ContractTester, DenomExt, PermissionedFn, QueryFn, RandExt, Rng, TestableNymContract,
+    ContractTester, DenomExt, PermissionedFn, QueryFn, RandExt, Rng, RngCore, TestableNymContract,
 };
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use crate::storage::NetworkMonitorsStorage;
 use nym_network_monitors_contract_common::constants::storage_keys;
@@ -89,16 +89,74 @@ pub trait NetworkMonitorsContractTesterExt:
         }
     }
 
-    fn random_ip(&mut self) -> IpAddr {
+    fn add_dummy_agent(&mut self, agent: SocketAddr) {
+        let orchestrators = self.all_orchestrators();
+        let orchestrator = match orchestrators.first() {
+            Some(orchestrator) => orchestrator.clone(),
+            None => self.add_orchestrator().unwrap().clone(),
+        };
+
+        self.execute_raw(
+            orchestrator,
+            ExecuteMsg::AuthoriseNetworkMonitor {
+                mixnet_address: agent,
+                bs58_x25519_noise: "noise123".to_string(),
+                noise_version: 1,
+            },
+        )
+        .unwrap();
+    }
+
+    fn random_ipv4(&mut self) -> IpAddr {
         let rng = self.raw_rng();
         IpAddr::V4(Ipv4Addr::new(rng.gen(), rng.gen(), rng.gen(), rng.gen()))
     }
 
-    fn all_agents(&self) -> Vec<IpAddr> {
+    fn random_ipv6(&mut self) -> IpAddr {
+        let rng = self.raw_rng();
+        IpAddr::V6(Ipv6Addr::new(
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+        ))
+    }
+
+    fn random_ip(&mut self) -> IpAddr {
+        let rng = self.raw_rng();
+
+        // toss a coin, if even => ipv4, if odd => ipv6
+        if rng.next_u32().is_multiple_of(2) {
+            self.random_ipv4()
+        } else {
+            self.random_ipv6()
+        }
+    }
+
+    fn random_socket_ipv4(&mut self) -> SocketAddr {
+        let port = self.raw_rng().gen();
+        SocketAddr::new(self.random_ipv4(), port)
+    }
+
+    fn random_socket_ipv6(&mut self) -> SocketAddr {
+        let port = self.raw_rng().gen();
+        SocketAddr::new(self.random_ipv6(), port)
+    }
+
+    fn random_socket(&mut self) -> SocketAddr {
+        let port = self.raw_rng().gen();
+        SocketAddr::new(self.random_ip(), port)
+    }
+
+    fn all_agents(&self) -> Vec<SocketAddr> {
         NetworkMonitorsStorage::new()
             .authorised_agents
             .range(self.storage(), None, None, Order::Ascending)
-            .map(|record| record.unwrap().0.parse().unwrap())
+            .map(|record| record.unwrap().1.mixnet_address)
             .collect()
     }
 
@@ -112,3 +170,12 @@ pub trait NetworkMonitorsContractTesterExt:
 }
 
 impl NetworkMonitorsContractTesterExt for ContractTester<NetworkMonitorsContract> {}
+
+pub(crate) fn storage_ip_comp(a: IpAddr, b: IpAddr) -> std::cmp::Ordering {
+    match (a, b) {
+        (IpAddr::V4(a), IpAddr::V4(b)) => a.octets().cmp(&b.octets()),
+        (IpAddr::V6(a), IpAddr::V6(b)) => a.octets().cmp(&b.octets()),
+        (IpAddr::V4(a), IpAddr::V6(b)) => a.octets().as_slice().cmp(&b.octets()),
+        (IpAddr::V6(a), IpAddr::V4(b)) => a.octets().as_slice().cmp(&b.octets()),
+    }
+}

--- a/contracts/network-monitors/src/transactions.rs
+++ b/contracts/network-monitors/src/transactions.rs
@@ -58,12 +58,16 @@ pub fn try_authorise_network_monitor(
     env: Env,
     info: MessageInfo,
     network_monitor_address: IpAddr,
+    bs58_x25519_noise: String,
+    noise_version: u8,
 ) -> Result<Response, NetworkMonitorsContractError> {
     NETWORK_MONITORS_CONTRACT_STORAGE.authorise_monitor(
         deps,
         &env,
         &info.sender,
         network_monitor_address,
+        bs58_x25519_noise,
+        noise_version,
     )?;
 
     Ok(Response::new())
@@ -393,7 +397,7 @@ mod tests {
             let res = test
                 .execute_raw(
                     non_orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                    ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
                 )
                 .unwrap_err();
 
@@ -407,7 +411,7 @@ mod tests {
             let orchestrator = test.add_orchestrator()?;
             let res = test.execute_raw(
                 orchestrator,
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             );
             assert!(res.is_ok());
 
@@ -427,7 +431,7 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             let info = NETWORK_MONITORS_CONTRACT_STORAGE
@@ -448,7 +452,7 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             let initial = NETWORK_MONITORS_CONTRACT_STORAGE
@@ -459,7 +463,7 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             let updated = NETWORK_MONITORS_CONTRACT_STORAGE
@@ -488,7 +492,7 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             let res = test
@@ -522,7 +526,7 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
@@ -586,15 +590,15 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent1 },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent1, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent2 },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent2, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent3 },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent3, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             Ok((test, orchestrator))

--- a/contracts/network-monitors/src/transactions.rs
+++ b/contracts/network-monitors/src/transactions.rs
@@ -61,6 +61,20 @@ pub fn try_authorise_network_monitor(
     bs58_x25519_noise: String,
     noise_version: u8,
 ) -> Result<Response, NetworkMonitorsContractError> {
+    // perform basic validation of the key, i.e. is it valid base58 and is it 32 bytes (i.e. x25519)?
+    let mut public_key = [0u8; 32];
+    let used = bs58::decode(&bs58_x25519_noise)
+        .onto(&mut public_key)
+        .map_err(|err| {
+            NetworkMonitorsContractError::MalformedX25519AgentNoiseKey(err.to_string())
+        })?;
+
+    if used != 32 {
+        return Err(NetworkMonitorsContractError::MalformedX25519AgentNoiseKey(
+            "Too few bytes provided for the public key".into(),
+        ));
+    }
+
     NETWORK_MONITORS_CONTRACT_STORAGE.authorise_monitor(
         deps,
         &env,
@@ -100,6 +114,9 @@ mod tests {
     use crate::testing::{init_contract_tester, NetworkMonitorsContractTesterExt};
     use nym_contracts_common_testing::{AdminExt, ContractOpts, RandExt};
     use nym_network_monitors_contract_common::ExecuteMsg;
+
+    // bs58 encoding of 32 zero bytes — a syntactically valid x25519 key for tests
+    const TEST_NOISE_KEY: &str = "11111111111111111111111111111111";
 
     #[cfg(test)]
     mod updating_contract_admin {
@@ -399,7 +416,7 @@ mod tests {
                     non_orchestrator.clone(),
                     ExecuteMsg::AuthoriseNetworkMonitor {
                         mixnet_address: agent,
-                        bs58_x25519_noise: "test_noise_key".to_string(),
+                        bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                         noise_version: 1,
                     },
                 )
@@ -417,7 +434,7 @@ mod tests {
                 orchestrator,
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent,
-                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                     noise_version: 1,
                 },
             );
@@ -441,7 +458,7 @@ mod tests {
                 orchestrator.clone(),
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent,
-                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                     noise_version: 1,
                 },
             )?;
@@ -466,7 +483,7 @@ mod tests {
                 orchestrator.clone(),
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent,
-                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                     noise_version: 1,
                 },
             )?;
@@ -481,7 +498,7 @@ mod tests {
                 orchestrator.clone(),
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent,
-                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                     noise_version: 1,
                 },
             )?;
@@ -513,7 +530,7 @@ mod tests {
                 orchestrator.clone(),
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent,
-                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                     noise_version: 1,
                 },
             )?;
@@ -541,7 +558,7 @@ mod tests {
                 orchestrator,
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent,
-                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                     noise_version: 1,
                 },
             )?;
@@ -574,7 +591,7 @@ mod tests {
                 orchestrator,
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent,
-                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                     noise_version: 1,
                 },
             )?;
@@ -603,7 +620,7 @@ mod tests {
                 orchestrator.clone(),
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent,
-                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                     noise_version: 1,
                 },
             )?;
@@ -675,7 +692,7 @@ mod tests {
                 orchestrator.clone(),
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent1,
-                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                     noise_version: 1,
                 },
             )?;
@@ -683,7 +700,7 @@ mod tests {
                 orchestrator.clone(),
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent2,
-                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                     noise_version: 1,
                 },
             )?;
@@ -691,7 +708,7 @@ mod tests {
                 orchestrator.clone(),
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent3,
-                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    bs58_x25519_noise: TEST_NOISE_KEY.to_string(),
                     noise_version: 1,
                 },
             )?;

--- a/contracts/network-monitors/src/transactions.rs
+++ b/contracts/network-monitors/src/transactions.rs
@@ -58,12 +58,16 @@ pub fn try_authorise_network_monitor(
     env: Env,
     info: MessageInfo,
     network_monitor_address: IpAddr,
+    bs58_x25519_noise: String,
+    noise_version: u8,
 ) -> Result<Response, NetworkMonitorsContractError> {
     NETWORK_MONITORS_CONTRACT_STORAGE.authorise_monitor(
         deps,
         &env,
         &info.sender,
         network_monitor_address,
+        bs58_x25519_noise,
+        noise_version,
     )?;
 
     Ok(Response::new())
@@ -393,7 +397,7 @@ mod tests {
             let res = test
                 .execute_raw(
                     non_orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                    ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
                 )
                 .unwrap_err();
 
@@ -407,7 +411,7 @@ mod tests {
             let orchestrator = test.add_orchestrator()?;
             let res = test.execute_raw(
                 orchestrator,
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             );
             assert!(res.is_ok());
 
@@ -427,7 +431,7 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             let info = NETWORK_MONITORS_CONTRACT_STORAGE
@@ -448,7 +452,7 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             let initial = NETWORK_MONITORS_CONTRACT_STORAGE
@@ -459,7 +463,7 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             let updated = NETWORK_MONITORS_CONTRACT_STORAGE
@@ -487,7 +491,7 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             let res = test.execute_raw(
@@ -556,7 +560,7 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
@@ -620,15 +624,15 @@ mod tests {
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent1 },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent1, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent2 },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent2, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent3 },
+                ExecuteMsg::AuthoriseNetworkMonitor { address: agent3, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
             )?;
 
             Ok((test, orchestrator))

--- a/contracts/network-monitors/src/transactions.rs
+++ b/contracts/network-monitors/src/transactions.rs
@@ -4,7 +4,7 @@
 use crate::storage::NETWORK_MONITORS_CONTRACT_STORAGE;
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
 use nym_network_monitors_contract_common::NetworkMonitorsContractError;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 
 pub fn try_update_contract_admin(
     deps: DepsMut<'_>,
@@ -57,7 +57,7 @@ pub fn try_authorise_network_monitor(
     deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
-    network_monitor_address: IpAddr,
+    network_monitor_address: SocketAddr,
     bs58_x25519_noise: String,
     noise_version: u8,
 ) -> Result<Response, NetworkMonitorsContractError> {
@@ -392,12 +392,16 @@ mod tests {
             let mut test = init_contract_tester();
 
             let non_orchestrator = test.generate_account();
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             let res = test
                 .execute_raw(
                     non_orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                    ExecuteMsg::AuthoriseNetworkMonitor {
+                        mixnet_address: agent,
+                        bs58_x25519_noise: "test_noise_key".to_string(),
+                        noise_version: 1,
+                    },
                 )
                 .unwrap_err();
 
@@ -411,7 +415,11 @@ mod tests {
             let orchestrator = test.add_orchestrator()?;
             let res = test.execute_raw(
                 orchestrator,
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             );
             assert!(res.is_ok());
 
@@ -422,23 +430,27 @@ mod tests {
         fn inserts_new_entry_for_fresh_agents() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
             let orchestrator = test.add_orchestrator()?;
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .may_load(test.storage(), agent.to_string())?
+                .may_load(test.storage(), agent.into())?
                 .is_none());
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             let info = NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .load(test.storage(), agent.to_string())?;
+                .load(test.storage(), agent.into())?;
 
-            assert_eq!(info.address, agent);
+            assert_eq!(info.mixnet_address, agent);
             assert_eq!(info.authorised_by, orchestrator);
 
             Ok(())
@@ -448,29 +460,37 @@ mod tests {
         fn renews_existing_agent_authorisation() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
             let orchestrator = test.add_orchestrator()?;
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             let initial = NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .load(test.storage(), agent.to_string())?;
+                .load(test.storage(), agent.into())?;
 
             test.advance_day_of_blocks();
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             let updated = NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .load(test.storage(), agent.to_string())?;
+                .load(test.storage(), agent.into())?;
 
-            assert_eq!(updated.address, agent);
+            assert_eq!(updated.mixnet_address, agent);
             assert_eq!(updated.authorised_by, orchestrator);
             assert!(updated.authorised_at > initial.authorised_at);
 
@@ -487,16 +507,22 @@ mod tests {
             let mut test = init_contract_tester();
 
             let orchestrator = test.add_orchestrator()?;
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             let res = test.execute_raw(
                 orchestrator,
-                ExecuteMsg::RevokeNetworkMonitor { address: agent },
+                ExecuteMsg::RevokeNetworkMonitor {
+                    address: agent.ip(),
+                },
             );
             assert!(res.is_ok());
 
@@ -509,19 +535,28 @@ mod tests {
 
             let admin = test.admin_unchecked();
             let orchestrator = test.add_orchestrator()?;
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             test.execute_raw(
                 orchestrator,
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
-            let res = test.execute_raw(admin, ExecuteMsg::RevokeNetworkMonitor { address: agent });
+            let res = test.execute_raw(
+                admin,
+                ExecuteMsg::RevokeNetworkMonitor {
+                    address: agent.ip(),
+                },
+            );
             assert!(res.is_ok());
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .may_load(test.storage(), agent.to_string())?
+                .may_load(test.storage(), agent.into())?
                 .is_none());
 
             Ok(())
@@ -533,17 +568,23 @@ mod tests {
 
             let orchestrator = test.add_orchestrator()?;
             let non_privileged = test.generate_account();
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             test.execute_raw(
                 orchestrator,
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             let res = test
                 .execute_raw(
                     non_privileged,
-                    ExecuteMsg::RevokeNetworkMonitor { address: agent },
+                    ExecuteMsg::RevokeNetworkMonitor {
+                        address: agent.ip(),
+                    },
                 )
                 .unwrap_err();
 
@@ -556,26 +597,32 @@ mod tests {
         fn deletes_entry_from_storage() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
             let orchestrator = test.add_orchestrator()?;
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .may_load(test.storage(), agent.to_string())?
+                .may_load(test.storage(), agent.into())?
                 .is_some());
 
             test.execute_raw(
                 orchestrator,
-                ExecuteMsg::RevokeNetworkMonitor { address: agent },
+                ExecuteMsg::RevokeNetworkMonitor {
+                    address: agent.ip(),
+                },
             )?;
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .may_load(test.storage(), agent.to_string())?
+                .may_load(test.storage(), agent.into())?
                 .is_none());
 
             Ok(())
@@ -585,22 +632,24 @@ mod tests {
         fn is_noop_for_non_existent_entries() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
             let orchestrator = test.add_orchestrator()?;
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .may_load(test.storage(), agent.to_string())?
+                .may_load(test.storage(), agent.into())?
                 .is_none());
 
             let res = test.execute_raw(
                 orchestrator,
-                ExecuteMsg::RevokeNetworkMonitor { address: agent },
+                ExecuteMsg::RevokeNetworkMonitor {
+                    address: agent.ip(),
+                },
             );
             assert!(res.is_ok());
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .may_load(test.storage(), agent.to_string())?
+                .may_load(test.storage(), agent.into())?
                 .is_none());
 
             Ok(())
@@ -618,21 +667,33 @@ mod tests {
             let mut test = init_contract_tester();
             let orchestrator = test.add_orchestrator()?;
 
-            let agent1 = test.random_ip();
-            let agent2 = test.random_ip();
-            let agent3 = test.random_ip();
+            let agent1 = test.random_socket();
+            let agent2 = test.random_socket();
+            let agent3 = test.random_socket();
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent1, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent1,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent2, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent2,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent3, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent3,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             Ok((test, orchestrator))
@@ -648,7 +709,7 @@ mod tests {
             for agent in agents {
                 assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                     .authorised_agents
-                    .may_load(test.storage(), agent.to_string())?
+                    .may_load(test.storage(), agent.into())?
                     .is_none());
             }
 
@@ -667,7 +728,7 @@ mod tests {
             for agent in agents {
                 assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                     .authorised_agents
-                    .may_load(test.storage(), agent.to_string())?
+                    .may_load(test.storage(), agent.into())?
                     .is_none());
             }
 
@@ -727,7 +788,7 @@ mod tests {
             for agent in agents {
                 assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                     .authorised_agents
-                    .may_load(test.storage(), agent.to_string())?
+                    .may_load(test.storage(), agent.into())?
                     .is_none());
             }
 

--- a/contracts/network-monitors/src/transactions.rs
+++ b/contracts/network-monitors/src/transactions.rs
@@ -4,7 +4,7 @@
 use crate::storage::NETWORK_MONITORS_CONTRACT_STORAGE;
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
 use nym_network_monitors_contract_common::NetworkMonitorsContractError;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 
 pub fn try_update_contract_admin(
     deps: DepsMut<'_>,
@@ -57,7 +57,7 @@ pub fn try_authorise_network_monitor(
     deps: DepsMut<'_>,
     env: Env,
     info: MessageInfo,
-    network_monitor_address: IpAddr,
+    network_monitor_address: SocketAddr,
     bs58_x25519_noise: String,
     noise_version: u8,
 ) -> Result<Response, NetworkMonitorsContractError> {
@@ -392,12 +392,16 @@ mod tests {
             let mut test = init_contract_tester();
 
             let non_orchestrator = test.generate_account();
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             let res = test
                 .execute_raw(
                     non_orchestrator.clone(),
-                    ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                    ExecuteMsg::AuthoriseNetworkMonitor {
+                        mixnet_address: agent,
+                        bs58_x25519_noise: "test_noise_key".to_string(),
+                        noise_version: 1,
+                    },
                 )
                 .unwrap_err();
 
@@ -411,7 +415,11 @@ mod tests {
             let orchestrator = test.add_orchestrator()?;
             let res = test.execute_raw(
                 orchestrator,
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             );
             assert!(res.is_ok());
 
@@ -422,23 +430,27 @@ mod tests {
         fn inserts_new_entry_for_fresh_agents() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
             let orchestrator = test.add_orchestrator()?;
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .may_load(test.storage(), agent.to_string())?
+                .may_load(test.storage(), agent.into())?
                 .is_none());
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             let info = NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .load(test.storage(), agent.to_string())?;
+                .load(test.storage(), agent.into())?;
 
-            assert_eq!(info.address, agent);
+            assert_eq!(info.mixnet_address, agent);
             assert_eq!(info.authorised_by, orchestrator);
 
             Ok(())
@@ -448,29 +460,37 @@ mod tests {
         fn renews_existing_agent_authorisation() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
             let orchestrator = test.add_orchestrator()?;
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             let initial = NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .load(test.storage(), agent.to_string())?;
+                .load(test.storage(), agent.into())?;
 
             test.advance_day_of_blocks();
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             let updated = NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .load(test.storage(), agent.to_string())?;
+                .load(test.storage(), agent.into())?;
 
-            assert_eq!(updated.address, agent);
+            assert_eq!(updated.mixnet_address, agent);
             assert_eq!(updated.authorised_by, orchestrator);
             assert!(updated.authorised_at > initial.authorised_at);
 
@@ -488,17 +508,23 @@ mod tests {
 
             let orchestrator = test.add_orchestrator()?;
             let non_orchestrator = test.generate_account();
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             let res = test
                 .execute_raw(
                     non_orchestrator.clone(),
-                    ExecuteMsg::RevokeNetworkMonitor { address: agent },
+                    ExecuteMsg::RevokeNetworkMonitor {
+                        address: agent.ip(),
+                    },
                 )
                 .unwrap_err();
 
@@ -511,7 +537,9 @@ mod tests {
 
             let res = test.execute_raw(
                 orchestrator,
-                ExecuteMsg::RevokeNetworkMonitor { address: agent },
+                ExecuteMsg::RevokeNetworkMonitor {
+                    address: agent.ip(),
+                },
             );
             assert!(res.is_ok());
 
@@ -522,26 +550,32 @@ mod tests {
         fn deletes_entry_from_storage() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
             let orchestrator = test.add_orchestrator()?;
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .may_load(test.storage(), agent.to_string())?
+                .may_load(test.storage(), agent.into())?
                 .is_some());
 
             test.execute_raw(
                 orchestrator,
-                ExecuteMsg::RevokeNetworkMonitor { address: agent },
+                ExecuteMsg::RevokeNetworkMonitor {
+                    address: agent.ip(),
+                },
             )?;
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .may_load(test.storage(), agent.to_string())?
+                .may_load(test.storage(), agent.into())?
                 .is_none());
 
             Ok(())
@@ -551,22 +585,24 @@ mod tests {
         fn is_noop_for_non_existent_entries() -> anyhow::Result<()> {
             let mut test = init_contract_tester();
             let orchestrator = test.add_orchestrator()?;
-            let agent = test.random_ip();
+            let agent = test.random_socket();
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .may_load(test.storage(), agent.to_string())?
+                .may_load(test.storage(), agent.into())?
                 .is_none());
 
             let res = test.execute_raw(
                 orchestrator,
-                ExecuteMsg::RevokeNetworkMonitor { address: agent },
+                ExecuteMsg::RevokeNetworkMonitor {
+                    address: agent.ip(),
+                },
             );
             assert!(res.is_ok());
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                 .authorised_agents
-                .may_load(test.storage(), agent.to_string())?
+                .may_load(test.storage(), agent.into())?
                 .is_none());
 
             Ok(())
@@ -584,21 +620,33 @@ mod tests {
             let mut test = init_contract_tester();
             let orchestrator = test.add_orchestrator()?;
 
-            let agent1 = test.random_ip();
-            let agent2 = test.random_ip();
-            let agent3 = test.random_ip();
+            let agent1 = test.random_socket();
+            let agent2 = test.random_socket();
+            let agent3 = test.random_socket();
 
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent1, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent1,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent2, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent2,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
             test.execute_raw(
                 orchestrator.clone(),
-                ExecuteMsg::AuthoriseNetworkMonitor { address: agent3, bs58_x25519_noise: "test_noise_key".to_string(), noise_version: 1 },
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent3,
+                    bs58_x25519_noise: "test_noise_key".to_string(),
+                    noise_version: 1,
+                },
             )?;
 
             Ok((test, orchestrator))
@@ -614,7 +662,7 @@ mod tests {
             for agent in agents {
                 assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                     .authorised_agents
-                    .may_load(test.storage(), agent.to_string())?
+                    .may_load(test.storage(), agent.into())?
                     .is_none());
             }
 
@@ -633,7 +681,7 @@ mod tests {
             for agent in agents {
                 assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                     .authorised_agents
-                    .may_load(test.storage(), agent.to_string())?
+                    .may_load(test.storage(), agent.into())?
                     .is_none());
             }
 
@@ -690,7 +738,7 @@ mod tests {
             for agent in agents {
                 assert!(NETWORK_MONITORS_CONTRACT_STORAGE
                     .authorised_agents
-                    .may_load(test.storage(), agent.to_string())?
+                    .may_load(test.storage(), agent.into())?
                     .is_none());
             }
 

--- a/nym-node/src/node/mixnet/shared/mod.rs
+++ b/nym-node/src/node/mixnet/shared/mod.rs
@@ -6,7 +6,7 @@ use crate::node::key_rotation::active_keys::ActiveSphinxKeys;
 use crate::node::mixnet::SharedFinalHopData;
 use crate::node::mixnet::handler::ConnectionHandler;
 use crate::node::replay_protection::bloomfilter::ReplayProtectionBloomfilters;
-use crate::node::routing_filter::network_filter::DeclaredNetworkMonitors;
+use crate::node::routing_filter::network_filter::RoutableNetworkMonitors;
 use nym_gateway::node::GatewayStorageError;
 use nym_mixnet_client::forwarder::{MixForwardingSender, PacketToForward};
 use nym_node_metrics::NymNodeMetrics;
@@ -85,7 +85,7 @@ pub(crate) struct SharedData {
 
     // list of all known network monitor agents that are permitted
     // to forward packets even if they replay them
-    pub(super) authorised_network_monitor_agents: DeclaredNetworkMonitors,
+    pub(super) authorised_network_monitor_agents: RoutableNetworkMonitors,
 
     pub(super) shutdown_token: ShutdownToken,
 }
@@ -107,7 +107,7 @@ impl SharedData {
         final_hop: SharedFinalHopData,
         noise_config: NoiseConfig,
         metrics: NymNodeMetrics,
-        authorised_network_monitor_agents: DeclaredNetworkMonitors,
+        authorised_network_monitor_agents: RoutableNetworkMonitors,
         shutdown_token: ShutdownToken,
     ) -> Self {
         SharedData {

--- a/nym-node/src/node/mod.rs
+++ b/nym-node/src/node/mod.rs
@@ -650,6 +650,7 @@ impl NymNode {
         &self,
         routing_filter: NetworkRoutingFilter,
         client: NymApisClient,
+        noise_view: NoiseNetworkView,
     ) -> Result<NetworkRefresher, NymNodeError> {
         let config = NetworkRefresherConfig::new(
             self.config.debug.topology_cache_ttl,
@@ -664,6 +665,7 @@ impl NymNode {
             config,
             client,
             routing_filter,
+            noise_view,
             self.shutdown_manager.clone_shutdown_token(),
         )
         .await
@@ -1369,6 +1371,7 @@ impl NymNode {
     async fn setup_nyx_chain_watcher(
         &self,
         network_monitors_handle: RoutableNetworkMonitors,
+        noise_network_view: NoiseNetworkView,
     ) -> Result<(), NymNodeError> {
         // START: module creation
         let Some(Ok(contract_address)) = self
@@ -1382,7 +1385,11 @@ impl NymNode {
             // queried this very contract before
             return Err(NymNodeError::MissingNetworkMonitorsContractAddress);
         };
-        let nm_agents = NetworkMonitorAgentsModule::new(contract_address, network_monitors_handle);
+        let nm_agents = NetworkMonitorAgentsModule::new(
+            contract_address,
+            network_monitors_handle,
+            noise_network_view,
+        );
 
         // END: module creation
         let cancellation = self.shutdown_manager.clone_shutdown_token();
@@ -1444,13 +1451,19 @@ impl NymNode {
             .with_known_network_monitors(known_network_monitors);
         let network_monitors_ref = routing_filter.known_network_monitors_handle();
 
+        let noise_view = NoiseNetworkView::new_empty();
         // retrieve the initial view of the network and update the known set of nym nodes in the routing filter
         let network_refresher = self
-            .build_network_refresher(routing_filter.clone(), nym_apis_client.clone())
+            .build_network_refresher(
+                routing_filter.clone(),
+                nym_apis_client.clone(),
+                noise_view.clone(),
+            )
             .await?;
 
         // setup nyx chain watcher (currently only used for updating the network monitors view)
-        self.setup_nyx_chain_watcher(network_monitors_ref).await?;
+        self.setup_nyx_chain_watcher(network_monitors_ref, noise_view.clone())
+            .await?;
 
         let active_clients_store = ActiveClientsStore::new();
         let lp_nodes = network_refresher.lp_nodes();
@@ -1460,7 +1473,7 @@ impl NymNode {
 
         let noise_config = NoiseConfig::new(
             self.x25519_noise_keys.clone(),
-            network_refresher.noise_view(),
+            noise_view,
             self.config.mixnet.debug.initial_connection_timeout,
         )
         .with_unsafe_disabled(self.config.mixnet.debug.unsafe_disable_noise);

--- a/nym-node/src/node/mod.rs
+++ b/nym-node/src/node/mod.rs
@@ -39,7 +39,7 @@ use crate::node::nyxd_watcher::network_monitor_agents::NetworkMonitorAgentsModul
 use crate::node::replay_protection::background_task::ReplayProtectionDiskFlush;
 use crate::node::replay_protection::bloomfilter::ReplayProtectionBloomfilters;
 use crate::node::replay_protection::manager::ReplayProtectionBloomfiltersManager;
-use crate::node::routing_filter::network_filter::{DeclaredNetworkMonitors, NetworkRoutingFilter};
+use crate::node::routing_filter::network_filter::{NetworkRoutingFilter, RoutableNetworkMonitors};
 use crate::node::routing_filter::{OpenFilter, RoutingFilter};
 use crate::node::shared_network::CachedNetwork;
 use crate::node::shared_network::refresher::{NetworkRefresher, NetworkRefresherConfig};
@@ -1255,7 +1255,7 @@ impl NymNode {
         active_clients_store: &ActiveClientsStore,
         replay_protection_bloomfilter: ReplayProtectionBloomfilters,
         routing_filter: F,
-        authorised_network_monitor_agents: DeclaredNetworkMonitors,
+        authorised_network_monitor_agents: RoutableNetworkMonitors,
         noise_config: NoiseConfig,
     ) -> Result<(MixForwardingSender, ActiveConnections), NymNodeError>
     where
@@ -1338,7 +1338,7 @@ impl NymNode {
             &ActiveClientsStore::new(),
             ReplayProtectionBloomfilters::new_disabled(),
             OpenFilter,
-            DeclaredNetworkMonitors::default(),
+            RoutableNetworkMonitors::default(),
             noise_config,
         )
         .await?;
@@ -1362,13 +1362,13 @@ impl NymNode {
             .get_all_network_monitor_agents()
             .await?
             .into_iter()
-            .map(|agent| agent.address)
+            .map(|agent| agent.mixnet_address.ip())
             .collect())
     }
 
     async fn setup_nyx_chain_watcher(
         &self,
-        network_monitors_handle: DeclaredNetworkMonitors,
+        network_monitors_handle: RoutableNetworkMonitors,
     ) -> Result<(), NymNodeError> {
         // START: module creation
         let Some(Ok(contract_address)) = self

--- a/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
+++ b/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
@@ -99,9 +99,11 @@ impl MsgModule for NetworkMonitorAgentsModule {
         };
 
         match exec_msg {
-            ExecuteMsg::AuthoriseNetworkMonitor { address } => {
-                self.network_monitors.add_known(address)
-            }
+            ExecuteMsg::AuthoriseNetworkMonitor {
+                address,
+                bs58_x25519_noise: _,
+                noise_version: _,
+            } => self.network_monitors.add_known(address),
             ExecuteMsg::RevokeNetworkMonitor { address } => {
                 self.network_monitors.remove_known(address)
             }

--- a/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
+++ b/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
@@ -95,9 +95,11 @@ impl MsgModule for NetworkMonitorAgentsModule {
         };
 
         match exec_msg {
-            ExecuteMsg::AuthoriseNetworkMonitor { address } => {
-                self.network_monitors.add_known(address)
-            }
+            ExecuteMsg::AuthoriseNetworkMonitor {
+                address,
+                bs58_x25519_noise: _,
+                noise_version: _,
+            } => self.network_monitors.add_known(address),
             ExecuteMsg::RevokeNetworkMonitor { address } => {
                 self.network_monitors.remove_known(address)
             }

--- a/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
+++ b/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
@@ -21,12 +21,16 @@
 
 use crate::node::routing_filter::network_filter::RoutableNetworkMonitors;
 use async_trait::async_trait;
+use nym_crypto::asymmetric::x25519;
+use nym_noise::config::{NoiseNetworkView, NoiseNode};
+use nym_noise_keys::{NoiseVersion, VersionedNoiseKeyV1};
 use nym_validator_client::nyxd::cosmwasm::MsgExecuteContract;
 use nym_validator_client::nyxd::nym_network_monitors_contract_common::ExecuteMsg;
 use nym_validator_client::nyxd::{AccountId, Any, Msg, Name};
 use nyxd_scraper_shared::error::ScraperError;
 use nyxd_scraper_shared::{DecodedMessage, MsgModule, ParsedTransactionDetails, parse_msg};
-use tracing::error;
+use std::net::{IpAddr, SocketAddr};
+use tracing::{debug, error, info};
 
 /// Blockchain message handler for Network Monitor agent authorisation events.
 ///
@@ -44,17 +48,70 @@ pub(crate) struct NetworkMonitorAgentsModule {
     /// Shared handle to the runtime list of authorised network monitor IPs.
     /// Updates are immediately visible to all packet processing threads.
     pub(crate) routable_network_monitors: RoutableNetworkMonitors,
+
+    /// Shared handle to the runtime list of noise keys of all network nodes
+    pub(crate) noise_view: NoiseNetworkView,
 }
 
 impl NetworkMonitorAgentsModule {
     pub(crate) fn new(
         contract_address: AccountId,
         routable_network_monitors: RoutableNetworkMonitors,
+        noise_view: NoiseNetworkView,
     ) -> Self {
         Self {
             contract_address,
             routable_network_monitors,
+            noise_view,
         }
+    }
+
+    async fn new_agent(&self, address: SocketAddr, bs58_x25519_noise: String, noise_version: u8) {
+        debug!("adding new NM agent {address}");
+
+        let Ok(x25519_pubkey) = x25519::PublicKey::from_base58_string(&bs58_x25519_noise) else {
+            error!("network monitor agent {address} has announced an invalid noise key - ignoring");
+            return;
+        };
+
+        let key = VersionedNoiseKeyV1 {
+            supported_version: NoiseVersion::from(noise_version),
+            x25519_pubkey,
+        };
+
+        // add ip to the routing filter
+        self.routable_network_monitors.add_known(address.ip());
+
+        // add noise key to the known nodes
+        let update_permit = self.noise_view.get_update_permit().await;
+        let mut nodes = self.noise_view.all_nodes();
+        nodes.insert(address.ip(), NoiseNode::new_network_monitor_agent(key));
+        self.noise_view.swap_view(update_permit, nodes);
+    }
+
+    async fn revoked_agent(&self, address: IpAddr) {
+        debug!("revoking NM agent {address}");
+
+        // remove ip from the routing filter
+        self.routable_network_monitors.remove_known(address);
+
+        // remove noise key from the known nodes
+        let update_permit = self.noise_view.get_update_permit().await;
+        let mut nodes = self.noise_view.all_nodes();
+        nodes.remove(&address);
+        self.noise_view.swap_view(update_permit, nodes);
+    }
+
+    async fn revoked_all_agents(&self) {
+        info!("revoking all NM agents");
+
+        self.routable_network_monitors.reset();
+
+        // remove all noise keys from the known nodes
+        let update_permit = self.noise_view.get_update_permit().await;
+        let mut nodes = self.noise_view.all_nodes();
+        nodes.retain(|_, node| node.is_nym_node());
+        self.noise_view.swap_view(update_permit, nodes);
     }
 }
 
@@ -103,13 +160,12 @@ impl MsgModule for NetworkMonitorAgentsModule {
                 mixnet_address,
                 bs58_x25519_noise,
                 noise_version,
-            } => self
-                .routable_network_monitors
-                .add_known(mixnet_address.ip()),
-            ExecuteMsg::RevokeNetworkMonitor { address } => {
-                self.routable_network_monitors.remove_known(address)
+            } => {
+                self.new_agent(mixnet_address, bs58_x25519_noise, noise_version)
+                    .await
             }
-            ExecuteMsg::RevokeAllNetworkMonitors => self.routable_network_monitors.reset(),
+            ExecuteMsg::RevokeNetworkMonitor { address } => self.revoked_agent(address).await,
+            ExecuteMsg::RevokeAllNetworkMonitors => self.revoked_all_agents().await,
 
             // we're not interested in those messages
             ExecuteMsg::UpdateAdmin { .. }

--- a/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
+++ b/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
@@ -62,6 +62,7 @@ impl NetworkMonitorAgentsModule {
         }
     }
 
+    /// Register a newly authorised NM agent in both the routing filter and the noise key map.
     async fn new_agent(&self, address: SocketAddr, bs58_x25519_noise: String, noise_version: u8) {
         debug!("adding new NM agent {address}");
 
@@ -106,6 +107,10 @@ impl NetworkMonitorAgentsModule {
         // remove all noise keys from the known nodes
         let update_permit = self.noise_view.get_update_permit().await;
         let mut nodes = self.noise_view.all_nodes();
+
+        // Only remove NM agent entries; nym-node entries must be preserved because they are
+        // managed by a completely separate code path (the nym-api topology refresher) and
+        // would not be restored until the next full topology refresh cycle.
         nodes.retain(|_, node| node.is_nym_node());
         self.noise_view.swap_view(update_permit, nodes);
     }

--- a/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
+++ b/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
@@ -66,6 +66,7 @@ impl NetworkMonitorAgentsModule {
         }
     }
 
+    /// Register a newly authorised NM agent in both the routing filter and the noise key map.
     async fn new_agent(&self, address: SocketAddr, bs58_x25519_noise: String, noise_version: u8) {
         debug!("adding new NM agent {address}");
 
@@ -110,6 +111,10 @@ impl NetworkMonitorAgentsModule {
         // remove all noise keys from the known nodes
         let update_permit = self.noise_view.get_update_permit().await;
         let mut nodes = self.noise_view.all_nodes();
+
+        // Only remove NM agent entries; nym-node entries must be preserved because they are
+        // managed by a completely separate code path (the nym-api topology refresher) and
+        // would not be restored until the next full topology refresh cycle.
         nodes.retain(|_, node| node.is_nym_node());
         self.noise_view.swap_view(update_permit, nodes);
     }

--- a/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
+++ b/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
@@ -19,7 +19,7 @@
 //! Only transactions executed against the configured Network Monitors contract address are
 //! processed.
 
-use crate::node::routing_filter::network_filter::DeclaredNetworkMonitors;
+use crate::node::routing_filter::network_filter::RoutableNetworkMonitors;
 use async_trait::async_trait;
 use nym_validator_client::nyxd::cosmwasm::MsgExecuteContract;
 use nym_validator_client::nyxd::nym_network_monitors_contract_common::ExecuteMsg;
@@ -39,17 +39,17 @@ pub(crate) struct NetworkMonitorAgentsModule {
 
     /// Shared handle to the runtime list of authorised network monitor IPs.
     /// Updates are immediately visible to all packet processing threads.
-    pub(crate) network_monitors: DeclaredNetworkMonitors,
+    pub(crate) routable_network_monitors: RoutableNetworkMonitors,
 }
 
 impl NetworkMonitorAgentsModule {
     pub(crate) fn new(
         contract_address: AccountId,
-        network_monitors: DeclaredNetworkMonitors,
+        routable_network_monitors: RoutableNetworkMonitors,
     ) -> Self {
         Self {
             contract_address,
-            network_monitors,
+            routable_network_monitors,
         }
     }
 }
@@ -96,14 +96,16 @@ impl MsgModule for NetworkMonitorAgentsModule {
 
         match exec_msg {
             ExecuteMsg::AuthoriseNetworkMonitor {
-                address,
-                bs58_x25519_noise: _,
-                noise_version: _,
-            } => self.network_monitors.add_known(address),
+                mixnet_address,
+                bs58_x25519_noise,
+                noise_version,
+            } => self
+                .routable_network_monitors
+                .add_known(mixnet_address.ip()),
             ExecuteMsg::RevokeNetworkMonitor { address } => {
-                self.network_monitors.remove_known(address)
+                self.routable_network_monitors.remove_known(address)
             }
-            ExecuteMsg::RevokeAllNetworkMonitors => self.network_monitors.reset(),
+            ExecuteMsg::RevokeAllNetworkMonitors => self.routable_network_monitors.reset(),
 
             // we're not interested in those messages
             ExecuteMsg::UpdateAdmin { .. }

--- a/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
+++ b/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
@@ -19,7 +19,7 @@
 //! Only transactions executed against the configured Network Monitors contract address are
 //! processed.
 
-use crate::node::routing_filter::network_filter::DeclaredNetworkMonitors;
+use crate::node::routing_filter::network_filter::RoutableNetworkMonitors;
 use async_trait::async_trait;
 use nym_validator_client::nyxd::cosmwasm::MsgExecuteContract;
 use nym_validator_client::nyxd::nym_network_monitors_contract_common::ExecuteMsg;
@@ -43,17 +43,17 @@ pub(crate) struct NetworkMonitorAgentsModule {
 
     /// Shared handle to the runtime list of authorised network monitor IPs.
     /// Updates are immediately visible to all packet processing threads.
-    pub(crate) network_monitors: DeclaredNetworkMonitors,
+    pub(crate) routable_network_monitors: RoutableNetworkMonitors,
 }
 
 impl NetworkMonitorAgentsModule {
     pub(crate) fn new(
         contract_address: AccountId,
-        network_monitors: DeclaredNetworkMonitors,
+        routable_network_monitors: RoutableNetworkMonitors,
     ) -> Self {
         Self {
             contract_address,
-            network_monitors,
+            routable_network_monitors,
         }
     }
 }
@@ -100,14 +100,16 @@ impl MsgModule for NetworkMonitorAgentsModule {
 
         match exec_msg {
             ExecuteMsg::AuthoriseNetworkMonitor {
-                address,
-                bs58_x25519_noise: _,
-                noise_version: _,
-            } => self.network_monitors.add_known(address),
+                mixnet_address,
+                bs58_x25519_noise,
+                noise_version,
+            } => self
+                .routable_network_monitors
+                .add_known(mixnet_address.ip()),
             ExecuteMsg::RevokeNetworkMonitor { address } => {
-                self.network_monitors.remove_known(address)
+                self.routable_network_monitors.remove_known(address)
             }
-            ExecuteMsg::RevokeAllNetworkMonitors => self.network_monitors.reset(),
+            ExecuteMsg::RevokeAllNetworkMonitors => self.routable_network_monitors.reset(),
 
             // we're not interested in those messages
             ExecuteMsg::UpdateAdmin { .. }

--- a/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
+++ b/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
@@ -21,12 +21,16 @@
 
 use crate::node::routing_filter::network_filter::RoutableNetworkMonitors;
 use async_trait::async_trait;
+use nym_crypto::asymmetric::x25519;
+use nym_noise::config::{NoiseNetworkView, NoiseNode};
+use nym_noise_keys::{NoiseVersion, VersionedNoiseKeyV1};
 use nym_validator_client::nyxd::cosmwasm::MsgExecuteContract;
 use nym_validator_client::nyxd::nym_network_monitors_contract_common::ExecuteMsg;
 use nym_validator_client::nyxd::{AccountId, Any, Msg, Name};
 use nyxd_scraper_shared::error::ScraperError;
 use nyxd_scraper_shared::{DecodedMessage, MsgModule, ParsedTransactionDetails, parse_msg};
-use tracing::error;
+use std::net::{IpAddr, SocketAddr};
+use tracing::{debug, error, info};
 
 /// Blockchain message handler for Network Monitor agent authorisation events.
 ///
@@ -40,17 +44,70 @@ pub(crate) struct NetworkMonitorAgentsModule {
     /// Shared handle to the runtime list of authorised network monitor IPs.
     /// Updates are immediately visible to all packet processing threads.
     pub(crate) routable_network_monitors: RoutableNetworkMonitors,
+
+    /// Shared handle to the runtime list of noise keys of all network nodes
+    pub(crate) noise_view: NoiseNetworkView,
 }
 
 impl NetworkMonitorAgentsModule {
     pub(crate) fn new(
         contract_address: AccountId,
         routable_network_monitors: RoutableNetworkMonitors,
+        noise_view: NoiseNetworkView,
     ) -> Self {
         Self {
             contract_address,
             routable_network_monitors,
+            noise_view,
         }
+    }
+
+    async fn new_agent(&self, address: SocketAddr, bs58_x25519_noise: String, noise_version: u8) {
+        debug!("adding new NM agent {address}");
+
+        let Ok(x25519_pubkey) = x25519::PublicKey::from_base58_string(&bs58_x25519_noise) else {
+            error!("network monitor agent {address} has announced an invalid noise key - ignoring");
+            return;
+        };
+
+        let key = VersionedNoiseKeyV1 {
+            supported_version: NoiseVersion::from(noise_version),
+            x25519_pubkey,
+        };
+
+        // add ip to the routing filter
+        self.routable_network_monitors.add_known(address.ip());
+
+        // add noise key to the known nodes
+        let update_permit = self.noise_view.get_update_permit().await;
+        let mut nodes = self.noise_view.all_nodes();
+        nodes.insert(address.ip(), NoiseNode::new_network_monitor_agent(key));
+        self.noise_view.swap_view(update_permit, nodes);
+    }
+
+    async fn revoked_agent(&self, address: IpAddr) {
+        debug!("revoking NM agent {address}");
+
+        // remove ip from the routing filter
+        self.routable_network_monitors.remove_known(address);
+
+        // remove noise key from the known nodes
+        let update_permit = self.noise_view.get_update_permit().await;
+        let mut nodes = self.noise_view.all_nodes();
+        nodes.remove(&address);
+        self.noise_view.swap_view(update_permit, nodes);
+    }
+
+    async fn revoked_all_agents(&self) {
+        info!("revoking all NM agents");
+
+        self.routable_network_monitors.reset();
+
+        // remove all noise keys from the known nodes
+        let update_permit = self.noise_view.get_update_permit().await;
+        let mut nodes = self.noise_view.all_nodes();
+        nodes.retain(|_, node| node.is_nym_node());
+        self.noise_view.swap_view(update_permit, nodes);
     }
 }
 
@@ -99,13 +156,12 @@ impl MsgModule for NetworkMonitorAgentsModule {
                 mixnet_address,
                 bs58_x25519_noise,
                 noise_version,
-            } => self
-                .routable_network_monitors
-                .add_known(mixnet_address.ip()),
-            ExecuteMsg::RevokeNetworkMonitor { address } => {
-                self.routable_network_monitors.remove_known(address)
+            } => {
+                self.new_agent(mixnet_address, bs58_x25519_noise, noise_version)
+                    .await
             }
-            ExecuteMsg::RevokeAllNetworkMonitors => self.routable_network_monitors.reset(),
+            ExecuteMsg::RevokeNetworkMonitor { address } => self.revoked_agent(address).await,
+            ExecuteMsg::RevokeAllNetworkMonitors => self.revoked_all_agents().await,
 
             // we're not interested in those messages
             ExecuteMsg::UpdateAdmin { .. }

--- a/nym-node/src/node/routing_filter/network_filter.rs
+++ b/nym-node/src/node/routing_filter/network_filter.rs
@@ -45,11 +45,11 @@ impl NetworkRoutingFilter {
         mut self,
         known_network_monitors: HashSet<IpAddr>,
     ) -> Self {
-        self.resolved.network_monitors = DeclaredNetworkMonitors::new(known_network_monitors);
+        self.resolved.network_monitors = RoutableNetworkMonitors::new(known_network_monitors);
         self
     }
 
-    pub(crate) fn known_network_monitors_handle(&self) -> DeclaredNetworkMonitors {
+    pub(crate) fn known_network_monitors_handle(&self) -> RoutableNetworkMonitors {
         self.resolved.network_monitors.clone()
     }
 
@@ -120,7 +120,7 @@ impl UnknownNodes {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct KnownNodes {
     nym_nodes: KnownNymNodes,
-    network_monitors: DeclaredNetworkMonitors,
+    network_monitors: RoutableNetworkMonitors,
 }
 
 impl KnownNodes {
@@ -148,11 +148,11 @@ impl KnownNodes {
 ///
 /// Cloning `DeclaredNetworkMonitors` is cheap (only clones the `Arc`), not the underlying data.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct DeclaredNetworkMonitors {
+pub(crate) struct RoutableNetworkMonitors {
     inner: Arc<DeclaredNetworkMonitorsInner>,
 }
 
-impl DeclaredNetworkMonitors {
+impl RoutableNetworkMonitors {
     pub(crate) fn new(known: HashSet<IpAddr>) -> Self {
         Self {
             inner: Arc::new(DeclaredNetworkMonitorsInner {

--- a/nym-node/src/node/routing_filter/network_filter.rs
+++ b/nym-node/src/node/routing_filter/network_filter.rs
@@ -46,11 +46,11 @@ impl NetworkRoutingFilter {
         mut self,
         known_network_monitors: HashSet<IpAddr>,
     ) -> Self {
-        self.resolved.network_monitors = DeclaredNetworkMonitors::new(known_network_monitors);
+        self.resolved.network_monitors = RoutableNetworkMonitors::new(known_network_monitors);
         self
     }
 
-    pub(crate) fn known_network_monitors_handle(&self) -> DeclaredNetworkMonitors {
+    pub(crate) fn known_network_monitors_handle(&self) -> RoutableNetworkMonitors {
         self.resolved.network_monitors.clone()
     }
 
@@ -134,7 +134,7 @@ impl UnknownNodes {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct KnownNodes {
     nym_nodes: KnownNymNodes,
-    network_monitors: DeclaredNetworkMonitors,
+    network_monitors: RoutableNetworkMonitors,
 }
 
 impl KnownNodes {
@@ -162,11 +162,11 @@ impl KnownNodes {
 ///
 /// Cloning `DeclaredNetworkMonitors` is cheap (only clones the `Arc`), not the underlying data.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct DeclaredNetworkMonitors {
+pub(crate) struct RoutableNetworkMonitors {
     inner: Arc<DeclaredNetworkMonitorsInner>,
 }
 
-impl DeclaredNetworkMonitors {
+impl RoutableNetworkMonitors {
     pub(crate) fn new(known: HashSet<IpAddr>) -> Self {
         Self {
             inner: Arc::new(DeclaredNetworkMonitorsInner {

--- a/nym-node/src/node/shared_network/refresher.rs
+++ b/nym-node/src/node/shared_network/refresher.rs
@@ -26,12 +26,11 @@ use crate::node::nym_apis_client::NymApisClient;
 use crate::node::routing_filter::network_filter::NetworkRoutingFilter;
 use crate::node::shared_network::CachedNetwork;
 use nym_node_metrics::prometheus_wrapper::{PROMETHEUS_METRICS, PrometheusMetric};
-use nym_noise::config::NoiseNetworkView;
+use nym_noise::config::{NoiseNetworkView, NoiseNode};
 use nym_task::ShutdownToken;
 use nym_topology::provider_trait::ToTopologyMetadata;
 use nym_validator_client::ValidatorClientError;
 use std::collections::{HashMap, HashSet};
-use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::time::{Instant, interval, sleep};
 use tracing::{debug, trace};
@@ -76,6 +75,7 @@ impl NetworkRefresher {
         config: NetworkRefresherConfig,
         client: NymApisClient,
         routing_filter: NetworkRoutingFilter,
+        noise_view: NoiseNetworkView,
         shutdown_token: ShutdownToken,
     ) -> Result<Self, NymNodeError> {
         let mut this = NetworkRefresher {
@@ -84,7 +84,7 @@ impl NetworkRefresher {
             shutdown_token,
             network: CachedNetwork::new_empty(),
             routing_filter,
-            noise_view: NoiseNetworkView::new_empty(),
+            noise_view,
             lp_nodes: Default::default(),
         };
 
@@ -192,21 +192,31 @@ impl NetworkRefresher {
         self.routing_filter.resolved.swap_denied(current_denied);
         self.routing_filter.pending.clear().await;
 
+        let noise_update_permit = self.noise_view.get_update_permit().await;
+        let current_nodes = self.noise_view.all_nodes();
+
         // update noise Nodes
-        let noise_nodes = nodes
-            .iter()
-            .filter(|n| n.x25519_noise_versioned_key.is_some())
-            .flat_map(|n| {
-                n.basic.ip_addresses.iter().map(|ip_addr| {
-                    (
-                        SocketAddr::new(*ip_addr, n.basic.mix_port),
-                        #[allow(clippy::unwrap_used)]
-                        n.x25519_noise_versioned_key.unwrap(), // SAFETY: we filtered out nodes where this option can be None
-                    )
-                })
-            })
-            .collect::<HashMap<_, _>>();
-        self.noise_view.swap_view(noise_nodes);
+        let mut new_noise_nodes = HashMap::new();
+
+        // 1. include all existing agents
+        for (ip, node) in current_nodes {
+            if !node.is_nym_node() {
+                new_noise_nodes.insert(ip, node);
+            }
+        }
+
+        // 2. iterate through the newly retrieved list of nym nodes
+        for node in &nodes {
+            let Some(noise_key) = node.x25519_noise_versioned_key else {
+                continue;
+            };
+            let entry = NoiseNode::new_nym_node(noise_key);
+            for ip_addr in &node.basic.ip_addresses {
+                new_noise_nodes.insert(*ip_addr, entry.clone());
+            }
+        }
+        self.noise_view
+            .swap_view(noise_update_permit, new_noise_nodes);
         debug!("unimplemented: update LP nodes data - will work very similarly to noise nodes");
 
         let mut network_guard = self.network.inner.write().await;
@@ -283,10 +293,6 @@ impl NetworkRefresher {
 
     pub(crate) fn cached_network(&self) -> CachedNetwork {
         self.network.clone()
-    }
-
-    pub(crate) fn noise_view(&self) -> NoiseNetworkView {
-        self.noise_view.clone()
     }
 
     pub(crate) fn lp_nodes(&self) -> LpNodes {

--- a/nym-node/src/node/shared_network/refresher.rs
+++ b/nym-node/src/node/shared_network/refresher.rs
@@ -198,14 +198,20 @@ impl NetworkRefresher {
         // update noise Nodes
         let mut new_noise_nodes = HashMap::new();
 
-        // 1. include all existing agents
+        // Rebuild the noise map in two passes to respect the two independent data sources:
+        //
+        // 1. Preserve existing NM agent entries — these come from blockchain events processed
+        //    by `NetworkMonitorAgentsModule` and are NOT available from nym-api. Dropping them
+        //    here would leave agents unable to perform noise handshakes until their
+        //    registration is renewed.
         for (ip, node) in current_nodes {
             if !node.is_nym_node() {
                 new_noise_nodes.insert(ip, node);
             }
         }
 
-        // 2. iterate through the newly retrieved list of nym nodes
+        // 2. Replace all nym-node entries with fresh data from nym-api.
+        //    (Stale nym-node keys are safe to overwrite — the source of truth is always nym-api)
         for node in &nodes {
             let Some(noise_key) = node.x25519_noise_versioned_key else {
                 continue;


### PR DESCRIPTION
Network Monitor agents need to perform Noise protocol handshakes with nym-nodes, just like any other nym-node on the network. Previously the contract stored only the agent's IP address, and the noise key map in nym-node only tracked keys for nym-api-sourced nodes. This PR closes the gap end-to-end: from on-chain registration through to live packet routing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6577)
<!-- Reviewable:end -->
