### PR TITLE
API-scraper update

### DIFF
--- a/documentation/scripts/api-scraping/api_targets.py
+++ b/documentation/scripts/api-scraping/api_targets.py
@@ -207,6 +207,90 @@ def current_desktop_version(args, response):
     print(df)
     # version=$(curl -s $release_url | jq -r '.[].tag_name' | grep '^nym-vpn-desktop-v' | sort -Vr | head -n 1 | awk -F'-v' '{print $NF}')
 
+###########################################
+########## NODES DESCRIBED FNs ############
+###########################################
+
+
+def get_all_paginated_data(url, page_size=1000, timeout=30):
+    session = requests.Session()
+    page = 0
+    all_data = []
+    total = None
+
+    while True:
+        r = session.get(
+            url,
+            params={"page": page, "size": page_size},
+            timeout=timeout
+        )
+        r.raise_for_status()
+        response = r.json()
+
+        page_data = response.get("data", [])
+        pagination = response.get("pagination", {})
+
+        if total is None:
+            total = pagination.get("total")
+
+        if not page_data:
+            break
+
+        all_data.extend(page_data)
+
+        if total is not None and len(all_data) >= int(total):
+            break
+
+        page += 1
+
+    return all_data
+
+
+def summarize_described_nodes(nodes):
+    unique_locations = set()
+    mixnodes = 0
+    exit_gateways = 0
+
+    for node in nodes:
+        description = node.get("description", {})
+        declared_role = description.get("declared_role", {})
+        auxiliary_details = description.get("auxiliary_details", {})
+
+        # location (2-letter country code like "FI")
+        location = auxiliary_details.get("location")
+        if location:
+            unique_locations.add(str(location).strip())
+
+        # roles
+        if declared_role.get("mixnode") is True:
+            mixnodes += 1
+
+        if declared_role.get("exit_nr") is True or declared_role.get("exit_ipr") is True:
+            exit_gateways += 1
+
+    summary = {
+        "nodes": len(nodes),
+        "locations": len(unique_locations),
+        "mixnodes": mixnodes,
+        "exit_gateways": exit_gateways,
+    }
+
+    return summary
+
+
+def read_described_nodes(args):
+    url = get_url(args)
+    nodes = get_all_paginated_data(url, page_size=args.page_size)
+    summary = summarize_described_nodes(nodes)
+
+    if args.value:
+        value = summary
+        for key in args.value:
+            value = value[key]
+        print(value)
+    else:
+        print(json.dumps(summary, indent=2))
+
 
 ###########################################
 ############### MAIN PARSER ###############
@@ -322,6 +406,40 @@ def parser_main():
     parser_nym_vpn.set_defaults(func=get_nym_vpn_version)
 
 
+    parser_described_nodes = subparsers.add_parser('described_nodes',
+            help='Summarise validator api/v1/nym-nodes/described',
+            aliases=['dn']
+            )
+
+    parser_described_nodes.add_argument(
+            "-a", "--api",
+            type=str,
+            default="mainnet",
+            help="choose: mainnet, perf, sandbox"
+            )
+
+    parser_described_nodes.add_argument(
+            "-e", "--endpoint",
+            type=str,
+            default="nym-nodes/described",
+            help="validator endpoint"
+            )
+
+    parser_described_nodes.add_argument(
+            "-v", "--value",
+            type=str,
+            help="optional summary key to print: nodes locations isps mixnodes exit_gateways",
+            nargs='+'
+            )
+
+    parser_described_nodes.add_argument(
+            "--page-size",
+            type=int,
+            default=1000,
+            help="pagination size per request; code keeps paging until all entries are fetched"
+            )
+
+    parser_described_nodes.set_defaults(func=read_described_nodes)
 
 
     args = parser.parse_args()

--- a/documentation/scripts/next-scripts/python-prebuild.sh
+++ b/documentation/scripts/next-scripts/python-prebuild.sh
@@ -25,6 +25,8 @@ python3 api_targets.py validator --api mainnet --endpoint epoch/reward_params --
 
 python3 api_targets.py validator --api mainnet --endpoint epoch/reward_params --value interval epoch_reward_budget --format markdown --separator _ > ../../docs/components/outputs/api-scraping-outputs/nyx-outputs/epoch-reward-budget.md &&
 
+python3 api_targets.py described_nodes > ../../docs/components/outputs/api-scraping-outputs/nodes-count.json
+
 python3 api_targets.py time_now > ../../docs/components/outputs/api-scraping-outputs/time-now.md &&
 
 python3 api_targets.py calculate --staking_target --separator _ > ../../docs/components/outputs/api-scraping-outputs/nyx-outputs/staking-target.md &&


### PR DESCRIPTION
Adding a snippet to [this](https://github.com/nymtech/nym/blob/max/doc-rework-jan-26/documentation/docs/pages/operators/tokenomics.mdx?plain=1) in order to get data on build. 

**Usage:**
```sh
cd nym/documentation/scripts/api-scraping

python api_targets.py described_nodes
```

**Output:**
```json
{
  "nodes": 731,
  "locations": 73,
  "mixnodes": 264,
  "exit_gateways": 458
}
```

Secondly adding this command to  `nym/documentation/scripts/next-scripts/python-prebuild.sh`  to auto-build the json output into `docs/components/outputs/api-scraping-outputs/nodes-count.json`

**Usage**

```mdx
import stats from 'components/outputs/api-scraping-outputs/nodes-count.json';

const { nodes, locations, mixnodes, exit_gateways } = stats;


Example text, where you want to show number of nodes: {nodes} and number of locations: {locations}.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6598)
<!-- Reviewable:end -->
