### PR TITLE
NTM Update

### DIFF
--- a/documentation/docs/components/operators/snippets/ports-nym-node.mdx
+++ b/documentation/docs/components/operators/snippets/ports-nym-node.mdx
@@ -1,42 +1,5 @@
-import { MyTab } from 'components/generic-tabs.tsx';
+import { Callout } from 'nextra/components';
 
- 
-
-<div>
-  <Tabs items={[
-    <code>--mode mixnode</code>,
-    <code>--mode exit-gateway</code> or any WireGuard GW,
-    ]} defaultIndex="0">
-    <MyTab><PortsNymNode/>
-</div>
-> Note: For operators considering to eventually run `nym-node` in Exit Gateway mode or supporting WireGuard routing, use `network-tunnel-manager.sh` (NTM) option in the next tab.
-
-For mixnode only open the needed ports for Nym services using Uncomplicated Firewall (`ufw`) by running these commands:
-
-      <Steps>
-
-###### 1. Ensure `ufw` functionality
-
-- Check if you have `ufw` installed:
-```sh
-ufw version
-```
-- If it's not installed, install with:
-```sh
-apt install ufw -y
-```
-- Enable ufw
-```sh
-ufw enable
-```
-- Check the status of the firewall
-```sh
-ufw status
-```
-
-###### 2. Open required ports for Nym services using `ufw`
-
-- Copy this whole block to open all ports for mixnode
 ```sh
 ufw allow 22/tcp                                  # SSH - you're in control of these ports
 ufw allow 80/tcp                                  # HTTP
@@ -49,30 +12,11 @@ ufw allow 9001/tcp                                # Nym specific - wss port
 ufw allow 41264/tcp                               # Nym specific - Lewes Protocol registration
 ufw allow 51264/udp                               # Nym specific - Lewes Protocol data
 ```
-- Note that these ports were moved to NTM as they are for Gateways only
-```sh 
+
+<Callout>
+Note that these ports were moved to [NTM](/operators/nodes/preliminary-steps/vps-setup#1-download-the-new-ntm) as they are for Gateways only
+```sh
 # ufw allow 51822/udp                               # WireGuard
 # ufw allow in on nymwg to any port 51830 proto tcp # bandwidth queries/topup - inside the tunnel
 ```
-      </Steps>
-    </MyTab>
-    <MyTab>
-Follow these commands to open ports for Nym related services, setup and configure Nym networking devices, configure Nym exit policy and run tests. For more info, read the chapter [*Routing configuration](/operators/nodes/nym-node/configuration#routing-configuration). 
-
-      <Steps>
-
-###### 1. Download the new NTM
-- Download the latest NTM and make it executable:
-```sh
-curl -L https://raw.githubusercontent.com/nymtech/nym/refs/heads/develop/scripts/nym-node-setup/network-tunnel-manager.sh -o ./network-tunnel-manager.sh && \
-chmod +x network-tunnel-manager.sh
-```
-
-###### 2. Update the exit policy
-- To ensure your routing is clean, run:
-```sh
-./network-tunnel-manager.sh complete_networking_configuration
-```
-      </ Steps>   
-    </MyTab>
-  </Tabs>
+</Callout>

--- a/documentation/docs/components/operators/snippets/ports-nym-node.mdx
+++ b/documentation/docs/components/operators/snippets/ports-nym-node.mdx
@@ -1,5 +1,42 @@
-Open the needed ports for `nym-node` by running these commands:
+import { MyTab } from 'components/generic-tabs.tsx';
 
+ 
+
+<div>
+  <Tabs items={[
+    <code>--mode mixnode</code>,
+    <code>--mode exit-gateway</code> or any WireGuard GW,
+    ]} defaultIndex="0">
+    <MyTab><PortsNymNode/>
+</div>
+> Note: For operators considering to eventually run `nym-node` in Exit Gateway mode or supporting WireGuard routing, use `network-tunnel-manager.sh` (NTM) option in the next tab.
+
+For mixnode only open the needed ports for Nym services using Uncomplicated Firewall (`ufw`) by running these commands:
+
+      <Steps>
+
+###### 1. Ensure `ufw` functionality
+
+- Check if you have `ufw` installed:
+```sh
+ufw version
+```
+- If it's not installed, install with:
+```sh
+apt install ufw -y
+```
+- Enable ufw
+```sh
+ufw enable
+```
+- Check the status of the firewall
+```sh
+ufw status
+```
+
+###### 2. Open required ports for Nym services using `ufw`
+
+- Copy this whole block to open all ports for mixnode
 ```sh
 ufw allow 22/tcp                                  # SSH - you're in control of these ports
 ufw allow 80/tcp                                  # HTTP
@@ -7,8 +44,35 @@ ufw allow 443/tcp                                 # HTTPS
 ufw allow 1789/tcp                                # Nym specific - Mixnet
 ufw allow 1790/tcp                                # Nym specific - Verloc
 ufw allow 8080/tcp                                # Nym specific - nym-node-api
-ufw allow 9000/tcp                                # Nym Specific - clients port
+ufw allow 9000/tcp                                # Nym specific - clients port
 ufw allow 9001/tcp                                # Nym specific - wss port
-ufw allow 51822/udp                               # WireGuard
-ufw allow in on nymwg to any port 51830 proto tcp # bandwidth queries/topup - inside the tunnel
+ufw allow 41264/tcp                               # Nym specific - Lewes Protocol registration
+ufw allow 51264/udp                               # Nym specific - Lewes Protocol data
 ```
+- Note that these ports were moved to NTM as they are for Gateways only
+```sh 
+# ufw allow 51822/udp                               # WireGuard
+# ufw allow in on nymwg to any port 51830 proto tcp # bandwidth queries/topup - inside the tunnel
+```
+      </Steps>
+    </MyTab>
+    <MyTab>
+Follow these commands to open ports for Nym related services, setup and configure Nym networking devices, configure Nym exit policy and run tests. For more info, read the chapter [*Routing configuration](/operators/nodes/nym-node/configuration#routing-configuration). 
+
+      <Steps>
+
+###### 1. Download the new NTM
+- Download the latest NTM and make it executable:
+```sh
+curl -L https://raw.githubusercontent.com/nymtech/nym/refs/heads/develop/scripts/nym-node-setup/network-tunnel-manager.sh -o ./network-tunnel-manager.sh && \
+chmod +x network-tunnel-manager.sh
+```
+
+###### 2. Update the exit policy
+- To ensure your routing is clean, run:
+```sh
+./network-tunnel-manager.sh complete_networking_configuration
+```
+      </ Steps>   
+    </MyTab>
+  </Tabs>

--- a/documentation/docs/components/operators/snippets/tabs-ports-nym-node.mdx
+++ b/documentation/docs/components/operators/snippets/tabs-ports-nym-node.mdx
@@ -4,11 +4,11 @@ import PortsNymNode from 'components/operators/snippets/ports-nym-node.mdx';
 
 <div>
   <Tabs
-    items={['Mixnode', 'Exit Gateway and WireGuard']}
+    items={['Mixnode', 'Gateways and WireGuard']}
     defaultIndex={0}
   >
     <MyTab>
-For operators considering to eventually run `nym-node` in Exit Gateway mode or supporting WireGuard routing, use the tab for Gateways & WireGuard.
+For operators considering to eventually run `nym-node` in a Gateway mode or supporting WireGuard routing, use the tab for Gateways & WireGuard.
 
 For mixnode only open the needed ports for Nym services using Uncomplicated Firewall (`ufw`) by running these commands:
 

--- a/documentation/docs/components/operators/snippets/tabs-ports-nym-node.mdx
+++ b/documentation/docs/components/operators/snippets/tabs-ports-nym-node.mdx
@@ -1,0 +1,79 @@
+import { MyTab } from 'components/generic-tabs.tsx';
+import { Tabs, Steps } from 'nextra/components';
+import PortsNymNode from 'components/operators/snippets/ports-nym-node.mdx';
+
+<div>
+  <Tabs
+    items={['Mixnode', 'Exit Gateway and WireGuard']}
+    defaultIndex={0}
+  >
+    <MyTab>
+For operators considering to eventually run `nym-node` in Exit Gateway mode or supporting WireGuard routing, use the tab for Gateways & WireGuard.
+
+For mixnode only open the needed ports for Nym services using Uncomplicated Firewall (`ufw`) by running these commands:
+
+<Steps>
+
+###### 1. Ensure `ufw` functionality
+
+- Check if you have `ufw` installed:
+```sh
+ufw version
+```
+
+- If it's not installed, install with:
+```sh
+apt install ufw -y
+```
+
+- Enable ufw
+```sh
+ufw enable
+```
+
+- Check the status of the firewall
+```sh
+ufw status
+```
+
+###### 2. Open required ports for Nym services using `ufw`
+
+- Copy this whole block to open all ports for mixnode
+
+<PortsNymNode />
+
+###### 3. Validate opened ports
+- Re-check the status of the firewall
+```sh
+ufw status
+```
+
+</Steps>
+    </MyTab>
+
+    <MyTab>
+Gateways (and WireGuard) nodes use [`network-tunnel-manager.sh` (NTM)](https://github.com/nymtech/nym/refs/heads/develop/scripts/nym-node-setup/network-tunnel-manager.sh) tool to open ports for Nym related services, setup and configure Nym networking devices, configure Nym exit policy and run tests. For more info, read the chapter [*Routing configuration*](/operators/nodes/nym-node/configuration#routing-configuration).
+
+Follow these steps to setup complete routing of your server hosting a Nym node.
+
+<Steps>
+
+###### 1. Download the new NTM
+
+- Download the latest NTM and make it executable:
+```sh
+curl -L https://raw.githubusercontent.com/nymtech/nym/refs/heads/develop/scripts/nym-node-setup/network-tunnel-manager.sh -o ./network-tunnel-manager.sh && \
+chmod +x network-tunnel-manager.sh
+```
+
+###### 2. Update the exit policy
+
+- To ensure your routing is clean, run:
+```sh
+./network-tunnel-manager.sh complete_networking_configuration
+```
+
+</Steps>
+    </MyTab>
+  </Tabs>
+</div>

--- a/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
+++ b/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
@@ -1,1 +1,1 @@
-Tuesday, March 24th 2026, 17:54:17 UTC
+Wednesday, March 25th 2026, 13:56:09 UTC

--- a/documentation/docs/components/outputs/command-outputs/node-api-check-query-help.md
+++ b/documentation/docs/components/outputs/command-outputs/node-api-check-query-help.md
@@ -11,7 +11,7 @@ options:
   --no_routing_history  Display node stats without routing history
   --no_verloc_metrics   Display node stats without verloc metrics
   -m, --markdown        Display results in markdown format
-  -o, --output [OUTPUT]
+  -o [OUTPUT], --output [OUTPUT]
                         Save results to file (in current dir or supply with
                         path without filename)
 ```

--- a/documentation/docs/components/outputs/command-outputs/nym-api-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-api-help.md
@@ -8,8 +8,12 @@ Commands:
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-  -c, --config-env-file <CONFIG_ENV_FILE>  Path pointing to an env file that configures the Nym API [env: NYMAPI_CONFIG_ENV_FILE_ARG=]
-      --no-banner                          A no-op flag included for consistency with other binaries (and compatibility with nymvisor, oops) [env: NYMAPI_NO_BANNER_ARG=]
-  -h, --help                               Print help
-  -V, --version                            Print version
+  -c, --config-env-file <CONFIG_ENV_FILE>
+          Path pointing to an env file that configures the Nym API [env: NYMAPI_CONFIG_ENV_FILE_ARG=]
+      --no-banner
+          A no-op flag included for consistency with other binaries (and compatibility with nymvisor, oops) [env: NYMAPI_NO_BANNER_ARG=]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```

--- a/documentation/docs/components/outputs/command-outputs/nym-node-cli-install-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-node-cli-install-help.md
@@ -12,7 +12,8 @@ usage: nym-node-cli install [-h] [-V] [-d BRANCH] [-v]
 options:
   -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
-  -d, --dev BRANCH      Define github branch (default: develop)
+  -d BRANCH, --dev BRANCH
+                        Define github branch (default: develop)
   -v, --verbose         Show full error tracebacks
   --mode {mixnode,entry-gateway,exit-gateway}
                         Node mode: 'mixnode', 'entry-gateway', or 'exit-

--- a/documentation/docs/components/outputs/command-outputs/nym-node-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-node-help.md
@@ -12,8 +12,12 @@ Commands:
   help                      Print this message or the help of the given subcommand(s)
 
 Options:
-  -c, --config-env-file <CONFIG_ENV_FILE>  Path pointing to an env file that configures the nym-node and overrides any preconfigured values [env: NYMNODE_CONFIG_ENV_FILE_ARG=]
-      --no-banner                          Flag used for disabling the printed banner in tty [env: NYMNODE_NO_BANNER=]
-  -h, --help                               Print help
-  -V, --version                            Print version
+  -c, --config-env-file <CONFIG_ENV_FILE>
+          Path pointing to an env file that configures the nym-node and overrides any preconfigured values [env: NYMNODE_CONFIG_ENV_FILE_ARG=]
+      --no-banner
+          Flag used for disabling the printed banner in tty [env: NYMNODE_NO_BANNER=]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```

--- a/documentation/docs/components/outputs/command-outputs/nym-node-run-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-node-run-help.md
@@ -4,86 +4,98 @@ Start this nym-node
 Usage: nym-node run [OPTIONS]
 
 Options:
-      --id <ID>                                                              Id of the nym-node to use [env: NYMNODE_ID=] [default: default-nym-node]
-      --config-file <CONFIG_FILE>                                            Path to a configuration file of this node [env: NYMNODE_CONFIG=]
-      --accept-operator-terms-and-conditions                                 Explicitly specify whether you agree with the terms and conditions of a nym node operator as defined at
-                                                                             <https://nymtech.net/terms-and-conditions/operators/v1.0.0> [env: NYMNODE_ACCEPT_OPERATOR_TERMS=]
-      --deny-init                                                            Forbid a new node from being initialised if configuration file for the provided specification doesn't already exist [env:
-                                                                             NYMNODE_DENY_INIT=]
-      --init-only                                                            If this is a brand new nym-node, specify whether it should only be initialised without actually running the subprocesses
-                                                                             [env: NYMNODE_INIT_ONLY=]
-      --local                                                                Flag specifying this node will be running in a local setting [env: NYMNODE_LOCAL=]
-      --mode [<MODE>...]                                                     Specifies the current mode(s) of this nym-node [env: NYMNODE_MODE=] [possible values: mixnode, entry-gateway, exit-gateway,
-                                                                             exit-providers-only]
-      --modes <MODES>                                                        Specifies the current mode(s) of this nym-node as a single flag [env: NYMNODE_MODES=] [possible values: mixnode,
-                                                                             entry-gateway, exit-gateway, exit-providers-only]
-  -w, --write-changes                                                        If this node has been initialised before, specify whether to write any new changes to the config file [env:
-                                                                             NYMNODE_WRITE_CONFIG_CHANGES=]
-      --bonding-information-output <BONDING_INFORMATION_OUTPUT>              Specify output file for bonding information of this nym-node, i.e. its encoded keys. NOTE: the required bonding information
-                                                                             is still a subject to change and this argument should be treated only as a preview of future features [env:
-                                                                             NYMNODE_BONDING_INFORMATION_OUTPUT=]
-  -o, --output <OUTPUT>                                                      Specify the output format of the bonding information (`text` or `json`) [env: NYMNODE_OUTPUT=] [default: text] [possible
-                                                                             values: text, json]
-      --public-ips <PUBLIC_IPS>                                              Comma separated list of public ip addresses that will be announced to the nym-api and subsequently to the clients. In
-                                                                             nearly all circumstances, it's going to be identical to the address you're going to use for bonding [env:
-                                                                             NYMNODE_PUBLIC_IPS=]
-      --hostname <HOSTNAME>                                                  Optional hostname associated with this gateway that will be announced to the nym-api and subsequently to the clients [env:
-                                                                             NYMNODE_HOSTNAME=]
-      --location <LOCATION>                                                  Optional **physical** location of this node's server. Either full country name (e.g. 'Poland'), two-letter alpha2 (e.g.
-                                                                             'PL'), three-letter alpha3 (e.g. 'POL') or three-digit numeric-3 (e.g. '616') can be provided [env: NYMNODE_LOCATION=]
-      --http-bind-address <HTTP_BIND_ADDRESS>                                Socket address this node will use for binding its http API. default: `[::]:8080` [env: NYMNODE_HTTP_BIND_ADDRESS=]
-      --landing-page-assets-path <LANDING_PAGE_ASSETS_PATH>                  Path to assets directory of custom landing page of this node [env: NYMNODE_HTTP_LANDING_ASSETS=]
-      --http-access-token <HTTP_ACCESS_TOKEN>                                An optional bearer token for accessing certain http endpoints. Currently only used for prometheus metrics [env:
-                                                                             NYMNODE_HTTP_ACCESS_TOKEN=]
-      --expose-system-info <EXPOSE_SYSTEM_INFO>                              Specify whether basic system information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_SYSTEM_INFO=] [possible
-                                                                             values: true, false]
-      --expose-system-hardware <EXPOSE_SYSTEM_HARDWARE>                      Specify whether basic system hardware information should be exposed. default: true [env:
-                                                                             NYMNODE_HTTP_EXPOSE_SYSTEM_HARDWARE=] [possible values: true, false]
-      --expose-crypto-hardware <EXPOSE_CRYPTO_HARDWARE>                      Specify whether detailed system crypto hardware information should be exposed. default: true [env:
-                                                                             NYMNODE_HTTP_EXPOSE_CRYPTO_HARDWARE=] [possible values: true, false]
-      --mixnet-bind-address <MIXNET_BIND_ADDRESS>                            Address this node will bind to for listening for mixnet packets default: `[::]:1789` [env: NYMNODE_MIXNET_BIND_ADDRESS=]
-      --mixnet-announce-port <MIXNET_ANNOUNCE_PORT>                          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node
-                                                                             is behind a proxy [env: NYMNODE_MIXNET_ANNOUNCE_PORT=]
-      --nym-api-urls <NYM_API_URLS>                                          Addresses to nym APIs from which the node gets the view of the network [env: NYMNODE_NYM_APIS=]
-      --nyxd-urls <NYXD_URLS>                                                Addresses to nyxd chain endpoint which the node will use for chain interactions [env: NYMNODE_NYXD=]
-      --enable-console-logging <ENABLE_CONSOLE_LOGGING>                      Specify whether running statistics of this node should be logged to the console [env: NYMNODE_ENABLE_CONSOLE_LOGGING=]
-                                                                             [possible values: true, false]
-      --wireguard-enabled <WIREGUARD_ENABLED>                                Specifies whether the wireguard service is enabled on this node [env: NYMNODE_WG_ENABLED=] [possible values: true, false]
-      --wireguard-bind-address <WIREGUARD_BIND_ADDRESS>                      Socket address this node will use for binding its wireguard interface. default: `[::]:51822` [env:
-                                                                             NYMNODE_WG_BIND_ADDRESS=]
-      --wireguard-tunnel-announced-port <WIREGUARD_TUNNEL_ANNOUNCED_PORT>    Tunnel port announced to external clients wishing to connect to the wireguard interface. Useful in the instances where the
-                                                                             node is behind a proxy [env: NYMNODE_WG_ANNOUNCED_PORT=]
-      --wireguard-private-network-prefix <WIREGUARD_PRIVATE_NETWORK_PREFIX>  The prefix denoting the maximum number of the clients that can be connected via Wireguard. The maximum value for IPv4 is 32
-                                                                             and for IPv6 is 128 [env: NYMNODE_WG_PRIVATE_NETWORK_PREFIX=]
-      --wireguard-userspace <WIREGUARD_USERSPACE>                            Use userspace implementation of WireGuard (wireguard-go) instead of kernel module. Useful in containerized environments
-                                                                             without kernel WireGuard support [env: NYMNODE_WG_USERSPACE=] [possible values: true, false]
-      --verloc-bind-address <VERLOC_BIND_ADDRESS>                            Socket address this node will use for binding its verloc API. default: `[::]:1790` [env: NYMNODE_VERLOC_BIND_ADDRESS=]
-      --verloc-announce-port <VERLOC_ANNOUNCE_PORT>                          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node
-                                                                             is behind a proxy [env: NYMNODE_VERLOC_ANNOUNCE_PORT=]
-      --entry-bind-address <ENTRY_BIND_ADDRESS>                              Socket address this node will use for binding its client websocket API. default: `[::]:9000` [env:
-                                                                             NYMNODE_ENTRY_BIND_ADDRESS=]
-      --announce-ws-port <ANNOUNCE_WS_PORT>                                  Custom announced port for listening for websocket client traffic. If unspecified, the value from the `bind_address` will be
-                                                                             used instead [env: NYMNODE_ENTRY_ANNOUNCE_WS_PORT=]
-      --announce-wss-port <ANNOUNCE_WSS_PORT>                                If applicable, announced port for listening for secure websocket client traffic [env: NYMNODE_ENTRY_ANNOUNCE_WSS_PORT=]
-      --enforce-zk-nyms <ENFORCE_ZK_NYMS>                                    Indicates whether this gateway is accepting only coconut credentials for accessing the mixnet or if it also accepts
-                                                                             non-paying clients [env: NYMNODE_ENFORCE_ZK_NYMS=] [possible values: true, false]
-      --mnemonic <MNEMONIC>                                                  Custom cosmos wallet mnemonic used for zk-nym redemption. If no value is provided, a fresh mnemonic is going to be
-                                                                             generated [env: NYMNODE_MNEMONIC=]
-      --upgrade-mode-attestation-url <UPGRADE_MODE_ATTESTATION_URL>          Endpoint to query to retrieve current upgrade mode attestation. This argument should never be set outside testnets and
-                                                                             local networks [env: NYMNODE_UPGRADE_MODE_ATTESTATION_URL=]
-      --upgrade-mode-attester-public-key <UPGRADE_MODE_ATTESTER_PUBLIC_KEY>  Expected public key of the entity signing the published attestation. This argument should never be set outside testnets and
-                                                                             local networks [env: NYMNODE_UPGRADE_MODE_ATTESTER_PUBKEY=]
-      --upstream-exit-policy-url <UPSTREAM_EXIT_POLICY_URL>                  Specifies the url for an upstream source of the exit policy used by this node [env: NYMNODE_UPSTREAM_EXIT_POLICY=]
-      --open-proxy <OPEN_PROXY>                                              Specifies whether this exit node should run in 'open-proxy' mode and thus would attempt to resolve **ANY** request it
-                                                                             receives [env: NYMNODE_OPEN_PROXY=] [possible values: true, false]
-      --lp-control-bind-address <LP_CONTROL_BIND_ADDRESS>                    Bind address for the TCP LP control traffic. default: `[::]:41264` [env: NYMNODE_LP_CONTROL_BIND_ADDRESS=]
-      --lp-control-announce-port <LP_CONTROL_ANNOUNCE_PORT>                  Custom announced port for listening for the TCP LP control traffic. If unspecified, the value from the
-                                                                             `lp_control_bind_address` will be used instead [env: NYMNODE_LP_CONTROL_ANNOUNCE_PORT=]
-      --lp-data-bind-address <LP_DATA_BIND_ADDRESS>                          Bind address for the UDP LP data traffic. default: `[::]:51264` [env: NYMNODE_LP_DATA_BIND_ADDRESS=]
-      --lp-data-announce-port <LP_DATA_ANNOUNCE_PORT>                        Custom announced port for listening for the UDP LP data traffic. If unspecified, the value from the `lp_data_bind_address`
-                                                                             will be used instead [env: NYMNODE_LP_DATA_ANNOUNCE_PORT=]
-      --lp-use-mock-ecash <LP_USE_MOCK_ECASH>                                Use mock ecash manager for LP testing. WARNING: Only use this for local testing! Never enable in production. When enabled,
-                                                                             the LP listener will accept any credential without blockchain verification [env: NYMNODE_LP_USE_MOCK_ECASH=] [possible
-                                                                             values: true, false]
-  -h, --help                                                                 Print help
+      --id <ID>
+          Id of the nym-node to use [env: NYMNODE_ID=] [default: default-nym-node]
+      --config-file <CONFIG_FILE>
+          Path to a configuration file of this node [env: NYMNODE_CONFIG=]
+      --accept-operator-terms-and-conditions
+          Explicitly specify whether you agree with the terms and conditions of a nym node operator as defined at <https://nymtech.net/terms-and-conditions/operators/v1.0.0> [env: NYMNODE_ACCEPT_OPERATOR_TERMS=]
+      --deny-init
+          Forbid a new node from being initialised if configuration file for the provided specification doesn't already exist [env: NYMNODE_DENY_INIT=]
+      --init-only
+          If this is a brand new nym-node, specify whether it should only be initialised without actually running the subprocesses [env: NYMNODE_INIT_ONLY=]
+      --local
+          Flag specifying this node will be running in a local setting [env: NYMNODE_LOCAL=]
+      --mode [<MODE>...]
+          Specifies the current mode(s) of this nym-node [env: NYMNODE_MODE=] [possible values: mixnode, entry-gateway, exit-gateway, exit-providers-only]
+      --modes <MODES>
+          Specifies the current mode(s) of this nym-node as a single flag [env: NYMNODE_MODES=] [possible values: mixnode, entry-gateway, exit-gateway, exit-providers-only]
+  -w, --write-changes
+          If this node has been initialised before, specify whether to write any new changes to the config file [env: NYMNODE_WRITE_CONFIG_CHANGES=]
+      --bonding-information-output <BONDING_INFORMATION_OUTPUT>
+          Specify output file for bonding information of this nym-node, i.e. its encoded keys. NOTE: the required bonding information is still a subject to change and this argument should be treated only as a preview of future features [env: NYMNODE_BONDING_INFORMATION_OUTPUT=]
+  -o, --output <OUTPUT>
+          Specify the output format of the bonding information (`text` or `json`) [env: NYMNODE_OUTPUT=] [default: text] [possible values: text, json]
+      --public-ips <PUBLIC_IPS>
+          Comma separated list of public ip addresses that will be announced to the nym-api and subsequently to the clients. In nearly all circumstances, it's going to be identical to the address you're going to use for bonding [env: NYMNODE_PUBLIC_IPS=]
+      --hostname <HOSTNAME>
+          Optional hostname associated with this gateway that will be announced to the nym-api and subsequently to the clients [env: NYMNODE_HOSTNAME=]
+      --location <LOCATION>
+          Optional **physical** location of this node's server. Either full country name (e.g. 'Poland'), two-letter alpha2 (e.g. 'PL'), three-letter alpha3 (e.g. 'POL') or three-digit numeric-3 (e.g. '616') can be provided [env: NYMNODE_LOCATION=]
+      --http-bind-address <HTTP_BIND_ADDRESS>
+          Socket address this node will use for binding its http API. default: `[::]:8080` [env: NYMNODE_HTTP_BIND_ADDRESS=]
+      --landing-page-assets-path <LANDING_PAGE_ASSETS_PATH>
+          Path to assets directory of custom landing page of this node [env: NYMNODE_HTTP_LANDING_ASSETS=]
+      --http-access-token <HTTP_ACCESS_TOKEN>
+          An optional bearer token for accessing certain http endpoints. Currently only used for prometheus metrics [env: NYMNODE_HTTP_ACCESS_TOKEN=]
+      --expose-system-info <EXPOSE_SYSTEM_INFO>
+          Specify whether basic system information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_SYSTEM_INFO=] [possible values: true, false]
+      --expose-system-hardware <EXPOSE_SYSTEM_HARDWARE>
+          Specify whether basic system hardware information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_SYSTEM_HARDWARE=] [possible values: true, false]
+      --expose-crypto-hardware <EXPOSE_CRYPTO_HARDWARE>
+          Specify whether detailed system crypto hardware information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_CRYPTO_HARDWARE=] [possible values: true, false]
+      --mixnet-bind-address <MIXNET_BIND_ADDRESS>
+          Address this node will bind to for listening for mixnet packets default: `[::]:1789` [env: NYMNODE_MIXNET_BIND_ADDRESS=]
+      --mixnet-announce-port <MIXNET_ANNOUNCE_PORT>
+          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node is behind a proxy [env: NYMNODE_MIXNET_ANNOUNCE_PORT=]
+      --nym-api-urls <NYM_API_URLS>
+          Addresses to nym APIs from which the node gets the view of the network [env: NYMNODE_NYM_APIS=]
+      --nyxd-urls <NYXD_URLS>
+          Addresses to nyxd chain endpoint which the node will use for chain interactions [env: NYMNODE_NYXD=]
+      --enable-console-logging <ENABLE_CONSOLE_LOGGING>
+          Specify whether running statistics of this node should be logged to the console [env: NYMNODE_ENABLE_CONSOLE_LOGGING=] [possible values: true, false]
+      --wireguard-enabled <WIREGUARD_ENABLED>
+          Specifies whether the wireguard service is enabled on this node [env: NYMNODE_WG_ENABLED=] [possible values: true, false]
+      --wireguard-bind-address <WIREGUARD_BIND_ADDRESS>
+          Socket address this node will use for binding its wireguard interface. default: `[::]:51822` [env: NYMNODE_WG_BIND_ADDRESS=]
+      --wireguard-tunnel-announced-port <WIREGUARD_TUNNEL_ANNOUNCED_PORT>
+          Tunnel port announced to external clients wishing to connect to the wireguard interface. Useful in the instances where the node is behind a proxy [env: NYMNODE_WG_ANNOUNCED_PORT=]
+      --wireguard-private-network-prefix <WIREGUARD_PRIVATE_NETWORK_PREFIX>
+          The prefix denoting the maximum number of the clients that can be connected via Wireguard. The maximum value for IPv4 is 32 and for IPv6 is 128 [env: NYMNODE_WG_PRIVATE_NETWORK_PREFIX=]
+      --wireguard-userspace <WIREGUARD_USERSPACE>
+          Use userspace implementation of WireGuard (wireguard-go) instead of kernel module. Useful in containerized environments without kernel WireGuard support [env: NYMNODE_WG_USERSPACE=] [possible values: true, false]
+      --verloc-bind-address <VERLOC_BIND_ADDRESS>
+          Socket address this node will use for binding its verloc API. default: `[::]:1790` [env: NYMNODE_VERLOC_BIND_ADDRESS=]
+      --verloc-announce-port <VERLOC_ANNOUNCE_PORT>
+          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node is behind a proxy [env: NYMNODE_VERLOC_ANNOUNCE_PORT=]
+      --entry-bind-address <ENTRY_BIND_ADDRESS>
+          Socket address this node will use for binding its client websocket API. default: `[::]:9000` [env: NYMNODE_ENTRY_BIND_ADDRESS=]
+      --announce-ws-port <ANNOUNCE_WS_PORT>
+          Custom announced port for listening for websocket client traffic. If unspecified, the value from the `bind_address` will be used instead [env: NYMNODE_ENTRY_ANNOUNCE_WS_PORT=]
+      --announce-wss-port <ANNOUNCE_WSS_PORT>
+          If applicable, announced port for listening for secure websocket client traffic [env: NYMNODE_ENTRY_ANNOUNCE_WSS_PORT=]
+      --enforce-zk-nyms <ENFORCE_ZK_NYMS>
+          Indicates whether this gateway is accepting only coconut credentials for accessing the mixnet or if it also accepts non-paying clients [env: NYMNODE_ENFORCE_ZK_NYMS=] [possible values: true, false]
+      --mnemonic <MNEMONIC>
+          Custom cosmos wallet mnemonic used for zk-nym redemption. If no value is provided, a fresh mnemonic is going to be generated [env: NYMNODE_MNEMONIC=]
+      --upgrade-mode-attestation-url <UPGRADE_MODE_ATTESTATION_URL>
+          Endpoint to query to retrieve current upgrade mode attestation. This argument should never be set outside testnets and local networks [env: NYMNODE_UPGRADE_MODE_ATTESTATION_URL=]
+      --upgrade-mode-attester-public-key <UPGRADE_MODE_ATTESTER_PUBLIC_KEY>
+          Expected public key of the entity signing the published attestation. This argument should never be set outside testnets and local networks [env: NYMNODE_UPGRADE_MODE_ATTESTER_PUBKEY=]
+      --upstream-exit-policy-url <UPSTREAM_EXIT_POLICY_URL>
+          Specifies the url for an upstream source of the exit policy used by this node [env: NYMNODE_UPSTREAM_EXIT_POLICY=]
+      --open-proxy <OPEN_PROXY>
+          Specifies whether this exit node should run in 'open-proxy' mode and thus would attempt to resolve **ANY** request it receives [env: NYMNODE_OPEN_PROXY=] [possible values: true, false]
+      --lp-control-bind-address <LP_CONTROL_BIND_ADDRESS>
+          Bind address for the TCP LP control traffic. default: `[::]:41264` [env: NYMNODE_LP_CONTROL_BIND_ADDRESS=]
+      --lp-control-announce-port <LP_CONTROL_ANNOUNCE_PORT>
+          Custom announced port for listening for the TCP LP control traffic. If unspecified, the value from the `lp_control_bind_address` will be used instead [env: NYMNODE_LP_CONTROL_ANNOUNCE_PORT=]
+      --lp-data-bind-address <LP_DATA_BIND_ADDRESS>
+          Bind address for the UDP LP data traffic. default: `[::]:51264` [env: NYMNODE_LP_DATA_BIND_ADDRESS=]
+      --lp-data-announce-port <LP_DATA_ANNOUNCE_PORT>
+          Custom announced port for listening for the UDP LP data traffic. If unspecified, the value from the `lp_data_bind_address` will be used instead [env: NYMNODE_LP_DATA_ANNOUNCE_PORT=]
+      --lp-use-mock-ecash <LP_USE_MOCK_ECASH>
+          Use mock ecash manager for LP testing. WARNING: Only use this for local testing! Never enable in production. When enabled, the LP listener will accept any credential without blockchain verification [env: NYMNODE_LP_USE_MOCK_ECASH=] [possible values: true, false]
+  -h, --help
+          Print help
 ```

--- a/documentation/docs/components/outputs/command-outputs/nymvisor-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nymvisor-help.md
@@ -11,7 +11,10 @@ Commands:
   help               Print this message or the help of the given subcommand(s)
 
 Options:
-  -c, --config-env-file <CONFIG_ENV_FILE>  Path pointing to an env file that configures the nymvisor and overrides any preconfigured values
-  -h, --help                               Print help
-  -V, --version                            Print version
+  -c, --config-env-file <CONFIG_ENV_FILE>
+          Path pointing to an env file that configures the nymvisor and overrides any preconfigured values
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```

--- a/documentation/docs/pages/operators/nodes/preliminary-steps/vps-setup.mdx
+++ b/documentation/docs/pages/operators/nodes/preliminary-steps/vps-setup.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components';
 import { VarInfo } from 'components/variable-info.tsx';
 import { Steps } from 'nextra/components';import { Tabs } from 'nextra/components';
 import { MyTab } from 'components/generic-tabs.tsx';
-import PortsNymNode from 'components/operators/snippets/ports-nym-node.mdx';
+import TabsPortsNymNode from 'components/operators/snippets/tabs-ports-nym-node.mdx';
 import PortsValidator from 'components/operators/snippets/ports-validator.mdx';
 import NymNodeSpecs from 'components/operators/snippets/nym-node-specs.mdx';
 import NTPSync from 'components/operators/snippets/ntp-time-sync.mdx'
@@ -54,43 +54,19 @@ apt install ufw --fix-missing
 
 <NTPSync />
 
-###### 3. Configure your firewall using Uncomplicated Firewall (UFW)
+###### 3. Configure your firewall
 
-For a `nym-node` or Nyx validator to recieve traffic, you need to open ports on the server. The following commands will allow you to set up a firewall using `ufw`.
-
-- Check if you have `ufw` installed:
-```sh
-ufw version
-```
-- If it's not installed, install with:
-```sh
-apt install ufw -y
-```
-- Enable ufw
-```sh
-ufw enable
-```
-- Check the status of the firewall
-```sh
-ufw status
-```
-
-###### 4. Open all needed ports to have your firewall for `nym-node` working correctly
+For a `nym-node` or Nyx validator to recieve traffic, you need to open ports on the server.
 
 <div>
   <Tabs items={[
     <code>nym-node</code>,
     <code>validator</code>,
     ]} defaultIndex="0">
-    <MyTab><PortsNymNode/></MyTab>
+    <MyTab><TabsPortsNymNode/></MyTab>
     <MyTab><PortsValidator/></MyTab>
   </Tabs>
 </div>
-
-- Re-check the status of the firewall:
-```sh
-ufw status
-```
 
 </Steps>
 

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -1550,6 +1550,7 @@ high level workflows:
   nym_tunnel_setup                  Install tunnel interfaces & setup networking
   configure_network_firewall        Install host firewall rules for nym services
   exit_policy_install               Install and configure wireguard exit policy
+
 tunnel and nat helpers:
   adjust_ip_forwarding              Enable ipv4/ipv6 forwarding via sysctl.d
   apply_iptables_rules              Apply nat/forward rules for ${TUNNEL_INTERFACE}

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -513,7 +513,138 @@ apply_smtps_465_rate_limit() {
 
 
 ###############################################################################
-# part 2: wireguard exit policy manager
+# part 2: host network firewall for nym services
+###############################################################################
+
+NETWORK_FIREWALL_COMMENT="NYM-NETWORK-FW"
+
+delete_managed_input_rules() {
+  local cmd="$1"
+
+  while read -r rule; do
+    [[ -z "$rule" ]] && continue
+    local spec
+    spec="${rule#-A INPUT }"
+    $cmd -D INPUT $spec 2>/dev/null || true
+  done < <($cmd -S INPUT | grep -F -- "$NETWORK_FIREWALL_COMMENT" || true)
+}
+
+add_input_port_rule() {
+  local cmd="$1"
+  local port="$2"
+  local protocol="$3"
+  local iface="${4:-}"
+
+  if [[ -n "$iface" ]]; then
+    if ! $cmd -C INPUT -i "$iface" -p "$protocol" --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+      $cmd -A INPUT -i "$iface" -p "$protocol" --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT
+      ok "added $cmd INPUT $protocol port $port on $iface"
+    fi
+  else
+    if ! $cmd -C INPUT -p "$protocol" --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+      $cmd -A INPUT -p "$protocol" --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT
+      ok "added $cmd INPUT $protocol port $port"
+    fi
+  fi
+}
+
+configure_network_firewall() {
+  info "configuring host network firewall for nym node services"
+
+  delete_managed_input_rules iptables
+  delete_managed_input_rules ip6tables
+
+  local tcp_ports=(22 80 443 1789 1790 8080 9000 9001 41264)
+  local udp_ports=(51822 51264)
+
+  local port
+  for port in "${tcp_ports[@]}"; do
+    add_input_port_rule iptables "$port" tcp
+    add_input_port_rule ip6tables "$port" tcp
+  done
+
+  for port in "${udp_ports[@]}"; do
+    add_input_port_rule iptables "$port" udp
+    add_input_port_rule ip6tables "$port" udp
+  done
+
+  add_input_port_rule iptables 51830 tcp "$WG_INTERFACE"
+  add_input_port_rule ip6tables 51830 tcp "$WG_INTERFACE"
+
+  save_iptables_rules
+  ok "host network firewall configuration completed"
+}
+
+show_network_firewall_status() {
+  info "managed host network firewall rules"
+  echo
+  info "ipv4 input rules:"
+  iptables -L INPUT -n -v --line-numbers | grep -E "($NETWORK_FIREWALL_COMMENT|dpt:22|dpt:80|dpt:443|dpt:1789|dpt:1790|dpt:8080|dpt:9000|dpt:9001|dpt:51822|dpt:51830|dpt:41264|dpt:51264)" || true
+  echo
+  info "ipv6 input rules:"
+  ip6tables -L INPUT -n -v --line-numbers | grep -E "($NETWORK_FIREWALL_COMMENT|dpt:22|dpt:80|dpt:443|dpt:1789|dpt:1790|dpt:8080|dpt:9000|dpt:9001|dpt:51822|dpt:51830|dpt:41264|dpt:51264)" || true
+}
+
+test_network_firewall_rules() {
+  info "testing host network firewall rules"
+
+  local failures=0
+  local tcp_ports=(22 80 443 1789 1790 8080 9000 9001 41264)
+  local udp_ports=(51822 51264)
+  local port
+
+  for port in "${tcp_ports[@]}"; do
+    if iptables -C INPUT -p tcp --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+      ok "ipv4 tcp port $port allowed"
+    else
+      error "ipv4 tcp port $port missing"
+      ((failures++))
+    fi
+
+    if ip6tables -C INPUT -p tcp --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+      ok "ipv6 tcp port $port allowed"
+    else
+      error "ipv6 tcp port $port missing"
+      ((failures++))
+    fi
+  done
+
+  for port in "${udp_ports[@]}"; do
+    if iptables -C INPUT -p udp --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+      ok "ipv4 udp port $port allowed"
+    else
+      error "ipv4 udp port $port missing"
+      ((failures++))
+    fi
+
+    if ip6tables -C INPUT -p udp --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+      ok "ipv6 udp port $port allowed"
+    else
+      error "ipv6 udp port $port missing"
+      ((failures++))
+    fi
+  done
+
+  if iptables -C INPUT -i "$WG_INTERFACE" -p tcp --dport 51830 -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+    ok "ipv4 tcp port 51830 allowed on $WG_INTERFACE"
+  else
+    error "ipv4 tcp port 51830 missing on $WG_INTERFACE"
+    ((failures++))
+  fi
+
+  if ip6tables -C INPUT -i "$WG_INTERFACE" -p tcp --dport 51830 -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+    ok "ipv6 tcp port 51830 allowed on $WG_INTERFACE"
+  else
+    error "ipv6 tcp port 51830 missing on $WG_INTERFACE"
+    ((failures++))
+  fi
+
+  return "$failures"
+}
+
+
+###############################################################################
+# part 3: wireguard exit policy manager
 ###############################################################################
 
 add_port_rules() {
@@ -892,6 +1023,8 @@ show_exit_policy_status() {
   echo
   ip6tables -L "$NYM_CHAIN" -n -v 2>/dev/null || echo "ipv6 chain not found"
   echo
+  show_network_firewall_status
+  echo
   info "ip forwarding:"
   echo "ipv4: $(cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo 0)"
   echo "ipv6: $(cat /proc/sys/net/ipv6/conf/all/forwarding 2>/dev/null || echo 0)"
@@ -942,7 +1075,7 @@ test_exit_policy_connectivity() {
 
 
 ###############################################################################
-# part 3: check the firewall setup
+# part 4: check the firewall setup
 ###############################################################################
 
 firewall_rule_line() {
@@ -1072,7 +1205,7 @@ check_firewall_setup() {
 
 
 ###############################################################################
-# part 4: full exit policy verification tests
+# part 5: full exit policy verification tests
 ###############################################################################
 
 test_port_range_rules() {
@@ -1227,6 +1360,9 @@ exit_policy_run_tests() {
   test_critical_services || ((failed += 1))
   ((total += 1))
 
+  test_network_firewall_rules || ((failed += 1))
+  ((total += 1))
+
   if [[ $skip_default -eq 0 ]]; then
     test_default_reject_rule || ((failed += 1))
     ((total += 1))
@@ -1243,7 +1379,7 @@ exit_policy_run_tests() {
 }
 
 ###############################################################################
-# part 5: high level workflows
+# part 6: high level workflows
 ###############################################################################
 
 nym_tunnel_setup() {
@@ -1286,9 +1422,10 @@ exit_policy_install() {
 }
 
 complete_networking_configuration() {
-  info "starting complete networking configuration: tunnels + exit policy"
+  info "starting complete networking configuration: tunnels + host firewall + exit policy"
 
   nym_tunnel_setup
+  configure_network_firewall
   exit_policy_install
   check_firewall_setup || error "firewall order checks reported problems, please review output"
   exit_policy_run_tests || error "exit policy tests reported problems, please review output"
@@ -1314,6 +1451,12 @@ case "$cmd" in
     ;;
   complete_networking_configuration)
     complete_networking_configuration
+    status=$?
+    ;;
+  
+  # nym firewall setup 
+  configure_network_firewall)
+    configure_network_firewall
     status=$?
     ;;
 
@@ -1403,8 +1546,9 @@ case "$cmd" in
 usage: $0 <command> [args]
 
 high level workflows:
-  complete_networking_configuration Install tunnel interfaces, setup networking, iptables, wg exit policy & tests
-  nym_tunnel_setup                 Install tunnel interfaces & setup networking
+  complete_networking_configuration Install tunnel interfaces, setup networking, host firewall, iptables, wg exit policy & tests
+  nym_tunnel_setup                  Install tunnel interfaces & setup networking
+  configure_network_firewall        Install host firewall rules for nym services
   exit_policy_install               Install and configure wireguard exit policy
 tunnel and nat helpers:
   adjust_ip_forwarding              Enable ipv4/ipv6 forwarding via sysctl.d

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -555,7 +555,7 @@ configure_network_firewall() {
   delete_managed_input_rules ip6tables
 
   local tcp_ports=(22 80 443 1789 1790 8080 9000 9001 41264)
-  local udp_ports=(51822 51264)
+  local udp_ports=(4443 51822 51264)
 
   local port
   for port in "${tcp_ports[@]}"; do

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -1146,21 +1146,15 @@ check_iptables_default_policies() {
   if [[ -z "${input_policy:-}" ]]; then
     error "unable to read INPUT default policy (iptables -S INPUT failed?)"
     issues=1
-  elif [[ "${input_policy^^}" != "DROP" ]]; then
-    error "INPUT default policy is ${input_policy^^}; expected DROP so traffic is only allowed by explicit rules."
-    issues=1
   else
-    ok "INPUT default policy is DROP"
+    info "INPUT default policy is ${input_policy^^}"
   fi
 
   if [[ -z "${forward_policy:-}" ]]; then
     error "unable to read FORWARD default policy (iptables -S FORWARD failed?)"
     issues=1
-  elif [[ "${forward_policy^^}" != "DROP" ]]; then
-    error "FORWARD default policy is ${forward_policy^^}; expected DROP to ensure traffic only flows via NYM-EXIT rules."
-    issues=1
   else
-    ok "FORWARD default policy is DROP"
+    info "FORWARD default policy is ${forward_policy^^}"
   fi
 
   if [[ -z "${output_policy:-}" ]]; then
@@ -1183,6 +1177,7 @@ check_firewall_setup() {
   check_iptables_default_policies || errors=1
   check_forward_chain || errors=1
   check_nym_exit_chain || errors=1
+  test_network_firewall_rules || errors=1
 
   if command -v ip6tables >/dev/null 2>&1; then
     info "checking ipv6 firewall ordering…"
@@ -1195,7 +1190,7 @@ check_firewall_setup() {
   fi
 
   if [[ $errors -ne 0 ]]; then
-    error "There may be some ordering issues, it is recommended to re-run network-tunnel-manager.sh exit_policy_install after configuring UFW."
+    error "There may be some ordering issues, it is recommended to re-run network-tunnel-manager.sh exit_policy_install and review the firewall output above."
     return 1
   fi
 


### PR DESCRIPTION
This PR updates network tunnel manager so that gw (and wg) operators set all firewall rules via NTM and don't have to touch `ufw`, that option will be left only for mixnode operators who in turn don't have to use NTM.  Documentation is updated as well

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6607)
<!-- Reviewable:end -->
