### PR TITLE
nym-node-setup: plumb HOST_SSH_PORT through tunnel manager, CLI, and env setup

### DIFF
--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -556,6 +556,34 @@ apply_smtps_465_rate_limit() {
 ###############################################################################
 
 NETWORK_FIREWALL_COMMENT="NYM-NETWORK-FW"
+SSH_PORT="${SSH_PORT:-22}"
+NETWORK_FIREWALL_TCP_PORTS=("$SSH_PORT" 80 443 1789 1790 8080 9000 9001 41264)
+NETWORK_FIREWALL_UDP_PORTS=(4443 51822 51264)
+NETWORK_FIREWALL_WG_TCP_PORT=51830
+
+validate_port_value() {
+  local name="$1"
+  local value="$2"
+
+  if ! [[ "$value" =~ ^[0-9]+$ ]] || (( 10#$value < 1 || 10#$value > 65535 )); then
+    error "invalid ${name}='${value}'. expected integer 1-65535"
+    exit 1
+  fi
+}
+
+validate_port_value "SSH_PORT" "$SSH_PORT"
+
+build_network_firewall_status_pattern() {
+  local patterns=("$NETWORK_FIREWALL_COMMENT")
+  local port
+
+  for port in "${NETWORK_FIREWALL_TCP_PORTS[@]}" "${NETWORK_FIREWALL_UDP_PORTS[@]}" "$NETWORK_FIREWALL_WG_TCP_PORT"; do
+    patterns+=("dpt:${port}")
+  done
+
+  local IFS='|'
+  printf '%s' "${patterns[*]}"
+}
 
 delete_managed_input_rules() {
   local cmd="$1"
@@ -593,22 +621,19 @@ configure_network_firewall() {
   delete_managed_input_rules iptables
   delete_managed_input_rules ip6tables
 
-  local tcp_ports=(22 80 443 1789 1790 8080 9000 9001 41264)
-  local udp_ports=(4443 51822 51264)
-
   local port
-  for port in "${tcp_ports[@]}"; do
+  for port in "${NETWORK_FIREWALL_TCP_PORTS[@]}"; do
     add_input_port_rule iptables "$port" tcp
     add_input_port_rule ip6tables "$port" tcp
   done
 
-  for port in "${udp_ports[@]}"; do
+  for port in "${NETWORK_FIREWALL_UDP_PORTS[@]}"; do
     add_input_port_rule iptables "$port" udp
     add_input_port_rule ip6tables "$port" udp
   done
 
-  add_input_port_rule iptables 51830 tcp "$WG_INTERFACE"
-  add_input_port_rule ip6tables 51830 tcp "$WG_INTERFACE"
+  add_input_port_rule iptables "$NETWORK_FIREWALL_WG_TCP_PORT" tcp "$WG_INTERFACE"
+  add_input_port_rule ip6tables "$NETWORK_FIREWALL_WG_TCP_PORT" tcp "$WG_INTERFACE"
 
   save_iptables_rules
   ok "host network firewall configuration completed"
@@ -616,23 +641,25 @@ configure_network_firewall() {
 
 show_network_firewall_status() {
   info "managed host network firewall rules"
+  local status_pattern
+
+  status_pattern="$(build_network_firewall_status_pattern)"
+
   echo
   info "ipv4 input rules:"
-  iptables -L INPUT -n -v --line-numbers | grep -E "($NETWORK_FIREWALL_COMMENT|dpt:22|dpt:80|dpt:443|dpt:1789|dpt:1790|dpt:8080|dpt:9000|dpt:9001|dpt:51822|dpt:51830|dpt:41264|dpt:51264)" || true
+  iptables -L INPUT -n -v --line-numbers | grep -E "(${status_pattern})" || true
   echo
   info "ipv6 input rules:"
-  ip6tables -L INPUT -n -v --line-numbers | grep -E "($NETWORK_FIREWALL_COMMENT|dpt:22|dpt:80|dpt:443|dpt:1789|dpt:1790|dpt:8080|dpt:9000|dpt:9001|dpt:51822|dpt:51830|dpt:41264|dpt:51264)" || true
+  ip6tables -L INPUT -n -v --line-numbers | grep -E "(${status_pattern})" || true
 }
 
 test_network_firewall_rules() {
   info "testing host network firewall rules"
 
   local failures=0
-  local tcp_ports=(22 80 443 1789 1790 8080 9000 9001 41264)
-  local udp_ports=(4443 51822 51264)
   local port
 
-  for port in "${tcp_ports[@]}"; do
+  for port in "${NETWORK_FIREWALL_TCP_PORTS[@]}"; do
     if iptables -C INPUT -p tcp --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
       ok "ipv4 tcp port $port allowed"
     else
@@ -648,7 +675,7 @@ test_network_firewall_rules() {
     fi
   done
 
-  for port in "${udp_ports[@]}"; do
+  for port in "${NETWORK_FIREWALL_UDP_PORTS[@]}"; do
     if iptables -C INPUT -p udp --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
       ok "ipv4 udp port $port allowed"
     else
@@ -664,17 +691,17 @@ test_network_firewall_rules() {
     fi
   done
 
-  if iptables -C INPUT -i "$WG_INTERFACE" -p tcp --dport 51830 -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
-    ok "ipv4 tcp port 51830 allowed on $WG_INTERFACE"
+  if iptables -C INPUT -i "$WG_INTERFACE" -p tcp --dport "$NETWORK_FIREWALL_WG_TCP_PORT" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+    ok "ipv4 tcp port $NETWORK_FIREWALL_WG_TCP_PORT allowed on $WG_INTERFACE"
   else
-    error "ipv4 tcp port 51830 missing on $WG_INTERFACE"
+    error "ipv4 tcp port $NETWORK_FIREWALL_WG_TCP_PORT missing on $WG_INTERFACE"
     ((failures++))
   fi
 
-  if ip6tables -C INPUT -i "$WG_INTERFACE" -p tcp --dport 51830 -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
-    ok "ipv6 tcp port 51830 allowed on $WG_INTERFACE"
+  if ip6tables -C INPUT -i "$WG_INTERFACE" -p tcp --dport "$NETWORK_FIREWALL_WG_TCP_PORT" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+    ok "ipv6 tcp port $NETWORK_FIREWALL_WG_TCP_PORT allowed on $WG_INTERFACE"
   else
-    error "ipv6 tcp port 51830 missing on $WG_INTERFACE"
+    error "ipv6 tcp port $NETWORK_FIREWALL_WG_TCP_PORT missing on $WG_INTERFACE"
     ((failures++))
   fi
 

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# nym tunnel and wireguard exit policy manager
+# nym host network firewall, tunnel and wireguard exit policy manager
 # run this script as root
 
 set -euo pipefail
@@ -556,8 +556,8 @@ apply_smtps_465_rate_limit() {
 ###############################################################################
 
 NETWORK_FIREWALL_COMMENT="NYM-NETWORK-FW"
-SSH_PORT="${SSH_PORT:-22}"
-NETWORK_FIREWALL_TCP_PORTS=("$SSH_PORT" 80 443 1789 1790 8080 9000 9001 41264)
+HOST_SSH_PORT="${HOST_SSH_PORT:-22}"
+NETWORK_FIREWALL_TCP_PORTS=("$HOST_SSH_PORT" 80 443 1789 1790 8080 9000 9001 41264)
 NETWORK_FIREWALL_UDP_PORTS=(4443 51822 51264)
 NETWORK_FIREWALL_WG_TCP_PORT=51830
 
@@ -571,7 +571,7 @@ validate_port_value() {
   fi
 }
 
-validate_port_value "SSH_PORT" "$SSH_PORT"
+validate_port_value "HOST_SSH_PORT" "$HOST_SSH_PORT"
 
 build_network_firewall_status_pattern() {
   local patterns=("$NETWORK_FIREWALL_COMMENT")
@@ -1722,6 +1722,7 @@ environment overrides:
   NETWORK_DEVICE_V6                 Auto-detected IPv6 uplink (e.g., eth2). Optional; if unset, IPv6-specific setup is skipped.
   TUNNEL_INTERFACE                  Default: nymtun0. Requires root privileges (sudo) to manage.
   WG_INTERFACE                      Default: nymwg - Must match your WireGuard interface name.
+  HOST_SSH_PORT                     Default: 22. Set manually if you connect to your host's SSH daemon through another port.
 
 EOF
     status=0

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -517,6 +517,34 @@ apply_smtps_465_rate_limit() {
 ###############################################################################
 
 NETWORK_FIREWALL_COMMENT="NYM-NETWORK-FW"
+SSH_PORT="${SSH_PORT:-22}"
+NETWORK_FIREWALL_TCP_PORTS=("$SSH_PORT" 80 443 1789 1790 8080 9000 9001 41264)
+NETWORK_FIREWALL_UDP_PORTS=(4443 51822 51264)
+NETWORK_FIREWALL_WG_TCP_PORT=51830
+
+validate_port_value() {
+  local name="$1"
+  local value="$2"
+
+  if ! [[ "$value" =~ ^[0-9]+$ ]] || (( 10#$value < 1 || 10#$value > 65535 )); then
+    error "invalid ${name}='${value}'. expected integer 1-65535"
+    exit 1
+  fi
+}
+
+validate_port_value "SSH_PORT" "$SSH_PORT"
+
+build_network_firewall_status_pattern() {
+  local patterns=("$NETWORK_FIREWALL_COMMENT")
+  local port
+
+  for port in "${NETWORK_FIREWALL_TCP_PORTS[@]}" "${NETWORK_FIREWALL_UDP_PORTS[@]}" "$NETWORK_FIREWALL_WG_TCP_PORT"; do
+    patterns+=("dpt:${port}")
+  done
+
+  local IFS='|'
+  printf '%s' "${patterns[*]}"
+}
 
 delete_managed_input_rules() {
   local cmd="$1"
@@ -554,22 +582,19 @@ configure_network_firewall() {
   delete_managed_input_rules iptables
   delete_managed_input_rules ip6tables
 
-  local tcp_ports=(22 80 443 1789 1790 8080 9000 9001 41264)
-  local udp_ports=(4443 51822 51264)
-
   local port
-  for port in "${tcp_ports[@]}"; do
+  for port in "${NETWORK_FIREWALL_TCP_PORTS[@]}"; do
     add_input_port_rule iptables "$port" tcp
     add_input_port_rule ip6tables "$port" tcp
   done
 
-  for port in "${udp_ports[@]}"; do
+  for port in "${NETWORK_FIREWALL_UDP_PORTS[@]}"; do
     add_input_port_rule iptables "$port" udp
     add_input_port_rule ip6tables "$port" udp
   done
 
-  add_input_port_rule iptables 51830 tcp "$WG_INTERFACE"
-  add_input_port_rule ip6tables 51830 tcp "$WG_INTERFACE"
+  add_input_port_rule iptables "$NETWORK_FIREWALL_WG_TCP_PORT" tcp "$WG_INTERFACE"
+  add_input_port_rule ip6tables "$NETWORK_FIREWALL_WG_TCP_PORT" tcp "$WG_INTERFACE"
 
   save_iptables_rules
   ok "host network firewall configuration completed"
@@ -577,23 +602,25 @@ configure_network_firewall() {
 
 show_network_firewall_status() {
   info "managed host network firewall rules"
+  local status_pattern
+
+  status_pattern="$(build_network_firewall_status_pattern)"
+
   echo
   info "ipv4 input rules:"
-  iptables -L INPUT -n -v --line-numbers | grep -E "($NETWORK_FIREWALL_COMMENT|dpt:22|dpt:80|dpt:443|dpt:1789|dpt:1790|dpt:8080|dpt:9000|dpt:9001|dpt:51822|dpt:51830|dpt:41264|dpt:51264)" || true
+  iptables -L INPUT -n -v --line-numbers | grep -E "(${status_pattern})" || true
   echo
   info "ipv6 input rules:"
-  ip6tables -L INPUT -n -v --line-numbers | grep -E "($NETWORK_FIREWALL_COMMENT|dpt:22|dpt:80|dpt:443|dpt:1789|dpt:1790|dpt:8080|dpt:9000|dpt:9001|dpt:51822|dpt:51830|dpt:41264|dpt:51264)" || true
+  ip6tables -L INPUT -n -v --line-numbers | grep -E "(${status_pattern})" || true
 }
 
 test_network_firewall_rules() {
   info "testing host network firewall rules"
 
   local failures=0
-  local tcp_ports=(22 80 443 1789 1790 8080 9000 9001 41264)
-  local udp_ports=(51822 51264)
   local port
 
-  for port in "${tcp_ports[@]}"; do
+  for port in "${NETWORK_FIREWALL_TCP_PORTS[@]}"; do
     if iptables -C INPUT -p tcp --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
       ok "ipv4 tcp port $port allowed"
     else
@@ -609,7 +636,7 @@ test_network_firewall_rules() {
     fi
   done
 
-  for port in "${udp_ports[@]}"; do
+  for port in "${NETWORK_FIREWALL_UDP_PORTS[@]}"; do
     if iptables -C INPUT -p udp --dport "$port" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
       ok "ipv4 udp port $port allowed"
     else
@@ -625,17 +652,17 @@ test_network_firewall_rules() {
     fi
   done
 
-  if iptables -C INPUT -i "$WG_INTERFACE" -p tcp --dport 51830 -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
-    ok "ipv4 tcp port 51830 allowed on $WG_INTERFACE"
+  if iptables -C INPUT -i "$WG_INTERFACE" -p tcp --dport "$NETWORK_FIREWALL_WG_TCP_PORT" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+    ok "ipv4 tcp port $NETWORK_FIREWALL_WG_TCP_PORT allowed on $WG_INTERFACE"
   else
-    error "ipv4 tcp port 51830 missing on $WG_INTERFACE"
+    error "ipv4 tcp port $NETWORK_FIREWALL_WG_TCP_PORT missing on $WG_INTERFACE"
     ((failures++))
   fi
 
-  if ip6tables -C INPUT -i "$WG_INTERFACE" -p tcp --dport 51830 -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
-    ok "ipv6 tcp port 51830 allowed on $WG_INTERFACE"
+  if ip6tables -C INPUT -i "$WG_INTERFACE" -p tcp --dport "$NETWORK_FIREWALL_WG_TCP_PORT" -m conntrack --ctstate NEW -m comment --comment "$NETWORK_FIREWALL_COMMENT" -j ACCEPT 2>/dev/null; then
+    ok "ipv6 tcp port $NETWORK_FIREWALL_WG_TCP_PORT allowed on $WG_INTERFACE"
   else
-    error "ipv6 tcp port 51830 missing on $WG_INTERFACE"
+    error "ipv6 tcp port $NETWORK_FIREWALL_WG_TCP_PORT missing on $WG_INTERFACE"
     ((failures++))
   fi
 

--- a/scripts/nym-node-setup/network-tunnel-manager.sh
+++ b/scripts/nym-node-setup/network-tunnel-manager.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# nym tunnel and wireguard exit policy manager
+# nym host network firewall, tunnel and wireguard exit policy manager
 # run this script as root
 
 set -euo pipefail
@@ -517,8 +517,8 @@ apply_smtps_465_rate_limit() {
 ###############################################################################
 
 NETWORK_FIREWALL_COMMENT="NYM-NETWORK-FW"
-SSH_PORT="${SSH_PORT:-22}"
-NETWORK_FIREWALL_TCP_PORTS=("$SSH_PORT" 80 443 1789 1790 8080 9000 9001 41264)
+HOST_SSH_PORT="${HOST_SSH_PORT:-22}"
+NETWORK_FIREWALL_TCP_PORTS=("$HOST_SSH_PORT" 80 443 1789 1790 8080 9000 9001 41264)
 NETWORK_FIREWALL_UDP_PORTS=(4443 51822 51264)
 NETWORK_FIREWALL_WG_TCP_PORT=51830
 
@@ -532,7 +532,7 @@ validate_port_value() {
   fi
 }
 
-validate_port_value "SSH_PORT" "$SSH_PORT"
+validate_port_value "HOST_SSH_PORT" "$HOST_SSH_PORT"
 
 build_network_firewall_status_pattern() {
   local patterns=("$NETWORK_FIREWALL_COMMENT")
@@ -1602,6 +1602,7 @@ environment overrides:
   NETWORK_DEVICE                    Auto-detected uplink (e.g., eth0). Set manually if detection fails.
   TUNNEL_INTERFACE                  Default: nymtun0. Requires root privileges (sudo) to manage.
   WG_INTERFACE                      Default: nymwg - Must match your WireGuard interface name.
+  HOST_SSH_PORT                     Default: 22. Set manually if you connect to your host's SSH daemon through another port.
 
 EOF
     status=0

--- a/scripts/nym-node-setup/nym-node-cli.py
+++ b/scripts/nym-node-setup/nym-node-cli.py
@@ -68,23 +68,60 @@ class NodeSetupCLI:
             print("Without confirming the points above, we cannot continue.")
             exit(1)
     
+    def _coerce_ssh_port(self, value) -> str:
+        sval = str(value).strip() if value is not None else ""
+        if not sval:
+            sval = "22"
+        if not sval.isdigit():
+            print(f"Invalid SSH port: {sval!r}. Expected integer 1..65535.")
+            raise SystemExit(1)
+        port = int(sval, 10)
+        if not 1 <= port <= 65535:
+            print(f"Invalid SSH port: {port}. Expected integer 1..65535.")
+            raise SystemExit(1)
+        return str(port)
+
+    def _resolve_field(args, existing, arg_name, env_key, prompt, *, default=None, validator=None):
+        cli_val = getattr(args, arg_name, None)
+
+        if cli_val is not None:
+            value = str(cli_val).strip()
+        elif existing.get(env_key):
+            value = str(existing[env_key]).strip()
+        else:
+            entered = input(prompt).strip()
+            value = entered if entered else (default if default is not None else "")
+
+        if validator:
+            value = validator(value)
+
+        return value
+
     def ensure_env_values(self, args):
         """Collect env vars from args or prompt interactively, then save to env.sh."""
         env_file = Path("env.sh")
         fields = [
-            ("hostname", "HOSTNAME", "Enter hostname (if you don't use a DNS, press enter): "),
-            ("location", "LOCATION", "Enter node location (country code or name): "),
-            ("email", "EMAIL", "Enter your email: "),
-            ("moniker", "MONIKER", "Enter node public moniker (visible in explorer & NymVPN app): "),
-            ("description", "DESCRIPTION", "Enter short node public description: "),
+            ("hostname", "HOSTNAME", "Enter hostname (if you don't use a DNS, press enter): ", None, None),
+            ("location", "LOCATION", "Enter node location (country code or name): ", None, None),
+            ("email", "EMAIL", "Enter your email: ", None, None),
+            ("moniker", "MONIKER", "Enter node public moniker (visible in explorer & NymVPN app): ", None, None),
+            ("description", "DESCRIPTION", "Enter short node public description: ", None, None),
+            ("host_ssh_port", "HOST_SSH_PORT", "Enter host SSH port (press enter for default port 22): ", "22", self._coerce_ssh_port),
         ]
 
         existing = self._read_env_file(env_file)
         updated = {}
 
-        for arg_name, key, prompt in fields:
-            cli_val = getattr(args, arg_name, None)
-            value = cli_val.strip() if cli_val else existing.get(key) or input(prompt).strip()
+        for arg_name, key, prompt, default, validator in fields:
+            value = self._resolve_field(
+                args,
+                existing,
+                arg_name,
+                key,
+                prompt,
+                default=default,
+                validator=validator,
+            )
             updated[key] = value
             os.environ[key] = value
 
@@ -639,6 +676,13 @@ class ArgParser:
         install_parser.add_argument("--moniker", help="Public moniker displayed in explorer & NymVPN app")
         install_parser.add_argument("--description", help="Short public description of the node")
         install_parser.add_argument("--public-ip", help="External IPv4 address (autodetected if omitted)")
+
+        install_parser.add_argument(
+            "--host-ssh-port",
+            type=int,
+            help="Host SSH port to allow in the firewall (default: 22)",
+        )
+
         install_parser.add_argument("--nym-node-binary", help="URL for nym-node binary (autodetected if omitted)")
         install_parser.add_argument("--uplink-dev", help="Override uplink interface used for NAT/FORWARD (e.g., 'eth0'; autodetected if omitted)")
         

--- a/scripts/nym-node-setup/setup-env-vars.sh
+++ b/scripts/nym-node-setup/setup-env-vars.sh
@@ -19,6 +19,8 @@ while true; do
   read -rp "Enter your email: " EMAIL
   read -rp "Enter node public moniker (visible in the explorer and NymVPN app): " MONIKER
   read -rp "Enter node public description: " DESCRIPTION
+  read -rp "Enter host SSH port (press enter for default port 22): " HOST_SSH_PORT
+  HOST_SSH_PORT="${HOST_SSH_PORT:-22}"
 
   # show summary table
   echo -e "\nPlease confirm the values you entered:"
@@ -28,6 +30,7 @@ while true; do
   printf "%-20s %s\n" "EMAIL:"       "$EMAIL"
   printf "%-20s %s\n" "MONIKER:"     "$MONIKER"
   printf "%-20s %s\n" "DESCRIPTION:" "$DESCRIPTION"
+  printf "%-20s %s\n" "HOST_SSH_PORT:" "$HOST_SSH_PORT"
   echo "---------------------------------------"
 
   read -rp "Are these correct? (y/n): " CONFIRM

--- a/scripts/nym-node-setup/setup-env-vars.sh
+++ b/scripts/nym-node-setup/setup-env-vars.sh
@@ -55,6 +55,7 @@ PUBLIC_IP=${PUBLIC_IP:-""}
   echo "export MONIKER=\"${MONIKER}\""
   echo "export DESCRIPTION=\"${DESCRIPTION}\""
   echo "export PUBLIC_IP=\"${PUBLIC_IP}\""
+  echo "export HOST_SSH_PORT=\"${HOST_SSH_PORT}\""
 } > env.sh
 
 echo -e "\nVariables saved to ./env.sh"


### PR DESCRIPTION
## Summary

This PR makes the host management SSH port configurable across the `nym-node-setup` flow instead of hardcoding port `22` in the tunnel manager.

It also removes host firewall drift in `network-tunnel-manager.sh` by using shared host firewall port definitions for configuration, status, and test output.

## What changed

### `scripts/nym-node-setup/network-tunnel-manager.sh`

- added support for `HOST_SSH_PORT` with a default of `22`
- validate `HOST_SSH_PORT` as an integer in the range `1..65535`
- load values from `ENV_FILE` (or local `env.sh`) so the script can consume operator-provided configuration
- replaced hardcoded host SSH port `22` in host firewall handling
- centralized managed host firewall TCP/UDP port definitions
- fixed the existing drift where UDP `4443` was opened during configuration but not shown in status output or checked in test output

### `scripts/nym-node-setup/nym-node-cli.py`

- added CLI support for `--host-ssh-port`
- plumbed `HOST_SSH_PORT` into the generated `env.sh`
- ensured the CLI validates and persists the configured host SSH port alongside the other setup values

### `scripts/nym-node-setup/setup-env-vars.sh`

- added interactive prompting for `HOST_SSH_PORT`
- validate the entered port before writing `env.sh`
- include `HOST_SSH_PORT` in the confirmation summary
- persist `HOST_SSH_PORT` in the generated env file

## Why

Before this change:

- the host management SSH port was hardcoded to `22`
- the tunnel manager did not cleanly consume a configured host SSH port from the broader setup flow
- the managed host firewall ports were defined separately in multiple places
- UDP `4443` was configured but omitted from status and test output
- the SSH-related naming was ambiguous

Using `HOST_SSH_PORT` makes it explicit that this setting controls the host's management SSH port, not any SSH-related traffic that might be relevant to exit-policy handling.

## Backwards compatibility

- default behavior remains unchanged when `HOST_SSH_PORT` is not set
- the host management SSH port still defaults to `22`
- existing setup flows continue to work without additional input
- operators can now override the host SSH port either interactively, via env, or via CLI

## Examples

Interactive setup:
```bash
./setup-env-vars.sh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6633)
<!-- Reviewable:end -->
