### PR TITLE
Bugfix: Ansible dwl fresh NTM on each run

### DIFF
--- a/ansible/nym-node/roles/tunnel/tasks/main.yml
+++ b/ansible/nym-node/roles/tunnel/tasks/main.yml
@@ -1,11 +1,18 @@
 ---
-- name: Configure tunnel manager
-  tags:
-    - network_tunnel_manager
-  become: true
-  command:
-    cmd: "/root/nym-binaries/network-tunnel-manager.sh {{ item }}"
+- name: Ensure nym binaries directory exists
+  file:
+    path: /root/nym-binaries
+    state: directory
+    mode: "0755"
+
+- name: Download network tunnel manager
+  get_url:
+    url: "{{ tunnel_manager_url }}"
+    dest: /root/nym-binaries/network-tunnel-manager.sh
+    mode: "0755"
+    force: yes
+
+- name: Run network tunnel manager
+  command: "/root/nym-binaries/network-tunnel-manager.sh {{ item }}"
   loop:
     - complete_networking_configuration
-  register: tunnel_mgr
-  failed_when: false


### PR DESCRIPTION
There was a missing part where Ansible playbook didn't download `develop` version of NTM and therefore ppl may have rerun the older version if it already existed in the working dir. this PR fixes that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6654)
<!-- Reviewable:end -->
