### PR TITLE
FIX: add tags to Ansible NTM role

### DIFF
--- a/ansible/nym-node/roles/tunnel/tasks/main.yml
+++ b/ansible/nym-node/roles/tunnel/tasks/main.yml
@@ -4,6 +4,10 @@
     path: /root/nym-binaries
     state: directory
     mode: "0755"
+  tags:
+    - tunnel
+    - network_tunnel_manager
+    - ntm
 
 - name: Download network tunnel manager
   get_url:
@@ -11,8 +15,16 @@
     dest: /root/nym-binaries/network-tunnel-manager.sh
     mode: "0755"
     force: yes
-
+  tags:
+    - tunnel
+    - network_tunnel_manager
+    - ntm
+    
 - name: Run network tunnel manager
   command: "/root/nym-binaries/network-tunnel-manager.sh {{ item }}"
   loop:
     - complete_networking_configuration
+  tags:
+    - tunnel
+    - network_tunnel_manager
+    - ntm


### PR DESCRIPTION
this pr simplifies management of exit policy as it allows ansible user to use the deploy.yml only with NTM role using `-t` flag pointing to the tag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6656)
<!-- Reviewable:end -->
