### PR TITLE
feat: NMv3: Support multiple network monitor agents per host

### DIFF
--- a/common/client-libs/validator-client/src/nyxd/contract_traits/network_monitors_query_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/network_monitors_query_client.rs
@@ -11,7 +11,7 @@ use nym_network_monitors_contract_common::{
     AuthorisedNetworkMonitorsPagedResponse, QueryMsg as NetworkMonitorsQueryMsg,
 };
 use serde::Deserialize;
-use std::net::IpAddr;
+use std::net::SocketAddr;
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -39,7 +39,7 @@ pub trait NetworkMonitorsQueryClient {
 
     async fn get_network_monitor_agents_paged(
         &self,
-        start_next_after: Option<IpAddr>,
+        start_next_after: Option<SocketAddr>,
         limit: Option<u32>,
     ) -> Result<AuthorisedNetworkMonitorsPagedResponse, NyxdError> {
         self.query_network_monitors_contract(NetworkMonitorsQueryMsg::NetworkMonitorAgents {

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/network_monitors_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/network_monitors_signing_client.rs
@@ -8,7 +8,7 @@ use crate::nyxd::{Coin, Fee, SigningCosmWasmClient};
 use crate::signing::signer::OfflineSigner;
 use async_trait::async_trait;
 use nym_network_monitors_contract_common::ExecuteMsg as NetworkMonitorsExecuteMsg;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -89,7 +89,7 @@ pub trait NetworkMonitorsSigningClient {
 
     async fn revoke_network_monitor(
         &self,
-        address: IpAddr,
+        address: SocketAddr,
         fee: Option<Fee>,
     ) -> Result<ExecuteResult, NyxdError> {
         let msg = NetworkMonitorsExecuteMsg::RevokeNetworkMonitor { address };

--- a/common/cosmwasm-smart-contracts/network-monitors-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/network-monitors-contract/src/msg.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use cosmwasm_schema::cw_serde;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
 #[cfg(feature = "schema")]
 use crate::{
@@ -42,7 +42,7 @@ pub enum ExecuteMsg {
     },
 
     /// Revoke network monitor authorisation.
-    RevokeNetworkMonitor { address: IpAddr },
+    RevokeNetworkMonitor { address: SocketAddr },
 
     /// Revoke all network monitor authorisations.
     RevokeAllNetworkMonitors,
@@ -64,7 +64,7 @@ pub enum QueryMsg {
     #[cfg_attr(feature = "schema", returns(AuthorisedNetworkMonitorsPagedResponse))]
     NetworkMonitorAgents {
         /// Pagination control for the values returned by the query. Note that the provided value itself will **not** be used for the response.
-        start_next_after: Option<IpAddr>,
+        start_next_after: Option<SocketAddr>,
 
         /// Controls the maximum number of entries returned by the query. Note that too large values will be overwritten by a saner default.
         limit: Option<u32>,

--- a/common/cosmwasm-smart-contracts/network-monitors-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/network-monitors-contract/src/types.rs
@@ -3,7 +3,7 @@
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Timestamp};
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
 pub type OrchestratorAddress = Addr;
 
@@ -45,5 +45,5 @@ pub struct AuthorisedNetworkMonitorOrchestratorsResponse {
 pub struct AuthorisedNetworkMonitorsPagedResponse {
     pub authorised: Vec<AuthorisedNetworkMonitor>,
 
-    pub start_next_after: Option<IpAddr>,
+    pub start_next_after: Option<SocketAddr>,
 }

--- a/common/nymnoise/src/config.rs
+++ b/common/nymnoise/src/config.rs
@@ -72,6 +72,12 @@ struct NoiseNetworkViewInner {
     nodes: ArcSwap<HashMap<IpAddr, NoiseNode>>,
 }
 
+/// A node in the noise network map, keyed by IP address.
+///
+/// A single IP can correspond to either one nym-node (which has a single noise key)
+/// or one-or-more network monitor agents (each with its own port and noise key).
+/// The two variants have independent lifecycles: nym-node entries come from the
+/// nym-api topology refresher, while agent entries come from blockchain events.
 #[derive(Debug, Clone)]
 pub enum NoiseNode {
     NymNode { key: VersionedNoiseKeyV1 },
@@ -103,6 +109,9 @@ impl NoiseNode {
     }
 }
 
+/// A single network monitor agent identified by its port on a shared host.
+///
+/// Multiple agents may share an IP address but are guaranteed to have unique ports.
 #[derive(Debug, Clone)]
 pub struct NetworkMonitorAgentNode {
     pub port: u16,
@@ -123,6 +132,7 @@ impl NoiseNetworkView {
         Self::new(Default::default())
     }
 
+    /// Build a noise view pre-populated with network monitor agents (used at startup).
     pub fn new_with_agents(agents: HashMap<IpAddr, Vec<NetworkMonitorAgentNode>>) -> Self {
         let mut nodes = HashMap::new();
         for (ip, agent_nodes) in agents {
@@ -190,6 +200,11 @@ impl NoiseConfig {
         self
     }
 
+    /// Look up the noise key for a specific remote socket address.
+    ///
+    /// Used on the **initiator** path where we need the responder's public key
+    /// to start the handshake. For nym-nodes the port is ignored (one key per IP);
+    /// for network monitor agents, the port disambiguates which agent's key to use.
     pub(crate) fn get_noise_key(&self, address: SocketAddr) -> Option<VersionedNoiseKeyV1> {
         let nodes = self.network.inner.nodes.load();
 
@@ -233,6 +248,10 @@ impl NoiseConfig {
     }
 }
 
+/// Resolve the noise key for `address` from a loaded snapshot of the node map.
+///
+/// For [`NoiseNode::NymNode`] entries the port is irrelevant — only the IP is matched.
+/// For [`NoiseNode::NetworkMonitorAgent`] entries the port selects the specific agent.
 fn get_noise_key_from_guard(
     guard: &Guard<Arc<HashMap<IpAddr, NoiseNode>>>,
     address: SocketAddr,
@@ -272,6 +291,199 @@ mod tests {
                 NoisePattern::XKpsk3 => assert_eq!(pattern.psk_position(), 3),
                 NoisePattern::IKpsk2 => assert_eq!(pattern.psk_position(), 2),
             }
+        }
+    }
+
+    mod noise_key_lookup {
+        use super::super::*;
+        use nym_crypto::asymmetric::x25519;
+        use nym_noise_keys::NoiseVersion;
+        use nym_test_utils::helpers::deterministic_rng;
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        fn dummy_key(seed: u8) -> VersionedNoiseKeyV1 {
+            VersionedNoiseKeyV1 {
+                supported_version: NoiseVersion::V1,
+                x25519_pubkey: x25519::PublicKey::from([seed; 32]),
+            }
+        }
+
+        fn make_config(nodes: HashMap<IpAddr, NoiseNode>) -> NoiseConfig {
+            NoiseConfig::new(
+                Arc::new(x25519::KeyPair::new(&mut deterministic_rng())),
+                NoiseNetworkView::new(nodes),
+                Duration::from_secs(5),
+            )
+        }
+
+        // -- get_noise_key tests --
+
+        #[test]
+        fn nym_node_key_returned_regardless_of_port() {
+            let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+            let key = dummy_key(1);
+            let config = make_config(HashMap::from([(ip, NoiseNode::new_nym_node(key))]));
+
+            // any port should resolve to the same key
+            assert_eq!(config.get_noise_key(SocketAddr::new(ip, 1000)), Some(key));
+            assert_eq!(config.get_noise_key(SocketAddr::new(ip, 9999)), Some(key));
+        }
+
+        #[test]
+        fn agent_key_resolved_by_port() {
+            let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+            let key_a = dummy_key(1);
+            let key_b = dummy_key(2);
+
+            let node = NoiseNode::NetworkMonitorAgent {
+                nodes: vec![
+                    NetworkMonitorAgentNode {
+                        port: 1000,
+                        key: key_a,
+                    },
+                    NetworkMonitorAgentNode {
+                        port: 2000,
+                        key: key_b,
+                    },
+                ],
+            };
+            let config = make_config(HashMap::from([(ip, node)]));
+
+            assert_eq!(config.get_noise_key(SocketAddr::new(ip, 1000)), Some(key_a));
+            assert_eq!(config.get_noise_key(SocketAddr::new(ip, 2000)), Some(key_b));
+        }
+
+        #[test]
+        fn agent_unknown_port_returns_none() {
+            let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+            let node = NoiseNode::NetworkMonitorAgent {
+                nodes: vec![NetworkMonitorAgentNode {
+                    port: 1000,
+                    key: dummy_key(1),
+                }],
+            };
+            let config = make_config(HashMap::from([(ip, node)]));
+
+            assert!(config.get_noise_key(SocketAddr::new(ip, 9999)).is_none());
+        }
+
+        #[test]
+        fn completely_unknown_address_returns_none() {
+            let config = make_config(HashMap::new());
+
+            assert!(config
+                .get_noise_key(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 80))
+                .is_none());
+        }
+
+        #[test]
+        fn canonical_ipv6_fallback_for_nym_node() {
+            // register under the plain IPv4 address
+            let v4 = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+            let key = dummy_key(1);
+            let config = make_config(HashMap::from([(v4, NoiseNode::new_nym_node(key))]));
+
+            // query with the IPv4-mapped IPv6 form (::ffff:1.2.3.4)
+            let v6_mapped = IpAddr::V6(Ipv4Addr::new(1, 2, 3, 4).to_ipv6_mapped());
+            assert_eq!(
+                config.get_noise_key(SocketAddr::new(v6_mapped, 1789)),
+                Some(key)
+            );
+        }
+
+        #[test]
+        fn canonical_ipv6_fallback_for_agent() {
+            let v4 = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+            let key = dummy_key(1);
+            let node = NoiseNode::NetworkMonitorAgent {
+                nodes: vec![NetworkMonitorAgentNode { port: 1000, key }],
+            };
+            let config = make_config(HashMap::from([(v4, node)]));
+
+            let v6_mapped = IpAddr::V6(Ipv4Addr::new(1, 2, 3, 4).to_ipv6_mapped());
+            assert_eq!(
+                config.get_noise_key(SocketAddr::new(v6_mapped, 1000)),
+                Some(key)
+            );
+            // wrong port still returns None even with the fallback
+            assert!(config
+                .get_noise_key(SocketAddr::new(v6_mapped, 9999))
+                .is_none());
+        }
+
+        // -- supports_noise tests --
+
+        #[test]
+        fn supports_noise_true_for_nym_node() {
+            let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+            let config = make_config(HashMap::from([(ip, NoiseNode::new_nym_node(dummy_key(1)))]));
+
+            assert!(config.supports_noise(ip));
+        }
+
+        #[test]
+        fn supports_noise_true_for_agent_ip() {
+            let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+            let node = NoiseNode::NetworkMonitorAgent {
+                nodes: vec![NetworkMonitorAgentNode {
+                    port: 1000,
+                    key: dummy_key(1),
+                }],
+            };
+            let config = make_config(HashMap::from([(ip, node)]));
+
+            assert!(config.supports_noise(ip));
+        }
+
+        #[test]
+        fn supports_noise_false_for_unknown_ip() {
+            let config = make_config(HashMap::new());
+
+            assert!(!config.supports_noise(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))));
+        }
+
+        #[test]
+        fn supports_noise_canonical_ipv6_fallback() {
+            let v4 = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+            let config = make_config(HashMap::from([(v4, NoiseNode::new_nym_node(dummy_key(1)))]));
+
+            let v6_mapped = IpAddr::V6(Ipv4Addr::new(1, 2, 3, 4).to_ipv6_mapped());
+            assert!(config.supports_noise(v6_mapped));
+        }
+
+        // -- new_with_agents test --
+
+        #[test]
+        fn new_with_agents_builds_correct_view() {
+            let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+            let key_a = dummy_key(1);
+            let key_b = dummy_key(2);
+
+            let agents = HashMap::from([(
+                ip,
+                vec![
+                    NetworkMonitorAgentNode {
+                        port: 1000,
+                        key: key_a,
+                    },
+                    NetworkMonitorAgentNode {
+                        port: 2000,
+                        key: key_b,
+                    },
+                ],
+            )]);
+
+            let config = NoiseConfig::new(
+                Arc::new(x25519::KeyPair::new(&mut deterministic_rng())),
+                NoiseNetworkView::new_with_agents(agents),
+                Duration::from_secs(5),
+            );
+
+            assert_eq!(config.get_noise_key(SocketAddr::new(ip, 1000)), Some(key_a));
+            assert_eq!(config.get_noise_key(SocketAddr::new(ip, 2000)), Some(key_b));
+            assert!(config.supports_noise(ip));
         }
     }
 }

--- a/common/nymnoise/src/config.rs
+++ b/common/nymnoise/src/config.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use arc_swap::{ArcSwap, Guard};
+use arc_swap::ArcSwap;
 use nym_crypto::asymmetric::x25519;
 use snow::params::NoiseParams;
 use std::{
@@ -120,10 +120,16 @@ pub struct NetworkMonitorAgentNode {
 
 impl NoiseNetworkView {
     pub fn new(nodes: HashMap<IpAddr, NoiseNode>) -> Self {
+        // ensure we're always storing canonical IPs
         NoiseNetworkView {
             inner: Arc::new(NoiseNetworkViewInner {
                 update_lock: Mutex::new(()),
-                nodes: ArcSwap::from_pointee(nodes),
+                nodes: ArcSwap::from_pointee(
+                    nodes
+                        .into_iter()
+                        .map(|(k, v)| (k.to_canonical(), v))
+                        .collect(),
+                ),
             }),
         }
     }
@@ -206,25 +212,19 @@ impl NoiseConfig {
     /// to start the handshake. For nym-nodes the port is ignored (one key per IP);
     /// for network monitor agents, the port disambiguates which agent's key to use.
     pub(crate) fn get_noise_key(&self, address: SocketAddr) -> Option<VersionedNoiseKeyV1> {
+        let ip_to_check = address.ip().to_canonical();
         let nodes = self.network.inner.nodes.load();
 
-        if let Some(key) = get_noise_key_from_guard(&nodes, address) {
-            return Some(key);
-        }
-
-        // When a nym-node binds on `[::]:1789` (the default), it will accept connections on both
-        // IPv4 and IPv6.  If an IPv4 initiator connects, the kernel may present its address to the
-        // responder as an IPv4-mapped IPv6 address (e.g. `::ffff:1.2.3.4`) rather than the plain
-        // IPv4 address (`1.2.3.4`) that was registered in the noise map.
-        // `to_canonical()` strips that mapping so we can find the entry either way.
-        let canonical = SocketAddr::new(address.ip().to_canonical(), address.port());
-        if canonical != address {
-            if let Some(key) = get_noise_key_from_guard(&nodes, canonical) {
-                return Some(key);
+        // Resolve the noise key for `address` from a loaded snapshot of the node map.
+        // For [`NoiseNode::NymNode`] entries the port is irrelevant — only the IP is matched.
+        // For [`NoiseNode::NetworkMonitorAgent`] entries the port selects the specific agent.
+        match nodes.get(&ip_to_check)? {
+            NoiseNode::NymNode { key } => Some(*key),
+            NoiseNode::NetworkMonitorAgent { nodes } => {
+                let port = address.port();
+                nodes.iter().find(|n| n.port == port).map(|n| n.key)
             }
         }
-
-        None
     }
 
     /// Check whether a remote IP is known to support noise.
@@ -233,37 +233,11 @@ impl NoiseConfig {
     // note: in the case of network monitor agents, it must hold
     // that ALL agents on given host support it (or don't support it)
     pub(crate) fn supports_noise(&self, ip_addr: IpAddr) -> bool {
-        let nodes = self.network.inner.nodes.load();
-
-        if nodes.contains_key(&ip_addr) {
-            return true;
-        }
-
-        let canonical = ip_addr.to_canonical();
-        if canonical != ip_addr && nodes.contains_key(&canonical) {
-            return true;
-        }
-
-        false
-    }
-}
-
-/// Resolve the noise key for `address` from a loaded snapshot of the node map.
-///
-/// For [`NoiseNode::NymNode`] entries the port is irrelevant — only the IP is matched.
-/// For [`NoiseNode::NetworkMonitorAgent`] entries the port selects the specific agent.
-fn get_noise_key_from_guard(
-    guard: &Guard<Arc<HashMap<IpAddr, NoiseNode>>>,
-    address: SocketAddr,
-) -> Option<VersionedNoiseKeyV1> {
-    let node = guard.get(&address.ip())?;
-
-    match node {
-        NoiseNode::NymNode { key } => Some(*key),
-        NoiseNode::NetworkMonitorAgent { nodes } => nodes
-            .iter()
-            .find(|n| n.port == address.port())
-            .map(|n| n.key),
+        self.network
+            .inner
+            .nodes
+            .load()
+            .contains_key(&ip_addr.to_canonical())
     }
 }
 

--- a/common/nymnoise/src/config.rs
+++ b/common/nymnoise/src/config.rs
@@ -1,10 +1,15 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, Guard};
 use nym_crypto::asymmetric::x25519;
 use snow::params::NoiseParams;
-use std::{collections::HashMap, net::IpAddr, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
 use strum_macros::{EnumIter, FromRepr};
 use tokio::sync::{Mutex, MutexGuard};
 
@@ -68,35 +73,40 @@ struct NoiseNetworkViewInner {
 }
 
 #[derive(Debug, Clone)]
-pub struct NoiseNode {
-    key: VersionedNoiseKeyV1,
-
-    // Distinguishes nym-node entries (sourced from nym-api topology refreshes) from
-    // network-monitor agent entries (sourced from blockchain events).
-    // This is needed because the two sources have independent lifecycles:
-    // `revoked_all_agents` must wipe NM entries while preserving nym-node entries,
-    // and `refresh_network_nodes` must rebuild nym-node entries without touching NM entries.
-    is_nym_node: bool,
+pub enum NoiseNode {
+    NymNode { key: VersionedNoiseKeyV1 },
+    // due to the structure of network monitor agents,
+    // it is possible to have multiple destinations with the same host ip address,
+    // but a different noise key.
+    // however, we are also guaranteed all of those are going to have a unique port.
+    // note: we're not storing it in a map, since at maximum we might have maybe 20 or so
+    // entries under a single ip address and linear look-up of a vec is faster than the overhead of a hashmap
+    NetworkMonitorAgent { nodes: Vec<NetworkMonitorAgentNode> },
 }
 
 impl NoiseNode {
     pub fn new_nym_node(key: VersionedNoiseKeyV1) -> Self {
-        NoiseNode {
-            key,
-            is_nym_node: true,
-        }
+        NoiseNode::NymNode { key }
     }
 
-    pub fn new_network_monitor_agent(key: VersionedNoiseKeyV1) -> Self {
-        NoiseNode {
-            key,
-            is_nym_node: false,
+    pub fn new_agent(socket_addr: SocketAddr, key: VersionedNoiseKeyV1) -> Self {
+        NoiseNode::NetworkMonitorAgent {
+            nodes: vec![NetworkMonitorAgentNode {
+                port: socket_addr.port(),
+                key,
+            }],
         }
     }
 
     pub fn is_nym_node(&self) -> bool {
-        self.is_nym_node
+        matches!(self, NoiseNode::NymNode { .. })
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct NetworkMonitorAgentNode {
+    pub port: u16,
+    pub key: VersionedNoiseKeyV1,
 }
 
 impl NoiseNetworkView {
@@ -110,12 +120,15 @@ impl NoiseNetworkView {
     }
 
     pub fn new_empty() -> Self {
-        NoiseNetworkView {
-            inner: Arc::new(NoiseNetworkViewInner {
-                update_lock: Mutex::new(()),
-                nodes: Default::default(),
-            }),
+        Self::new(Default::default())
+    }
+
+    pub fn new_with_agents(agents: HashMap<IpAddr, Vec<NetworkMonitorAgentNode>>) -> Self {
+        let mut nodes = HashMap::new();
+        for (ip, agent_nodes) in agents {
+            nodes.insert(ip, NoiseNode::NetworkMonitorAgent { nodes: agent_nodes });
         }
+        Self::new(nodes)
     }
 
     pub async fn get_update_permit(&self) -> MutexGuard<'_, ()> {
@@ -177,24 +190,61 @@ impl NoiseConfig {
         self
     }
 
-    pub(crate) fn get_noise_key(&self, address: IpAddr) -> Option<VersionedNoiseKeyV1> {
+    pub(crate) fn get_noise_key(&self, address: SocketAddr) -> Option<VersionedNoiseKeyV1> {
+        let nodes = self.network.inner.nodes.load();
+
+        if let Some(key) = get_noise_key_from_guard(&nodes, address) {
+            return Some(key);
+        }
+
         // When a nym-node binds on `[::]:1789` (the default), it will accept connections on both
         // IPv4 and IPv6.  If an IPv4 initiator connects, the kernel may present its address to the
         // responder as an IPv4-mapped IPv6 address (e.g. `::ffff:1.2.3.4`) rather than the plain
         // IPv4 address (`1.2.3.4`) that was registered in the noise map.
         // `to_canonical()` strips that mapping so we can find the entry either way.
-        let base_ip = address;
-        let canonical_ip = base_ip.to_canonical();
-
-        if let Some(node) = self.network.inner.nodes.load().get(&base_ip) {
-            return Some(node.key);
+        let canonical = SocketAddr::new(address.ip().to_canonical(), address.port());
+        if canonical != address {
+            if let Some(key) = get_noise_key_from_guard(&nodes, canonical) {
+                return Some(key);
+            }
         }
 
-        Some(self.network.inner.nodes.load().get(&canonical_ip)?.key)
+        None
     }
 
+    /// Check whether a remote IP is known to support noise.
+    /// Used on the responder path where we don't need the remote's key
+    /// (the initiator sends it during the handshake).
+    // note: in the case of network monitor agents, it must hold
+    // that ALL agents on given host support it (or don't support it)
     pub(crate) fn supports_noise(&self, ip_addr: IpAddr) -> bool {
-        self.get_noise_key(ip_addr).is_some()
+        let nodes = self.network.inner.nodes.load();
+
+        if nodes.contains_key(&ip_addr) {
+            return true;
+        }
+
+        let canonical = ip_addr.to_canonical();
+        if canonical != ip_addr && nodes.contains_key(&canonical) {
+            return true;
+        }
+
+        false
+    }
+}
+
+fn get_noise_key_from_guard(
+    guard: &Guard<Arc<HashMap<IpAddr, NoiseNode>>>,
+    address: SocketAddr,
+) -> Option<VersionedNoiseKeyV1> {
+    let node = guard.get(&address.ip())?;
+
+    match node {
+        NoiseNode::NymNode { key } => Some(*key),
+        NoiseNode::NetworkMonitorAgent { nodes } => nodes
+            .iter()
+            .find(|n| n.port == address.port())
+            .map(|n| n.key),
     }
 }
 

--- a/common/nymnoise/src/lib.rs
+++ b/common/nymnoise/src/lib.rs
@@ -66,7 +66,7 @@ pub async fn upgrade_noise_initiator(
         Error::Prereq(Prerequisite::RemotePublicKey)
     })?;
 
-    let Some(key) = config.get_noise_key(responder_addr.ip()) else {
+    let Some(key) = config.get_noise_key(responder_addr) else {
         warn!("{responder_addr} can't speak Noise yet, falling back to TCP");
         return Ok(Connection::Raw(conn));
     };

--- a/contracts/network-monitors/src/queries.rs
+++ b/contracts/network-monitors/src/queries.rs
@@ -9,7 +9,7 @@ use nym_network_monitors_contract_common::{
     AuthorisedNetworkMonitorOrchestratorsResponse, AuthorisedNetworkMonitorsPagedResponse,
     NetworkMonitorsContractError,
 };
-use std::net::IpAddr;
+use std::net::SocketAddr;
 
 pub fn query_admin(deps: Deps) -> Result<AdminResponse, NetworkMonitorsContractError> {
     NETWORK_MONITORS_CONTRACT_STORAGE
@@ -33,7 +33,7 @@ pub fn query_network_monitor_orchestrators(
 
 pub fn query_network_monitor_agents(
     deps: Deps,
-    start_after: Option<IpAddr>,
+    start_after: Option<SocketAddr>,
     limit: Option<u32>,
 ) -> Result<AuthorisedNetworkMonitorsPagedResponse, NetworkMonitorsContractError> {
     let limit = limit
@@ -49,7 +49,7 @@ pub fn query_network_monitor_agents(
         .map(|record| record.map(|(_, details)| details))
         .collect::<StdResult<Vec<_>>>()?;
 
-    let start_next_after = authorised.last().map(|last| last.mixnet_address.ip());
+    let start_next_after = authorised.last().map(|last| last.mixnet_address);
 
     Ok(AuthorisedNetworkMonitorsPagedResponse {
         authorised,
@@ -187,7 +187,7 @@ mod tests {
     mod network_monitor_agents_query {
         use super::*;
         use crate::testing::{
-            init_contract_tester, storage_ip_comp, NetworkMonitorsContract,
+            init_contract_tester, storage_socket_comp, NetworkMonitorsContract,
             NetworkMonitorsContractTesterExt,
         };
         use nym_contracts_common_testing::{ContractOpts, ContractTester};
@@ -202,8 +202,7 @@ mod tests {
                 ips.push(test.random_socket());
             }
 
-            ips.sort_by(|a, b| storage_ip_comp(a.ip(), b.ip()));
-            // ips.into_iter().map(|ip| ip.parse().unwrap()).collect()
+            ips.sort_by(|a, b| storage_socket_comp(*a, *b));
             ips
         }
 
@@ -231,7 +230,7 @@ mod tests {
             let res = query_network_monitor_agents(test.deps(), None, None)?;
 
             assert_eq!(res.authorised.len(), agents.len());
-            assert_eq!(res.start_next_after, agents.last().map(|a| a.ip()));
+            assert_eq!(res.start_next_after, agents.last().copied());
 
             for agent in &agents {
                 assert!(res.authorised.iter().any(|a| a.mixnet_address == *agent));
@@ -254,7 +253,7 @@ mod tests {
             assert_eq!(res.authorised.len(), 2);
             assert_eq!(res.authorised[0].mixnet_address, agents[0]);
             assert_eq!(res.authorised[1].mixnet_address, agents[1]);
-            assert_eq!(res.start_next_after, Some(agents[1].ip()));
+            assert_eq!(res.start_next_after, Some(agents[1]));
 
             Ok(())
         }
@@ -268,12 +267,12 @@ mod tests {
                 test.add_dummy_agent(*agent)
             }
 
-            let res = query_network_monitor_agents(test.deps(), Some(agents[1].ip()), Some(2))?;
+            let res = query_network_monitor_agents(test.deps(), Some(agents[1]), Some(2))?;
 
             assert_eq!(res.authorised.len(), 2);
             assert_eq!(res.authorised[0].mixnet_address, agents[2]);
             assert_eq!(res.authorised[1].mixnet_address, agents[3]);
-            assert_eq!(res.start_next_after, Some(agents[3].ip()));
+            assert_eq!(res.start_next_after, Some(agents[3]));
 
             Ok(())
         }
@@ -300,7 +299,7 @@ mod tests {
             );
             assert_eq!(
                 res.start_next_after,
-                Some(agents[retrieval_limits::AGENTS_MAX_LIMIT as usize - 1].ip())
+                Some(agents[retrieval_limits::AGENTS_MAX_LIMIT as usize - 1])
             );
 
             Ok(())
@@ -315,7 +314,7 @@ mod tests {
                 test.add_dummy_agent(*agent)
             }
 
-            let res = query_network_monitor_agents(test.deps(), Some(agents[2].ip()), Some(10))?;
+            let res = query_network_monitor_agents(test.deps(), Some(agents[2]), Some(10))?;
 
             assert!(res.authorised.is_empty());
             assert_eq!(res.start_next_after, None);
@@ -334,11 +333,14 @@ mod tests {
 
             let res = query_network_monitor_agents(test.deps(), None, None)?;
 
-            assert!(res.authorised.windows(2).all(|window| storage_ip_comp(
-                window[0].mixnet_address.ip(),
-                window[1].mixnet_address.ip()
-            )
-            .is_le()));
+            assert!(res
+                .authorised
+                .windows(2)
+                .all(|window| storage_socket_comp(
+                    window[0].mixnet_address,
+                    window[1].mixnet_address
+                )
+                .is_le()));
 
             Ok(())
         }

--- a/contracts/network-monitors/src/queries.rs
+++ b/contracts/network-monitors/src/queries.rs
@@ -333,14 +333,11 @@ mod tests {
 
             let res = query_network_monitor_agents(test.deps(), None, None)?;
 
-            assert!(res
-                .authorised
-                .windows(2)
-                .all(|window| storage_socket_comp(
-                    window[0].mixnet_address,
-                    window[1].mixnet_address
-                )
-                .is_le()));
+            assert!(res.authorised.windows(2).all(|window| storage_socket_comp(
+                window[0].mixnet_address,
+                window[1].mixnet_address
+            )
+            .is_le()));
 
             Ok(())
         }

--- a/contracts/network-monitors/src/storage.rs
+++ b/contracts/network-monitors/src/storage.rs
@@ -25,10 +25,10 @@ pub struct NetworkMonitorsStorage {
     pub(crate) authorised_agents: Map<AgentStorageKey, AuthorisedNetworkMonitor>,
 }
 
-// implement explicit wrapper for the storage key rather than use string representation
-// to make use of type safety and avoid accidentally mixing up `IpAddr` and `SocketAddr`
+// implement explicit wrapper for the storage key to encode a SocketAddr
+// (IP + port) as a composite storage key, enabling multiple agents per host
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct AgentStorageKey(IpAddr);
+pub(crate) struct AgentStorageKey(SocketAddr);
 
 impl PrimaryKey<'_> for AgentStorageKey {
     type Prefix = ();
@@ -37,40 +37,53 @@ impl PrimaryKey<'_> for AgentStorageKey {
     type SuperSuffix = Self;
 
     fn key(&'_ self) -> Vec<Key<'_>> {
-        match self.0 {
-            IpAddr::V4(ipv4) => vec![Key::Val32(ipv4.octets())],
-            IpAddr::V6(ipv6) => vec![Key::Val128(ipv6.octets())],
+        let port = self.0.port().to_be_bytes();
+        match self.0.ip() {
+            IpAddr::V4(ipv4) => vec![Key::Val32(ipv4.octets()), Key::Val16(port)],
+            IpAddr::V6(ipv6) => vec![Key::Val128(ipv6.octets()), Key::Val16(port)],
         }
     }
 }
 
 impl KeyDeserialize for AgentStorageKey {
     type Output = AgentStorageKey;
-    const KEY_ELEMS: u16 = 1;
+    const KEY_ELEMS: u16 = 2;
 
     fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+        // format: 2-byte length prefix + IP bytes + 2-byte port
+        if value.len() < 4 {
+            return Err(StdError::generic_err("invalid socket address length"));
+        }
+
         // SAFETY: we're using the correct number of bytes for the conversion
         #[allow(clippy::unwrap_used)]
-        let ip = match value.len() {
-            4 => IpAddr::V4(Ipv4Addr::from(TryInto::<[u8; 4]>::try_into(value).unwrap())),
+        let ip_len = u16::from_be_bytes([value[0], value[1]]) as usize;
+        let ip_bytes = &value[2..2 + ip_len];
+        let port_bytes = &value[2 + ip_len..];
+
+        #[allow(clippy::unwrap_used)]
+        let ip = match ip_len {
+            4 => IpAddr::V4(Ipv4Addr::from(
+                TryInto::<[u8; 4]>::try_into(ip_bytes).unwrap(),
+            )),
             16 => IpAddr::V6(Ipv6Addr::from(
-                TryInto::<[u8; 16]>::try_into(value).unwrap(),
+                TryInto::<[u8; 16]>::try_into(ip_bytes).unwrap(),
             )),
             _ => return Err(StdError::generic_err("invalid IP address length")),
         };
-        Ok(AgentStorageKey(ip))
-    }
-}
 
-impl From<IpAddr> for AgentStorageKey {
-    fn from(ip: IpAddr) -> Self {
-        Self(ip)
+        let port = u16::from_be_bytes(
+            TryInto::<[u8; 2]>::try_into(port_bytes)
+                .map_err(|_| StdError::generic_err("invalid port length"))?,
+        );
+
+        Ok(AgentStorageKey(SocketAddr::new(ip, port)))
     }
 }
 
 impl From<SocketAddr> for AgentStorageKey {
     fn from(addr: SocketAddr) -> Self {
-        Self(addr.ip())
+        Self(addr)
     }
 }
 
@@ -226,7 +239,7 @@ impl NetworkMonitorsStorage {
         &self,
         deps: DepsMut,
         sender: &Addr,
-        monitor_address: IpAddr,
+        monitor_address: SocketAddr,
     ) -> Result<(), NetworkMonitorsContractError> {
         // the contract admin or an authorised orchestrator may revoke a monitor
         if !self.is_admin(deps.as_ref(), sender)? && !self.is_orchestrator(deps.as_ref(), sender)? {
@@ -260,6 +273,248 @@ pub mod retrieval_limits {
 
 #[cfg(test)]
 mod tests {
+
+    #[cfg(test)]
+    mod agent_storage_key {
+        use super::super::AgentStorageKey;
+        use cw_storage_plus::{KeyDeserialize, Map, PrimaryKey};
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+        #[test]
+        fn ipv4_key_roundtrips_through_joined_key_and_from_vec() {
+            let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 42)), 8080);
+            let key = AgentStorageKey::from(addr);
+            let joined = key.joined_key();
+            let recovered = AgentStorageKey::from_vec(joined).unwrap();
+            assert_eq!(recovered.0, addr);
+        }
+
+        #[test]
+        fn ipv6_key_roundtrips_through_joined_key_and_from_vec() {
+            let addr = SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+                443,
+            );
+            let key = AgentStorageKey::from(addr);
+            let joined = key.joined_key();
+            let recovered = AgentStorageKey::from_vec(joined).unwrap();
+            assert_eq!(recovered.0, addr);
+        }
+
+        #[test]
+        fn port_zero_roundtrips() {
+            let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 0);
+            let key = AgentStorageKey::from(addr);
+            let joined = key.joined_key();
+            let recovered = AgentStorageKey::from_vec(joined).unwrap();
+            assert_eq!(recovered.0, addr);
+        }
+
+        #[test]
+        fn port_max_roundtrips() {
+            let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), u16::MAX);
+            let key = AgentStorageKey::from(addr);
+            let joined = key.joined_key();
+            let recovered = AgentStorageKey::from_vec(joined).unwrap();
+            assert_eq!(recovered.0, addr);
+        }
+
+        #[test]
+        fn same_ip_different_ports_produce_different_keys() {
+            let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+            let a = AgentStorageKey::from(SocketAddr::new(ip, 1000));
+            let b = AgentStorageKey::from(SocketAddr::new(ip, 2000));
+            assert_ne!(a.joined_key(), b.joined_key());
+        }
+
+        #[test]
+        fn ipv4_keys_sort_by_ip_then_port() {
+            let addrs = [
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 2000),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1000),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 500),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 9999),
+            ];
+
+            let mut keys: Vec<_> = addrs
+                .iter()
+                .map(|a| (AgentStorageKey::from(*a).joined_key(), *a))
+                .collect();
+            keys.sort_by(|a, b| a.0.cmp(&b.0));
+
+            let sorted_addrs: Vec<_> = keys.iter().map(|(_, a)| *a).collect();
+            assert_eq!(
+                sorted_addrs,
+                vec![
+                    // 1.2.3.4 < 10.0.0.1 < 10.0.0.2
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 9999),
+                    // same IP, port 1000 < 2000
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1000),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 2000),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)), 500),
+                ]
+            );
+        }
+
+        #[test]
+        fn ipv4_sorts_before_ipv6() {
+            let v4 = AgentStorageKey::from(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255)),
+                65535,
+            ));
+            let v6 = AgentStorageKey::from(SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                1,
+            ));
+            assert!(v4.joined_key() < v6.joined_key());
+        }
+
+        #[test]
+        fn map_save_and_load_roundtrip_ipv4() {
+            use cosmwasm_std::testing::MockStorage;
+
+            let map: Map<AgentStorageKey, String> = Map::new("test");
+            let mut storage = MockStorage::new();
+
+            let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080);
+            map.save(&mut storage, addr.into(), &"agent-v4".to_string())
+                .unwrap();
+
+            let loaded = map.load(&storage, addr.into()).unwrap();
+            assert_eq!(loaded, "agent-v4");
+        }
+
+        #[test]
+        fn map_save_and_load_roundtrip_ipv6() {
+            use cosmwasm_std::testing::MockStorage;
+
+            let map: Map<AgentStorageKey, String> = Map::new("test");
+            let mut storage = MockStorage::new();
+
+            let addr = SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+                443,
+            );
+            map.save(&mut storage, addr.into(), &"agent-v6".to_string())
+                .unwrap();
+
+            let loaded = map.load(&storage, addr.into()).unwrap();
+            assert_eq!(loaded, "agent-v6");
+        }
+
+        #[test]
+        fn map_stores_same_ip_different_ports_independently() {
+            use cosmwasm_std::testing::MockStorage;
+
+            let map: Map<AgentStorageKey, String> = Map::new("test");
+            let mut storage = MockStorage::new();
+
+            let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+            let agent_a = SocketAddr::new(ip, 1000);
+            let agent_b = SocketAddr::new(ip, 2000);
+
+            map.save(&mut storage, agent_a.into(), &"agent-a".to_string())
+                .unwrap();
+            map.save(&mut storage, agent_b.into(), &"agent-b".to_string())
+                .unwrap();
+
+            assert_eq!(map.load(&storage, agent_a.into()).unwrap(), "agent-a");
+            assert_eq!(map.load(&storage, agent_b.into()).unwrap(), "agent-b");
+        }
+
+        #[test]
+        fn map_remove_one_agent_preserves_other_on_same_ip() {
+            use cosmwasm_std::testing::MockStorage;
+
+            let map: Map<AgentStorageKey, String> = Map::new("test");
+            let mut storage = MockStorage::new();
+
+            let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+            let agent_a = SocketAddr::new(ip, 1000);
+            let agent_b = SocketAddr::new(ip, 2000);
+
+            map.save(&mut storage, agent_a.into(), &"agent-a".to_string())
+                .unwrap();
+            map.save(&mut storage, agent_b.into(), &"agent-b".to_string())
+                .unwrap();
+
+            map.remove(&mut storage, agent_a.into());
+
+            assert!(map.may_load(&storage, agent_a.into()).unwrap().is_none());
+            assert_eq!(map.load(&storage, agent_b.into()).unwrap(), "agent-b");
+        }
+
+        #[test]
+        fn map_range_returns_correct_order_with_mixed_ips_and_ports() {
+            use cosmwasm_std::testing::MockStorage;
+            use cosmwasm_std::{Order, StdResult};
+
+            let map: Map<AgentStorageKey, String> = Map::new("test");
+            let mut storage = MockStorage::new();
+
+            let addrs = [
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 2000),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1000),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 80),
+                SocketAddr::new(
+                    IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                    443,
+                ),
+            ];
+
+            for addr in &addrs {
+                map.save(&mut storage, (*addr).into(), &addr.to_string())
+                    .unwrap();
+            }
+
+            let all: Vec<SocketAddr> = map
+                .range(&storage, None, None, Order::Ascending)
+                .map(|r: StdResult<(AgentStorageKey, String)>| r.unwrap().0 .0)
+                .collect();
+
+            assert_eq!(
+                all,
+                vec![
+                    // IPv4 sorted by octets, then port
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 80),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1000),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 2000),
+                    // IPv6 after all IPv4
+                    SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 443),
+                ]
+            );
+        }
+
+        #[test]
+        fn map_range_with_exclusive_bound_skips_exact_match() {
+            use cosmwasm_std::testing::MockStorage;
+            use cosmwasm_std::{Order, StdResult};
+            use cw_storage_plus::Bound;
+
+            let map: Map<AgentStorageKey, String> = Map::new("test");
+            let mut storage = MockStorage::new();
+
+            let addrs = [
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1000),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 2000),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 3000),
+            ];
+
+            for addr in &addrs {
+                map.save(&mut storage, (*addr).into(), &addr.to_string())
+                    .unwrap();
+            }
+
+            // paginate after the second entry
+            let start = Bound::exclusive(AgentStorageKey::from(addrs[1]));
+            let page: Vec<SocketAddr> = map
+                .range(&storage, Some(start), None, Order::Ascending)
+                .map(|r: StdResult<(AgentStorageKey, String)>| r.unwrap().0 .0)
+                .collect();
+
+            assert_eq!(page, vec![addrs[2]]);
+        }
+    }
 
     #[cfg(test)]
     mod network_monitors_storage {
@@ -931,12 +1186,12 @@ mod tests {
 
                 let deps = tester.deps_mut();
                 let res = storage
-                    .remove_monitor_authorisation(deps, &non_privileged, agent.ip())
+                    .remove_monitor_authorisation(deps, &non_privileged, agent)
                     .unwrap_err();
                 assert_eq!(NetworkMonitorsContractError::Unauthorized, res);
 
                 let deps = tester.deps_mut();
-                let res2 = storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip());
+                let res2 = storage.remove_monitor_authorisation(deps, &orchestrator, agent);
                 assert_eq!(res2, Ok(()));
 
                 Ok(())
@@ -999,7 +1254,7 @@ mod tests {
                     .is_some());
 
                 let deps = tester.deps_mut();
-                storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip())?;
+                storage.remove_monitor_authorisation(deps, &orchestrator, agent)?;
 
                 assert!(storage
                     .authorised_agents
@@ -1028,7 +1283,7 @@ mod tests {
                     .is_some());
 
                 let deps = tester.deps_mut();
-                storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip())?;
+                storage.remove_monitor_authorisation(deps, &orchestrator, agent)?;
 
                 assert!(storage
                     .authorised_agents
@@ -1052,7 +1307,7 @@ mod tests {
                     .is_none());
 
                 let deps = tester.deps_mut();
-                let res = storage.remove_monitor_authorisation(deps, &orchestrator, agent.ip());
+                let res = storage.remove_monitor_authorisation(deps, &orchestrator, agent);
                 assert_eq!(res, Ok(()));
 
                 assert!(storage

--- a/contracts/network-monitors/src/storage.rs
+++ b/contracts/network-monitors/src/storage.rs
@@ -25,8 +25,18 @@ pub struct NetworkMonitorsStorage {
     pub(crate) authorised_agents: Map<AgentStorageKey, AuthorisedNetworkMonitor>,
 }
 
-// implement explicit wrapper for the storage key to encode a SocketAddr
-// (IP + port) as a composite storage key, enabling multiple agents per host
+/// CosmWasm storage key encoding a [`SocketAddr`] as a composite primary key.
+///
+/// ## On-disk layout
+///
+/// The key is encoded as two elements (see [`PrimaryKey::key`]):
+///   1. IP octets — `Val32` (4 bytes) for IPv4, `Val128` (16 bytes) for IPv6
+///   2. Port — `Val16` (2 bytes, big-endian)
+///
+/// cw-storage-plus prepends each element with a 2-byte big-endian length prefix,
+/// so the full byte sequence is `[0, ip_len][ip_octets...][0, 2][port_be]`.
+/// This means IPv4 keys naturally sort before IPv6, and within the same IP
+/// family keys sort by IP octets then by port.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct AgentStorageKey(SocketAddr);
 
@@ -456,10 +466,7 @@ mod tests {
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 2000),
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 1000),
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 80),
-                SocketAddr::new(
-                    IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-                    443,
-                ),
+                SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 443),
             ];
 
             for addr in &addrs {

--- a/contracts/network-monitors/src/storage.rs
+++ b/contracts/network-monitors/src/storage.rs
@@ -1225,7 +1225,7 @@ mod tests {
                 )?;
 
                 let deps = tester.deps_mut();
-                storage.remove_monitor_authorisation(deps, &admin, agent.ip())?;
+                storage.remove_monitor_authorisation(deps, &admin, agent)?;
 
                 assert!(storage
                     .authorised_agents

--- a/contracts/network-monitors/src/testing/mod.rs
+++ b/contracts/network-monitors/src/testing/mod.rs
@@ -171,11 +171,18 @@ pub trait NetworkMonitorsContractTesterExt:
 
 impl NetworkMonitorsContractTesterExt for ContractTester<NetworkMonitorsContract> {}
 
-pub(crate) fn storage_ip_comp(a: IpAddr, b: IpAddr) -> std::cmp::Ordering {
-    match (a, b) {
+/// Compare SocketAddrs in the same order as the storage key encoding.
+///
+/// Storage keys are: `[0, ip_len] [ip_octets...] [port_be_bytes]`
+/// This means IPv4 (len=4) always sorts before IPv6 (len=16),
+/// within the same type keys sort by IP octets then by port.
+pub(crate) fn storage_socket_comp(a: SocketAddr, b: SocketAddr) -> std::cmp::Ordering {
+    let ip_ord = match (a.ip(), b.ip()) {
         (IpAddr::V4(a), IpAddr::V4(b)) => a.octets().cmp(&b.octets()),
         (IpAddr::V6(a), IpAddr::V6(b)) => a.octets().cmp(&b.octets()),
-        (IpAddr::V4(a), IpAddr::V6(b)) => a.octets().as_slice().cmp(&b.octets()),
-        (IpAddr::V6(a), IpAddr::V4(b)) => a.octets().as_slice().cmp(&b.octets()),
-    }
+        // length prefix [0, 4] < [0, 16] so all IPv4 sorts before all IPv6
+        (IpAddr::V4(_), IpAddr::V6(_)) => std::cmp::Ordering::Less,
+        (IpAddr::V6(_), IpAddr::V4(_)) => std::cmp::Ordering::Greater,
+    };
+    ip_ord.then(a.port().cmp(&b.port()))
 }

--- a/contracts/network-monitors/src/transactions.rs
+++ b/contracts/network-monitors/src/transactions.rs
@@ -4,7 +4,7 @@
 use crate::storage::NETWORK_MONITORS_CONTRACT_STORAGE;
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
 use nym_network_monitors_contract_common::NetworkMonitorsContractError;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
 pub fn try_update_contract_admin(
     deps: DepsMut<'_>,
@@ -90,7 +90,7 @@ pub fn try_authorise_network_monitor(
 pub fn try_revoke_network_monitor(
     deps: DepsMut<'_>,
     info: MessageInfo,
-    network_monitor_address: IpAddr,
+    network_monitor_address: SocketAddr,
 ) -> Result<Response, NetworkMonitorsContractError> {
     NETWORK_MONITORS_CONTRACT_STORAGE.remove_monitor_authorisation(
         deps,
@@ -537,10 +537,8 @@ mod tests {
 
             let res = test.execute_raw(
                 orchestrator,
-                ExecuteMsg::RevokeNetworkMonitor {
-                    address: agent.ip(),
-                },
-            );
+                    ExecuteMsg::RevokeNetworkMonitor { address: agent },
+                );
             assert!(res.is_ok());
 
             Ok(())
@@ -566,7 +564,7 @@ mod tests {
             let res = test.execute_raw(
                 admin,
                 ExecuteMsg::RevokeNetworkMonitor {
-                    address: agent.ip(),
+                    address: agent,
                 },
             );
             assert!(res.is_ok());
@@ -633,7 +631,7 @@ mod tests {
             test.execute_raw(
                 orchestrator,
                 ExecuteMsg::RevokeNetworkMonitor {
-                    address: agent.ip(),
+                    address: agent,
                 },
             )?;
 
@@ -659,7 +657,7 @@ mod tests {
             let res = test.execute_raw(
                 orchestrator,
                 ExecuteMsg::RevokeNetworkMonitor {
-                    address: agent.ip(),
+                    address: agent,
                 },
             );
             assert!(res.is_ok());
@@ -668,6 +666,65 @@ mod tests {
                 .authorised_agents
                 .may_load(test.storage(), agent.into())?
                 .is_none());
+
+            Ok(())
+        }
+
+        #[test]
+        fn revoking_one_agent_preserves_other_on_same_host() -> anyhow::Result<()> {
+            use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+            let mut test = init_contract_tester();
+            let orchestrator = test.add_orchestrator()?;
+
+            // two agents on the same IP but different ports
+            let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+            let agent_a = SocketAddr::new(ip, 1000);
+            let agent_b = SocketAddr::new(ip, 2000);
+
+            test.execute_raw(
+                orchestrator.clone(),
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent_a,
+                    bs58_x25519_noise: "noise_key_a".to_string(),
+                    noise_version: 1,
+                },
+            )?;
+            test.execute_raw(
+                orchestrator.clone(),
+                ExecuteMsg::AuthoriseNetworkMonitor {
+                    mixnet_address: agent_b,
+                    bs58_x25519_noise: "noise_key_b".to_string(),
+                    noise_version: 1,
+                },
+            )?;
+
+            // both exist
+            assert!(NETWORK_MONITORS_CONTRACT_STORAGE
+                .authorised_agents
+                .may_load(test.storage(), agent_a.into())?
+                .is_some());
+            assert!(NETWORK_MONITORS_CONTRACT_STORAGE
+                .authorised_agents
+                .may_load(test.storage(), agent_b.into())?
+                .is_some());
+
+            // revoke agent_a
+            test.execute_raw(
+                orchestrator,
+                ExecuteMsg::RevokeNetworkMonitor { address: agent_a },
+            )?;
+
+            // agent_a gone, agent_b still present
+            assert!(NETWORK_MONITORS_CONTRACT_STORAGE
+                .authorised_agents
+                .may_load(test.storage(), agent_a.into())?
+                .is_none());
+            let remaining = NETWORK_MONITORS_CONTRACT_STORAGE
+                .authorised_agents
+                .load(test.storage(), agent_b.into())?;
+            assert_eq!(remaining.mixnet_address, agent_b);
+            assert_eq!(remaining.bs58_x25519_noise, "noise_key_b");
 
             Ok(())
         }

--- a/contracts/network-monitors/src/transactions.rs
+++ b/contracts/network-monitors/src/transactions.rs
@@ -537,8 +537,8 @@ mod tests {
 
             let res = test.execute_raw(
                 orchestrator,
-                    ExecuteMsg::RevokeNetworkMonitor { address: agent },
-                );
+                ExecuteMsg::RevokeNetworkMonitor { address: agent },
+            );
             assert!(res.is_ok());
 
             Ok(())
@@ -561,10 +561,7 @@ mod tests {
                 },
             )?;
 
-            let res = test.execute_raw(
-                admin,
-                ExecuteMsg::RevokeNetworkMonitor { address: agent },
-            );
+            let res = test.execute_raw(admin, ExecuteMsg::RevokeNetworkMonitor { address: agent });
             assert!(res.is_ok());
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
@@ -595,9 +592,7 @@ mod tests {
             let res = test
                 .execute_raw(
                     non_privileged,
-                    ExecuteMsg::RevokeNetworkMonitor {
-                        address: agent.ip(),
-                    },
+                    ExecuteMsg::RevokeNetworkMonitor { address: agent },
                 )
                 .unwrap_err();
 
@@ -676,11 +671,15 @@ mod tests {
             let agent_a = SocketAddr::new(ip, 1000);
             let agent_b = SocketAddr::new(ip, 2000);
 
+            // two syntactically valid (32-byte) bs58 x25519 keys
+            let noise_key_a = TEST_NOISE_KEY.to_string();
+            let noise_key_b = "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi".to_string();
+
             test.execute_raw(
                 orchestrator.clone(),
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent_a,
-                    bs58_x25519_noise: "noise_key_a".to_string(),
+                    bs58_x25519_noise: noise_key_a,
                     noise_version: 1,
                 },
             )?;
@@ -688,7 +687,7 @@ mod tests {
                 orchestrator.clone(),
                 ExecuteMsg::AuthoriseNetworkMonitor {
                     mixnet_address: agent_b,
-                    bs58_x25519_noise: "noise_key_b".to_string(),
+                    bs58_x25519_noise: noise_key_b.clone(),
                     noise_version: 1,
                 },
             )?;
@@ -718,7 +717,10 @@ mod tests {
                 .authorised_agents
                 .load(test.storage(), agent_b.into())?;
             assert_eq!(remaining.mixnet_address, agent_b);
-            assert_eq!(remaining.bs58_x25519_noise, "noise_key_b");
+            assert_eq!(
+                remaining.bs58_x25519_noise,
+                "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi"
+            );
 
             Ok(())
         }

--- a/contracts/network-monitors/src/transactions.rs
+++ b/contracts/network-monitors/src/transactions.rs
@@ -563,9 +563,7 @@ mod tests {
 
             let res = test.execute_raw(
                 admin,
-                ExecuteMsg::RevokeNetworkMonitor {
-                    address: agent,
-                },
+                ExecuteMsg::RevokeNetworkMonitor { address: agent },
             );
             assert!(res.is_ok());
 
@@ -630,9 +628,7 @@ mod tests {
 
             test.execute_raw(
                 orchestrator,
-                ExecuteMsg::RevokeNetworkMonitor {
-                    address: agent,
-                },
+                ExecuteMsg::RevokeNetworkMonitor { address: agent },
             )?;
 
             assert!(NETWORK_MONITORS_CONTRACT_STORAGE
@@ -656,9 +652,7 @@ mod tests {
 
             let res = test.execute_raw(
                 orchestrator,
-                ExecuteMsg::RevokeNetworkMonitor {
-                    address: agent,
-                },
+                ExecuteMsg::RevokeNetworkMonitor { address: agent },
             );
             assert!(res.is_ok());
 

--- a/nym-network-monitor-v3/nym-network-monitor-agent/src/agent/tested_node.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-agent/src/agent/tested_node.rs
@@ -33,8 +33,8 @@ impl TestedNodeDetails {
     /// Returns a [`NoiseNode`] representation of this node for use in the Noise network view.
     pub(crate) fn as_noise_node(&self) -> NoiseNode {
         NoiseNode::new_nym_node(VersionedNoiseKeyV1 {
-            x25519_pubkey: self.noise_key,
             supported_version: NoiseVersion::V1,
+            x25519_pubkey: self.noise_key,
         })
     }
 }

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/http/api/mod.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/http/api/mod.rs
@@ -35,6 +35,8 @@ pub(crate) fn build_router(
 
     Router::new()
         .route(routes::ROOT, swagger_redirect())
+        .route("/swagger/", swagger_redirect())
+        .route("/swagger/index.html", swagger_redirect())
         .merge(api_docs::route())
         .nest(routes::V1, v1::routes(agents_auth, metrics_auth))
         .layer(axum::middleware::from_fn(log_request_debug))

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/mod.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/mod.rs
@@ -156,7 +156,6 @@ impl NetworkMonitorOrchestrator {
         );
         self.shutdown_manager
             .try_spawn_named(http_server_fut, "http-server");
-
         // node refresher
         self.shutdown_manager.try_spawn_named(
             async move {

--- a/nym-node/src/node/mod.rs
+++ b/nym-node/src/node/mod.rs
@@ -69,12 +69,13 @@ use nym_node_metrics::events::MetricEventsSender;
 use nym_node_requests::api::SignedData;
 use nym_node_requests::api::v1::lewes_protocol::models::{LPHashFunction, LPKEM, LewesProtocol};
 use nym_node_requests::api::v1::node::models::{AnnouncePorts, NodeDescription};
-use nym_noise::config::{NoiseConfig, NoiseNetworkView};
+use nym_noise::config::{NetworkMonitorAgentNode, NoiseConfig, NoiseNetworkView};
 use nym_noise_keys::VersionedNoiseKeyV1;
 use nym_sphinx_acknowledgements::AckKey;
 use nym_sphinx_addressing::Recipient;
 use nym_task::{ShutdownManager, ShutdownToken, ShutdownTracker};
 use nym_validator_client::nyxd::contract_traits::PagedNetworkMonitorsQueryClient;
+use nym_validator_client::nyxd::nym_network_monitors_contract_common::AuthorisedNetworkMonitor;
 use nym_validator_client::{QueryHttpRpcNyxdClient, UserAgent};
 use nym_verloc::measurements::SharedVerlocStats;
 use nym_verloc::{self, measurements::VerlocMeasurer};
@@ -83,13 +84,13 @@ use nyxd_scraper_shared::watcher::{NyxdWatcher, WatcherConfig};
 use rand::rngs::OsRng;
 use rand::{CryptoRng, RngCore};
 use rand09::SeedableRng;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::{IpAddr, SocketAddr};
 use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{debug, info, trace};
+use tracing::{debug, error, info, trace};
 use zeroize::Zeroizing;
 
 pub mod bonding_information;
@@ -1351,7 +1352,7 @@ impl NymNode {
         Ok(())
     }
 
-    async fn known_network_monitors(&self) -> Result<HashSet<IpAddr>, NymNodeError> {
+    async fn known_network_monitors(&self) -> Result<Vec<AuthorisedNetworkMonitor>, NymNodeError> {
         // 1. create a nyx rpc client
         // (TODO: we should have unified client later on for all chain interactions)
         let client = QueryHttpRpcNyxdClient::connect_with_network_details(
@@ -1359,13 +1360,8 @@ impl NymNode {
             self.network.clone(),
         )?;
 
-        // 2. run the queries to retrieve all known ip addresses of the agents
-        Ok(client
-            .get_all_network_monitor_agents()
-            .await?
-            .into_iter()
-            .map(|agent| agent.mixnet_address.ip())
-            .collect())
+        // 2. run the queries to retrieve all agents
+        Ok(client.get_all_network_monitor_agents().await?)
     }
 
     async fn setup_nyx_chain_watcher(
@@ -1446,12 +1442,38 @@ impl NymNode {
         // obtain the initial list of known network monitors
         let known_network_monitors = self.known_network_monitors().await?;
 
+        let mut known_network_monitor_ips = HashSet::new();
+        let mut known_network_monitor_nodes: HashMap<IpAddr, Vec<NetworkMonitorAgentNode>> =
+            HashMap::new();
+        for agent in known_network_monitors {
+            let Ok(x25519_pubkey) = x25519::PublicKey::from_base58_string(&agent.bs58_x25519_noise)
+            else {
+                error!(
+                    "network monitor agent {} has announced an invalid noise key - ignoring",
+                    agent.mixnet_address
+                );
+                continue;
+            };
+
+            let ip = agent.mixnet_address.ip();
+            known_network_monitor_ips.insert(ip);
+
+            let entry = known_network_monitor_nodes.entry(ip).or_default();
+            entry.push(NetworkMonitorAgentNode {
+                port: agent.mixnet_address.port(),
+                key: VersionedNoiseKeyV1 {
+                    supported_version: agent.noise_version.into(),
+                    x25519_pubkey,
+                },
+            })
+        }
+
         // build routing filter
         let routing_filter = NetworkRoutingFilter::new_empty(self.config.debug.testnet)
-            .with_known_network_monitors(known_network_monitors);
+            .with_known_network_monitors(known_network_monitor_ips);
         let network_monitors_ref = routing_filter.known_network_monitors_handle();
 
-        let noise_view = NoiseNetworkView::new_empty();
+        let noise_view = NoiseNetworkView::new_with_agents(known_network_monitor_nodes);
         // retrieve the initial view of the network and update the known set of nym nodes in the routing filter
         let network_refresher = self
             .build_network_refresher(

--- a/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
+++ b/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
@@ -22,15 +22,15 @@
 use crate::node::routing_filter::network_filter::RoutableNetworkMonitors;
 use async_trait::async_trait;
 use nym_crypto::asymmetric::x25519;
-use nym_noise::config::{NoiseNetworkView, NoiseNode};
+use nym_noise::config::{NetworkMonitorAgentNode, NoiseNetworkView, NoiseNode};
 use nym_noise_keys::{NoiseVersion, VersionedNoiseKeyV1};
 use nym_validator_client::nyxd::cosmwasm::MsgExecuteContract;
 use nym_validator_client::nyxd::nym_network_monitors_contract_common::ExecuteMsg;
 use nym_validator_client::nyxd::{AccountId, Any, Msg, Name};
 use nyxd_scraper_shared::error::ScraperError;
 use nyxd_scraper_shared::{DecodedMessage, MsgModule, ParsedTransactionDetails, parse_msg};
-use std::net::{IpAddr, SocketAddr};
-use tracing::{debug, error, info};
+use std::net::SocketAddr;
+use tracing::{debug, error, info, warn};
 
 /// Blockchain message handler for Network Monitor agent authorisation events.
 ///
@@ -63,7 +63,12 @@ impl NetworkMonitorAgentsModule {
     }
 
     /// Register a newly authorised NM agent in both the routing filter and the noise key map.
-    async fn new_agent(&self, address: SocketAddr, bs58_x25519_noise: String, noise_version: u8) {
+    async fn new_agent(
+        &mut self,
+        address: SocketAddr,
+        bs58_x25519_noise: String,
+        noise_version: u8,
+    ) {
         debug!("adding new NM agent {address}");
 
         let Ok(x25519_pubkey) = x25519::PublicKey::from_base58_string(&bs58_x25519_noise) else {
@@ -76,30 +81,73 @@ impl NetworkMonitorAgentsModule {
             x25519_pubkey,
         };
 
-        // add ip to the routing filter
+        // add ip to the routing filter (it's a no-op if it already exists)
         self.routable_network_monitors.add_known(address.ip());
 
         // add noise key to the known nodes
         let update_permit = self.noise_view.get_update_permit().await;
         let mut nodes = self.noise_view.all_nodes();
-        nodes.insert(address.ip(), NoiseNode::new_network_monitor_agent(key));
+        let ip = address.ip();
+        match nodes.get_mut(&ip) {
+            None => {
+                nodes.insert(ip, NoiseNode::new_agent(address, key));
+            }
+            Some(existing_entry) => match existing_entry {
+                NoiseNode::NymNode { .. } => {
+                    error!(
+                        "the authorised agent runs on the same host as a known nym-node! ignoring"
+                    );
+                }
+                NoiseNode::NetworkMonitorAgent { nodes } => {
+                    nodes.push(NetworkMonitorAgentNode {
+                        port: address.port(),
+                        key,
+                    });
+                }
+            },
+        }
+
         self.noise_view.swap_view(update_permit, nodes);
     }
 
-    async fn revoked_agent(&self, address: IpAddr) {
+    async fn revoked_agent(&mut self, address: SocketAddr) {
         debug!("revoking NM agent {address}");
 
-        // remove ip from the routing filter
-        self.routable_network_monitors.remove_known(address);
+        let ip = address.ip();
 
-        // remove noise key from the known nodes
         let update_permit = self.noise_view.get_update_permit().await;
         let mut nodes = self.noise_view.all_nodes();
-        nodes.remove(&address);
+
+        let mut final_agent = false;
+        match nodes.get_mut(&ip) {
+            None => {
+                warn!("attempted to revoke a non-existent agent at {address}");
+                return;
+            }
+            Some(node) => match node {
+                NoiseNode::NymNode { .. } => {
+                    error!(
+                        "the revoked agent runs on the same host as a known nym-node! ignoring the revocation"
+                    );
+                    return;
+                }
+                NoiseNode::NetworkMonitorAgent { nodes } => {
+                    nodes.retain(|agent| agent.port != address.port());
+                    if nodes.is_empty() {
+                        final_agent = true;
+                    }
+                }
+            },
+        }
+
+        if final_agent {
+            nodes.remove(&ip);
+            self.routable_network_monitors.remove_known(ip);
+        }
         self.noise_view.swap_view(update_permit, nodes);
     }
 
-    async fn revoked_all_agents(&self) {
+    async fn revoked_all_agents(&mut self) {
         info!("revoking all NM agents");
 
         self.routable_network_monitors.reset();

--- a/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
+++ b/nym-node/src/node/nyxd_watcher/network_monitor_agents.rs
@@ -88,6 +88,8 @@ impl NetworkMonitorAgentsModule {
         let update_permit = self.noise_view.get_update_permit().await;
         let mut nodes = self.noise_view.all_nodes();
         let ip = address.ip();
+        let port = address.port();
+
         match nodes.get_mut(&ip) {
             None => {
                 nodes.insert(ip, NoiseNode::new_agent(address, key));
@@ -99,10 +101,11 @@ impl NetworkMonitorAgentsModule {
                     );
                 }
                 NoiseNode::NetworkMonitorAgent { nodes } => {
-                    nodes.push(NetworkMonitorAgentNode {
-                        port: address.port(),
-                        key,
-                    });
+                    if let Some(existing) = nodes.iter_mut().find(|n| n.port == address.port()) {
+                        existing.key = key;
+                    } else {
+                        nodes.push(NetworkMonitorAgentNode { port, key });
+                    }
                 }
             },
         }


### PR DESCRIPTION
NYM-1118

**Summary**

- Change the unique identity of network monitor agents from IP address to socket address, allowing multiple agents to run on the same host
- Update the contract storage key (AgentStorageKey) to encode both IP and port as a composite key, with full roundtrip and ordering tests
- Refactor NoiseNode from a struct with an `is_nym_node flag` to an enum (`NymNode` / `NetworkMonitorAgent`), where the agent variant holds a Vec of per-port noise keys
- Update nym-node's noise handshake initiator path to resolve the correct key by socket address, while the responder path remains IP-only

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6679)
<!-- Reviewable:end -->
