### PR TITLE
feat: NMv3: Eviction of stale testrun data

### DIFF
--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/mod.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/mod.rs
@@ -8,6 +8,7 @@ use crate::http::api::{build_router, run_http_server};
 use crate::http::state::{AppState, KnownAgents};
 use crate::orchestrator::config::Config;
 use crate::orchestrator::node_refresher::NodeRefresher;
+use crate::orchestrator::stale_results_eviction::StaleResultsEviction;
 use crate::storage::NetworkMonitorStorage;
 use crate::storage::models::{
     NewNymNode, NewTestRun, NymNode, TestRun, TestRunInProgress, TestType,
@@ -26,6 +27,7 @@ use zeroize::Zeroizing;
 
 pub(crate) mod config;
 mod node_refresher;
+mod stale_results_eviction;
 pub(crate) mod testruns;
 
 pub(crate) struct NetworkMonitorOrchestrator {
@@ -152,7 +154,20 @@ impl NetworkMonitorOrchestrator {
             self.metrics_http_auth_token.clone(),
         );
 
-        // 4. start all the tasks
+        // 4. build task for evicting stale test run results
+        let stale_results_eviction = StaleResultsEviction::new(
+            self.storage.clone(),
+            self.config.testrun_eviction_age,
+            self.config.test_timeout,
+        );
+
+        // 5. evict stale data before starting anything else
+        stale_results_eviction
+            .evict_stale_results()
+            .await
+            .context("failed to evict stale data")?;
+
+        // 6. start all the tasks
         // http server
         let http_server_fut = run_http_server(
             http_router,
@@ -167,6 +182,10 @@ impl NetworkMonitorOrchestrator {
                 node_refresher.run().await;
             },
             "node-refresher",
+        );
+        self.shutdown_manager.try_spawn_named(
+            async move { stale_results_eviction.run().await },
+            "stale-data-eviction",
         );
 
         error!("unimplemented");

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/mod.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/mod.rs
@@ -159,9 +159,14 @@ impl NetworkMonitorOrchestrator {
             self.storage.clone(),
             self.config.testrun_eviction_age,
             self.config.test_timeout,
+            self.shutdown_manager.clone_shutdown_token(),
         );
 
-        // 5. evict stale data before starting anything else
+        // 5. evict stale data before starting anything else so any test runs
+        //    left "in progress" by a prior crashed/restarted orchestrator are
+        //    freed up before agents start polling for work. Note: this is a
+        //    blocking call — a hung DB at start-up will prevent the
+        //    orchestrator from serving, which is the desired fail-fast here.
         stale_results_eviction
             .evict_stale_results()
             .await

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/stale_results_eviction.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/stale_results_eviction.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::storage::NetworkMonitorStorage;
+use std::time::Duration;
+use tokio::time::{Instant, interval_at};
+use tracing::error;
+
+pub(crate) struct StaleResultsEviction {
+    storage: NetworkMonitorStorage,
+    max_result_age: Duration,
+    max_testrun_timeout: Duration,
+    check_interval: Duration,
+}
+
+impl StaleResultsEviction {
+    pub(crate) fn new(
+        storage: NetworkMonitorStorage,
+        max_result_age: Duration,
+        max_testrun_timeout: Duration,
+    ) -> Self {
+        // let check interval be half of the minimum of the two timeouts
+        let check_interval = Duration::min(max_result_age, max_testrun_timeout) / 2;
+
+        Self {
+            storage,
+            max_result_age,
+            max_testrun_timeout,
+            check_interval,
+        }
+    }
+
+    pub(crate) async fn evict_stale_results(&self) -> anyhow::Result<()> {
+        self.storage
+            .clear_timed_out_testruns_in_progress(self.max_testrun_timeout)
+            .await?;
+        self.storage.evict_old_testruns(self.max_result_age).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn run(&self) {
+        let mut interval = interval_at(Instant::now() + self.check_interval, self.check_interval);
+        loop {
+            interval.tick().await;
+            if let Err(err) = self.evict_stale_results().await {
+                error!("Failed to evict stale results: {err}");
+            }
+        }
+    }
+}

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/stale_results_eviction.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/stale_results_eviction.rs
@@ -115,13 +115,13 @@ impl StaleResultsEviction {
             tokio::select! {
                 biased;
                 _ = self.shutdown_token.cancelled() => break,
-                _ = interval.tick() => {}
-            }
-
-            if let Err(err) = self.evict_stale_results().await {
-                // Transient storage errors shouldn't kill the task — the next
-                // tick will retry and any missed items simply age a bit longer.
-                error!("failed to evict stale results: {err}");
+                _ = interval.tick() => {
+                    if let Err(err) = self.evict_stale_results().await {
+                        // Transient storage errors shouldn't kill the task — the next
+                        // tick will retry and any missed items simply age a bit longer.
+                        error!("failed to evict stale results: {err}");
+                    }
+                }
             }
         }
 

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/stale_results_eviction.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/stale_results_eviction.rs
@@ -2,49 +2,129 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::storage::NetworkMonitorStorage;
+use nym_task::ShutdownToken;
 use std::time::Duration;
-use tokio::time::{Instant, interval_at};
-use tracing::error;
+use tokio::time::{Instant, MissedTickBehavior, interval_at};
+use tracing::{debug, error, info};
 
+/// Background task that periodically purges stale data from the storage.
+///
+/// Two distinct kinds of staleness are handled:
+/// - in-progress test runs whose assigned agent has gone silent past
+///   `test_timeout` (freed so they can be reassigned),
+/// - finalised test runs older than `testrun_eviction_age` (dropped to keep
+///   the results table bounded).
+///
+/// The two deletions are deliberately issued as separate statements rather
+/// than wrapped in a transaction: they touch disjoint tables, a partial
+/// failure is self-healing on the next tick, and keeping them independent
+/// avoids holding a write lock across both for the whole sweep.
 pub(crate) struct StaleResultsEviction {
     storage: NetworkMonitorStorage,
-    max_result_age: Duration,
-    max_testrun_timeout: Duration,
+
+    /// Age past which a finalised test run is considered stale and removed.
+    /// Mirrors `Config::testrun_eviction_age`.
+    testrun_eviction_age: Duration,
+
+    /// Maximum time a test run may remain "in progress" before we assume the
+    /// assigned agent has died and free the slot for reassignment.
+    /// Mirrors `Config::test_timeout`.
+    test_timeout: Duration,
+
+    /// Cadence at which [`Self::run`] performs an eviction sweep.
     check_interval: Duration,
+
+    shutdown_token: ShutdownToken,
 }
+
+/// Lower bound on the sweep cadence to avoid hammering the DB (or panicking
+/// `interval_at`) when either timeout is configured to an unrealistically
+/// small value.
+const MIN_CHECK_INTERVAL: Duration = Duration::from_secs(60);
 
 impl StaleResultsEviction {
     pub(crate) fn new(
         storage: NetworkMonitorStorage,
-        max_result_age: Duration,
-        max_testrun_timeout: Duration,
+        testrun_eviction_age: Duration,
+        test_timeout: Duration,
+        shutdown_token: ShutdownToken,
     ) -> Self {
-        // let check interval be half of the minimum of the two timeouts
-        let check_interval = Duration::min(max_result_age, max_testrun_timeout) / 2;
+        // Sweep at least twice per shortest timeout window so the worst-case
+        // lag between an item going stale and being evicted is bounded by
+        // roughly 1.5x that timeout rather than 2x. Floored at
+        // `MIN_CHECK_INTERVAL` to stay safe under degenerate configs.
+        let check_interval = Duration::max(
+            MIN_CHECK_INTERVAL,
+            Duration::min(testrun_eviction_age, test_timeout) / 2,
+        );
 
         Self {
             storage,
-            max_result_age,
-            max_testrun_timeout,
+            testrun_eviction_age,
+            test_timeout,
             check_interval,
+            shutdown_token,
         }
     }
 
+    /// Performs a single eviction sweep: clears timed-out in-progress test
+    /// runs and deletes results older than the configured retention window.
+    /// Logs how many rows were affected so ops can confirm the task is doing
+    /// real work (and spot unexpected spikes).
     pub(crate) async fn evict_stale_results(&self) -> anyhow::Result<()> {
-        self.storage
-            .clear_timed_out_testruns_in_progress(self.max_testrun_timeout)
+        let cleared_in_progress = self
+            .storage
+            .clear_timed_out_testruns_in_progress(self.test_timeout)
             .await?;
-        self.storage.evict_old_testruns(self.max_result_age).await?;
+        let evicted_old = self
+            .storage
+            .evict_old_testruns(self.testrun_eviction_age)
+            .await?;
+
+        if cleared_in_progress > 0 || evicted_old > 0 {
+            info!(
+                cleared_in_progress,
+                evicted_old, "stale data eviction sweep completed"
+            );
+        } else {
+            debug!("stale data eviction sweep completed: nothing to evict");
+        }
         Ok(())
     }
 
+    /// Runs the eviction loop until the shutdown token is cancelled.
+    ///
+    /// Cancellation is cooperative: it is only observed between sweeps, so a
+    /// sweep already in flight is allowed to finish. This keeps partial
+    /// deletions from being left on the floor at shutdown.
+    ///
+    /// The first tick is deliberately offset by `check_interval` because the
+    /// orchestrator invokes [`Self::evict_stale_results`] once during start-up
+    /// (to reap anything left behind by a prior crash or restart), so an
+    /// immediate tick here would redo that work.
+    ///
+    /// `MissedTickBehavior::Delay` prevents burst catch-up ticks when a sweep
+    /// runs long under DB load — otherwise a slow sweep would queue multiple
+    /// back-to-back ticks and amplify the pressure that made it slow in the
+    /// first place.
     pub(crate) async fn run(&self) {
         let mut interval = interval_at(Instant::now() + self.check_interval, self.check_interval);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
         loop {
-            interval.tick().await;
+            tokio::select! {
+                biased;
+                _ = self.shutdown_token.cancelled() => break,
+                _ = interval.tick() => {}
+            }
+
             if let Err(err) = self.evict_stale_results().await {
-                error!("Failed to evict stale results: {err}");
+                // Transient storage errors shouldn't kill the task — the next
+                // tick will retry and any missed items simply age a bit longer.
+                error!("failed to evict stale results: {err}");
             }
         }
+
+        info!("stale results eviction stopped");
     }
 }

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/storage/manager.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/storage/manager.rs
@@ -136,14 +136,14 @@ impl StorageManager {
     pub(crate) async fn clear_timed_out_testruns_in_progress(
         &self,
         cutoff: OffsetDateTime,
-    ) -> anyhow::Result<()> {
-        sqlx::query!(
+    ) -> anyhow::Result<u64> {
+        let res = sqlx::query!(
             "DELETE FROM testrun_in_progress WHERE started_at < ?",
             cutoff,
         )
         .execute(&self.connection_pool)
         .await?;
-        Ok(())
+        Ok(res.rows_affected())
     }
 
     /// Removes the in-progress marker for a node once its test run has completed or been abandoned.
@@ -230,11 +230,11 @@ impl StorageManager {
     ///
     /// Any `nym_node.last_testrun` foreign key that pointed at an evicted row is automatically
     /// set to `NULL` by the database (`ON DELETE SET NULL`).
-    pub(crate) async fn evict_old_testruns(&self, cutoff: OffsetDateTime) -> anyhow::Result<()> {
-        sqlx::query!("DELETE FROM testrun WHERE test_timestamp < ?", cutoff)
+    pub(crate) async fn evict_old_testruns(&self, cutoff: OffsetDateTime) -> anyhow::Result<u64> {
+        let res = sqlx::query!("DELETE FROM testrun WHERE test_timestamp < ?", cutoff)
             .execute(&self.connection_pool)
             .await?;
-        Ok(())
+        Ok(res.rows_affected())
     }
 
     /// Updates `nym_node.last_testrun` to point at the given test run ID.

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/storage/mod.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/storage/mod.rs
@@ -84,7 +84,7 @@ impl NetworkMonitorStorage {
     pub(crate) async fn clear_timed_out_testruns_in_progress(
         &self,
         timeout: Duration,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<u64> {
         let cutoff = OffsetDateTime::now_utc() - timeout;
         self.storage_manager
             .clear_timed_out_testruns_in_progress(cutoff)
@@ -125,7 +125,7 @@ impl NetworkMonitorStorage {
     ///
     /// Any `nym_node.last_testrun` foreign key that pointed at an evicted row is automatically
     /// set to `NULL` by the database (`ON DELETE SET NULL`).
-    pub(crate) async fn evict_old_testruns(&self, eviction_age: Duration) -> anyhow::Result<()> {
+    pub(crate) async fn evict_old_testruns(&self, eviction_age: Duration) -> anyhow::Result<u64> {
         let cutoff = OffsetDateTime::now_utc() - eviction_age;
         self.storage_manager.evict_old_testruns(cutoff).await
     }


### PR DESCRIPTION
NYM-756

## Summary
- Adds a background task that periodically evicts stale data: test runs stuck "in progress" past `test_timeout` (freed for reassignment) and finalised test runs older than `testrun_eviction_age` (dropped to bound the results table).
- Runs one synchronous sweep at orchestrator start-up so crash-left state is cleared before agents poll for work, then loops on a cadence derived from the smaller of the two timeouts (floored at 60s, `MissedTickBehavior::Delay`).
- Cooperative shutdown: cancellation is observed between sweeps, so an in-flight sweep is allowed to finish.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6685)
<!-- Reviewable:end -->
