### PR TITLE
Only init SHARED_CLIENT if requested

### DIFF
--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1152,7 +1152,10 @@ impl ApiClientCore for Client {
 
             #[cfg(target_arch = "wasm32")]
             let response: Result<Response, HttpClientError> = {
-                let client = self.reqwest_client.as_ref().unwrap_or(&*SHARED_CLIENT);
+                let client = self
+                    .reqwest_client
+                    .as_ref()
+                    .unwrap_or_else(|| &*SHARED_CLIENT);
                 Ok(
                     wasmtimer::tokio::timeout(self.request_timeout, client.execute(req))
                         .await
@@ -1162,7 +1165,10 @@ impl ApiClientCore for Client {
 
             #[cfg(not(target_arch = "wasm32"))]
             let response = {
-                let client = self.reqwest_client.as_ref().unwrap_or(&*SHARED_CLIENT);
+                let client = self
+                    .reqwest_client
+                    .as_ref()
+                    .unwrap_or_else(|| &*SHARED_CLIENT);
                 client.execute(req).await
             };
 


### PR DESCRIPTION
This PR prevents shared reqwest client from being initialized even when `self.reqwest_client` is used instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6708)
<!-- Reviewable:end -->
