### PR TITLE
feat: Node Families: contract queries

### DIFF
--- a/common/cosmwasm-smart-contracts/node-families-contract/src/constants.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/constants.rs
@@ -13,8 +13,12 @@ pub mod storage_keys {
     pub const CONTRACT_ADMIN: &str = "contract-admin";
     /// `Item<NodeFamilyId>`: monotonically increasing id counter for new families.
     pub const NODE_FAMILY_ID_COUNTER: &str = "node-family-id-counter";
-    /// `Map<NodeId, NodeFamilyId>`: lookup of which family a node currently belongs to.
+    /// Primary namespace for the current family-members `IndexedMap`,
+    /// keyed by `NodeId` with value [`crate::FamilyMembership`].
     pub const NODE_FAMILY_MEMBERS: &str = "node-family-members";
+    /// Multi-index over current family members keyed by family id —
+    /// enables paginated listing of all nodes in a given family.
+    pub const NODE_FAMILY_MEMBERS_FAMILY_IDX_NAMESPACE: &str = "node-family-members__family";
 
     /// Primary namespace for the families `IndexedMap`.
     pub const FAMILIES_NAMESPACE: &str = "families";

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
@@ -1,14 +1,15 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::NodeFamilyId;
+use crate::{GlobalPastFamilyInvitationCursor, NodeFamilyId, PastFamilyInvitationCursor};
 use cosmwasm_schema::cw_serde;
 use nym_mixnet_contract_common::NodeId;
 
 #[cfg(feature = "schema")]
 use crate::{
-    FamiliesPagedResponse, FamilyMembersPagedResponse, NodeFamilyMembershipResponse,
-    NodeFamilyResponse, PendingFamilyInvitationResponse, PendingFamilyInvitationsPagedResponse,
+    AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse, FamilyMembersPagedResponse,
+    NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationsPagedResponse,
+    PendingFamilyInvitationResponse, PendingFamilyInvitationsPagedResponse,
     PendingInvitationsPagedResponse,
 };
 
@@ -70,6 +71,23 @@ pub enum QueryMsg {
     #[cfg_attr(feature = "schema", returns(PendingInvitationsPagedResponse))]
     GetAllPendingInvitationsPaged {
         start_after: Option<(NodeFamilyId, NodeId)>,
+        limit: Option<u32>,
+    },
+
+    /// Page through every archived (terminal-state) invitation issued by a
+    /// given family.
+    #[cfg_attr(feature = "schema", returns(PastFamilyInvitationsPagedResponse))]
+    GetPastInvitationsForFamilyPaged {
+        family_id: NodeFamilyId,
+        start_after: Option<PastFamilyInvitationCursor>,
+        limit: Option<u32>,
+    },
+
+    /// Page through every archived (terminal-state) invitation across all
+    /// families.
+    #[cfg_attr(feature = "schema", returns(AllPastFamilyInvitationsPagedResponse))]
+    GetAllPastInvitationsPaged {
+        start_after: Option<GlobalPastFamilyInvitationCursor>,
         limit: Option<u32>,
     },
 }

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::NodeFamilyId;
-#[cfg(feature = "schema")]
-use crate::{NodeFamilyMembershipResponse, NodeFamilyResponse, PendingFamilyInvitationResponse};
 use cosmwasm_schema::cw_serde;
 use nym_mixnet_contract_common::NodeId;
+
+#[cfg(feature = "schema")]
+use crate::{
+    FamiliesPagedResponse, NodeFamilyMembershipResponse, NodeFamilyResponse,
+    PendingFamilyInvitationResponse,
+};
 
 /// Message used to instantiate the node families contract.
 #[cw_serde]
@@ -26,9 +30,17 @@ pub enum QueryMsg {
     /// Look up a single family by its id.
     #[cfg_attr(feature = "schema", returns(NodeFamilyResponse))]
     GetFamilyById { family_id: NodeFamilyId },
+
+    #[cfg_attr(feature = "schema", returns(FamiliesPagedResponse))]
+    GetFamiliesPaged {
+        start_after: Option<NodeFamilyId>,
+        limit: Option<u32>,
+    },
+
     /// Look up which family — if any — a node currently belongs to.
     #[cfg_attr(feature = "schema", returns(NodeFamilyMembershipResponse))]
     GetFamilyMembership { node_id: NodeId },
+
     /// Look up the pending invitation for a specific `(family_id, node_id)`
     /// pair.
     #[cfg_attr(feature = "schema", returns(PendingFamilyInvitationResponse))]

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
@@ -43,9 +43,9 @@ pub enum QueryMsg {
     #[cfg_attr(feature = "schema", returns(NodeFamilyByOwnerResponse))]
     GetFamilyByOwner { owner: String },
 
-    /// Look up a single family by its (globally-unique) name. Compared by raw
-    /// bytes — callers must normalise upstream if they want case-insensitive
-    /// matching.
+    /// Look up a single family by its name. The lookup is normalised
+    /// contract-side (lowercased, non-alphanumerics stripped), so equivalent
+    /// inputs resolve to the same family.
     #[cfg_attr(feature = "schema", returns(NodeFamilyByNameResponse))]
     GetFamilyByName { name: String },
 

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     GlobalPastFamilyInvitationCursor, NodeFamilyId, PastFamilyInvitationCursor,
-    PastFamilyInvitationForNodeCursor,
+    PastFamilyInvitationForNodeCursor, PastFamilyMemberCursor,
 };
 use cosmwasm_schema::cw_serde;
 use nym_mixnet_contract_common::NodeId;
@@ -12,9 +12,9 @@ use nym_mixnet_contract_common::NodeId;
 use crate::{
     AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse, FamilyMembersPagedResponse,
     NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationsForNodePagedResponse,
-    PastFamilyInvitationsPagedResponse, PendingFamilyInvitationResponse,
-    PendingFamilyInvitationsPagedResponse, PendingInvitationsForNodePagedResponse,
-    PendingInvitationsPagedResponse,
+    PastFamilyInvitationsPagedResponse, PastFamilyMembersPagedResponse,
+    PendingFamilyInvitationResponse, PendingFamilyInvitationsPagedResponse,
+    PendingInvitationsForNodePagedResponse, PendingInvitationsPagedResponse,
 };
 
 /// Message used to instantiate the node families contract.
@@ -109,6 +109,15 @@ pub enum QueryMsg {
     #[cfg_attr(feature = "schema", returns(AllPastFamilyInvitationsPagedResponse))]
     GetAllPastInvitationsPaged {
         start_after: Option<GlobalPastFamilyInvitationCursor>,
+        limit: Option<u32>,
+    },
+
+    /// Page through every archived membership record for a given family
+    /// (nodes that used to belong to it but have since been removed).
+    #[cfg_attr(feature = "schema", returns(PastFamilyMembersPagedResponse))]
+    GetPastMembersForFamilyPaged {
+        family_id: NodeFamilyId,
+        start_after: Option<PastFamilyMemberCursor>,
         limit: Option<u32>,
     },
 }

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     GlobalPastFamilyInvitationCursor, NodeFamilyId, PastFamilyInvitationCursor,
-    PastFamilyInvitationForNodeCursor, PastFamilyMemberCursor,
+    PastFamilyInvitationForNodeCursor, PastFamilyMemberCursor, PastFamilyMemberForNodeCursor,
 };
 use cosmwasm_schema::cw_serde;
 use nym_mixnet_contract_common::NodeId;
@@ -12,9 +12,10 @@ use nym_mixnet_contract_common::NodeId;
 use crate::{
     AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse, FamilyMembersPagedResponse,
     NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationsForNodePagedResponse,
-    PastFamilyInvitationsPagedResponse, PastFamilyMembersPagedResponse,
-    PendingFamilyInvitationResponse, PendingFamilyInvitationsPagedResponse,
-    PendingInvitationsForNodePagedResponse, PendingInvitationsPagedResponse,
+    PastFamilyInvitationsPagedResponse, PastFamilyMembersForNodePagedResponse,
+    PastFamilyMembersPagedResponse, PendingFamilyInvitationResponse,
+    PendingFamilyInvitationsPagedResponse, PendingInvitationsForNodePagedResponse,
+    PendingInvitationsPagedResponse,
 };
 
 /// Message used to instantiate the node families contract.
@@ -118,6 +119,16 @@ pub enum QueryMsg {
     GetPastMembersForFamilyPaged {
         family_id: NodeFamilyId,
         start_after: Option<PastFamilyMemberCursor>,
+        limit: Option<u32>,
+    },
+
+    /// Page through every archived membership record for a given node
+    /// (every family the node used to belong to but has since been removed
+    /// from), across all families.
+    #[cfg_attr(feature = "schema", returns(PastFamilyMembersForNodePagedResponse))]
+    GetPastMembersForNodePaged {
+        node_id: NodeId,
+        start_after: Option<PastFamilyMemberForNodeCursor>,
         limit: Option<u32>,
     },
 }

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
@@ -1,7 +1,11 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use crate::NodeFamilyId;
+#[cfg(feature = "schema")]
+use crate::{NodeFamilyMembershipResponse, NodeFamilyResponse, PendingFamilyInvitationResponse};
 use cosmwasm_schema::cw_serde;
+use nym_mixnet_contract_common::NodeId;
 
 /// Message used to instantiate the node families contract.
 #[cw_serde]
@@ -19,7 +23,19 @@ pub enum ExecuteMsg {
 #[cw_serde]
 #[cfg_attr(feature = "schema", derive(cosmwasm_schema::QueryResponses))]
 pub enum QueryMsg {
-    //
+    /// Look up a single family by its id.
+    #[cfg_attr(feature = "schema", returns(NodeFamilyResponse))]
+    GetFamilyById { family_id: NodeFamilyId },
+    /// Look up which family — if any — a node currently belongs to.
+    #[cfg_attr(feature = "schema", returns(NodeFamilyMembershipResponse))]
+    GetFamilyMembership { node_id: NodeId },
+    /// Look up the pending invitation for a specific `(family_id, node_id)`
+    /// pair.
+    #[cfg_attr(feature = "schema", returns(PendingFamilyInvitationResponse))]
+    GetPendingInvitation {
+        family_id: NodeFamilyId,
+        node_id: NodeId,
+    },
 }
 
 /// Message passed to the contract's `migrate` entry point.

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
@@ -11,7 +11,8 @@ use nym_mixnet_contract_common::NodeId;
 #[cfg(feature = "schema")]
 use crate::{
     AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse, FamilyMembersPagedResponse,
-    NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationsForNodePagedResponse,
+    NodeFamilyByNameResponse, NodeFamilyByOwnerResponse, NodeFamilyMembershipResponse,
+    NodeFamilyResponse, PastFamilyInvitationsForNodePagedResponse,
     PastFamilyInvitationsPagedResponse, PastFamilyMembersForNodePagedResponse,
     PastFamilyMembersPagedResponse, PendingFamilyInvitationResponse,
     PendingFamilyInvitationsPagedResponse, PendingInvitationsForNodePagedResponse,
@@ -37,6 +38,16 @@ pub enum QueryMsg {
     /// Look up a single family by its id.
     #[cfg_attr(feature = "schema", returns(NodeFamilyResponse))]
     GetFamilyById { family_id: NodeFamilyId },
+
+    /// Look up the (at most one) family owned by a given address.
+    #[cfg_attr(feature = "schema", returns(NodeFamilyByOwnerResponse))]
+    GetFamilyByOwner { owner: String },
+
+    /// Look up a single family by its (globally-unique) name. Compared by raw
+    /// bytes — callers must normalise upstream if they want case-insensitive
+    /// matching.
+    #[cfg_attr(feature = "schema", returns(NodeFamilyByNameResponse))]
+    GetFamilyByName { name: String },
 
     #[cfg_attr(feature = "schema", returns(FamiliesPagedResponse))]
     GetFamiliesPaged {

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
@@ -7,8 +7,8 @@ use nym_mixnet_contract_common::NodeId;
 
 #[cfg(feature = "schema")]
 use crate::{
-    FamiliesPagedResponse, NodeFamilyMembershipResponse, NodeFamilyResponse,
-    PendingFamilyInvitationResponse,
+    FamiliesPagedResponse, FamilyMembersPagedResponse, NodeFamilyMembershipResponse,
+    NodeFamilyResponse, PendingFamilyInvitationResponse,
 };
 
 /// Message used to instantiate the node families contract.
@@ -40,6 +40,14 @@ pub enum QueryMsg {
     /// Look up which family — if any — a node currently belongs to.
     #[cfg_attr(feature = "schema", returns(NodeFamilyMembershipResponse))]
     GetFamilyMembership { node_id: NodeId },
+
+    /// Page through every node currently in a given family.
+    #[cfg_attr(feature = "schema", returns(FamilyMembersPagedResponse))]
+    GetFamilyMembersPaged {
+        family_id: NodeFamilyId,
+        start_after: Option<NodeId>,
+        limit: Option<u32>,
+    },
 
     /// Look up the pending invitation for a specific `(family_id, node_id)`
     /// pair.

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
@@ -1,15 +1,19 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::{GlobalPastFamilyInvitationCursor, NodeFamilyId, PastFamilyInvitationCursor};
+use crate::{
+    GlobalPastFamilyInvitationCursor, NodeFamilyId, PastFamilyInvitationCursor,
+    PastFamilyInvitationForNodeCursor,
+};
 use cosmwasm_schema::cw_serde;
 use nym_mixnet_contract_common::NodeId;
 
 #[cfg(feature = "schema")]
 use crate::{
     AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse, FamilyMembersPagedResponse,
-    NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationsPagedResponse,
-    PendingFamilyInvitationResponse, PendingFamilyInvitationsPagedResponse,
+    NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationsForNodePagedResponse,
+    PastFamilyInvitationsPagedResponse, PendingFamilyInvitationResponse,
+    PendingFamilyInvitationsPagedResponse, PendingInvitationsForNodePagedResponse,
     PendingInvitationsPagedResponse,
 };
 
@@ -67,6 +71,14 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
 
+    /// Page through every pending invitation issued for a given node.
+    #[cfg_attr(feature = "schema", returns(PendingInvitationsForNodePagedResponse))]
+    GetPendingInvitationsForNodePaged {
+        node_id: NodeId,
+        start_after: Option<NodeFamilyId>,
+        limit: Option<u32>,
+    },
+
     /// Page through every pending invitation across all families.
     #[cfg_attr(feature = "schema", returns(PendingInvitationsPagedResponse))]
     GetAllPendingInvitationsPaged {
@@ -80,6 +92,15 @@ pub enum QueryMsg {
     GetPastInvitationsForFamilyPaged {
         family_id: NodeFamilyId,
         start_after: Option<PastFamilyInvitationCursor>,
+        limit: Option<u32>,
+    },
+
+    /// Page through every archived (terminal-state) invitation issued to a
+    /// given node.
+    #[cfg_attr(feature = "schema", returns(PastFamilyInvitationsForNodePagedResponse))]
+    GetPastInvitationsForNodePaged {
+        node_id: NodeId,
+        start_after: Option<PastFamilyInvitationForNodeCursor>,
         limit: Option<u32>,
     },
 

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
@@ -8,7 +8,8 @@ use nym_mixnet_contract_common::NodeId;
 #[cfg(feature = "schema")]
 use crate::{
     FamiliesPagedResponse, FamilyMembersPagedResponse, NodeFamilyMembershipResponse,
-    NodeFamilyResponse, PendingFamilyInvitationResponse,
+    NodeFamilyResponse, PendingFamilyInvitationResponse, PendingFamilyInvitationsPagedResponse,
+    PendingInvitationsPagedResponse,
 };
 
 /// Message used to instantiate the node families contract.
@@ -55,6 +56,21 @@ pub enum QueryMsg {
     GetPendingInvitation {
         family_id: NodeFamilyId,
         node_id: NodeId,
+    },
+
+    /// Page through every pending invitation issued by a given family.
+    #[cfg_attr(feature = "schema", returns(PendingFamilyInvitationsPagedResponse))]
+    GetPendingInvitationsForFamilyPaged {
+        family_id: NodeFamilyId,
+        start_after: Option<NodeId>,
+        limit: Option<u32>,
+    },
+
+    /// Page through every pending invitation across all families.
+    #[cfg_attr(feature = "schema", returns(PendingInvitationsPagedResponse))]
+    GetAllPendingInvitationsPaged {
+        start_after: Option<(NodeFamilyId, NodeId)>,
+        limit: Option<u32>,
     },
 }
 

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
@@ -15,6 +15,12 @@ pub type NodeFamilyId = u32;
 pub struct Config {
     /// Fee charged on each successful `create_family` execution.
     pub create_family_fee: Coin,
+
+    /// Maximum allowed length, in characters, of a family name.
+    pub family_name_length_limit: usize,
+
+    /// Maximum allowed length, in characters, of a family description.
+    pub family_description_length_limit: usize,
 }
 
 /// On-chain representation of a node family.
@@ -140,4 +146,15 @@ pub struct PendingFamilyInvitationResponse {
     /// The matching pending invitation along with an explicit expiry flag,
     /// or `None` if no such invitation exists.
     pub invitation: Option<PendingFamilyInvitationDetails>,
+}
+
+/// Response to [`QueryMsg::GetFamiliesPaged`](crate::QueryMsg::GetFamiliesPaged).
+#[cw_serde]
+pub struct FamiliesPagedResponse {
+    /// The families on this page, in ascending [`NodeFamilyId`] order.
+    pub families: Vec<NodeFamily>,
+
+    /// Cursor to pass as `start_after` on the next call, or `None` if this
+    /// page is empty (which the caller should treat as end-of-list).
+    pub start_next_after: Option<NodeFamilyId>,
 }

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
@@ -302,6 +302,29 @@ pub struct AllPastFamilyInvitationsPagedResponse {
     pub start_next_after: Option<GlobalPastFamilyInvitationCursor>,
 }
 
+/// Cursor for paginating per-family past-member listings: identifies a single
+/// archive entry within a family by `(node_id, counter)`. The `counter` is the
+/// per-`(family, node)` archive slot — multiple archived membership entries
+/// can exist for the same `(family, node)` pair (a node may join, leave, and
+/// re-join the same family more than once).
+pub type PastFamilyMemberCursor = (NodeId, u64);
+
+/// Response to [`QueryMsg::GetPastMembersForFamilyPaged`](crate::QueryMsg::GetPastMembersForFamilyPaged).
+#[cw_serde]
+pub struct PastFamilyMembersPagedResponse {
+    /// The family whose archived memberships were queried, echoed back so
+    /// paginated callers can correlate.
+    pub family_id: NodeFamilyId,
+
+    /// The archived membership records on this page, in ascending
+    /// `(node_id, counter)` order.
+    pub members: Vec<PastFamilyMember>,
+
+    /// Cursor to pass as `start_after` on the next call, or `None` if this
+    /// page is empty (treat as end-of-list).
+    pub start_next_after: Option<PastFamilyMemberCursor>,
+}
+
 /// Response to [`QueryMsg::GetFamiliesPaged`](crate::QueryMsg::GetFamiliesPaged).
 #[cw_serde]
 pub struct FamiliesPagedResponse {

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
@@ -63,6 +63,21 @@ pub struct FamilyInvitation {
     pub expires_at: u64,
 }
 
+/// On-chain record of a node's current family membership.
+///
+/// A node belongs to at most one family at a time, so this is keyed by
+/// `NodeId` alone — `family_id` is carried in the value to support reverse
+/// lookups (all nodes in a given family) via a secondary index.
+#[cw_serde]
+pub struct FamilyMembership {
+    /// The family the node is currently a member of.
+    pub family_id: NodeFamilyId,
+
+    /// Block timestamp (unix seconds) at which the node accepted its
+    /// invitation and joined the family.
+    pub joined_at: u64,
+}
+
 /// Historical record of a node that used to be part of a family but has since been
 /// removed (kicked, left voluntarily, or because the family was disbanded).
 #[cw_serde]
@@ -102,6 +117,7 @@ pub enum FamilyInvitationStatus {
 pub struct PastFamilyInvitation {
     /// The original invitation as it was issued.
     pub invitation: FamilyInvitation,
+
     /// What ultimately happened to it.
     pub status: FamilyInvitationStatus,
 }
@@ -111,6 +127,7 @@ pub struct PastFamilyInvitation {
 pub struct NodeFamilyResponse {
     /// The id that was queried, echoed back so paginated callers can correlate.
     pub family_id: NodeFamilyId,
+
     /// The matching family, or `None` if no family with `family_id` exists.
     pub family: Option<NodeFamily>,
 }
@@ -120,6 +137,7 @@ pub struct NodeFamilyResponse {
 pub struct NodeFamilyMembershipResponse {
     /// The node that was queried.
     pub node_id: NodeId,
+
     /// The id of the family the node currently belongs to, or `None` if the
     /// node is not currently a member of any family.
     pub family_id: Option<NodeFamilyId>,
@@ -131,6 +149,7 @@ pub struct NodeFamilyMembershipResponse {
 pub struct PendingFamilyInvitationDetails {
     /// The stored invitation as it was issued.
     pub invitation: FamilyInvitation,
+
     /// `true` iff `now >= invitation.expires_at` at query time, i.e. the
     /// invitation is still in the pending map but can no longer be acted on.
     pub expired: bool,
@@ -141,11 +160,39 @@ pub struct PendingFamilyInvitationDetails {
 pub struct PendingFamilyInvitationResponse {
     /// The family component of the queried `(family_id, node_id)` key.
     pub family_id: NodeFamilyId,
+
     /// The node component of the queried `(family_id, node_id)` key.
     pub node_id: NodeId,
+
     /// The matching pending invitation along with an explicit expiry flag,
     /// or `None` if no such invitation exists.
     pub invitation: Option<PendingFamilyInvitationDetails>,
+}
+
+/// One entry in a [`FamilyMembersPagedResponse`] page — pairs a node id with
+/// its [`FamilyMembership`] record (notably its `joined_at` timestamp).
+#[cw_serde]
+pub struct FamilyMemberRecord {
+    /// The node currently in the family.
+    pub node_id: NodeId,
+
+    /// The membership record (carries `family_id` and `joined_at`).
+    pub membership: FamilyMembership,
+}
+
+/// Response to [`QueryMsg::GetFamilyMembersPaged`](crate::QueryMsg::GetFamilyMembersPaged).
+#[cw_serde]
+pub struct FamilyMembersPagedResponse {
+    /// The family whose members were queried, echoed back so paginated
+    /// callers can correlate.
+    pub family_id: NodeFamilyId,
+
+    /// The members on this page, in ascending [`NodeId`] order.
+    pub members: Vec<FamilyMemberRecord>,
+
+    /// Cursor to pass as `start_after` on the next call, or `None` if this
+    /// page is empty (which the caller should treat as end-of-list).
+    pub start_next_after: Option<NodeId>,
 }
 
 /// Response to [`QueryMsg::GetFamiliesPaged`](crate::QueryMsg::GetFamiliesPaged).

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
@@ -147,8 +147,6 @@ pub struct NodeFamilyByOwnerResponse {
 #[cw_serde]
 pub struct NodeFamilyByNameResponse {
     /// The name that was queried, echoed back so callers can correlate.
-    /// Compared by raw bytes — callers must normalise (e.g. lowercase/trim)
-    /// upstream if they want case-insensitive matching.
     pub name: String,
 
     /// The matching family, or `None` if no family with that name exists.

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
@@ -195,6 +195,37 @@ pub struct FamilyMembersPagedResponse {
     pub start_next_after: Option<NodeId>,
 }
 
+/// Response to [`QueryMsg::GetPendingInvitationsForFamilyPaged`](crate::QueryMsg::GetPendingInvitationsForFamilyPaged).
+#[cw_serde]
+pub struct PendingFamilyInvitationsPagedResponse {
+    /// The family whose pending invitations were queried, echoed back so
+    /// paginated callers can correlate.
+    pub family_id: NodeFamilyId,
+
+    /// The pending invitations on this page, in ascending invitee
+    /// [`NodeId`] order, each stamped with whether it had already timed out
+    /// at the time the query was served.
+    pub invitations: Vec<PendingFamilyInvitationDetails>,
+
+    /// Cursor (last invitee node id) to pass as `start_after` on the next
+    /// call, or `None` if this page is empty (treat as end-of-list).
+    pub start_next_after: Option<NodeId>,
+}
+
+/// Response to [`QueryMsg::GetAllPendingInvitationsPaged`](crate::QueryMsg::GetAllPendingInvitationsPaged).
+#[cw_serde]
+pub struct PendingInvitationsPagedResponse {
+    /// The pending invitations on this page, in ascending
+    /// `(family_id, node_id)` order, each stamped with whether it had
+    /// already timed out at the time the query was served.
+    pub invitations: Vec<PendingFamilyInvitationDetails>,
+
+    /// Cursor (last `(family_id, node_id)` pair) to pass as `start_after`
+    /// on the next call, or `None` if this page is empty (treat as
+    /// end-of-list).
+    pub start_next_after: Option<(NodeFamilyId, NodeId)>,
+}
+
 /// Response to [`QueryMsg::GetFamiliesPaged`](crate::QueryMsg::GetFamiliesPaged).
 #[cw_serde]
 pub struct FamiliesPagedResponse {

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
@@ -132,6 +132,29 @@ pub struct NodeFamilyResponse {
     pub family: Option<NodeFamily>,
 }
 
+/// Response to [`QueryMsg::GetFamilyByOwner`](crate::QueryMsg::GetFamilyByOwner).
+#[cw_serde]
+pub struct NodeFamilyByOwnerResponse {
+    /// The (validated) owner address that was queried, echoed back so callers
+    /// can correlate.
+    pub owner: Addr,
+
+    /// The matching family, or `None` if `owner` does not currently own one.
+    pub family: Option<NodeFamily>,
+}
+
+/// Response to [`QueryMsg::GetFamilyByName`](crate::QueryMsg::GetFamilyByName).
+#[cw_serde]
+pub struct NodeFamilyByNameResponse {
+    /// The name that was queried, echoed back so callers can correlate.
+    /// Compared by raw bytes — callers must normalise (e.g. lowercase/trim)
+    /// upstream if they want case-insensitive matching.
+    pub name: String,
+
+    /// The matching family, or `None` if no family with that name exists.
+    pub family: Option<NodeFamily>,
+}
+
 /// Response to [`QueryMsg::GetFamilyMembership`](crate::QueryMsg::GetFamilyMembership).
 #[cw_serde]
 pub struct NodeFamilyMembershipResponse {

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
@@ -309,6 +309,10 @@ pub struct AllPastFamilyInvitationsPagedResponse {
 /// re-join the same family more than once).
 pub type PastFamilyMemberCursor = (NodeId, u64);
 
+/// Cursor for paginating per-node past-member listings: identifies a single
+/// archive entry for a fixed node by `(family_id, counter)`.
+pub type PastFamilyMemberForNodeCursor = (NodeFamilyId, u64);
+
 /// Response to [`QueryMsg::GetPastMembersForFamilyPaged`](crate::QueryMsg::GetPastMembersForFamilyPaged).
 #[cw_serde]
 pub struct PastFamilyMembersPagedResponse {
@@ -323,6 +327,22 @@ pub struct PastFamilyMembersPagedResponse {
     /// Cursor to pass as `start_after` on the next call, or `None` if this
     /// page is empty (treat as end-of-list).
     pub start_next_after: Option<PastFamilyMemberCursor>,
+}
+
+/// Response to [`QueryMsg::GetPastMembersForNodePaged`](crate::QueryMsg::GetPastMembersForNodePaged).
+#[cw_serde]
+pub struct PastFamilyMembersForNodePagedResponse {
+    /// The node whose archived memberships were queried, echoed back so
+    /// paginated callers can correlate.
+    pub node_id: NodeId,
+
+    /// The archived membership records for this node on this page, in
+    /// ascending `(family_id, counter)` order.
+    pub members: Vec<PastFamilyMember>,
+
+    /// Cursor to pass as `start_after` on the next call, or `None` if this
+    /// page is empty (treat as end-of-list).
+    pub start_next_after: Option<PastFamilyMemberForNodeCursor>,
 }
 
 /// Response to [`QueryMsg::GetFamiliesPaged`](crate::QueryMsg::GetFamiliesPaged).

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
@@ -212,6 +212,23 @@ pub struct PendingFamilyInvitationsPagedResponse {
     pub start_next_after: Option<NodeId>,
 }
 
+/// Response to [`QueryMsg::GetPendingInvitationsForNodePaged`](crate::QueryMsg::GetPendingInvitationsForNodePaged).
+#[cw_serde]
+pub struct PendingInvitationsForNodePagedResponse {
+    /// The node whose pending invitations were queried, echoed back so
+    /// paginated callers can correlate.
+    pub node_id: NodeId,
+
+    /// The pending invitations addressed to this node on this page, in
+    /// ascending [`NodeFamilyId`] order, each stamped with whether it had
+    /// already timed out at the time the query was served.
+    pub invitations: Vec<PendingFamilyInvitationDetails>,
+
+    /// Cursor (last issuing family id) to pass as `start_after` on the
+    /// next call, or `None` if this page is empty (treat as end-of-list).
+    pub start_next_after: Option<NodeFamilyId>,
+}
+
 /// Response to [`QueryMsg::GetAllPendingInvitationsPaged`](crate::QueryMsg::GetAllPendingInvitationsPaged).
 #[cw_serde]
 pub struct PendingInvitationsPagedResponse {
@@ -233,6 +250,10 @@ pub struct PendingInvitationsPagedResponse {
 /// invited and have the invitation reach a terminal state more than once).
 pub type PastFamilyInvitationCursor = (NodeId, u64);
 
+/// Cursor for paginating per-node past-invitation listings: identifies a
+/// single archive entry addressed to a fixed node by `(family_id, counter)`.
+pub type PastFamilyInvitationForNodeCursor = (NodeFamilyId, u64);
+
 /// Cursor for paginating global past-invitation listings: identifies a
 /// single archive entry across all families by `((family_id, node_id), counter)`.
 pub type GlobalPastFamilyInvitationCursor = ((NodeFamilyId, NodeId), u64);
@@ -251,6 +272,22 @@ pub struct PastFamilyInvitationsPagedResponse {
     /// Cursor to pass as `start_after` on the next call, or `None` if this
     /// page is empty (treat as end-of-list).
     pub start_next_after: Option<PastFamilyInvitationCursor>,
+}
+
+/// Response to [`QueryMsg::GetPastInvitationsForNodePaged`](crate::QueryMsg::GetPastInvitationsForNodePaged).
+#[cw_serde]
+pub struct PastFamilyInvitationsForNodePagedResponse {
+    /// The node whose past invitations were queried, echoed back so
+    /// paginated callers can correlate.
+    pub node_id: NodeId,
+
+    /// The archived invitations addressed to this node on this page, in
+    /// ascending `(family_id, counter)` order across all terminal statuses.
+    pub invitations: Vec<PastFamilyInvitation>,
+
+    /// Cursor to pass as `start_after` on the next call, or `None` if this
+    /// page is empty (treat as end-of-list).
+    pub start_next_after: Option<PastFamilyInvitationForNodeCursor>,
 }
 
 /// Response to [`QueryMsg::GetAllPastInvitationsPaged`](crate::QueryMsg::GetAllPastInvitationsPaged).

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
@@ -226,6 +226,45 @@ pub struct PendingInvitationsPagedResponse {
     pub start_next_after: Option<(NodeFamilyId, NodeId)>,
 }
 
+/// Cursor for paginating per-family past-invitation listings: identifies a
+/// single archive entry within a family by `(node_id, counter)`. The
+/// `counter` is the per-`(family, node)` archive slot — multiple archived
+/// invitations can exist for the same `(family, node)` pair (a node may be
+/// invited and have the invitation reach a terminal state more than once).
+pub type PastFamilyInvitationCursor = (NodeId, u64);
+
+/// Cursor for paginating global past-invitation listings: identifies a
+/// single archive entry across all families by `((family_id, node_id), counter)`.
+pub type GlobalPastFamilyInvitationCursor = ((NodeFamilyId, NodeId), u64);
+
+/// Response to [`QueryMsg::GetPastInvitationsForFamilyPaged`](crate::QueryMsg::GetPastInvitationsForFamilyPaged).
+#[cw_serde]
+pub struct PastFamilyInvitationsPagedResponse {
+    /// The family whose archived invitations were queried, echoed back so
+    /// paginated callers can correlate.
+    pub family_id: NodeFamilyId,
+
+    /// The archived invitations on this page, in ascending
+    /// `(node_id, counter)` order across all terminal statuses.
+    pub invitations: Vec<PastFamilyInvitation>,
+
+    /// Cursor to pass as `start_after` on the next call, or `None` if this
+    /// page is empty (treat as end-of-list).
+    pub start_next_after: Option<PastFamilyInvitationCursor>,
+}
+
+/// Response to [`QueryMsg::GetAllPastInvitationsPaged`](crate::QueryMsg::GetAllPastInvitationsPaged).
+#[cw_serde]
+pub struct AllPastFamilyInvitationsPagedResponse {
+    /// The archived invitations on this page, in ascending
+    /// `((family_id, node_id), counter)` order across all terminal statuses.
+    pub invitations: Vec<PastFamilyInvitation>,
+
+    /// Cursor to pass as `start_after` on the next call, or `None` if this
+    /// page is empty (treat as end-of-list).
+    pub start_next_after: Option<GlobalPastFamilyInvitationCursor>,
+}
+
 /// Response to [`QueryMsg::GetFamiliesPaged`](crate::QueryMsg::GetFamiliesPaged).
 #[cw_serde]
 pub struct FamiliesPagedResponse {

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
@@ -99,3 +99,45 @@ pub struct PastFamilyInvitation {
     /// What ultimately happened to it.
     pub status: FamilyInvitationStatus,
 }
+
+/// Response to [`QueryMsg::GetFamilyById`](crate::QueryMsg::GetFamilyById).
+#[cw_serde]
+pub struct NodeFamilyResponse {
+    /// The id that was queried, echoed back so paginated callers can correlate.
+    pub family_id: NodeFamilyId,
+    /// The matching family, or `None` if no family with `family_id` exists.
+    pub family: Option<NodeFamily>,
+}
+
+/// Response to [`QueryMsg::GetFamilyMembership`](crate::QueryMsg::GetFamilyMembership).
+#[cw_serde]
+pub struct NodeFamilyMembershipResponse {
+    /// The node that was queried.
+    pub node_id: NodeId,
+    /// The id of the family the node currently belongs to, or `None` if the
+    /// node is not currently a member of any family.
+    pub family_id: Option<NodeFamilyId>,
+}
+
+/// A pending [`FamilyInvitation`] paired with whether it has already timed
+/// out at the time the query was served.
+#[cw_serde]
+pub struct PendingFamilyInvitationDetails {
+    /// The stored invitation as it was issued.
+    pub invitation: FamilyInvitation,
+    /// `true` iff `now >= invitation.expires_at` at query time, i.e. the
+    /// invitation is still in the pending map but can no longer be acted on.
+    pub expired: bool,
+}
+
+/// Response to [`QueryMsg::GetPendingInvitation`](crate::QueryMsg::GetPendingInvitation).
+#[cw_serde]
+pub struct PendingFamilyInvitationResponse {
+    /// The family component of the queried `(family_id, node_id)` key.
+    pub family_id: NodeFamilyId,
+    /// The node component of the queried `(family_id, node_id)` key.
+    pub node_id: NodeId,
+    /// The matching pending invitation along with an explicit expiry flag,
+    /// or `None` if no such invitation exists.
+    pub invitation: Option<PendingFamilyInvitationDetails>,
+}

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1166,21 +1166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
-name = "mixnet-vesting-integration-tests"
-version = "0.1.0"
-dependencies = [
- "cosmwasm-std",
- "cw-multi-test",
- "nym-contracts-common 1.20.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "nym-crypto",
- "nym-mixnet-contract",
- "nym-mixnet-contract-common 1.20.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "nym-vesting-contract",
- "nym-vesting-contract-common",
- "rand_chacha",
-]
-
-[[package]]
 name = "node-families"
 version = "0.1.0"
 dependencies = [

--- a/contracts/node-families/src/contract.rs
+++ b/contracts/node-families/src/contract.rs
@@ -3,8 +3,12 @@
 
 //! CosmWasm entry points for the node families contract.
 
-use crate::queries::{query_family_by_id, query_family_membership, query_pending_invitation};
-use cosmwasm_std::{entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
+use crate::queries::{
+    query_families_paged, query_family_by_id, query_family_membership, query_pending_invitation,
+};
+use cosmwasm_std::{
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
+};
 use node_families_contract_common::{
     ExecuteMsg, InstantiateMsg, MigrateMsg, NodeFamiliesContractError, QueryMsg,
 };
@@ -65,6 +69,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamilies
         }
         QueryMsg::GetPendingInvitation { family_id, node_id } => Ok(to_json_binary(
             &query_pending_invitation(deps, env, family_id, node_id)?,
+        )?),
+        QueryMsg::GetFamiliesPaged { start_after, limit } => Ok(to_json_binary(
+            &query_families_paged(deps, start_after, limit)?,
         )?),
     }
 }

--- a/contracts/node-families/src/contract.rs
+++ b/contracts/node-families/src/contract.rs
@@ -5,11 +5,11 @@
 
 use crate::queries::{
     query_all_past_invitations_paged, query_all_pending_invitations_paged, query_families_paged,
-    query_family_by_id, query_family_members_paged, query_family_membership,
-    query_past_invitations_for_family_paged, query_past_invitations_for_node_paged,
-    query_past_members_for_family_paged, query_past_members_for_node_paged,
-    query_pending_invitation, query_pending_invitations_for_family_paged,
-    query_pending_invitations_for_node_paged,
+    query_family_by_id, query_family_by_name, query_family_by_owner, query_family_members_paged,
+    query_family_membership, query_past_invitations_for_family_paged,
+    query_past_invitations_for_node_paged, query_past_members_for_family_paged,
+    query_past_members_for_node_paged, query_pending_invitation,
+    query_pending_invitations_for_family_paged, query_pending_invitations_for_node_paged,
 };
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
@@ -69,6 +69,12 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamilies
         QueryMsg::GetFamilyById { family_id } => {
             Ok(to_json_binary(&query_family_by_id(deps, family_id)?)?)
         }
+        QueryMsg::GetFamilyByOwner { owner } => {
+            Ok(to_json_binary(&query_family_by_owner(deps, owner)?)?)
+        }
+        QueryMsg::GetFamilyByName { name } => {
+            Ok(to_json_binary(&query_family_by_name(deps, name)?)?)
+        }
         QueryMsg::GetFamilyMembership { node_id } => {
             Ok(to_json_binary(&query_family_membership(deps, node_id)?)?)
         }
@@ -89,13 +95,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamilies
             family_id,
             start_after,
             limit,
-        } => Ok(to_json_binary(&query_pending_invitations_for_family_paged(
-            deps,
-            env,
-            family_id,
-            start_after,
-            limit,
-        )?)?),
+        } => Ok(to_json_binary(
+            &query_pending_invitations_for_family_paged(deps, env, family_id, start_after, limit)?,
+        )?),
         QueryMsg::GetPendingInvitationsForNodePaged {
             node_id,
             start_after,

--- a/contracts/node-families/src/contract.rs
+++ b/contracts/node-families/src/contract.rs
@@ -6,8 +6,9 @@
 use crate::queries::{
     query_all_past_invitations_paged, query_all_pending_invitations_paged, query_families_paged,
     query_family_by_id, query_family_members_paged, query_family_membership,
-    query_past_invitations_for_family_paged, query_pending_invitation,
-    query_pending_invitations_for_family_paged,
+    query_past_invitations_for_family_paged, query_past_invitations_for_node_paged,
+    query_pending_invitation, query_pending_invitations_for_family_paged,
+    query_pending_invitations_for_node_paged,
 };
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
@@ -94,6 +95,17 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamilies
             start_after,
             limit,
         )?)?),
+        QueryMsg::GetPendingInvitationsForNodePaged {
+            node_id,
+            start_after,
+            limit,
+        } => Ok(to_json_binary(&query_pending_invitations_for_node_paged(
+            deps,
+            env,
+            node_id,
+            start_after,
+            limit,
+        )?)?),
         QueryMsg::GetAllPendingInvitationsPaged { start_after, limit } => Ok(to_json_binary(
             &query_all_pending_invitations_paged(deps, env, start_after, limit)?,
         )?),
@@ -104,6 +116,16 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamilies
         } => Ok(to_json_binary(&query_past_invitations_for_family_paged(
             deps,
             family_id,
+            start_after,
+            limit,
+        )?)?),
+        QueryMsg::GetPastInvitationsForNodePaged {
+            node_id,
+            start_after,
+            limit,
+        } => Ok(to_json_binary(&query_past_invitations_for_node_paged(
+            deps,
+            node_id,
             start_after,
             limit,
         )?)?),

--- a/contracts/node-families/src/contract.rs
+++ b/contracts/node-families/src/contract.rs
@@ -4,7 +4,8 @@
 //! CosmWasm entry points for the node families contract.
 
 use crate::queries::{
-    query_families_paged, query_family_by_id, query_family_membership, query_pending_invitation,
+    query_families_paged, query_family_by_id, query_family_members_paged, query_family_membership,
+    query_pending_invitation,
 };
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
@@ -67,6 +68,16 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamilies
         QueryMsg::GetFamilyMembership { node_id } => {
             Ok(to_json_binary(&query_family_membership(deps, node_id)?)?)
         }
+        QueryMsg::GetFamilyMembersPaged {
+            family_id,
+            start_after,
+            limit,
+        } => Ok(to_json_binary(&query_family_members_paged(
+            deps,
+            family_id,
+            start_after,
+            limit,
+        )?)?),
         QueryMsg::GetPendingInvitation { family_id, node_id } => Ok(to_json_binary(
             &query_pending_invitation(deps, env, family_id, node_id)?,
         )?),

--- a/contracts/node-families/src/contract.rs
+++ b/contracts/node-families/src/contract.rs
@@ -7,8 +7,9 @@ use crate::queries::{
     query_all_past_invitations_paged, query_all_pending_invitations_paged, query_families_paged,
     query_family_by_id, query_family_members_paged, query_family_membership,
     query_past_invitations_for_family_paged, query_past_invitations_for_node_paged,
-    query_past_members_for_family_paged, query_pending_invitation,
-    query_pending_invitations_for_family_paged, query_pending_invitations_for_node_paged,
+    query_past_members_for_family_paged, query_past_members_for_node_paged,
+    query_pending_invitation, query_pending_invitations_for_family_paged,
+    query_pending_invitations_for_node_paged,
 };
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
@@ -139,6 +140,16 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamilies
         } => Ok(to_json_binary(&query_past_members_for_family_paged(
             deps,
             family_id,
+            start_after,
+            limit,
+        )?)?),
+        QueryMsg::GetPastMembersForNodePaged {
+            node_id,
+            start_after,
+            limit,
+        } => Ok(to_json_binary(&query_past_members_for_node_paged(
+            deps,
+            node_id,
             start_after,
             limit,
         )?)?),

--- a/contracts/node-families/src/contract.rs
+++ b/contracts/node-families/src/contract.rs
@@ -7,8 +7,8 @@ use crate::queries::{
     query_all_past_invitations_paged, query_all_pending_invitations_paged, query_families_paged,
     query_family_by_id, query_family_members_paged, query_family_membership,
     query_past_invitations_for_family_paged, query_past_invitations_for_node_paged,
-    query_pending_invitation, query_pending_invitations_for_family_paged,
-    query_pending_invitations_for_node_paged,
+    query_past_members_for_family_paged, query_pending_invitation,
+    query_pending_invitations_for_family_paged, query_pending_invitations_for_node_paged,
 };
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
@@ -132,6 +132,16 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamilies
         QueryMsg::GetAllPastInvitationsPaged { start_after, limit } => Ok(to_json_binary(
             &query_all_past_invitations_paged(deps, start_after, limit)?,
         )?),
+        QueryMsg::GetPastMembersForFamilyPaged {
+            family_id,
+            start_after,
+            limit,
+        } => Ok(to_json_binary(&query_past_members_for_family_paged(
+            deps,
+            family_id,
+            start_after,
+            limit,
+        )?)?),
         QueryMsg::GetFamiliesPaged { start_after, limit } => Ok(to_json_binary(
             &query_families_paged(deps, start_after, limit)?,
         )?),

--- a/contracts/node-families/src/contract.rs
+++ b/contracts/node-families/src/contract.rs
@@ -4,8 +4,9 @@
 //! CosmWasm entry points for the node families contract.
 
 use crate::queries::{
-    query_families_paged, query_family_by_id, query_family_members_paged, query_family_membership,
-    query_pending_invitation,
+    query_all_pending_invitations_paged, query_families_paged, query_family_by_id,
+    query_family_members_paged, query_family_membership, query_pending_invitation,
+    query_pending_invitations_for_family_paged,
 };
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
@@ -80,6 +81,20 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamilies
         )?)?),
         QueryMsg::GetPendingInvitation { family_id, node_id } => Ok(to_json_binary(
             &query_pending_invitation(deps, env, family_id, node_id)?,
+        )?),
+        QueryMsg::GetPendingInvitationsForFamilyPaged {
+            family_id,
+            start_after,
+            limit,
+        } => Ok(to_json_binary(&query_pending_invitations_for_family_paged(
+            deps,
+            env,
+            family_id,
+            start_after,
+            limit,
+        )?)?),
+        QueryMsg::GetAllPendingInvitationsPaged { start_after, limit } => Ok(to_json_binary(
+            &query_all_pending_invitations_paged(deps, env, start_after, limit)?,
         )?),
         QueryMsg::GetFamiliesPaged { start_after, limit } => Ok(to_json_binary(
             &query_families_paged(deps, start_after, limit)?,

--- a/contracts/node-families/src/contract.rs
+++ b/contracts/node-families/src/contract.rs
@@ -4,8 +4,9 @@
 //! CosmWasm entry points for the node families contract.
 
 use crate::queries::{
-    query_all_pending_invitations_paged, query_families_paged, query_family_by_id,
-    query_family_members_paged, query_family_membership, query_pending_invitation,
+    query_all_past_invitations_paged, query_all_pending_invitations_paged, query_families_paged,
+    query_family_by_id, query_family_members_paged, query_family_membership,
+    query_past_invitations_for_family_paged, query_pending_invitation,
     query_pending_invitations_for_family_paged,
 };
 use cosmwasm_std::{
@@ -95,6 +96,19 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamilies
         )?)?),
         QueryMsg::GetAllPendingInvitationsPaged { start_after, limit } => Ok(to_json_binary(
             &query_all_pending_invitations_paged(deps, env, start_after, limit)?,
+        )?),
+        QueryMsg::GetPastInvitationsForFamilyPaged {
+            family_id,
+            start_after,
+            limit,
+        } => Ok(to_json_binary(&query_past_invitations_for_family_paged(
+            deps,
+            family_id,
+            start_after,
+            limit,
+        )?)?),
+        QueryMsg::GetAllPastInvitationsPaged { start_after, limit } => Ok(to_json_binary(
+            &query_all_past_invitations_paged(deps, start_after, limit)?,
         )?),
         QueryMsg::GetFamiliesPaged { start_after, limit } => Ok(to_json_binary(
             &query_families_paged(deps, start_after, limit)?,

--- a/contracts/node-families/src/contract.rs
+++ b/contracts/node-families/src/contract.rs
@@ -3,7 +3,8 @@
 
 //! CosmWasm entry points for the node families contract.
 
-use cosmwasm_std::{entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response};
+use crate::queries::{query_family_by_id, query_family_membership, query_pending_invitation};
+use cosmwasm_std::{entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
 use node_families_contract_common::{
     ExecuteMsg, InstantiateMsg, MigrateMsg, NodeFamiliesContractError, QueryMsg,
 };
@@ -55,10 +56,17 @@ pub fn execute(
 /// wired up here as variants are added to [`QueryMsg`].
 #[entry_point]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamiliesContractError> {
-    let _ = deps;
-    let _ = env;
-    let _ = msg;
-    Ok(Binary::default())
+    match msg {
+        QueryMsg::GetFamilyById { family_id } => {
+            Ok(to_json_binary(&query_family_by_id(deps, family_id)?)?)
+        }
+        QueryMsg::GetFamilyMembership { node_id } => {
+            Ok(to_json_binary(&query_family_membership(deps, node_id)?)?)
+        }
+        QueryMsg::GetPendingInvitation { family_id, node_id } => Ok(to_json_binary(
+            &query_pending_invitation(deps, env, family_id, node_id)?,
+        )?),
+    }
 }
 
 /// Migration entry point.

--- a/contracts/node-families/src/helpers.rs
+++ b/contracts/node-families/src/helpers.rs
@@ -8,7 +8,6 @@
 /// the storage layer's unique-name index. Callers should pass the normalised
 /// value to [`node_families_contract_common::NodeFamily::name`] when creating a family and when looking one
 /// up by name.
-#[allow(dead_code)]
 pub fn normalise_family_name(name: &str) -> String {
     name.chars()
         .filter(|c| c.is_ascii_alphanumeric())

--- a/contracts/node-families/src/helpers.rs
+++ b/contracts/node-families/src/helpers.rs
@@ -5,9 +5,7 @@
 ///
 /// Drops every character that isn't an ASCII letter or digit and lowercases
 /// the rest, so `"  Foo-Bar! "`, `"foobar"` and `"FOO BAR"` all collide on
-/// the storage layer's unique-name index. Callers should pass the normalised
-/// value to [`node_families_contract_common::NodeFamily::name`] when creating a family and when looking one
-/// up by name.
+/// the storage layer's unique-name index.
 pub fn normalise_family_name(name: &str) -> String {
     name.chars()
         .filter(|c| c.is_ascii_alphanumeric())

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -1,13 +1,15 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use crate::helpers::normalise_family_name;
 use crate::storage::{retrieval_limits, NodeFamiliesStorage};
 use cosmwasm_std::{Deps, Env, Order, StdResult};
 use cw_storage_plus::Bound;
 use node_families_contract_common::{
     AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse, FamilyMemberRecord,
     FamilyMembersPagedResponse, GlobalPastFamilyInvitationCursor, NodeFamiliesContractError,
-    NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationCursor,
+    NodeFamilyByNameResponse, NodeFamilyByOwnerResponse, NodeFamilyId,
+    NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationCursor,
     PastFamilyInvitationForNodeCursor, PastFamilyInvitationsForNodePagedResponse,
     PastFamilyInvitationsPagedResponse, PastFamilyMemberCursor, PastFamilyMemberForNodeCursor,
     PastFamilyMembersForNodePagedResponse, PastFamilyMembersPagedResponse,
@@ -27,6 +29,45 @@ pub fn query_family_by_id(
         .families
         .may_load(deps.storage, family_id)?;
     Ok(NodeFamilyResponse { family_id, family })
+}
+
+/// Resolve the (at most one) family owned by `owner`. Returns `family: None`
+/// if `owner` does not currently own a family. Backed by the `owner`
+/// `UniqueIndex`, so cost is O(1).
+pub fn query_family_by_owner(
+    deps: Deps,
+    owner: String,
+) -> Result<NodeFamilyByOwnerResponse, NodeFamiliesContractError> {
+    let owner = deps.api.addr_validate(&owner)?;
+    let family = NodeFamiliesStorage::new()
+        .families
+        .idx
+        .owner
+        .item(deps.storage, owner.clone())?
+        .map(|(_, family)| family);
+    Ok(NodeFamilyByOwnerResponse { owner, family })
+}
+
+/// Resolve a single family by its name. The lookup runs the input through
+/// [`normalise_family_name`] before hitting the `name` `UniqueIndex`, so
+/// e.g. `"foo"`, `"FoO"` and `"  foo!  "` all resolve to the same family.
+/// Returns `family: None` if no family with that (normalised) name exists.
+/// Backed by the `name` `UniqueIndex`, so cost is O(1).
+///
+/// The echoed `name` in the response is the normalised form actually used
+/// for the lookup, so callers can correlate after the normalisation.
+pub fn query_family_by_name(
+    deps: Deps,
+    name: String,
+) -> Result<NodeFamilyByNameResponse, NodeFamiliesContractError> {
+    let name = normalise_family_name(&name);
+    let family = NodeFamiliesStorage::new()
+        .families
+        .idx
+        .name
+        .item(deps.storage, name.clone())?
+        .map(|(_, family)| family);
+    Ok(NodeFamilyByNameResponse { name, family })
 }
 
 /// Report which family — if any — a node currently belongs to.
@@ -329,8 +370,8 @@ pub fn query_past_invitations_for_node_paged(
         .unwrap_or(retrieval_limits::PAST_INVITATIONS_DEFAULT_LIMIT)
         .min(retrieval_limits::PAST_INVITATIONS_MAX_LIMIT) as usize;
 
-    let start = start_after
-        .map(|(family_id, counter)| Bound::exclusive(((family_id, node_id), counter)));
+    let start =
+        start_after.map(|(family_id, counter)| Bound::exclusive(((family_id, node_id), counter)));
 
     let storage = NodeFamiliesStorage::new();
     let entries = storage
@@ -463,8 +504,8 @@ pub fn query_past_members_for_node_paged(
         .unwrap_or(retrieval_limits::PAST_MEMBERS_DEFAULT_LIMIT)
         .min(retrieval_limits::PAST_MEMBERS_MAX_LIMIT) as usize;
 
-    let start = start_after
-        .map(|(family_id, counter)| Bound::exclusive(((family_id, node_id), counter)));
+    let start =
+        start_after.map(|(family_id, counter)| Bound::exclusive(((family_id, node_id), counter)));
 
     let storage = NodeFamiliesStorage::new();
     let entries = storage
@@ -549,6 +590,130 @@ mod tests {
             let res = query_family_by_id(tester.deps(), f.id).unwrap();
             assert_eq!(res.family_id, f.id);
             assert_eq!(res.family, Some(f));
+        }
+    }
+
+    #[cfg(test)]
+    mod family_by_owner {
+        use super::*;
+
+        #[test]
+        fn returns_none_when_owner_owns_no_family() {
+            let tester = init_contract_tester();
+            let alice = tester.addr_make("alice");
+
+            let res = query_family_by_owner(tester.deps(), alice.to_string()).unwrap();
+            assert_eq!(res.owner, alice);
+            assert!(res.family.is_none());
+        }
+
+        #[test]
+        fn returns_persisted_family_for_owner() {
+            let mut tester = init_contract_tester();
+            let alice = tester.addr_make("alice");
+            let f = tester.make_family(&alice);
+
+            let res = query_family_by_owner(tester.deps(), alice.to_string()).unwrap();
+            assert_eq!(res.owner, alice);
+            assert_eq!(res.family, Some(f));
+        }
+
+        #[test]
+        fn distinguishes_owners() {
+            let mut tester = init_contract_tester();
+            let alice = tester.addr_make("alice");
+            let bob = tester.addr_make("bob");
+            let f_alice = tester.make_family(&alice);
+            let f_bob = tester.make_family(&bob);
+
+            let res = query_family_by_owner(tester.deps(), alice.to_string()).unwrap();
+            assert_eq!(res.family, Some(f_alice));
+            let res = query_family_by_owner(tester.deps(), bob.to_string()).unwrap();
+            assert_eq!(res.family, Some(f_bob));
+        }
+
+        #[test]
+        fn errors_on_invalid_address() {
+            let tester = init_contract_tester();
+
+            let res = query_family_by_owner(tester.deps(), "not a valid addr".to_string());
+            assert!(res.is_err());
+        }
+    }
+
+    #[cfg(test)]
+    mod family_by_name {
+        use super::*;
+
+        #[test]
+        fn returns_none_when_name_does_not_exist() {
+            let tester = init_contract_tester();
+
+            let res = query_family_by_name(tester.deps(), "missing".to_string()).unwrap();
+            assert_eq!(res.name, "missing");
+            assert!(res.family.is_none());
+        }
+
+        #[test]
+        fn returns_persisted_family_by_exact_name() {
+            let mut tester = init_contract_tester();
+            let s = NodeFamiliesStorage::new();
+            let env = tester.env();
+            let alice = tester.addr_make("alice");
+            let f = s
+                .register_new_family(tester.storage_mut(), &env, alice, "foo".into(), "".into())
+                .unwrap();
+
+            let res = query_family_by_name(tester.deps(), "foo".to_string()).unwrap();
+            assert_eq!(res.name, "foo");
+            assert_eq!(res.family, Some(f));
+        }
+
+        #[test]
+        fn lookup_is_case_insensitive() {
+            let mut tester = init_contract_tester();
+            let s = NodeFamiliesStorage::new();
+            let env = tester.env();
+            let alice = tester.addr_make("alice");
+            let f = s
+                .register_new_family(tester.storage_mut(), &env, alice, "foo".into(), "".into())
+                .unwrap();
+
+            for variant in ["foo", "FOO", "FoO", "fOo"] {
+                let res = query_family_by_name(tester.deps(), variant.to_string()).unwrap();
+                assert_eq!(res.name, "foo");
+                assert_eq!(res.family, Some(f.clone()));
+            }
+        }
+
+        #[test]
+        fn lookup_strips_non_alphanumerics() {
+            let mut tester = init_contract_tester();
+            let s = NodeFamiliesStorage::new();
+            let env = tester.env();
+            let alice = tester.addr_make("alice");
+            let f = s
+                .register_new_family(
+                    tester.storage_mut(),
+                    &env,
+                    alice,
+                    "foobar".into(),
+                    "".into(),
+                )
+                .unwrap();
+
+            let res = query_family_by_name(tester.deps(), "  Foo-Bar! ".to_string()).unwrap();
+            assert_eq!(res.name, "foobar");
+            assert_eq!(res.family, Some(f));
+        }
+
+        #[test]
+        fn echoes_normalised_name_even_when_no_match() {
+            let tester = init_contract_tester();
+
+            let res = query_family_by_name(tester.deps(), "  Foo-Bar! ".to_string()).unwrap();
+            assert_eq!(res.name, "foobar");
+            assert!(res.family.is_none());
         }
     }
 
@@ -1515,9 +1680,8 @@ mod tests {
             let tester = init_contract_tester();
             let env = tester.env();
 
-            let res =
-                query_pending_invitations_for_node_paged(tester.deps(), env, 42, None, None)
-                    .unwrap();
+            let res = query_pending_invitations_for_node_paged(tester.deps(), env, 42, None, None)
+                .unwrap();
             assert_eq!(res.node_id, 42);
             assert!(res.invitations.is_empty());
             assert!(res.start_next_after.is_none());
@@ -1533,9 +1697,8 @@ mod tests {
             tester.invite_to_family(f2.id, 10);
 
             let env = tester.env();
-            let res =
-                query_pending_invitations_for_node_paged(tester.deps(), env, 10, None, None)
-                    .unwrap();
+            let res = query_pending_invitations_for_node_paged(tester.deps(), env, 10, None, None)
+                .unwrap();
             let pairs: Vec<_> = res
                 .invitations
                 .iter()
@@ -1556,9 +1719,8 @@ mod tests {
             tester.invite_to_family(f2.id, 7);
 
             let env = tester.env();
-            let res =
-                query_pending_invitations_for_node_paged(tester.deps(), env, 7, None, None)
-                    .unwrap();
+            let res = query_pending_invitations_for_node_paged(tester.deps(), env, 7, None, None)
+                .unwrap();
             let ids: Vec<_> = res
                 .invitations
                 .iter()
@@ -1633,9 +1795,8 @@ mod tests {
 
             tester.advance_time_by(60);
             let env = tester.env();
-            let res =
-                query_pending_invitations_for_node_paged(tester.deps(), env, 7, None, None)
-                    .unwrap();
+            let res = query_pending_invitations_for_node_paged(tester.deps(), env, 7, None, None)
+                .unwrap();
             let by_family: std::collections::HashMap<_, _> = res
                 .invitations
                 .iter()
@@ -1679,8 +1840,7 @@ mod tests {
         fn empty_when_node_has_no_archive_entries() {
             let tester = init_contract_tester();
 
-            let res =
-                query_past_invitations_for_node_paged(tester.deps(), 42, None, None).unwrap();
+            let res = query_past_invitations_for_node_paged(tester.deps(), 42, None, None).unwrap();
             assert_eq!(res.node_id, 42);
             assert!(res.invitations.is_empty());
             assert!(res.start_next_after.is_none());
@@ -1695,8 +1855,7 @@ mod tests {
             tester.add_to_family(f1.id, 8);
             tester.add_to_family(f2.id, 7);
 
-            let res =
-                query_past_invitations_for_node_paged(tester.deps(), 7, None, None).unwrap();
+            let res = query_past_invitations_for_node_paged(tester.deps(), 7, None, None).unwrap();
             assert_eq!(res.invitations.len(), 2);
             for entry in &res.invitations {
                 assert_eq!(entry.invitation.node_id, 7);
@@ -1718,8 +1877,7 @@ mod tests {
             tester.invite_to_family(f3.id, 7);
             tester.revoke_invitation(f3.id, 7);
 
-            let res =
-                query_past_invitations_for_node_paged(tester.deps(), 7, None, None).unwrap();
+            let res = query_past_invitations_for_node_paged(tester.deps(), 7, None, None).unwrap();
             let by_family: std::collections::HashMap<_, _> = res
                 .invitations
                 .iter()
@@ -1752,8 +1910,7 @@ mod tests {
             // one Accepted in f2
             tester.add_to_family(f2.id, 7);
 
-            let res =
-                query_past_invitations_for_node_paged(tester.deps(), 7, None, None).unwrap();
+            let res = query_past_invitations_for_node_paged(tester.deps(), 7, None, None).unwrap();
             let pairs: Vec<_> = res
                 .invitations
                 .iter()
@@ -1818,13 +1975,8 @@ mod tests {
                 tester.remove_from_family(7);
             }
 
-            let res = query_past_invitations_for_node_paged(
-                tester.deps(),
-                7,
-                None,
-                Some(u32::MAX),
-            )
-            .unwrap();
+            let res = query_past_invitations_for_node_paged(tester.deps(), 7, None, Some(u32::MAX))
+                .unwrap();
             assert_eq!(
                 res.invitations.len(),
                 retrieval_limits::PAST_INVITATIONS_MAX_LIMIT as usize
@@ -1841,8 +1993,7 @@ mod tests {
             let mut tester = init_contract_tester();
             let f = tester.add_dummy_family();
 
-            let res =
-                query_past_members_for_family_paged(tester.deps(), f.id, None, None).unwrap();
+            let res = query_past_members_for_family_paged(tester.deps(), f.id, None, None).unwrap();
             assert_eq!(res.family_id, f.id);
             assert!(res.members.is_empty());
             assert!(res.start_next_after.is_none());
@@ -1852,8 +2003,7 @@ mod tests {
         fn empty_for_unknown_family_id() {
             let tester = init_contract_tester();
 
-            let res =
-                query_past_members_for_family_paged(tester.deps(), 99, None, None).unwrap();
+            let res = query_past_members_for_family_paged(tester.deps(), 99, None, None).unwrap();
             assert_eq!(res.family_id, 99);
             assert!(res.members.is_empty());
             assert!(res.start_next_after.is_none());
@@ -1884,8 +2034,7 @@ mod tests {
             let removed_at = tester.env().block.time.seconds();
             tester.remove_from_family(42);
 
-            let res =
-                query_past_members_for_family_paged(tester.deps(), f.id, None, None).unwrap();
+            let res = query_past_members_for_family_paged(tester.deps(), f.id, None, None).unwrap();
             let entry = res.members.into_iter().next().unwrap();
             assert_eq!(entry.family_id, f.id);
             assert_eq!(entry.node_id, 42);
@@ -1905,8 +2054,7 @@ mod tests {
             tester.add_to_family(f.id, 7);
             tester.remove_from_family(7);
 
-            let res =
-                query_past_members_for_family_paged(tester.deps(), f.id, None, None).unwrap();
+            let res = query_past_members_for_family_paged(tester.deps(), f.id, None, None).unwrap();
             let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
             // 7 comes before 42; 42 appears twice
             assert_eq!(ids, vec![7, 42, 42]);
@@ -1959,13 +2107,9 @@ mod tests {
                 tester.remove_from_family(n);
             }
 
-            let res = query_past_members_for_family_paged(
-                tester.deps(),
-                f.id,
-                None,
-                Some(u32::MAX),
-            )
-            .unwrap();
+            let res =
+                query_past_members_for_family_paged(tester.deps(), f.id, None, Some(u32::MAX))
+                    .unwrap();
             assert_eq!(
                 res.members.len(),
                 retrieval_limits::PAST_MEMBERS_MAX_LIMIT as usize
@@ -2052,30 +2196,21 @@ mod tests {
             tester.add_to_family(f3.id, 7);
             tester.remove_from_family(7);
 
-            let p1 =
-                query_past_members_for_node_paged(tester.deps(), 7, None, Some(2)).unwrap();
+            let p1 = query_past_members_for_node_paged(tester.deps(), 7, None, Some(2)).unwrap();
             let ids: Vec<_> = p1.members.iter().map(|m| m.family_id).collect();
             assert_eq!(ids, vec![f1.id, f2.id]);
             assert_eq!(p1.start_next_after, Some((f2.id, 0)));
 
-            let p2 = query_past_members_for_node_paged(
-                tester.deps(),
-                7,
-                p1.start_next_after,
-                Some(2),
-            )
-            .unwrap();
+            let p2 =
+                query_past_members_for_node_paged(tester.deps(), 7, p1.start_next_after, Some(2))
+                    .unwrap();
             let ids: Vec<_> = p2.members.iter().map(|m| m.family_id).collect();
             assert_eq!(ids, vec![f3.id]);
             assert_eq!(p2.start_next_after, Some((f3.id, 0)));
 
-            let p3 = query_past_members_for_node_paged(
-                tester.deps(),
-                7,
-                p2.start_next_after,
-                Some(2),
-            )
-            .unwrap();
+            let p3 =
+                query_past_members_for_node_paged(tester.deps(), 7, p2.start_next_after, Some(2))
+                    .unwrap();
             assert!(p3.members.is_empty());
             assert!(p3.start_next_after.is_none());
         }

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -5,8 +5,9 @@ use crate::storage::{retrieval_limits, NodeFamiliesStorage};
 use cosmwasm_std::{Deps, Env, Order, StdResult};
 use cw_storage_plus::Bound;
 use node_families_contract_common::{
-    FamiliesPagedResponse, NodeFamiliesContractError, NodeFamilyId, NodeFamilyMembershipResponse,
-    NodeFamilyResponse, PendingFamilyInvitationDetails, PendingFamilyInvitationResponse,
+    FamiliesPagedResponse, FamilyMemberRecord, FamilyMembersPagedResponse,
+    NodeFamiliesContractError, NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse,
+    PendingFamilyInvitationDetails, PendingFamilyInvitationResponse,
 };
 use nym_mixnet_contract_common::NodeId;
 
@@ -29,7 +30,8 @@ pub fn query_family_membership(
 ) -> Result<NodeFamilyMembershipResponse, NodeFamiliesContractError> {
     let family_id = NodeFamiliesStorage::new()
         .family_members
-        .may_load(deps.storage, node_id)?;
+        .may_load(deps.storage, node_id)?
+        .map(|m| m.family_id);
     Ok(NodeFamilyMembershipResponse { node_id, family_id })
 }
 
@@ -54,6 +56,55 @@ pub fn query_pending_invitation(
         family_id,
         node_id,
         invitation,
+    })
+}
+
+/// Page through every node currently in `family_id`, in ascending
+/// [`NodeId`] order.
+///
+/// Backed by the `family` multi-index over [`crate::storage::NodeFamiliesStorage::family_members`],
+/// so the cost is O(page size) regardless of how many other families exist.
+/// Does not verify that `family_id` refers to an existing family — an
+/// unknown id simply yields an empty page.
+///
+/// `start_after` is exclusive — pass the previous page's `start_next_after`
+/// to fetch the next page; pass `None` to start from the lowest-id member.
+/// `limit` defaults to [`retrieval_limits::FAMILY_MEMBERS_DEFAULT_LIMIT`]
+/// and is clamped to [`retrieval_limits::FAMILY_MEMBERS_MAX_LIMIT`].
+pub fn query_family_members_paged(
+    deps: Deps,
+    family_id: NodeFamilyId,
+    start_after: Option<NodeId>,
+    limit: Option<u32>,
+) -> Result<FamilyMembersPagedResponse, NodeFamiliesContractError> {
+    let limit = limit
+        .unwrap_or(retrieval_limits::FAMILY_MEMBERS_DEFAULT_LIMIT)
+        .min(retrieval_limits::FAMILY_MEMBERS_MAX_LIMIT) as usize;
+
+    let start = start_after.map(Bound::exclusive);
+
+    let storage = NodeFamiliesStorage::new();
+    let members = storage
+        .family_members
+        .idx
+        .family
+        .prefix(family_id)
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|res| {
+            res.map(|(node_id, membership)| FamilyMemberRecord {
+                node_id,
+                membership,
+            })
+        })
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let start_next_after = members.last().map(|record| record.node_id);
+
+    Ok(FamilyMembersPagedResponse {
+        family_id,
+        members,
+        start_next_after,
     })
 }
 
@@ -336,6 +387,177 @@ mod tests {
             let res = query_families_paged(tester.deps(), Some(f.id), None).unwrap();
             assert!(res.families.is_empty());
             assert!(res.start_next_after.is_none());
+        }
+    }
+
+    #[cfg(test)]
+    mod family_members_paged {
+        use super::*;
+
+        #[test]
+        fn empty_when_family_has_no_members() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+
+            let res = query_family_members_paged(tester.deps(), f.id, None, None).unwrap();
+            assert_eq!(res.family_id, f.id);
+            assert!(res.members.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn empty_for_unknown_family_id() {
+            let tester = init_contract_tester();
+
+            let res = query_family_members_paged(tester.deps(), 99, None, None).unwrap();
+            assert_eq!(res.family_id, 99);
+            assert!(res.members.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn returns_only_members_of_requested_family() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+
+            tester.add_to_family(f1.id, 10);
+            tester.add_to_family(f1.id, 11);
+            tester.add_to_family(f2.id, 20);
+
+            let res = query_family_members_paged(tester.deps(), f1.id, None, None).unwrap();
+            let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
+            assert_eq!(ids, vec![10, 11]);
+            for record in &res.members {
+                assert_eq!(record.membership.family_id, f1.id);
+            }
+        }
+
+        #[test]
+        fn member_record_carries_joined_at_timestamp() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            tester.add_to_family(f.id, 42);
+
+            let expected = tester.env().block.time.seconds();
+            let res = query_family_members_paged(tester.deps(), f.id, None, None).unwrap();
+            let record = res.members.into_iter().next().unwrap();
+            assert_eq!(record.node_id, 42);
+            assert_eq!(record.membership.family_id, f.id);
+            assert_eq!(record.membership.joined_at, expected);
+        }
+
+        #[test]
+        fn members_returned_in_ascending_node_id_order() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            // insert out of order to confirm ordering isn't insertion order
+            tester.add_to_family(f.id, 30);
+            tester.add_to_family(f.id, 10);
+            tester.add_to_family(f.id, 20);
+
+            let res = query_family_members_paged(tester.deps(), f.id, None, None).unwrap();
+            let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
+            assert_eq!(ids, vec![10, 20, 30]);
+        }
+
+        #[test]
+        fn limit_caps_page_size() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            for n in [10, 11, 12] {
+                tester.add_to_family(f.id, n);
+            }
+
+            let res = query_family_members_paged(tester.deps(), f.id, None, Some(2)).unwrap();
+            let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
+            assert_eq!(ids, vec![10, 11]);
+            assert_eq!(res.start_next_after, Some(11));
+        }
+
+        #[test]
+        fn start_after_is_exclusive() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            for n in [10, 11, 12] {
+                tester.add_to_family(f.id, n);
+            }
+
+            let res = query_family_members_paged(tester.deps(), f.id, Some(10), None).unwrap();
+            let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
+            assert_eq!(ids, vec![11, 12]);
+            assert_eq!(res.start_next_after, Some(12));
+        }
+
+        #[test]
+        fn paginates_through_all_members() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            for n in [10, 11, 12, 13, 14] {
+                tester.add_to_family(f.id, n);
+            }
+
+            let p1 = query_family_members_paged(tester.deps(), f.id, None, Some(2)).unwrap();
+            assert_eq!(
+                p1.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
+                vec![10, 11]
+            );
+            assert_eq!(p1.start_next_after, Some(11));
+
+            let p2 =
+                query_family_members_paged(tester.deps(), f.id, p1.start_next_after, Some(2))
+                    .unwrap();
+            assert_eq!(
+                p2.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
+                vec![12, 13]
+            );
+            assert_eq!(p2.start_next_after, Some(13));
+
+            let p3 =
+                query_family_members_paged(tester.deps(), f.id, p2.start_next_after, Some(2))
+                    .unwrap();
+            assert_eq!(
+                p3.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
+                vec![14]
+            );
+            assert_eq!(p3.start_next_after, Some(14));
+
+            let p4 =
+                query_family_members_paged(tester.deps(), f.id, p3.start_next_after, Some(2))
+                    .unwrap();
+            assert!(p4.members.is_empty());
+            assert!(p4.start_next_after.is_none());
+        }
+
+        #[test]
+        fn limit_is_clamped_to_max() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            let total = retrieval_limits::FAMILY_MEMBERS_MAX_LIMIT as u32 + 5;
+            for n in 1..=total {
+                tester.add_to_family(f.id, n);
+            }
+
+            let res = query_family_members_paged(tester.deps(), f.id, None, Some(u32::MAX))
+                .unwrap();
+            assert_eq!(
+                res.members.len(),
+                retrieval_limits::FAMILY_MEMBERS_MAX_LIMIT as usize
+            );
+        }
+
+        #[test]
+        fn excludes_node_after_it_leaves_family() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            tester.add_to_family(f.id, 10);
+            tester.add_to_family(f.id, 11);
+
+            tester.remove_from_family(10);
+
+            let res = query_family_members_paged(tester.deps(), f.id, None, None).unwrap();
+            let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
+            assert_eq!(ids, vec![11]);
         }
     }
 }

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -8,6 +8,7 @@ use node_families_contract_common::{
     FamiliesPagedResponse, FamilyMemberRecord, FamilyMembersPagedResponse,
     NodeFamiliesContractError, NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse,
     PendingFamilyInvitationDetails, PendingFamilyInvitationResponse,
+    PendingFamilyInvitationsPagedResponse, PendingInvitationsPagedResponse,
 };
 use nym_mixnet_contract_common::NodeId;
 
@@ -104,6 +105,103 @@ pub fn query_family_members_paged(
     Ok(FamilyMembersPagedResponse {
         family_id,
         members,
+        start_next_after,
+    })
+}
+
+/// Page through every pending invitation issued by `family_id`, in ascending
+/// invitee [`NodeId`] order. Each entry is stamped with `expired` based on
+/// the current block time, so callers don't have to compare it themselves.
+///
+/// Backed by a prefix scan on the composite primary key
+/// `(family_id, node_id)` of `pending_family_invitations`, so cost is
+/// O(page size). Does not verify that `family_id` refers to an existing
+/// family — an unknown id simply yields an empty page.
+///
+/// `start_after` is exclusive — pass the previous page's `start_next_after`
+/// to fetch the next page; pass `None` to start from the lowest-id invitee.
+/// `limit` defaults to [`retrieval_limits::PENDING_INVITATIONS_DEFAULT_LIMIT`]
+/// and is clamped to [`retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT`].
+pub fn query_pending_invitations_for_family_paged(
+    deps: Deps,
+    env: Env,
+    family_id: NodeFamilyId,
+    start_after: Option<NodeId>,
+    limit: Option<u32>,
+) -> Result<PendingFamilyInvitationsPagedResponse, NodeFamiliesContractError> {
+    let limit = limit
+        .unwrap_or(retrieval_limits::PENDING_INVITATIONS_DEFAULT_LIMIT)
+        .min(retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT) as usize;
+
+    let now = env.block.time.seconds();
+    let start = start_after.map(Bound::exclusive);
+
+    let storage = NodeFamiliesStorage::new();
+    let invitations = storage
+        .pending_family_invitations
+        .prefix(family_id)
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|res| {
+            res.map(|(_node_id, invitation)| PendingFamilyInvitationDetails {
+                expired: now >= invitation.expires_at,
+                invitation,
+            })
+        })
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let start_next_after = invitations.last().map(|d| d.invitation.node_id);
+
+    Ok(PendingFamilyInvitationsPagedResponse {
+        family_id,
+        invitations,
+        start_next_after,
+    })
+}
+
+/// Page through every pending invitation across all families, in ascending
+/// `(family_id, node_id)` order. Each entry is stamped with `expired` based
+/// on the current block time.
+///
+/// Cost is O(page size) — full range scan over the
+/// `pending_family_invitations` map without any prefix filter.
+///
+/// `start_after` is exclusive — pass the previous page's `start_next_after`
+/// to fetch the next page; pass `None` to start from the first entry.
+/// `limit` defaults to [`retrieval_limits::PENDING_INVITATIONS_DEFAULT_LIMIT`]
+/// and is clamped to [`retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT`].
+pub fn query_all_pending_invitations_paged(
+    deps: Deps,
+    env: Env,
+    start_after: Option<(NodeFamilyId, NodeId)>,
+    limit: Option<u32>,
+) -> Result<PendingInvitationsPagedResponse, NodeFamiliesContractError> {
+    let limit = limit
+        .unwrap_or(retrieval_limits::PENDING_INVITATIONS_DEFAULT_LIMIT)
+        .min(retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT) as usize;
+
+    let now = env.block.time.seconds();
+    let start = start_after.map(Bound::exclusive);
+
+    let storage = NodeFamiliesStorage::new();
+    let invitations = storage
+        .pending_family_invitations
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|res| {
+            res.map(|(_key, invitation)| PendingFamilyInvitationDetails {
+                expired: now >= invitation.expires_at,
+                invitation,
+            })
+        })
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let start_next_after = invitations
+        .last()
+        .map(|d| (d.invitation.family_id, d.invitation.node_id));
+
+    Ok(PendingInvitationsPagedResponse {
+        invitations,
         start_next_after,
     })
 }
@@ -558,6 +656,304 @@ mod tests {
             let res = query_family_members_paged(tester.deps(), f.id, None, None).unwrap();
             let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
             assert_eq!(ids, vec![11]);
+        }
+    }
+
+    #[cfg(test)]
+    mod pending_invitations_for_family_paged {
+        use super::*;
+
+        #[test]
+        fn empty_when_family_has_no_pending_invitations() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            let env = tester.env();
+
+            let res = query_pending_invitations_for_family_paged(
+                tester.deps(),
+                env,
+                f.id,
+                None,
+                None,
+            )
+            .unwrap();
+            assert_eq!(res.family_id, f.id);
+            assert!(res.invitations.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn empty_for_unknown_family_id() {
+            let tester = init_contract_tester();
+            let env = tester.env();
+
+            let res =
+                query_pending_invitations_for_family_paged(tester.deps(), env, 99, None, None)
+                    .unwrap();
+            assert_eq!(res.family_id, 99);
+            assert!(res.invitations.is_empty());
+        }
+
+        #[test]
+        fn returns_only_invitations_from_requested_family() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.invite_to_family(f1.id, 10);
+            tester.invite_to_family(f1.id, 11);
+            tester.invite_to_family(f2.id, 20);
+
+            let env = tester.env();
+            let res = query_pending_invitations_for_family_paged(
+                tester.deps(),
+                env,
+                f1.id,
+                None,
+                None,
+            )
+            .unwrap();
+            let ids: Vec<_> = res.invitations.iter().map(|d| d.invitation.node_id).collect();
+            assert_eq!(ids, vec![10, 11]);
+            for d in &res.invitations {
+                assert_eq!(d.invitation.family_id, f1.id);
+            }
+        }
+
+        #[test]
+        fn returned_in_ascending_node_id_order() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            // out-of-order inserts
+            tester.invite_to_family(f.id, 30);
+            tester.invite_to_family(f.id, 10);
+            tester.invite_to_family(f.id, 20);
+
+            let env = tester.env();
+            let res =
+                query_pending_invitations_for_family_paged(tester.deps(), env, f.id, None, None)
+                    .unwrap();
+            let ids: Vec<_> = res.invitations.iter().map(|d| d.invitation.node_id).collect();
+            assert_eq!(ids, vec![10, 20, 30]);
+        }
+
+        #[test]
+        fn flags_expired_against_current_block_time() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            let now = tester.env().block.time.seconds();
+
+            tester.invite_to_family_with_expiration(f.id, 10, now + 5);
+            tester.invite_to_family_with_expiration(f.id, 11, now + 1000);
+
+            tester.advance_time_by(60);
+            let env = tester.env();
+            let res =
+                query_pending_invitations_for_family_paged(tester.deps(), env, f.id, None, None)
+                    .unwrap();
+
+            assert_eq!(res.invitations[0].invitation.node_id, 10);
+            assert!(res.invitations[0].expired);
+            assert_eq!(res.invitations[1].invitation.node_id, 11);
+            assert!(!res.invitations[1].expired);
+        }
+
+        #[test]
+        fn limit_caps_page_size_and_start_after_is_exclusive() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            for n in [10, 11, 12] {
+                tester.invite_to_family(f.id, n);
+            }
+
+            let env = tester.env();
+            let p1 = query_pending_invitations_for_family_paged(
+                tester.deps(),
+                env.clone(),
+                f.id,
+                None,
+                Some(2),
+            )
+            .unwrap();
+            let ids: Vec<_> = p1.invitations.iter().map(|d| d.invitation.node_id).collect();
+            assert_eq!(ids, vec![10, 11]);
+            assert_eq!(p1.start_next_after, Some(11));
+
+            let p2 = query_pending_invitations_for_family_paged(
+                tester.deps(),
+                env,
+                f.id,
+                p1.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            let ids: Vec<_> = p2.invitations.iter().map(|d| d.invitation.node_id).collect();
+            assert_eq!(ids, vec![12]);
+        }
+
+        #[test]
+        fn limit_is_clamped_to_max() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            let total = retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT as u32 + 5;
+            for n in 1..=total {
+                tester.invite_to_family(f.id, n);
+            }
+
+            let env = tester.env();
+            let res = query_pending_invitations_for_family_paged(
+                tester.deps(),
+                env,
+                f.id,
+                None,
+                Some(u32::MAX),
+            )
+            .unwrap();
+            assert_eq!(
+                res.invitations.len(),
+                retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT as usize
+            );
+        }
+
+        #[test]
+        fn excludes_invitation_after_it_is_revoked() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            tester.invite_to_family(f.id, 10);
+            tester.invite_to_family(f.id, 11);
+
+            // accepting moves the invitation out of the pending map
+            tester.accept_invitation(f.id, 10);
+
+            let env = tester.env();
+            let res =
+                query_pending_invitations_for_family_paged(tester.deps(), env, f.id, None, None)
+                    .unwrap();
+            let ids: Vec<_> = res.invitations.iter().map(|d| d.invitation.node_id).collect();
+            assert_eq!(ids, vec![11]);
+        }
+    }
+
+    #[cfg(test)]
+    mod all_pending_invitations_paged {
+        use super::*;
+
+        #[test]
+        fn empty_when_no_pending_invitations() {
+            let tester = init_contract_tester();
+            let env = tester.env();
+
+            let res = query_all_pending_invitations_paged(tester.deps(), env, None, None).unwrap();
+            assert!(res.invitations.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn returns_invitations_across_all_families() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.invite_to_family(f1.id, 10);
+            tester.invite_to_family(f1.id, 20);
+            tester.invite_to_family(f2.id, 5);
+
+            let env = tester.env();
+            let res = query_all_pending_invitations_paged(tester.deps(), env, None, None).unwrap();
+
+            let pairs: Vec<_> = res
+                .invitations
+                .iter()
+                .map(|d| (d.invitation.family_id, d.invitation.node_id))
+                .collect();
+            // ordered by (family_id asc, node_id asc)
+            assert_eq!(pairs, vec![(f1.id, 10), (f1.id, 20), (f2.id, 5)]);
+            assert_eq!(res.start_next_after, Some((f2.id, 5)));
+        }
+
+        #[test]
+        fn flags_expired_against_current_block_time() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            let now = tester.env().block.time.seconds();
+            tester.invite_to_family_with_expiration(f.id, 10, now + 5);
+            tester.invite_to_family_with_expiration(f.id, 11, now + 1000);
+
+            tester.advance_time_by(60);
+            let env = tester.env();
+            let res = query_all_pending_invitations_paged(tester.deps(), env, None, None).unwrap();
+
+            let by_node: std::collections::HashMap<_, _> = res
+                .invitations
+                .iter()
+                .map(|d| (d.invitation.node_id, d.expired))
+                .collect();
+            assert_eq!(by_node[&10], true);
+            assert_eq!(by_node[&11], false);
+        }
+
+        #[test]
+        fn paginates_with_composite_cursor() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.invite_to_family(f1.id, 10);
+            tester.invite_to_family(f1.id, 20);
+            tester.invite_to_family(f2.id, 5);
+            tester.invite_to_family(f2.id, 15);
+
+            let env = tester.env();
+            let p1 =
+                query_all_pending_invitations_paged(tester.deps(), env.clone(), None, Some(2))
+                    .unwrap();
+            let pairs: Vec<_> = p1
+                .invitations
+                .iter()
+                .map(|d| (d.invitation.family_id, d.invitation.node_id))
+                .collect();
+            assert_eq!(pairs, vec![(f1.id, 10), (f1.id, 20)]);
+            assert_eq!(p1.start_next_after, Some((f1.id, 20)));
+
+            let p2 = query_all_pending_invitations_paged(
+                tester.deps(),
+                env.clone(),
+                p1.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            let pairs: Vec<_> = p2
+                .invitations
+                .iter()
+                .map(|d| (d.invitation.family_id, d.invitation.node_id))
+                .collect();
+            assert_eq!(pairs, vec![(f2.id, 5), (f2.id, 15)]);
+
+            let p3 = query_all_pending_invitations_paged(
+                tester.deps(),
+                env,
+                p2.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            assert!(p3.invitations.is_empty());
+            assert!(p3.start_next_after.is_none());
+        }
+
+        #[test]
+        fn limit_is_clamped_to_max() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            let total = retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT as u32 + 5;
+            for n in 1..=total {
+                tester.invite_to_family(f.id, n);
+            }
+
+            let env = tester.env();
+            let res =
+                query_all_pending_invitations_paged(tester.deps(), env, None, Some(u32::MAX))
+                    .unwrap();
+            assert_eq!(
+                res.invitations.len(),
+                retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT as usize
+            );
         }
     }
 }

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -1,11 +1,12 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::storage::NodeFamiliesStorage;
-use cosmwasm_std::{Deps, Env};
+use crate::storage::{retrieval_limits, NodeFamiliesStorage};
+use cosmwasm_std::{Deps, Env, Order, StdResult};
+use cw_storage_plus::Bound;
 use node_families_contract_common::{
-    NodeFamiliesContractError, NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse,
-    PendingFamilyInvitationDetails, PendingFamilyInvitationResponse,
+    FamiliesPagedResponse, NodeFamiliesContractError, NodeFamilyId, NodeFamilyMembershipResponse,
+    NodeFamilyResponse, PendingFamilyInvitationDetails, PendingFamilyInvitationResponse,
 };
 use nym_mixnet_contract_common::NodeId;
 
@@ -53,6 +54,39 @@ pub fn query_pending_invitation(
         family_id,
         node_id,
         invitation,
+    })
+}
+
+/// Page through every existing family in ascending [`NodeFamilyId`] order.
+///
+/// `start_after` is exclusive — pass the previous page's `start_next_after`
+/// to fetch the next page; pass `None` to start from the first family.
+/// `limit` defaults to [`retrieval_limits::FAMILIES_DEFAULT_LIMIT`] and is
+/// clamped to [`retrieval_limits::FAMILIES_MAX_LIMIT`].
+pub fn query_families_paged(
+    deps: Deps,
+    start_after: Option<NodeFamilyId>,
+    limit: Option<u32>,
+) -> Result<FamiliesPagedResponse, NodeFamiliesContractError> {
+    let limit = limit
+        .unwrap_or(retrieval_limits::FAMILIES_DEFAULT_LIMIT)
+        .min(retrieval_limits::FAMILIES_MAX_LIMIT) as usize;
+
+    let start = start_after.map(Bound::exclusive);
+
+    let storage = NodeFamiliesStorage::new();
+    let families = storage
+        .families
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|res| res.map(|item| item.1))
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let start_next_after = families.last().map(|family| family.id);
+
+    Ok(FamiliesPagedResponse {
+        families,
+        start_next_after,
     })
 }
 
@@ -171,6 +205,137 @@ mod tests {
             let details = res.invitation.unwrap();
             assert_eq!(details.invitation.expires_at, expires_at);
             assert!(details.expired);
+        }
+    }
+
+    #[cfg(test)]
+    mod families_paged {
+        use super::*;
+
+        #[test]
+        fn empty_when_no_families_exist() {
+            let tester = init_contract_tester();
+
+            let res = query_families_paged(tester.deps(), None, None).unwrap();
+            assert!(res.families.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn returns_all_families_within_default_limit() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let f3 = tester.add_dummy_family();
+
+            let res = query_families_paged(tester.deps(), None, None).unwrap();
+            assert_eq!(res.families, vec![f1, f2, f3.clone()]);
+            assert_eq!(res.start_next_after, Some(f3.id));
+        }
+
+        #[test]
+        fn returns_families_in_ascending_id_order() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let f3 = tester.add_dummy_family();
+
+            let res = query_families_paged(tester.deps(), None, None).unwrap();
+            let ids: Vec<_> = res.families.iter().map(|f| f.id).collect();
+            assert_eq!(ids, vec![f1.id, f2.id, f3.id]);
+        }
+
+        #[test]
+        fn limit_caps_page_size() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let _f3 = tester.add_dummy_family();
+
+            let res = query_families_paged(tester.deps(), None, Some(2)).unwrap();
+            assert_eq!(res.families, vec![f1, f2.clone()]);
+            assert_eq!(res.start_next_after, Some(f2.id));
+        }
+
+        #[test]
+        fn start_after_is_exclusive() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let f3 = tester.add_dummy_family();
+
+            let res = query_families_paged(tester.deps(), Some(f1.id), None).unwrap();
+            assert_eq!(res.families, vec![f2, f3.clone()]);
+            assert_eq!(res.start_next_after, Some(f3.id));
+        }
+
+        #[test]
+        fn paginates_through_all_families() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let f3 = tester.add_dummy_family();
+            let f4 = tester.add_dummy_family();
+            let f5 = tester.add_dummy_family();
+
+            let page1 = query_families_paged(tester.deps(), None, Some(2)).unwrap();
+            assert_eq!(page1.families, vec![f1, f2.clone()]);
+            assert_eq!(page1.start_next_after, Some(f2.id));
+
+            let page2 =
+                query_families_paged(tester.deps(), page1.start_next_after, Some(2)).unwrap();
+            assert_eq!(page2.families, vec![f3, f4.clone()]);
+            assert_eq!(page2.start_next_after, Some(f4.id));
+
+            let page3 =
+                query_families_paged(tester.deps(), page2.start_next_after, Some(2)).unwrap();
+            assert_eq!(page3.families, vec![f5.clone()]);
+            assert_eq!(page3.start_next_after, Some(f5.id));
+
+            let page4 =
+                query_families_paged(tester.deps(), page3.start_next_after, Some(2)).unwrap();
+            assert!(page4.families.is_empty());
+            assert!(page4.start_next_after.is_none());
+        }
+
+        #[test]
+        fn limit_is_clamped_to_max() {
+            let mut tester = init_contract_tester();
+            let total = retrieval_limits::FAMILIES_MAX_LIMIT as usize + 5;
+            for _ in 0..total {
+                tester.add_dummy_family();
+            }
+
+            let res = query_families_paged(tester.deps(), None, Some(u32::MAX)).unwrap();
+            assert_eq!(
+                res.families.len(),
+                retrieval_limits::FAMILIES_MAX_LIMIT as usize
+            );
+        }
+
+        #[test]
+        fn default_limit_applied_when_unspecified() {
+            let mut tester = init_contract_tester();
+            let total = retrieval_limits::FAMILIES_DEFAULT_LIMIT as usize + 5;
+            for _ in 0..total {
+                tester.add_dummy_family();
+            }
+
+            let res = query_families_paged(tester.deps(), None, None).unwrap();
+            assert_eq!(
+                res.families.len(),
+                retrieval_limits::FAMILIES_DEFAULT_LIMIT as usize
+            );
+        }
+
+        #[test]
+        fn start_after_past_end_returns_empty() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+
+            let res = query_families_paged(tester.deps(), Some(f.id), None).unwrap();
+            assert!(res.families.is_empty());
+            assert!(res.start_next_after.is_none());
         }
     }
 }

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -8,8 +8,10 @@ use node_families_contract_common::{
     AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse, FamilyMemberRecord,
     FamilyMembersPagedResponse, GlobalPastFamilyInvitationCursor, NodeFamiliesContractError,
     NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationCursor,
-    PastFamilyInvitationsPagedResponse, PendingFamilyInvitationDetails,
-    PendingFamilyInvitationResponse, PendingFamilyInvitationsPagedResponse,
+    PastFamilyInvitationForNodeCursor, PastFamilyInvitationsForNodePagedResponse,
+    PastFamilyInvitationsPagedResponse,
+    PendingFamilyInvitationDetails, PendingFamilyInvitationResponse,
+    PendingFamilyInvitationsPagedResponse, PendingInvitationsForNodePagedResponse,
     PendingInvitationsPagedResponse,
 };
 use nym_mixnet_contract_common::NodeId;
@@ -161,6 +163,54 @@ pub fn query_pending_invitations_for_family_paged(
     })
 }
 
+/// Page through every pending invitation addressed to `node_id`, in ascending
+/// issuing [`NodeFamilyId`] order. Each entry is stamped with `expired` based
+/// on the current block time.
+///
+/// Backed by the `node` multi-index over `pending_family_invitations`, so
+/// cost is O(page size). `start_after` is exclusive — pass the previous
+/// page's `start_next_after` to fetch the next page. `limit` defaults to
+/// [`retrieval_limits::PENDING_INVITATIONS_DEFAULT_LIMIT`] and is clamped to
+/// [`retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT`].
+pub fn query_pending_invitations_for_node_paged(
+    deps: Deps,
+    env: Env,
+    node_id: NodeId,
+    start_after: Option<NodeFamilyId>,
+    limit: Option<u32>,
+) -> Result<PendingInvitationsForNodePagedResponse, NodeFamiliesContractError> {
+    let limit = limit
+        .unwrap_or(retrieval_limits::PENDING_INVITATIONS_DEFAULT_LIMIT)
+        .min(retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT) as usize;
+
+    let now = env.block.time.seconds();
+    let start = start_after.map(|family_id| Bound::exclusive((family_id, node_id)));
+
+    let storage = NodeFamiliesStorage::new();
+    let invitations = storage
+        .pending_family_invitations
+        .idx
+        .node
+        .prefix(node_id)
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|res| {
+            res.map(|(_pk, invitation)| PendingFamilyInvitationDetails {
+                expired: now >= invitation.expires_at,
+                invitation,
+            })
+        })
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let start_next_after = invitations.last().map(|d| d.invitation.family_id);
+
+    Ok(PendingInvitationsForNodePagedResponse {
+        node_id,
+        invitations,
+        start_next_after,
+    })
+}
+
 /// Page through every pending invitation across all families, in ascending
 /// `(family_id, node_id)` order. Each entry is stamped with `expired` based
 /// on the current block time.
@@ -254,6 +304,51 @@ pub fn query_past_invitations_for_family_paged(
 
     Ok(PastFamilyInvitationsPagedResponse {
         family_id,
+        invitations,
+        start_next_after,
+    })
+}
+
+/// Page through every archived (terminal-state) invitation addressed to
+/// `node_id`, in ascending `(family_id, counter)` order across all
+/// `Accepted` / `Rejected` / `Revoked` statuses.
+///
+/// Backed by the `node` multi-index over `past_family_invitations`, so
+/// cost is O(page size). `start_after` is exclusive — pass the previous
+/// page's `start_next_after` to fetch the next page. `limit` defaults to
+/// [`retrieval_limits::PAST_INVITATIONS_DEFAULT_LIMIT`] and is clamped to
+/// [`retrieval_limits::PAST_INVITATIONS_MAX_LIMIT`].
+pub fn query_past_invitations_for_node_paged(
+    deps: Deps,
+    node_id: NodeId,
+    start_after: Option<PastFamilyInvitationForNodeCursor>,
+    limit: Option<u32>,
+) -> Result<PastFamilyInvitationsForNodePagedResponse, NodeFamiliesContractError> {
+    let limit = limit
+        .unwrap_or(retrieval_limits::PAST_INVITATIONS_DEFAULT_LIMIT)
+        .min(retrieval_limits::PAST_INVITATIONS_MAX_LIMIT) as usize;
+
+    let start = start_after
+        .map(|(family_id, counter)| Bound::exclusive(((family_id, node_id), counter)));
+
+    let storage = NodeFamiliesStorage::new();
+    let entries = storage
+        .past_family_invitations
+        .idx
+        .node
+        .prefix(node_id)
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let start_next_after = entries
+        .last()
+        .map(|(((family_id, _), counter), _)| (*family_id, *counter));
+
+    let invitations = entries.into_iter().map(|(_, v)| v).collect();
+
+    Ok(PastFamilyInvitationsForNodePagedResponse {
+        node_id,
         invitations,
         start_next_after,
     })
@@ -1307,6 +1402,332 @@ mod tests {
 
             let res =
                 query_all_past_invitations_paged(tester.deps(), None, Some(u32::MAX)).unwrap();
+            assert_eq!(
+                res.invitations.len(),
+                retrieval_limits::PAST_INVITATIONS_MAX_LIMIT as usize
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod pending_invitations_for_node_paged {
+        use super::*;
+
+        #[test]
+        fn empty_when_node_has_no_pending_invitations() {
+            let tester = init_contract_tester();
+            let env = tester.env();
+
+            let res =
+                query_pending_invitations_for_node_paged(tester.deps(), env, 42, None, None)
+                    .unwrap();
+            assert_eq!(res.node_id, 42);
+            assert!(res.invitations.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn returns_only_invitations_for_requested_node() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.invite_to_family(f1.id, 10);
+            tester.invite_to_family(f1.id, 11);
+            tester.invite_to_family(f2.id, 10);
+
+            let env = tester.env();
+            let res =
+                query_pending_invitations_for_node_paged(tester.deps(), env, 10, None, None)
+                    .unwrap();
+            let pairs: Vec<_> = res
+                .invitations
+                .iter()
+                .map(|d| (d.invitation.family_id, d.invitation.node_id))
+                .collect();
+            assert_eq!(pairs, vec![(f1.id, 10), (f2.id, 10)]);
+        }
+
+        #[test]
+        fn ordered_by_ascending_family_id() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let f3 = tester.add_dummy_family();
+            // out-of-order inserts
+            tester.invite_to_family(f3.id, 7);
+            tester.invite_to_family(f1.id, 7);
+            tester.invite_to_family(f2.id, 7);
+
+            let env = tester.env();
+            let res =
+                query_pending_invitations_for_node_paged(tester.deps(), env, 7, None, None)
+                    .unwrap();
+            let ids: Vec<_> = res
+                .invitations
+                .iter()
+                .map(|d| d.invitation.family_id)
+                .collect();
+            assert_eq!(ids, vec![f1.id, f2.id, f3.id]);
+        }
+
+        #[test]
+        fn paginates_with_family_id_cursor() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let f3 = tester.add_dummy_family();
+            tester.invite_to_family(f1.id, 7);
+            tester.invite_to_family(f2.id, 7);
+            tester.invite_to_family(f3.id, 7);
+
+            let env = tester.env();
+            let p1 = query_pending_invitations_for_node_paged(
+                tester.deps(),
+                env.clone(),
+                7,
+                None,
+                Some(2),
+            )
+            .unwrap();
+            let ids: Vec<_> = p1
+                .invitations
+                .iter()
+                .map(|d| d.invitation.family_id)
+                .collect();
+            assert_eq!(ids, vec![f1.id, f2.id]);
+            assert_eq!(p1.start_next_after, Some(f2.id));
+
+            let p2 = query_pending_invitations_for_node_paged(
+                tester.deps(),
+                env.clone(),
+                7,
+                p1.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            let ids: Vec<_> = p2
+                .invitations
+                .iter()
+                .map(|d| d.invitation.family_id)
+                .collect();
+            assert_eq!(ids, vec![f3.id]);
+            assert_eq!(p2.start_next_after, Some(f3.id));
+
+            let p3 = query_pending_invitations_for_node_paged(
+                tester.deps(),
+                env,
+                7,
+                p2.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            assert!(p3.invitations.is_empty());
+            assert!(p3.start_next_after.is_none());
+        }
+
+        #[test]
+        fn flags_expired_against_current_block_time() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let now = tester.env().block.time.seconds();
+            tester.invite_to_family_with_expiration(f1.id, 7, now + 5);
+            tester.invite_to_family_with_expiration(f2.id, 7, now + 1000);
+
+            tester.advance_time_by(60);
+            let env = tester.env();
+            let res =
+                query_pending_invitations_for_node_paged(tester.deps(), env, 7, None, None)
+                    .unwrap();
+            let by_family: std::collections::HashMap<_, _> = res
+                .invitations
+                .iter()
+                .map(|d| (d.invitation.family_id, d.expired))
+                .collect();
+            assert!(by_family[&f1.id]);
+            assert!(!by_family[&f2.id]);
+        }
+
+        #[test]
+        fn limit_is_clamped_to_max() {
+            let mut tester = init_contract_tester();
+            let total = retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT + 5;
+            for _ in 0..total {
+                let f = tester.add_dummy_family();
+                tester.invite_to_family(f.id, 7);
+            }
+
+            let env = tester.env();
+            let res = query_pending_invitations_for_node_paged(
+                tester.deps(),
+                env,
+                7,
+                None,
+                Some(u32::MAX),
+            )
+            .unwrap();
+            assert_eq!(
+                res.invitations.len(),
+                retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT as usize
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod past_invitations_for_node_paged {
+        use super::*;
+        use node_families_contract_common::FamilyInvitationStatus;
+
+        #[test]
+        fn empty_when_node_has_no_archive_entries() {
+            let tester = init_contract_tester();
+
+            let res =
+                query_past_invitations_for_node_paged(tester.deps(), 42, None, None).unwrap();
+            assert_eq!(res.node_id, 42);
+            assert!(res.invitations.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn returns_only_archives_for_requested_node() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.add_to_family(f1.id, 7);
+            tester.add_to_family(f1.id, 8);
+            tester.add_to_family(f2.id, 7);
+
+            let res =
+                query_past_invitations_for_node_paged(tester.deps(), 7, None, None).unwrap();
+            assert_eq!(res.invitations.len(), 2);
+            for entry in &res.invitations {
+                assert_eq!(entry.invitation.node_id, 7);
+            }
+        }
+
+        #[test]
+        fn covers_all_terminal_statuses() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let f3 = tester.add_dummy_family();
+            // Accepted in f1
+            tester.add_to_family(f1.id, 7);
+            // Rejected in f2
+            tester.invite_to_family(f2.id, 7);
+            tester.reject_invitation(f2.id, 7);
+            // Revoked in f3
+            tester.invite_to_family(f3.id, 7);
+            tester.revoke_invitation(f3.id, 7);
+
+            let res =
+                query_past_invitations_for_node_paged(tester.deps(), 7, None, None).unwrap();
+            let by_family: std::collections::HashMap<_, _> = res
+                .invitations
+                .iter()
+                .map(|p| (p.invitation.family_id, p.status.clone()))
+                .collect();
+            assert!(matches!(
+                by_family[&f1.id],
+                FamilyInvitationStatus::Accepted { .. }
+            ));
+            assert!(matches!(
+                by_family[&f2.id],
+                FamilyInvitationStatus::Rejected { .. }
+            ));
+            assert!(matches!(
+                by_family[&f3.id],
+                FamilyInvitationStatus::Revoked { .. }
+            ));
+        }
+
+        #[test]
+        fn ordered_by_family_id_then_counter() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            // node 7 joins and leaves f1 twice — counters 0 and 1 in f1
+            for _ in 0..2 {
+                tester.add_to_family(f1.id, 7);
+                tester.remove_from_family(7);
+            }
+            // one Accepted in f2
+            tester.add_to_family(f2.id, 7);
+
+            let res =
+                query_past_invitations_for_node_paged(tester.deps(), 7, None, None).unwrap();
+            let pairs: Vec<_> = res
+                .invitations
+                .iter()
+                .map(|p| p.invitation.family_id)
+                .collect();
+            assert_eq!(pairs, vec![f1.id, f1.id, f2.id]);
+        }
+
+        #[test]
+        fn paginates_with_family_counter_cursor() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let f3 = tester.add_dummy_family();
+            tester.add_to_family(f1.id, 7);
+            tester.add_to_family(f2.id, 7);
+            tester.add_to_family(f3.id, 7);
+
+            let p1 =
+                query_past_invitations_for_node_paged(tester.deps(), 7, None, Some(2)).unwrap();
+            let ids: Vec<_> = p1
+                .invitations
+                .iter()
+                .map(|p| p.invitation.family_id)
+                .collect();
+            assert_eq!(ids, vec![f1.id, f2.id]);
+            assert_eq!(p1.start_next_after, Some((f2.id, 0)));
+
+            let p2 = query_past_invitations_for_node_paged(
+                tester.deps(),
+                7,
+                p1.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            let ids: Vec<_> = p2
+                .invitations
+                .iter()
+                .map(|p| p.invitation.family_id)
+                .collect();
+            assert_eq!(ids, vec![f3.id]);
+            assert_eq!(p2.start_next_after, Some((f3.id, 0)));
+
+            let p3 = query_past_invitations_for_node_paged(
+                tester.deps(),
+                7,
+                p2.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            assert!(p3.invitations.is_empty());
+            assert!(p3.start_next_after.is_none());
+        }
+
+        #[test]
+        fn limit_is_clamped_to_max() {
+            let mut tester = init_contract_tester();
+            let total = retrieval_limits::PAST_INVITATIONS_MAX_LIMIT + 5;
+            for _ in 0..total {
+                let f = tester.add_dummy_family();
+                tester.add_to_family(f.id, 7);
+                tester.remove_from_family(7);
+            }
+
+            let res = query_past_invitations_for_node_paged(
+                tester.deps(),
+                7,
+                None,
+                Some(u32::MAX),
+            )
+            .unwrap();
             assert_eq!(
                 res.invitations.len(),
                 retrieval_limits::PAST_INVITATIONS_MAX_LIMIT as usize

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -9,7 +9,7 @@ use node_families_contract_common::{
     FamilyMembersPagedResponse, GlobalPastFamilyInvitationCursor, NodeFamiliesContractError,
     NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationCursor,
     PastFamilyInvitationForNodeCursor, PastFamilyInvitationsForNodePagedResponse,
-    PastFamilyInvitationsPagedResponse,
+    PastFamilyInvitationsPagedResponse, PastFamilyMemberCursor, PastFamilyMembersPagedResponse,
     PendingFamilyInvitationDetails, PendingFamilyInvitationResponse,
     PendingFamilyInvitationsPagedResponse, PendingInvitationsForNodePagedResponse,
     PendingInvitationsPagedResponse,
@@ -388,6 +388,57 @@ pub fn query_all_past_invitations_paged(
 
     Ok(AllPastFamilyInvitationsPagedResponse {
         invitations,
+        start_next_after,
+    })
+}
+
+/// Page through every archived membership record for `family_id` (nodes that
+/// used to belong to it but have since been removed), in ascending
+/// `(node_id, counter)` order.
+///
+/// Uses a direct bounds-based range scan on the primary map keyed by
+/// `((family_id, node_id), counter)` — `family_id` is already the leftmost
+/// key component, so this avoids the extra storage read per entry that
+/// going through the `family` multi-index would incur. Cost is O(page
+/// size). Does not verify that `family_id` refers to an existing
+/// family — an unknown id simply yields an empty page.
+///
+/// `start_after` is exclusive — pass the previous page's `start_next_after`
+/// to fetch the next page; pass `None` to start from the first archived
+/// entry. `limit` defaults to [`retrieval_limits::PAST_MEMBERS_DEFAULT_LIMIT`]
+/// and is clamped to [`retrieval_limits::PAST_MEMBERS_MAX_LIMIT`].
+pub fn query_past_members_for_family_paged(
+    deps: Deps,
+    family_id: NodeFamilyId,
+    start_after: Option<PastFamilyMemberCursor>,
+    limit: Option<u32>,
+) -> Result<PastFamilyMembersPagedResponse, NodeFamiliesContractError> {
+    let limit = limit
+        .unwrap_or(retrieval_limits::PAST_MEMBERS_DEFAULT_LIMIT)
+        .min(retrieval_limits::PAST_MEMBERS_MAX_LIMIT) as usize;
+
+    let lower =
+        start_after.map(|(node_id, counter)| Bound::exclusive(((family_id, node_id), counter)));
+
+    // upper bound = first key of next family;
+    let upper = Some(Bound::exclusive(((family_id + 1, 0), 0)));
+
+    let storage = NodeFamiliesStorage::new();
+    let entries = storage
+        .past_family_members
+        .range(deps.storage, lower, upper, Order::Ascending)
+        .take(limit)
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let start_next_after = entries
+        .last()
+        .map(|(((_, node_id), counter), _)| (*node_id, *counter));
+
+    let members = entries.into_iter().map(|(_, v)| v).collect();
+
+    Ok(PastFamilyMembersPagedResponse {
+        family_id,
+        members,
         start_next_after,
     })
 }
@@ -1731,6 +1782,147 @@ mod tests {
             assert_eq!(
                 res.invitations.len(),
                 retrieval_limits::PAST_INVITATIONS_MAX_LIMIT as usize
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod past_members_for_family_paged {
+        use super::*;
+
+        #[test]
+        fn empty_when_no_archive_entries() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+
+            let res =
+                query_past_members_for_family_paged(tester.deps(), f.id, None, None).unwrap();
+            assert_eq!(res.family_id, f.id);
+            assert!(res.members.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn empty_for_unknown_family_id() {
+            let tester = init_contract_tester();
+
+            let res =
+                query_past_members_for_family_paged(tester.deps(), 99, None, None).unwrap();
+            assert_eq!(res.family_id, 99);
+            assert!(res.members.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn returns_only_archives_from_requested_family() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.add_to_family(f1.id, 10);
+            tester.remove_from_family(10);
+            tester.add_to_family(f2.id, 20);
+            tester.remove_from_family(20);
+
+            let res =
+                query_past_members_for_family_paged(tester.deps(), f1.id, None, None).unwrap();
+            assert_eq!(res.members.len(), 1);
+            assert_eq!(res.members[0].family_id, f1.id);
+            assert_eq!(res.members[0].node_id, 10);
+        }
+
+        #[test]
+        fn record_carries_removed_at_timestamp() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            tester.add_to_family(f.id, 42);
+            let removed_at = tester.env().block.time.seconds();
+            tester.remove_from_family(42);
+
+            let res =
+                query_past_members_for_family_paged(tester.deps(), f.id, None, None).unwrap();
+            let entry = res.members.into_iter().next().unwrap();
+            assert_eq!(entry.family_id, f.id);
+            assert_eq!(entry.node_id, 42);
+            assert_eq!(entry.removed_at, removed_at);
+        }
+
+        #[test]
+        fn ordered_by_node_id_then_counter() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            // node 42 joins/leaves twice — counters 0 and 1
+            for _ in 0..2 {
+                tester.add_to_family(f.id, 42);
+                tester.remove_from_family(42);
+            }
+            // node 7 once
+            tester.add_to_family(f.id, 7);
+            tester.remove_from_family(7);
+
+            let res =
+                query_past_members_for_family_paged(tester.deps(), f.id, None, None).unwrap();
+            let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
+            // 7 comes before 42; 42 appears twice
+            assert_eq!(ids, vec![7, 42, 42]);
+        }
+
+        #[test]
+        fn paginates_with_node_counter_cursor() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            for n in [10, 11, 12] {
+                tester.add_to_family(f.id, n);
+                tester.remove_from_family(n);
+            }
+
+            let p1 =
+                query_past_members_for_family_paged(tester.deps(), f.id, None, Some(2)).unwrap();
+            let ids: Vec<_> = p1.members.iter().map(|m| m.node_id).collect();
+            assert_eq!(ids, vec![10, 11]);
+            assert_eq!(p1.start_next_after, Some((11, 0)));
+
+            let p2 = query_past_members_for_family_paged(
+                tester.deps(),
+                f.id,
+                p1.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            let ids: Vec<_> = p2.members.iter().map(|m| m.node_id).collect();
+            assert_eq!(ids, vec![12]);
+            assert_eq!(p2.start_next_after, Some((12, 0)));
+
+            let p3 = query_past_members_for_family_paged(
+                tester.deps(),
+                f.id,
+                p2.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            assert!(p3.members.is_empty());
+            assert!(p3.start_next_after.is_none());
+        }
+
+        #[test]
+        fn limit_is_clamped_to_max() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            let total = retrieval_limits::PAST_MEMBERS_MAX_LIMIT + 5;
+            for n in 1..=total {
+                tester.add_to_family(f.id, n);
+                tester.remove_from_family(n);
+            }
+
+            let res = query_past_members_for_family_paged(
+                tester.deps(),
+                f.id,
+                None,
+                Some(u32::MAX),
+            )
+            .unwrap();
+            assert_eq!(
+                res.members.len(),
+                retrieval_limits::PAST_MEMBERS_MAX_LIMIT as usize
             );
         }
     }

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -1,2 +1,176 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
+
+use crate::storage::NodeFamiliesStorage;
+use cosmwasm_std::{Deps, Env};
+use node_families_contract_common::{
+    NodeFamiliesContractError, NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse,
+    PendingFamilyInvitationDetails, PendingFamilyInvitationResponse,
+};
+use nym_mixnet_contract_common::NodeId;
+
+/// Resolve a single family by its id. Returns `family: None` if no family
+/// with that id exists.
+pub fn query_family_by_id(
+    deps: Deps,
+    family_id: NodeFamilyId,
+) -> Result<NodeFamilyResponse, NodeFamiliesContractError> {
+    let family = NodeFamiliesStorage::new()
+        .families
+        .may_load(deps.storage, family_id)?;
+    Ok(NodeFamilyResponse { family_id, family })
+}
+
+/// Report which family — if any — a node currently belongs to.
+pub fn query_family_membership(
+    deps: Deps,
+    node_id: NodeId,
+) -> Result<NodeFamilyMembershipResponse, NodeFamiliesContractError> {
+    let family_id = NodeFamiliesStorage::new()
+        .family_members
+        .may_load(deps.storage, node_id)?;
+    Ok(NodeFamilyMembershipResponse { node_id, family_id })
+}
+
+/// Resolve a pending invitation by its composite `(family_id, node_id)` key,
+/// stamping it with whether it has already timed out at the current block
+/// time so the caller doesn't have to do the comparison itself.
+pub fn query_pending_invitation(
+    deps: Deps,
+    env: Env,
+    family_id: NodeFamilyId,
+    node_id: NodeId,
+) -> Result<PendingFamilyInvitationResponse, NodeFamiliesContractError> {
+    let now = env.block.time.seconds();
+    let invitation = NodeFamiliesStorage::new()
+        .pending_family_invitations
+        .may_load(deps.storage, (family_id, node_id))?
+        .map(|invitation| PendingFamilyInvitationDetails {
+            expired: now >= invitation.expires_at,
+            invitation,
+        });
+    Ok(PendingFamilyInvitationResponse {
+        family_id,
+        node_id,
+        invitation,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::{init_contract_tester, NodeFamiliesContractTesterExt};
+    use nym_contracts_common_testing::{ChainOpts, ContractOpts};
+
+    #[cfg(test)]
+    mod family_by_id {
+        use super::*;
+
+        #[test]
+        fn family_by_id_returns_none_when_missing() {
+            let tester = init_contract_tester();
+
+            let res = query_family_by_id(tester.deps(), 99).unwrap();
+            assert_eq!(res.family_id, 99);
+            assert!(res.family.is_none());
+        }
+
+        #[test]
+        fn family_by_id_returns_persisted_family() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+
+            let res = query_family_by_id(tester.deps(), f.id).unwrap();
+            assert_eq!(res.family_id, f.id);
+            assert_eq!(res.family, Some(f));
+        }
+    }
+
+    #[cfg(test)]
+    mod family_membership {
+        use super::*;
+
+        #[test]
+        fn family_membership_returns_none_for_unaffiliated_node() {
+            let tester = init_contract_tester();
+
+            let res = query_family_membership(tester.deps(), 999).unwrap();
+            assert_eq!(res.node_id, 999);
+            assert!(res.family_id.is_none());
+        }
+
+        #[test]
+        fn family_membership_returns_family_id_for_member() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+
+            tester.add_to_family(f.id, 42);
+
+            let res = query_family_membership(tester.deps(), 42).unwrap();
+            assert_eq!(res.node_id, 42);
+            assert_eq!(res.family_id, Some(f.id));
+        }
+
+        #[test]
+        fn family_membership_returns_none_after_node_is_removed() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+
+            tester.add_to_family(f.id, 42);
+            tester.remove_from_family(42);
+
+            let res = query_family_membership(tester.deps(), 42).unwrap();
+            assert!(res.family_id.is_none());
+        }
+    }
+
+    #[cfg(test)]
+    mod pending_invitation {
+        use super::*;
+
+        #[test]
+        fn pending_invitation_returns_none_when_missing() {
+            let tester = init_contract_tester();
+            let env = tester.env();
+
+            let res = query_pending_invitation(tester.deps(), env, 1, 42).unwrap();
+            assert_eq!(res.family_id, 1);
+            assert_eq!(res.node_id, 42);
+            assert!(res.invitation.is_none());
+        }
+
+        #[test]
+        fn pending_invitation_returns_unexpired_when_in_future() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+
+            let inv = tester.invite_to_family(f.id, 42);
+            let env = tester.env();
+
+            let res = query_pending_invitation(tester.deps(), env, f.id, 42).unwrap();
+            let details = res.invitation.unwrap();
+            assert_eq!(details.invitation, inv);
+            assert!(!details.expired);
+        }
+
+        #[test]
+        fn pending_invitation_flagged_as_expired_after_block_time() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+
+            let expires_at = tester.env().block.time.seconds() + 5;
+            tester.invite_to_family_with_expiration(f.id, 42, expires_at);
+
+            // advance block time well past the expiry
+            tester.advance_time_by(60);
+
+            let env = tester.env();
+            assert!(env.block.time.seconds() >= expires_at);
+
+            let res = query_pending_invitation(tester.deps(), env, f.id, 42).unwrap();
+            let details = res.invitation.unwrap();
+            assert_eq!(details.invitation.expires_at, expires_at);
+            assert!(details.expired);
+        }
+    }
+}

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -9,7 +9,8 @@ use node_families_contract_common::{
     FamilyMembersPagedResponse, GlobalPastFamilyInvitationCursor, NodeFamiliesContractError,
     NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationCursor,
     PastFamilyInvitationForNodeCursor, PastFamilyInvitationsForNodePagedResponse,
-    PastFamilyInvitationsPagedResponse, PastFamilyMemberCursor, PastFamilyMembersPagedResponse,
+    PastFamilyInvitationsPagedResponse, PastFamilyMemberCursor, PastFamilyMemberForNodeCursor,
+    PastFamilyMembersForNodePagedResponse, PastFamilyMembersPagedResponse,
     PendingFamilyInvitationDetails, PendingFamilyInvitationResponse,
     PendingFamilyInvitationsPagedResponse, PendingInvitationsForNodePagedResponse,
     PendingInvitationsPagedResponse,
@@ -438,6 +439,51 @@ pub fn query_past_members_for_family_paged(
 
     Ok(PastFamilyMembersPagedResponse {
         family_id,
+        members,
+        start_next_after,
+    })
+}
+
+/// Page through every archived membership record for `node_id` (every family
+/// the node used to belong to but has since been removed from), in ascending
+/// `(family_id, counter)` order.
+///
+/// Backed by the `node` multi-index over `past_family_members`, so cost is
+/// O(page size). `start_after` is exclusive — pass the previous page's
+/// `start_next_after` to fetch the next page. `limit` defaults to
+/// [`retrieval_limits::PAST_MEMBERS_DEFAULT_LIMIT`] and is clamped to
+/// [`retrieval_limits::PAST_MEMBERS_MAX_LIMIT`].
+pub fn query_past_members_for_node_paged(
+    deps: Deps,
+    node_id: NodeId,
+    start_after: Option<PastFamilyMemberForNodeCursor>,
+    limit: Option<u32>,
+) -> Result<PastFamilyMembersForNodePagedResponse, NodeFamiliesContractError> {
+    let limit = limit
+        .unwrap_or(retrieval_limits::PAST_MEMBERS_DEFAULT_LIMIT)
+        .min(retrieval_limits::PAST_MEMBERS_MAX_LIMIT) as usize;
+
+    let start = start_after
+        .map(|(family_id, counter)| Bound::exclusive(((family_id, node_id), counter)));
+
+    let storage = NodeFamiliesStorage::new();
+    let entries = storage
+        .past_family_members
+        .idx
+        .node
+        .prefix(node_id)
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let start_next_after = entries
+        .last()
+        .map(|(((family_id, _), counter), _)| (*family_id, *counter));
+
+    let members = entries.into_iter().map(|(_, v)| v).collect();
+
+    Ok(PastFamilyMembersForNodePagedResponse {
+        node_id,
         members,
         start_next_after,
     })
@@ -1920,6 +1966,132 @@ mod tests {
                 Some(u32::MAX),
             )
             .unwrap();
+            assert_eq!(
+                res.members.len(),
+                retrieval_limits::PAST_MEMBERS_MAX_LIMIT as usize
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod past_members_for_node_paged {
+        use super::*;
+
+        #[test]
+        fn empty_when_node_has_no_archive_entries() {
+            let tester = init_contract_tester();
+
+            let res = query_past_members_for_node_paged(tester.deps(), 42, None, None).unwrap();
+            assert_eq!(res.node_id, 42);
+            assert!(res.members.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn returns_only_archives_for_requested_node() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.add_to_family(f1.id, 7);
+            tester.add_to_family(f1.id, 8);
+            tester.add_to_family(f2.id, 7);
+            tester.remove_from_family(7);
+            tester.remove_from_family(8);
+
+            let res = query_past_members_for_node_paged(tester.deps(), 7, None, None).unwrap();
+            assert_eq!(res.members.len(), 1);
+            for entry in &res.members {
+                assert_eq!(entry.node_id, 7);
+            }
+        }
+
+        #[test]
+        fn record_carries_removed_at_timestamp() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            tester.add_to_family(f.id, 42);
+            let removed_at = tester.env().block.time.seconds();
+            tester.remove_from_family(42);
+
+            let res = query_past_members_for_node_paged(tester.deps(), 42, None, None).unwrap();
+            let entry = res.members.into_iter().next().unwrap();
+            assert_eq!(entry.family_id, f.id);
+            assert_eq!(entry.node_id, 42);
+            assert_eq!(entry.removed_at, removed_at);
+        }
+
+        #[test]
+        fn ordered_by_family_id_then_counter() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            // node 7 joins/leaves f1 twice — counters 0 and 1 in f1
+            for _ in 0..2 {
+                tester.add_to_family(f1.id, 7);
+                tester.remove_from_family(7);
+            }
+            // one record in f2
+            tester.add_to_family(f2.id, 7);
+            tester.remove_from_family(7);
+
+            let res = query_past_members_for_node_paged(tester.deps(), 7, None, None).unwrap();
+            let ids: Vec<_> = res.members.iter().map(|m| m.family_id).collect();
+            assert_eq!(ids, vec![f1.id, f1.id, f2.id]);
+        }
+
+        #[test]
+        fn paginates_with_family_counter_cursor() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let f3 = tester.add_dummy_family();
+            tester.add_to_family(f1.id, 7);
+            tester.remove_from_family(7);
+            tester.add_to_family(f2.id, 7);
+            tester.remove_from_family(7);
+            tester.add_to_family(f3.id, 7);
+            tester.remove_from_family(7);
+
+            let p1 =
+                query_past_members_for_node_paged(tester.deps(), 7, None, Some(2)).unwrap();
+            let ids: Vec<_> = p1.members.iter().map(|m| m.family_id).collect();
+            assert_eq!(ids, vec![f1.id, f2.id]);
+            assert_eq!(p1.start_next_after, Some((f2.id, 0)));
+
+            let p2 = query_past_members_for_node_paged(
+                tester.deps(),
+                7,
+                p1.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            let ids: Vec<_> = p2.members.iter().map(|m| m.family_id).collect();
+            assert_eq!(ids, vec![f3.id]);
+            assert_eq!(p2.start_next_after, Some((f3.id, 0)));
+
+            let p3 = query_past_members_for_node_paged(
+                tester.deps(),
+                7,
+                p2.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            assert!(p3.members.is_empty());
+            assert!(p3.start_next_after.is_none());
+        }
+
+        #[test]
+        fn limit_is_clamped_to_max() {
+            let mut tester = init_contract_tester();
+            let total = retrieval_limits::PAST_MEMBERS_MAX_LIMIT + 5;
+            for _ in 0..total {
+                let f = tester.add_dummy_family();
+                tester.add_to_family(f.id, 7);
+                tester.remove_from_family(7);
+            }
+
+            let res =
+                query_past_members_for_node_paged(tester.deps(), 7, None, Some(u32::MAX)).unwrap();
             assert_eq!(
                 res.members.len(),
                 retrieval_limits::PAST_MEMBERS_MAX_LIMIT as usize

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -5,10 +5,12 @@ use crate::storage::{retrieval_limits, NodeFamiliesStorage};
 use cosmwasm_std::{Deps, Env, Order, StdResult};
 use cw_storage_plus::Bound;
 use node_families_contract_common::{
-    FamiliesPagedResponse, FamilyMemberRecord, FamilyMembersPagedResponse,
-    NodeFamiliesContractError, NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse,
-    PendingFamilyInvitationDetails, PendingFamilyInvitationResponse,
-    PendingFamilyInvitationsPagedResponse, PendingInvitationsPagedResponse,
+    AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse, FamilyMemberRecord,
+    FamilyMembersPagedResponse, GlobalPastFamilyInvitationCursor, NodeFamiliesContractError,
+    NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationCursor,
+    PastFamilyInvitationsPagedResponse, PendingFamilyInvitationDetails,
+    PendingFamilyInvitationResponse, PendingFamilyInvitationsPagedResponse,
+    PendingInvitationsPagedResponse,
 };
 use nym_mixnet_contract_common::NodeId;
 
@@ -201,6 +203,95 @@ pub fn query_all_pending_invitations_paged(
         .map(|d| (d.invitation.family_id, d.invitation.node_id));
 
     Ok(PendingInvitationsPagedResponse {
+        invitations,
+        start_next_after,
+    })
+}
+
+/// Page through every archived (terminal-state) invitation issued by
+/// `family_id`, in ascending `(node_id, counter)` order across all
+/// `Accepted` / `Rejected` / `Revoked` statuses.
+///
+/// Uses a direct bounds-based range scan on the primary map keyed by
+/// `((family_id, node_id), counter)` — `family_id` is already the leftmost
+/// key component, so this avoids the extra storage read per entry that
+/// going through the `family` multi-index would incur. Cost is O(page
+/// size). Does not verify that `family_id` refers to an existing
+/// family — an unknown id simply yields an empty page.
+///
+/// `start_after` is exclusive — pass the previous page's `start_next_after`
+/// to fetch the next page; pass `None` to start from the first archived
+/// entry. `limit` defaults to [`retrieval_limits::PAST_INVITATIONS_DEFAULT_LIMIT`]
+/// and is clamped to [`retrieval_limits::PAST_INVITATIONS_MAX_LIMIT`].
+pub fn query_past_invitations_for_family_paged(
+    deps: Deps,
+    family_id: NodeFamilyId,
+    start_after: Option<PastFamilyInvitationCursor>,
+    limit: Option<u32>,
+) -> Result<PastFamilyInvitationsPagedResponse, NodeFamiliesContractError> {
+    let limit = limit
+        .unwrap_or(retrieval_limits::PAST_INVITATIONS_DEFAULT_LIMIT)
+        .min(retrieval_limits::PAST_INVITATIONS_MAX_LIMIT) as usize;
+
+    let lower =
+        start_after.map(|(node_id, counter)| Bound::exclusive(((family_id, node_id), counter)));
+
+    // upper bound = first key of next family;
+    let upper = Some(Bound::exclusive(((family_id + 1, 0), 0)));
+
+    let storage = NodeFamiliesStorage::new();
+    let entries = storage
+        .past_family_invitations
+        .range(deps.storage, lower, upper, Order::Ascending)
+        .take(limit)
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let start_next_after = entries
+        .last()
+        .map(|(((_, node_id), counter), _)| (*node_id, *counter));
+
+    let invitations = entries.into_iter().map(|(_, v)| v).collect();
+
+    Ok(PastFamilyInvitationsPagedResponse {
+        family_id,
+        invitations,
+        start_next_after,
+    })
+}
+
+/// Page through every archived (terminal-state) invitation across all
+/// families, in ascending `((family_id, node_id), counter)` order.
+///
+/// Cost is O(page size) — full range scan over the
+/// `past_family_invitations` map without any prefix filter.
+///
+/// `start_after` is exclusive — pass the previous page's `start_next_after`
+/// to fetch the next page; pass `None` to start from the first entry.
+/// `limit` defaults to [`retrieval_limits::PAST_INVITATIONS_DEFAULT_LIMIT`]
+/// and is clamped to [`retrieval_limits::PAST_INVITATIONS_MAX_LIMIT`].
+pub fn query_all_past_invitations_paged(
+    deps: Deps,
+    start_after: Option<GlobalPastFamilyInvitationCursor>,
+    limit: Option<u32>,
+) -> Result<AllPastFamilyInvitationsPagedResponse, NodeFamiliesContractError> {
+    let limit = limit
+        .unwrap_or(retrieval_limits::PAST_INVITATIONS_DEFAULT_LIMIT)
+        .min(retrieval_limits::PAST_INVITATIONS_MAX_LIMIT) as usize;
+
+    let start = start_after.map(Bound::exclusive);
+
+    let storage = NodeFamiliesStorage::new();
+    let entries = storage
+        .past_family_invitations
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let start_next_after = entries.last().map(|(key, _)| *key);
+
+    let invitations = entries.into_iter().map(|(_, v)| v).collect();
+
+    Ok(AllPastFamilyInvitationsPagedResponse {
         invitations,
         start_next_after,
     })
@@ -602,27 +693,24 @@ mod tests {
             );
             assert_eq!(p1.start_next_after, Some(11));
 
-            let p2 =
-                query_family_members_paged(tester.deps(), f.id, p1.start_next_after, Some(2))
-                    .unwrap();
+            let p2 = query_family_members_paged(tester.deps(), f.id, p1.start_next_after, Some(2))
+                .unwrap();
             assert_eq!(
                 p2.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
                 vec![12, 13]
             );
             assert_eq!(p2.start_next_after, Some(13));
 
-            let p3 =
-                query_family_members_paged(tester.deps(), f.id, p2.start_next_after, Some(2))
-                    .unwrap();
+            let p3 = query_family_members_paged(tester.deps(), f.id, p2.start_next_after, Some(2))
+                .unwrap();
             assert_eq!(
                 p3.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
                 vec![14]
             );
             assert_eq!(p3.start_next_after, Some(14));
 
-            let p4 =
-                query_family_members_paged(tester.deps(), f.id, p3.start_next_after, Some(2))
-                    .unwrap();
+            let p4 = query_family_members_paged(tester.deps(), f.id, p3.start_next_after, Some(2))
+                .unwrap();
             assert!(p4.members.is_empty());
             assert!(p4.start_next_after.is_none());
         }
@@ -631,13 +719,11 @@ mod tests {
         fn limit_is_clamped_to_max() {
             let mut tester = init_contract_tester();
             let f = tester.add_dummy_family();
-            let total = retrieval_limits::FAMILY_MEMBERS_MAX_LIMIT as u32 + 5;
-            for n in 1..=total {
-                tester.add_to_family(f.id, n);
-            }
+            let total = retrieval_limits::FAMILY_MEMBERS_MAX_LIMIT + 5;
+            tester.add_n_family_members(f.id, total);
 
-            let res = query_family_members_paged(tester.deps(), f.id, None, Some(u32::MAX))
-                .unwrap();
+            let res =
+                query_family_members_paged(tester.deps(), f.id, None, Some(u32::MAX)).unwrap();
             assert_eq!(
                 res.members.len(),
                 retrieval_limits::FAMILY_MEMBERS_MAX_LIMIT as usize
@@ -669,14 +755,9 @@ mod tests {
             let f = tester.add_dummy_family();
             let env = tester.env();
 
-            let res = query_pending_invitations_for_family_paged(
-                tester.deps(),
-                env,
-                f.id,
-                None,
-                None,
-            )
-            .unwrap();
+            let res =
+                query_pending_invitations_for_family_paged(tester.deps(), env, f.id, None, None)
+                    .unwrap();
             assert_eq!(res.family_id, f.id);
             assert!(res.invitations.is_empty());
             assert!(res.start_next_after.is_none());
@@ -704,15 +785,14 @@ mod tests {
             tester.invite_to_family(f2.id, 20);
 
             let env = tester.env();
-            let res = query_pending_invitations_for_family_paged(
-                tester.deps(),
-                env,
-                f1.id,
-                None,
-                None,
-            )
-            .unwrap();
-            let ids: Vec<_> = res.invitations.iter().map(|d| d.invitation.node_id).collect();
+            let res =
+                query_pending_invitations_for_family_paged(tester.deps(), env, f1.id, None, None)
+                    .unwrap();
+            let ids: Vec<_> = res
+                .invitations
+                .iter()
+                .map(|d| d.invitation.node_id)
+                .collect();
             assert_eq!(ids, vec![10, 11]);
             for d in &res.invitations {
                 assert_eq!(d.invitation.family_id, f1.id);
@@ -732,7 +812,11 @@ mod tests {
             let res =
                 query_pending_invitations_for_family_paged(tester.deps(), env, f.id, None, None)
                     .unwrap();
-            let ids: Vec<_> = res.invitations.iter().map(|d| d.invitation.node_id).collect();
+            let ids: Vec<_> = res
+                .invitations
+                .iter()
+                .map(|d| d.invitation.node_id)
+                .collect();
             assert_eq!(ids, vec![10, 20, 30]);
         }
 
@@ -774,7 +858,11 @@ mod tests {
                 Some(2),
             )
             .unwrap();
-            let ids: Vec<_> = p1.invitations.iter().map(|d| d.invitation.node_id).collect();
+            let ids: Vec<_> = p1
+                .invitations
+                .iter()
+                .map(|d| d.invitation.node_id)
+                .collect();
             assert_eq!(ids, vec![10, 11]);
             assert_eq!(p1.start_next_after, Some(11));
 
@@ -786,7 +874,11 @@ mod tests {
                 Some(2),
             )
             .unwrap();
-            let ids: Vec<_> = p2.invitations.iter().map(|d| d.invitation.node_id).collect();
+            let ids: Vec<_> = p2
+                .invitations
+                .iter()
+                .map(|d| d.invitation.node_id)
+                .collect();
             assert_eq!(ids, vec![12]);
         }
 
@@ -794,7 +886,7 @@ mod tests {
         fn limit_is_clamped_to_max() {
             let mut tester = init_contract_tester();
             let f = tester.add_dummy_family();
-            let total = retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT as u32 + 5;
+            let total = retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT + 5;
             for n in 1..=total {
                 tester.invite_to_family(f.id, n);
             }
@@ -828,7 +920,11 @@ mod tests {
             let res =
                 query_pending_invitations_for_family_paged(tester.deps(), env, f.id, None, None)
                     .unwrap();
-            let ids: Vec<_> = res.invitations.iter().map(|d| d.invitation.node_id).collect();
+            let ids: Vec<_> = res
+                .invitations
+                .iter()
+                .map(|d| d.invitation.node_id)
+                .collect();
             assert_eq!(ids, vec![11]);
         }
     }
@@ -886,8 +982,8 @@ mod tests {
                 .iter()
                 .map(|d| (d.invitation.node_id, d.expired))
                 .collect();
-            assert_eq!(by_node[&10], true);
-            assert_eq!(by_node[&11], false);
+            assert!(by_node[&10]);
+            assert!(!by_node[&11]);
         }
 
         #[test]
@@ -901,9 +997,8 @@ mod tests {
             tester.invite_to_family(f2.id, 15);
 
             let env = tester.env();
-            let p1 =
-                query_all_pending_invitations_paged(tester.deps(), env.clone(), None, Some(2))
-                    .unwrap();
+            let p1 = query_all_pending_invitations_paged(tester.deps(), env.clone(), None, Some(2))
+                .unwrap();
             let pairs: Vec<_> = p1
                 .invitations
                 .iter()
@@ -941,18 +1036,280 @@ mod tests {
         fn limit_is_clamped_to_max() {
             let mut tester = init_contract_tester();
             let f = tester.add_dummy_family();
-            let total = retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT as u32 + 5;
+            let total = retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT + 5;
             for n in 1..=total {
                 tester.invite_to_family(f.id, n);
             }
 
             let env = tester.env();
-            let res =
-                query_all_pending_invitations_paged(tester.deps(), env, None, Some(u32::MAX))
-                    .unwrap();
+            let res = query_all_pending_invitations_paged(tester.deps(), env, None, Some(u32::MAX))
+                .unwrap();
             assert_eq!(
                 res.invitations.len(),
                 retrieval_limits::PENDING_INVITATIONS_MAX_LIMIT as usize
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod past_invitations_for_family_paged {
+        use super::*;
+        use node_families_contract_common::FamilyInvitationStatus;
+
+        #[test]
+        fn empty_when_family_has_no_archive_entries() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+
+            let res =
+                query_past_invitations_for_family_paged(tester.deps(), f.id, None, None).unwrap();
+            assert_eq!(res.family_id, f.id);
+            assert!(res.invitations.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn empty_for_unknown_family_id() {
+            let tester = init_contract_tester();
+
+            let res =
+                query_past_invitations_for_family_paged(tester.deps(), 99, None, None).unwrap();
+            assert_eq!(res.family_id, 99);
+            assert!(res.invitations.is_empty());
+        }
+
+        #[test]
+        fn returns_only_archived_invitations_from_requested_family() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            // produce one Accepted in each family, plus one Rejected in f1
+            tester.add_to_family(f1.id, 10);
+            tester.invite_to_family(f1.id, 11);
+            tester.reject_invitation(f1.id, 11);
+            tester.add_to_family(f2.id, 20);
+
+            let res =
+                query_past_invitations_for_family_paged(tester.deps(), f1.id, None, None).unwrap();
+            assert_eq!(res.invitations.len(), 2);
+            for entry in &res.invitations {
+                assert_eq!(entry.invitation.family_id, f1.id);
+            }
+        }
+
+        #[test]
+        fn covers_all_terminal_statuses() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+
+            // Accepted
+            tester.add_to_family(f.id, 10);
+            // Rejected
+            tester.invite_to_family(f.id, 11);
+            tester.reject_invitation(f.id, 11);
+            // Revoked
+            tester.invite_to_family(f.id, 12);
+            tester.revoke_invitation(f.id, 12);
+
+            let res =
+                query_past_invitations_for_family_paged(tester.deps(), f.id, None, None).unwrap();
+            let by_node: std::collections::HashMap<_, _> = res
+                .invitations
+                .iter()
+                .map(|p| (p.invitation.node_id, p.status.clone()))
+                .collect();
+            assert!(matches!(
+                by_node[&10],
+                FamilyInvitationStatus::Accepted { .. }
+            ));
+            assert!(matches!(
+                by_node[&11],
+                FamilyInvitationStatus::Rejected { .. }
+            ));
+            assert!(matches!(
+                by_node[&12],
+                FamilyInvitationStatus::Revoked { .. }
+            ));
+        }
+
+        #[test]
+        fn ordered_by_node_id_then_counter() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+
+            // node 42 joins and leaves twice — produces two Accepted entries with counters 0 and 1
+            for _ in 0..2 {
+                tester.add_to_family(f.id, 42);
+                tester.remove_from_family(42);
+            }
+            // node 7 has one Accepted entry
+            tester.add_to_family(f.id, 7);
+
+            let res =
+                query_past_invitations_for_family_paged(tester.deps(), f.id, None, None).unwrap();
+            let pairs: Vec<_> = res
+                .invitations
+                .iter()
+                .map(|p| p.invitation.node_id)
+                .collect();
+            // 7 comes before 42; 42's two entries come together (both with counter 0 and 1)
+            assert_eq!(pairs, vec![7, 42, 42]);
+        }
+
+        #[test]
+        fn paginates_with_node_counter_cursor() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            for n in [10, 11, 12] {
+                tester.add_to_family(f.id, n);
+            }
+
+            let p1 = query_past_invitations_for_family_paged(tester.deps(), f.id, None, Some(2))
+                .unwrap();
+            let ids: Vec<_> = p1
+                .invitations
+                .iter()
+                .map(|p| p.invitation.node_id)
+                .collect();
+            assert_eq!(ids, vec![10, 11]);
+            assert_eq!(p1.start_next_after, Some((11, 0)));
+
+            let p2 = query_past_invitations_for_family_paged(
+                tester.deps(),
+                f.id,
+                p1.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            let ids: Vec<_> = p2
+                .invitations
+                .iter()
+                .map(|p| p.invitation.node_id)
+                .collect();
+            assert_eq!(ids, vec![12]);
+            assert_eq!(p2.start_next_after, Some((12, 0)));
+
+            let p3 = query_past_invitations_for_family_paged(
+                tester.deps(),
+                f.id,
+                p2.start_next_after,
+                Some(2),
+            )
+            .unwrap();
+            assert!(p3.invitations.is_empty());
+            assert!(p3.start_next_after.is_none());
+        }
+
+        #[test]
+        fn limit_is_clamped_to_max() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            let total = retrieval_limits::PAST_INVITATIONS_MAX_LIMIT + 5;
+            tester.add_n_family_members(f.id, total);
+
+            let res =
+                query_past_invitations_for_family_paged(tester.deps(), f.id, None, Some(u32::MAX))
+                    .unwrap();
+            assert_eq!(
+                res.invitations.len(),
+                retrieval_limits::PAST_INVITATIONS_MAX_LIMIT as usize
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod all_past_invitations_paged {
+        use super::*;
+
+        #[test]
+        fn empty_when_no_archive_entries() {
+            let tester = init_contract_tester();
+
+            let res = query_all_past_invitations_paged(tester.deps(), None, None).unwrap();
+            assert!(res.invitations.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn returns_archives_across_all_families() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.add_to_family(f1.id, 10);
+            tester.add_to_family(f1.id, 20);
+            tester.add_to_family(f2.id, 5);
+
+            let res = query_all_past_invitations_paged(tester.deps(), None, None).unwrap();
+            let pairs: Vec<_> = res
+                .invitations
+                .iter()
+                .map(|p| (p.invitation.family_id, p.invitation.node_id))
+                .collect();
+            assert_eq!(pairs, vec![(f1.id, 10), (f1.id, 20), (f2.id, 5)]);
+            assert_eq!(res.start_next_after, Some(((f2.id, 5), 0)));
+        }
+
+        #[test]
+        fn paginates_with_composite_cursor() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.add_to_family(f1.id, 10);
+            tester.add_to_family(f1.id, 20);
+            tester.add_to_family(f2.id, 5);
+            tester.add_to_family(f2.id, 15);
+
+            let p1 = query_all_past_invitations_paged(tester.deps(), None, Some(2)).unwrap();
+            let pairs: Vec<_> = p1
+                .invitations
+                .iter()
+                .map(|p| (p.invitation.family_id, p.invitation.node_id))
+                .collect();
+            assert_eq!(pairs, vec![(f1.id, 10), (f1.id, 20)]);
+            assert_eq!(p1.start_next_after, Some(((f1.id, 20), 0)));
+
+            let p2 = query_all_past_invitations_paged(tester.deps(), p1.start_next_after, Some(2))
+                .unwrap();
+            let pairs: Vec<_> = p2
+                .invitations
+                .iter()
+                .map(|p| (p.invitation.family_id, p.invitation.node_id))
+                .collect();
+            assert_eq!(pairs, vec![(f2.id, 5), (f2.id, 15)]);
+
+            let p3 = query_all_past_invitations_paged(tester.deps(), p2.start_next_after, Some(2))
+                .unwrap();
+            assert!(p3.invitations.is_empty());
+            assert!(p3.start_next_after.is_none());
+        }
+
+        #[test]
+        fn per_pair_counter_disambiguates_repeat_archive_entries() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            // node 42 joins and leaves twice — two Accepted entries for (f, 42) with counters 0 and 1
+            for _ in 0..2 {
+                tester.add_to_family(f.id, 42);
+                tester.remove_from_family(42);
+            }
+
+            let res = query_all_past_invitations_paged(tester.deps(), None, None).unwrap();
+            assert_eq!(res.invitations.len(), 2);
+            assert_eq!(res.start_next_after, Some(((f.id, 42), 1)));
+        }
+
+        #[test]
+        fn limit_is_clamped_to_max() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            let total = retrieval_limits::PAST_INVITATIONS_MAX_LIMIT + 5;
+            tester.add_n_family_members(f.id, total);
+
+            let res =
+                query_all_past_invitations_paged(tester.deps(), None, Some(u32::MAX)).unwrap();
+            assert_eq!(
+                res.invitations.len(),
+                retrieval_limits::PAST_INVITATIONS_MAX_LIMIT as usize
             );
         }
     }

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -53,19 +53,16 @@ pub fn query_family_by_owner(
 /// e.g. `"foo"`, `"FoO"` and `"  foo!  "` all resolve to the same family.
 /// Returns `family: None` if no family with that (normalised) name exists.
 /// Backed by the `name` `UniqueIndex`, so cost is O(1).
-///
-/// The echoed `name` in the response is the normalised form actually used
-/// for the lookup, so callers can correlate after the normalisation.
 pub fn query_family_by_name(
     deps: Deps,
     name: String,
 ) -> Result<NodeFamilyByNameResponse, NodeFamiliesContractError> {
-    let name = normalise_family_name(&name);
+    let normalised_name = normalise_family_name(&name);
     let family = NodeFamiliesStorage::new()
         .families
         .idx
         .name
-        .item(deps.storage, name.clone())?
+        .item(deps.storage, normalised_name)?
         .map(|(_, family)| family);
     Ok(NodeFamilyByNameResponse { name, family })
 }
@@ -644,6 +641,7 @@ mod tests {
     #[cfg(test)]
     mod family_by_name {
         use super::*;
+        use nym_contracts_common_testing::RandExt;
 
         #[test]
         fn returns_none_when_name_does_not_exist() {
@@ -657,12 +655,8 @@ mod tests {
         #[test]
         fn returns_persisted_family_by_exact_name() {
             let mut tester = init_contract_tester();
-            let s = NodeFamiliesStorage::new();
-            let env = tester.env();
             let alice = tester.addr_make("alice");
-            let f = s
-                .register_new_family(tester.storage_mut(), &env, alice, "foo".into(), "".into())
-                .unwrap();
+            let f = tester.make_named_family(&alice, "foo");
 
             let res = query_family_by_name(tester.deps(), "foo".to_string()).unwrap();
             assert_eq!(res.name, "foo");
@@ -670,50 +664,21 @@ mod tests {
         }
 
         #[test]
-        fn lookup_is_case_insensitive() {
-            let mut tester = init_contract_tester();
-            let s = NodeFamiliesStorage::new();
-            let env = tester.env();
-            let alice = tester.addr_make("alice");
-            let f = s
-                .register_new_family(tester.storage_mut(), &env, alice, "foo".into(), "".into())
-                .unwrap();
+        fn lookup_normalises_name() {
+            let variants = ["foo", "FOO", "FoO", "fOo", "foo🚀", "🚀Foo", "   foo-!"];
 
-            for variant in ["foo", "FOO", "FoO", "fOo"] {
-                let res = query_family_by_name(tester.deps(), variant.to_string()).unwrap();
-                assert_eq!(res.name, "foo");
-                assert_eq!(res.family, Some(f.clone()));
+            for family_name in variants {
+                let mut tester = init_contract_tester();
+                let owner = tester.generate_account();
+                let f = tester.make_named_family(&owner, family_name);
+
+                for query_name in variants {
+                    let res = query_family_by_name(tester.deps(), query_name.to_string()).unwrap();
+                    assert_eq!(res.name, query_name);
+                    assert_eq!(res.family, Some(f.clone()));
+                    assert_eq!(res.family.unwrap().name, normalise_family_name(family_name));
+                }
             }
-        }
-
-        #[test]
-        fn lookup_strips_non_alphanumerics() {
-            let mut tester = init_contract_tester();
-            let s = NodeFamiliesStorage::new();
-            let env = tester.env();
-            let alice = tester.addr_make("alice");
-            let f = s
-                .register_new_family(
-                    tester.storage_mut(),
-                    &env,
-                    alice,
-                    "foobar".into(),
-                    "".into(),
-                )
-                .unwrap();
-
-            let res = query_family_by_name(tester.deps(), "  Foo-Bar! ".to_string()).unwrap();
-            assert_eq!(res.name, "foobar");
-            assert_eq!(res.family, Some(f));
-        }
-
-        #[test]
-        fn echoes_normalised_name_even_when_no_match() {
-            let tester = init_contract_tester();
-
-            let res = query_family_by_name(tester.deps(), "  Foo-Bar! ".to_string()).unwrap();
-            assert_eq!(res.name, "foobar");
-            assert!(res.family.is_none());
         }
     }
 

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -322,8 +322,10 @@ pub fn query_past_invitations_for_family_paged(
         .unwrap_or(retrieval_limits::PAST_INVITATIONS_DEFAULT_LIMIT)
         .min(retrieval_limits::PAST_INVITATIONS_MAX_LIMIT) as usize;
 
-    let lower =
-        start_after.map(|(node_id, counter)| Bound::exclusive(((family_id, node_id), counter)));
+    let lower = Some(match start_after {
+        Some((node_id, counter)) => Bound::exclusive(((family_id, node_id), counter)),
+        None => Bound::inclusive(((family_id, 0), 0)),
+    });
 
     // upper bound = first key of next family;
     let upper = Some(Bound::exclusive(((family_id + 1, 0), 0)));
@@ -456,8 +458,10 @@ pub fn query_past_members_for_family_paged(
         .unwrap_or(retrieval_limits::PAST_MEMBERS_DEFAULT_LIMIT)
         .min(retrieval_limits::PAST_MEMBERS_MAX_LIMIT) as usize;
 
-    let lower =
-        start_after.map(|(node_id, counter)| Bound::exclusive(((family_id, node_id), counter)));
+    let lower = Some(match start_after {
+        Some((node_id, counter)) => Bound::exclusive(((family_id, node_id), counter)),
+        None => Bound::inclusive(((family_id, 0), 0)),
+    });
 
     // upper bound = first key of next family;
     let upper = Some(Bound::exclusive(((family_id + 1, 0), 0)));
@@ -1537,6 +1541,29 @@ mod tests {
                 retrieval_limits::PAST_INVITATIONS_MAX_LIMIT as usize
             );
         }
+
+        #[test]
+        fn start_after_none_does_not_leak_earlier_families() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.add_to_family(f1.id, 10);
+            tester.add_to_family(f1.id, 11);
+
+            let res =
+                query_past_invitations_for_family_paged(tester.deps(), f2.id, None, None).unwrap();
+
+            assert_eq!(res.family_id, f2.id);
+            assert!(
+                res.invitations.is_empty(),
+                "expected no entries for f2 but got: {:?}",
+                res.invitations
+                    .iter()
+                    .map(|e| (e.invitation.family_id, e.invitation.node_id))
+                    .collect::<Vec<_>>()
+            );
+            assert!(res.start_next_after.is_none());
+        }
     }
 
     #[cfg(test)]
@@ -2079,6 +2106,31 @@ mod tests {
                 res.members.len(),
                 retrieval_limits::PAST_MEMBERS_MAX_LIMIT as usize
             );
+        }
+
+        #[test]
+        fn start_after_none_does_not_leak_earlier_families() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.add_to_family(f1.id, 10);
+            tester.add_to_family(f1.id, 11);
+            tester.remove_from_family(10);
+            tester.remove_from_family(11);
+
+            let res =
+                query_past_members_for_family_paged(tester.deps(), f2.id, None, None).unwrap();
+
+            assert_eq!(res.family_id, f2.id);
+            assert!(
+                res.members.is_empty(),
+                "expected no entries for f2 but got: {:?}",
+                res.members
+                    .iter()
+                    .map(|m| (m.family_id, m.node_id))
+                    .collect::<Vec<_>>()
+            );
+            assert!(res.start_next_after.is_none());
         }
     }
 

--- a/contracts/node-families/src/storage/mod.rs
+++ b/contracts/node-families/src/storage/mod.rs
@@ -18,6 +18,7 @@ use node_families_contract_common::{
 };
 use nym_mixnet_contract_common::NodeId;
 
+pub(crate) mod retrieval_limits;
 mod storage_indexes;
 
 /// Composite primary key for the invitation / past-member maps:

--- a/contracts/node-families/src/storage/mod.rs
+++ b/contracts/node-families/src/storage/mod.rs
@@ -5,7 +5,7 @@
 #![allow(dead_code)]
 
 use crate::storage::storage_indexes::{
-    NodeFamiliesIndex, NodeFamilyInvitationIndex, PastFamilyInvitationsIndex,
+    FamilyMembersIndex, NodeFamiliesIndex, NodeFamilyInvitationIndex, PastFamilyInvitationsIndex,
     PastFamilyMembersIndex,
 };
 use cosmwasm_std::{Addr, Env, Order, StdResult, Storage};
@@ -13,8 +13,8 @@ use cw_controllers::Admin;
 use cw_storage_plus::{IndexedMap, Item, Map};
 use node_families_contract_common::constants::storage_keys;
 use node_families_contract_common::{
-    FamilyInvitation, FamilyInvitationStatus, NodeFamiliesContractError, NodeFamily, NodeFamilyId,
-    PastFamilyInvitation, PastFamilyMember,
+    FamilyInvitation, FamilyInvitationStatus, FamilyMembership, NodeFamiliesContractError,
+    NodeFamily, NodeFamilyId, PastFamilyInvitation, PastFamilyMember,
 };
 use nym_mixnet_contract_common::NodeId;
 
@@ -49,9 +49,11 @@ pub struct NodeFamiliesStorage<'a> {
     /// callers normalise upstream if case-insensitive uniqueness is desired).
     pub(crate) families: IndexedMap<NodeFamilyId, NodeFamily, NodeFamiliesIndex<'a>>,
 
-    /// Mapping from a node id to the family it currently belongs to. A node
-    /// belongs to at most one family at a time, so this is a plain `Map`.
-    pub(crate) family_members: Map<NodeId, NodeFamilyId>,
+    /// Current family membership records, keyed by [`NodeId`]. A node
+    /// belongs to at most one family at a time, so the PK is the node id.
+    /// A `family` multi-index enables paginated listing of all nodes
+    /// belonging to a given family.
+    pub(crate) family_members: IndexedMap<NodeId, FamilyMembership, FamilyMembersIndex<'a>>,
 
     /// Currently outstanding family invitations, indexed by both family id
     /// and node id (a single node can simultaneously hold invitations from
@@ -98,7 +100,10 @@ impl NodeFamiliesStorage<'_> {
             mixnet_contract_address: Item::new(storage_keys::MIXNET_CONTRACT_ADDRESS),
             node_family_id_counter: Item::new(storage_keys::NODE_FAMILY_ID_COUNTER),
             families: IndexedMap::new(storage_keys::FAMILIES_NAMESPACE, NodeFamiliesIndex::new()),
-            family_members: Map::new(storage_keys::NODE_FAMILY_MEMBERS),
+            family_members: IndexedMap::new(
+                storage_keys::NODE_FAMILY_MEMBERS,
+                FamilyMembersIndex::new(),
+            ),
             pending_family_invitations: IndexedMap::new(
                 storage_keys::INVITATIONS_NAMESPACE,
                 NodeFamilyInvitationIndex::new(),
@@ -318,7 +323,14 @@ impl NodeFamiliesStorage<'_> {
 
         self.pending_family_invitations.remove(store, key)?;
 
-        self.family_members.save(store, node_id, &family_id)?;
+        self.family_members.save(
+            store,
+            node_id,
+            &FamilyMembership {
+                family_id,
+                joined_at: now,
+            },
+        )?;
 
         let mut family = self
             .families
@@ -470,9 +482,10 @@ impl NodeFamiliesStorage<'_> {
         let family_id = self
             .family_members
             .may_load(store, node_id)?
-            .ok_or(NodeFamiliesContractError::NodeNotInFamily { node_id })?;
+            .ok_or(NodeFamiliesContractError::NodeNotInFamily { node_id })?
+            .family_id;
 
-        self.family_members.remove(store, node_id);
+        self.family_members.remove(store, node_id)?;
 
         let mut family = self
             .families
@@ -799,7 +812,9 @@ mod tests {
             .may_load(tester.storage(), (f.id, 42))
             .unwrap()
             .is_none());
-        assert_eq!(s.family_members.load(tester.storage(), 42).unwrap(), f.id);
+        let membership = s.family_members.load(tester.storage(), 42).unwrap();
+        assert_eq!(membership.family_id, f.id);
+        assert_eq!(membership.joined_at, tester.env().block.time.seconds());
         assert_eq!(s.families.load(tester.storage(), f.id).unwrap().members, 1);
 
         let past = s

--- a/contracts/node-families/src/storage/retrieval_limits.rs
+++ b/contracts/node-families/src/storage/retrieval_limits.rs
@@ -12,3 +12,10 @@ pub const FAMILY_MEMBERS_DEFAULT_LIMIT: u32 = 50;
 
 /// Hard cap on the page size for paginated family-member listings; larger values are clamped.
 pub const FAMILY_MEMBERS_MAX_LIMIT: u32 = 100;
+
+/// Default page size for paginated pending-invitation listings (both per-family
+/// and global) when the caller omits `limit`.
+pub const PENDING_INVITATIONS_DEFAULT_LIMIT: u32 = 50;
+
+/// Hard cap on the page size for paginated pending-invitation listings; larger values are clamped.
+pub const PENDING_INVITATIONS_MAX_LIMIT: u32 = 100;

--- a/contracts/node-families/src/storage/retrieval_limits.rs
+++ b/contracts/node-families/src/storage/retrieval_limits.rs
@@ -26,3 +26,9 @@ pub const PAST_INVITATIONS_DEFAULT_LIMIT: u32 = 50;
 
 /// Hard cap on the page size for paginated past-invitation listings; larger values are clamped.
 pub const PAST_INVITATIONS_MAX_LIMIT: u32 = 100;
+
+/// Default page size for paginated past-member (archive) listings when the caller omits `limit`.
+pub const PAST_MEMBERS_DEFAULT_LIMIT: u32 = 50;
+
+/// Hard cap on the page size for paginated past-member listings; larger values are clamped.
+pub const PAST_MEMBERS_MAX_LIMIT: u32 = 100;

--- a/contracts/node-families/src/storage/retrieval_limits.rs
+++ b/contracts/node-families/src/storage/retrieval_limits.rs
@@ -19,3 +19,10 @@ pub const PENDING_INVITATIONS_DEFAULT_LIMIT: u32 = 50;
 
 /// Hard cap on the page size for paginated pending-invitation listings; larger values are clamped.
 pub const PENDING_INVITATIONS_MAX_LIMIT: u32 = 100;
+
+/// Default page size for paginated past-invitation (archive) listings (both
+/// per-family and global) when the caller omits `limit`.
+pub const PAST_INVITATIONS_DEFAULT_LIMIT: u32 = 50;
+
+/// Hard cap on the page size for paginated past-invitation listings; larger values are clamped.
+pub const PAST_INVITATIONS_MAX_LIMIT: u32 = 100;

--- a/contracts/node-families/src/storage/retrieval_limits.rs
+++ b/contracts/node-families/src/storage/retrieval_limits.rs
@@ -1,0 +1,14 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+/// Default page size for paginated family listings when the caller omits `limit`.
+pub const FAMILIES_DEFAULT_LIMIT: u32 = 50;
+
+/// Hard cap on the page size for paginated family listings; larger values are clamped.
+pub const FAMILIES_MAX_LIMIT: u32 = 100;
+
+/// Default page size for paginated family-member listings when the caller omits `limit`.
+pub const FAMILY_MEMBERS_DEFAULT_LIMIT: u32 = 50;
+
+/// Hard cap on the page size for paginated family-member listings; larger values are clamped.
+pub const FAMILY_MEMBERS_MAX_LIMIT: u32 = 100;

--- a/contracts/node-families/src/storage/storage_indexes.rs
+++ b/contracts/node-families/src/storage/storage_indexes.rs
@@ -6,7 +6,8 @@ use cosmwasm_std::Addr;
 use cw_storage_plus::{Index, IndexList, MultiIndex, UniqueIndex};
 use node_families_contract_common::constants::storage_keys;
 use node_families_contract_common::{
-    FamilyInvitation, NodeFamily, NodeFamilyId, PastFamilyInvitation, PastFamilyMember,
+    FamilyInvitation, FamilyMembership, NodeFamily, NodeFamilyId, PastFamilyInvitation,
+    PastFamilyMember,
 };
 use nym_mixnet_contract_common::NodeId;
 
@@ -40,6 +41,34 @@ impl NodeFamiliesIndex<'_> {
 impl IndexList<NodeFamily> for NodeFamiliesIndex<'_> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<NodeFamily>> + '_> {
         let v: Vec<&dyn Index<NodeFamily>> = vec![&self.owner, &self.name];
+        Box::new(v.into_iter())
+    }
+}
+
+/// Secondary indexes over current [`FamilyMembership`] records. The PK is
+/// `NodeId` (one family per node), and the family-id multi-index enables
+/// paginated listing of all nodes belonging to a given family.
+pub(crate) struct FamilyMembersIndex<'a> {
+    /// Multi-index: every node currently in a given family.
+    pub(crate) family: MultiIndex<'a, NodeFamilyId, FamilyMembership, NodeId>,
+}
+
+impl FamilyMembersIndex<'_> {
+    #[allow(clippy::new_without_default)]
+    pub(crate) fn new() -> Self {
+        FamilyMembersIndex {
+            family: MultiIndex::new(
+                |_pk, m| m.family_id,
+                storage_keys::NODE_FAMILY_MEMBERS,
+                storage_keys::NODE_FAMILY_MEMBERS_FAMILY_IDX_NAMESPACE,
+            ),
+        }
+    }
+}
+
+impl IndexList<FamilyMembership> for FamilyMembersIndex<'_> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<FamilyMembership>> + '_> {
+        let v: Vec<&dyn Index<FamilyMembership>> = vec![&self.family];
         Box::new(v.into_iter())
     }
 }

--- a/contracts/node-families/src/testing.rs
+++ b/contracts/node-families/src/testing.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::contract::{execute, instantiate, migrate, query};
+use crate::helpers::normalise_family_name;
 use crate::storage::NodeFamiliesStorage;
 use cosmwasm_std::{Addr, MessageInfo, StdError, StdResult, Storage};
 use node_families_contract_common::{
@@ -115,13 +116,24 @@ pub trait NodeFamiliesContractTesterExt:
         self.set_contract_storage_value(address, key, value)
     }
 
-    fn make_family(&mut self, owner: &Addr) -> NodeFamily {
+    fn make_named_family(&mut self, owner: &Addr, name: &str) -> NodeFamily {
+        let name = normalise_family_name(name);
         let env = self.env();
+        NodeFamiliesStorage::new()
+            .register_new_family(
+                self,
+                &env,
+                owner.clone(),
+                name.to_string(),
+                "dummy".to_string(),
+            )
+            .unwrap()
+    }
+
+    fn make_family(&mut self, owner: &Addr) -> NodeFamily {
         // names must be globally unique; derive from owner addr (also unique)
         let name = format!("family-{owner}");
-        NodeFamiliesStorage::new()
-            .register_new_family(self, &env, owner.clone(), name, "dummy".to_string())
-            .unwrap()
+        self.make_named_family(owner, &name)
     }
 
     fn add_dummy_family(&mut self) -> NodeFamily {

--- a/contracts/node-families/src/testing.rs
+++ b/contracts/node-families/src/testing.rs
@@ -152,6 +152,20 @@ pub trait NodeFamiliesContractTesterExt:
             .unwrap();
     }
 
+    fn reject_invitation(&mut self, family: NodeFamilyId, node: NodeId) {
+        let env = self.env();
+        NodeFamiliesStorage::new()
+            .reject_pending_invitation(self, &env, family, node)
+            .unwrap();
+    }
+
+    fn revoke_invitation(&mut self, family: NodeFamilyId, node: NodeId) {
+        let env = self.env();
+        NodeFamiliesStorage::new()
+            .revoke_pending_invitation(self, &env, family, node)
+            .unwrap();
+    }
+
     fn add_to_family(&mut self, family: NodeFamilyId, node: NodeId) {
         self.invite_to_family(family, node);
         self.accept_invitation(family, node);
@@ -162,6 +176,12 @@ pub trait NodeFamiliesContractTesterExt:
         NodeFamiliesStorage::new()
             .remove_family_member(self, &env, node)
             .unwrap();
+    }
+
+    fn add_n_family_members(&mut self, family: NodeFamilyId, count: u32) {
+        for n in 1..=count {
+            self.add_to_family(family, n);
+        }
     }
 }
 

--- a/contracts/node-families/src/testing.rs
+++ b/contracts/node-families/src/testing.rs
@@ -156,6 +156,13 @@ pub trait NodeFamiliesContractTesterExt:
         self.invite_to_family(family, node);
         self.accept_invitation(family, node);
     }
+
+    fn remove_from_family(&mut self, node: NodeId) {
+        let env = self.env();
+        NodeFamiliesStorage::new()
+            .remove_family_member(self, &env, node)
+            .unwrap();
+    }
 }
 
 impl NodeFamiliesContractTesterExt for ContractTester<NodeFamiliesContract> {}


### PR DESCRIPTION
NYM-1201

## Summary

Exposes the read-only query surface for the node-families contract so the Nym API, wallet, and other consumers can read family state without modifying it. Backs every unbounded list (i.e. all families, members, etc.) with a paginated query (exclusive `start_after` cursor + `limit` clamped per query)

Storage layer was already in place on the parent branch (#6717) - this PR is queries-only. `instantiate` / `execute` remain stubs and are out of scope.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6731)
<!-- Reviewable:end -->
