### PR TITLE
Re-order default API urls for network details

### DIFF
--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -44,12 +44,12 @@ pub const NYM_APIS: &[ApiUrlConst] = &[
         front_hosts: None,
     },
     ApiUrlConst {
-        url: "https://nym-frontdoor.vercel.app/api/",
-        front_hosts: Some(&["vercel.app", "vercel.com"]),
-    },
-    ApiUrlConst {
         url: "https://nym-frontdoor.global.ssl.fastly.net/api/",
         front_hosts: Some(&["yelp.global.ssl.fastly.net"]),
+    },
+    ApiUrlConst {
+        url: "https://nym-frontdoor.vercel.app/api/",
+        front_hosts: Some(&["vercel.app", "vercel.com"]),
     },
     ApiUrlConst {
         url: "https://cdn1.media-platform.net/api/",
@@ -68,11 +68,15 @@ pub const UPGRADE_MODE_ATTESTER_ED25519_BS58_PUBKEY: &str =
 pub const NYM_VPN_APIS: &[ApiUrlConst] = &[
     ApiUrlConst {
         url: NYM_VPN_API,
-        front_hosts: Some(&["vercel.app", "vercel.com"]),
+        front_hosts: None,
     },
     ApiUrlConst {
         url: "https://nymvpn-frontdoor.global.ssl.fastly.net/api/",
         front_hosts: Some(&["yelp.global.ssl.fastly.net"]),
+    },
+    ApiUrlConst {
+        url: NYM_VPN_API,
+        front_hosts: Some(&["vercel.app", "vercel.com"]),
     },
 ];
 

--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -48,10 +48,6 @@ pub const NYM_APIS: &[ApiUrlConst] = &[
         front_hosts: Some(&["yelp.global.ssl.fastly.net"]),
     },
     ApiUrlConst {
-        url: "https://nym-frontdoor.vercel.app/api/",
-        front_hosts: Some(&["vercel.app", "vercel.com"]),
-    },
-    ApiUrlConst {
         url: "https://cdn1.media-platform.net/api/",
         front_hosts: None,
     },
@@ -73,10 +69,6 @@ pub const NYM_VPN_APIS: &[ApiUrlConst] = &[
     ApiUrlConst {
         url: "https://nymvpn-frontdoor.global.ssl.fastly.net/api/",
         front_hosts: Some(&["yelp.global.ssl.fastly.net"]),
-    },
-    ApiUrlConst {
-        url: NYM_VPN_API,
-        front_hosts: Some(&["vercel.app", "vercel.com"]),
     },
 ];
 


### PR DESCRIPTION
## Ticket

NYM-1310

## Description

Promote the API resources using Fastly to have priority over Vercel while we investigate performace related improvements for vercel services

## Changelog
- [x] Prioritise Fastly API resources over Vercel in default discovery info for the mainnet env 

@coderabbitai ignore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6767)
<!-- Reviewable:end -->
