### PR TITLE
[bugfix] IPR v8<->v9 mismatch

### DIFF
--- a/nym-ip-packet-client/src/lib.rs
+++ b/nym-ip-packet-client/src/lib.rs
@@ -11,4 +11,4 @@ pub use error::Error;
 pub use listener::{IprListener, MixnetMessageOutcome};
 
 // Re-export the currently used version
-pub use nym_ip_packet_requests::v9 as current;
+pub use nym_ip_packet_requests::v8 as current;


### PR DESCRIPTION
Use v8 for non SDK IPR client

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6770)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated IP packet client library version compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym/pull/6770)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->