### PR TITLE
feat: Node Families: cache and expose family data within nym API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8576,6 +8576,7 @@ dependencies = [
  "flate2",
  "futures",
  "itertools 0.14.0",
+ "node-families-contract-common",
  "nym-api-requests",
  "nym-coconut-dkg-common",
  "nym-compact-ecash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5579,21 +5579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
-name = "node-families-contract-common"
-version = "1.20.5"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-controllers",
- "cw-utils",
- "nym-contracts-common",
- "nym-mixnet-contract-common",
- "schemars 0.8.22",
- "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5783,6 +5768,7 @@ dependencies = [
  "nym-http-api-client",
  "nym-http-api-common",
  "nym-mixnet-contract-common",
+ "nym-node-families-contract-common",
  "nym-node-requests",
  "nym-node-tester-utils",
  "nym-pemstore",
@@ -7624,6 +7610,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-node-families-contract-common"
+version = "1.20.5"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers",
+ "cw-utils",
+ "nym-contracts-common",
+ "nym-mixnet-contract-common",
+ "schemars 0.8.22",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "nym-node-metrics"
 version = "1.20.5"
 dependencies = [
@@ -8576,7 +8577,6 @@ dependencies = [
  "flate2",
  "futures",
  "itertools 0.14.0",
- "node-families-contract-common",
  "nym-api-requests",
  "nym-coconut-dkg-common",
  "nym-compact-ecash",
@@ -8588,6 +8588,7 @@ dependencies = [
  "nym-mixnet-contract-common",
  "nym-multisig-contract-common",
  "nym-network-defaults",
+ "nym-node-families-contract-common",
  "nym-performance-contract-common",
  "nym-serde-helpers",
  "nym-vesting-contract-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -473,6 +473,7 @@ nym-noise-keys = { version = "1.20.4", path = "common/nymnoise/keys" }
 nym-nonexhaustive-delayqueue = { version = "1.20.4", path = "common/nonexhaustive-delayqueue" }
 nym-node-requests = { version = "1.20.4", path = "nym-node/nym-node-requests", default-features = false }
 nym-node-metrics = { version = "1.20.4", path = "nym-node/nym-node-metrics" }
+node-families-contract-common = { version = "1.20.5", path = "common/cosmwasm-smart-contracts/node-families-contract" }
 nym-ordered-buffer = { version = "1.20.4", path = "common/socks5/ordered-buffer" }
 nym-outfox = { version = "1.20.4", path = "nym-outfox" }
 nym-registration-common = { version = "1.20.4", path = "common/registration" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -473,7 +473,7 @@ nym-noise-keys = { version = "1.20.4", path = "common/nymnoise/keys" }
 nym-nonexhaustive-delayqueue = { version = "1.20.4", path = "common/nonexhaustive-delayqueue" }
 nym-node-requests = { version = "1.20.4", path = "nym-node/nym-node-requests", default-features = false }
 nym-node-metrics = { version = "1.20.4", path = "nym-node/nym-node-metrics" }
-node-families-contract-common = { version = "1.20.5", path = "common/cosmwasm-smart-contracts/node-families-contract" }
+nym-node-families-contract-common = { version = "1.20.5", path = "common/cosmwasm-smart-contracts/node-families-contract" }
 nym-ordered-buffer = { version = "1.20.4", path = "common/socks5/ordered-buffer" }
 nym-outfox = { version = "1.20.4", path = "nym-outfox" }
 nym-registration-common = { version = "1.20.4", path = "common/registration" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -473,7 +473,7 @@ nym-noise-keys = { version = "1.20.4", path = "common/nymnoise/keys" }
 nym-nonexhaustive-delayqueue = { version = "1.20.4", path = "common/nonexhaustive-delayqueue" }
 nym-node-requests = { version = "1.20.4", path = "nym-node/nym-node-requests", default-features = false }
 nym-node-metrics = { version = "1.20.4", path = "nym-node/nym-node-metrics" }
-nym-node-families-contract-common = { version = "1.20.5", path = "common/cosmwasm-smart-contracts/node-families-contract" }
+nym-node-families-contract-common = { version = "1.20.4", path = "common/cosmwasm-smart-contracts/node-families-contract" }
 nym-ordered-buffer = { version = "1.20.4", path = "common/socks5/ordered-buffer" }
 nym-outfox = { version = "1.20.4", path = "nym-outfox" }
 nym-registration-common = { version = "1.20.4", path = "common/registration" }

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -26,7 +26,7 @@ nym-ecash-contract-common = { workspace = true }
 nym-multisig-contract-common = { workspace = true }
 nym-group-contract-common = { workspace = true }
 nym-performance-contract-common = { workspace = true }
-node-families-contract-common = { workspace = true }
+nym-node-families-contract-common = { workspace = true }
 nym-serde-helpers = { workspace = true, features = ["hex", "base64"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/common/client-libs/validator-client/Cargo.toml
+++ b/common/client-libs/validator-client/Cargo.toml
@@ -26,6 +26,7 @@ nym-ecash-contract-common = { workspace = true }
 nym-multisig-contract-common = { workspace = true }
 nym-group-contract-common = { workspace = true }
 nym-performance-contract-common = { workspace = true }
+node-families-contract-common = { workspace = true }
 nym-serde-helpers = { workspace = true, features = ["hex", "base64"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/mod.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/mod.rs
@@ -13,6 +13,7 @@ pub mod ecash_query_client;
 pub mod group_query_client;
 pub mod mixnet_query_client;
 pub mod multisig_query_client;
+pub mod node_families_query_client;
 pub mod performance_query_client;
 pub mod vesting_query_client;
 
@@ -22,6 +23,7 @@ pub mod ecash_signing_client;
 pub mod group_signing_client;
 pub mod mixnet_signing_client;
 pub mod multisig_signing_client;
+pub mod node_families_signing_client;
 pub mod performance_signing_client;
 pub mod vesting_signing_client;
 
@@ -31,6 +33,7 @@ pub use ecash_query_client::{EcashQueryClient, PagedEcashQueryClient};
 pub use group_query_client::{GroupQueryClient, PagedGroupQueryClient};
 pub use mixnet_query_client::{MixnetQueryClient, PagedMixnetQueryClient};
 pub use multisig_query_client::{MultisigQueryClient, PagedMultisigQueryClient};
+pub use node_families_query_client::{NodeFamiliesQueryClient, PagedNodeFamiliesQueryClient};
 pub use performance_query_client::{PagedPerformanceQueryClient, PerformanceQueryClient};
 pub use vesting_query_client::{PagedVestingQueryClient, VestingQueryClient};
 
@@ -40,6 +43,7 @@ pub use ecash_signing_client::EcashSigningClient;
 pub use group_signing_client::GroupSigningClient;
 pub use mixnet_signing_client::MixnetSigningClient;
 pub use multisig_signing_client::MultisigSigningClient;
+pub use node_families_signing_client::NodeFamiliesSigningClient;
 pub use performance_signing_client::PerformanceSigningClient;
 pub use vesting_signing_client::VestingSigningClient;
 
@@ -49,6 +53,7 @@ pub trait NymContractsProvider {
     fn mixnet_contract_address(&self) -> Option<&AccountId>;
     fn vesting_contract_address(&self) -> Option<&AccountId>;
     fn performance_contract_address(&self) -> Option<&AccountId>;
+    fn node_families_contract_address(&self) -> Option<&AccountId>;
 
     // coconut-related
     fn ecash_contract_address(&self) -> Option<&AccountId>;
@@ -62,6 +67,7 @@ pub struct TypedNymContracts {
     pub mixnet_contract_address: Option<AccountId>,
     pub vesting_contract_address: Option<AccountId>,
     pub performance_contract_address: Option<AccountId>,
+    pub node_families_contract_address: Option<AccountId>,
 
     pub ecash_contract_address: Option<AccountId>,
     pub group_contract_address: Option<AccountId>,
@@ -84,6 +90,10 @@ impl TryFrom<NymContracts> for TypedNymContracts {
                 .transpose()?,
             performance_contract_address: value
                 .performance_contract_address
+                .map(|addr| addr.parse())
+                .transpose()?,
+            node_families_contract_address: value
+                .node_families_contract_address
                 .map(|addr| addr.parse())
                 .transpose()?,
             ecash_contract_address: value

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/node_families_query_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/node_families_query_client.rs
@@ -1,0 +1,421 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::collect_paged;
+use crate::nyxd::contract_traits::NymContractsProvider;
+use crate::nyxd::error::NyxdError;
+use crate::nyxd::CosmWasmClient;
+use async_trait::async_trait;
+use cosmrs::AccountId;
+use serde::Deserialize;
+
+pub use node_families_contract_common::{
+    msg::QueryMsg as NodeFamiliesQueryMsg, AllPastFamilyInvitationsPagedResponse,
+    FamiliesPagedResponse, FamilyMemberRecord, FamilyMembersPagedResponse,
+    GlobalPastFamilyInvitationCursor, NodeFamily, NodeFamilyByNameResponse,
+    NodeFamilyByOwnerResponse, NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse,
+    PastFamilyInvitation, PastFamilyInvitationCursor, PastFamilyInvitationForNodeCursor,
+    PastFamilyInvitationsForNodePagedResponse, PastFamilyInvitationsPagedResponse,
+    PastFamilyMember, PastFamilyMemberCursor, PastFamilyMemberForNodeCursor,
+    PastFamilyMembersForNodePagedResponse, PastFamilyMembersPagedResponse,
+    PendingFamilyInvitationDetails, PendingFamilyInvitationResponse,
+    PendingFamilyInvitationsPagedResponse, PendingInvitationsForNodePagedResponse,
+    PendingInvitationsPagedResponse,
+};
+use nym_mixnet_contract_common::NodeId;
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait NodeFamiliesQueryClient {
+    async fn query_node_families_contract<T>(
+        &self,
+        query: NodeFamiliesQueryMsg,
+    ) -> Result<T, NyxdError>
+    where
+        for<'a> T: Deserialize<'a>;
+
+    async fn get_family_by_id(
+        &self,
+        family_id: NodeFamilyId,
+    ) -> Result<NodeFamilyResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetFamilyById { family_id })
+            .await
+    }
+
+    async fn get_family_by_owner(
+        &self,
+        owner: &AccountId,
+    ) -> Result<NodeFamilyByOwnerResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetFamilyByOwner {
+            owner: owner.to_string(),
+        })
+        .await
+    }
+
+    async fn get_family_by_name(
+        &self,
+        name: String,
+    ) -> Result<NodeFamilyByNameResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetFamilyByName { name })
+            .await
+    }
+
+    async fn get_families_paged(
+        &self,
+        start_after: Option<NodeFamilyId>,
+        limit: Option<u32>,
+    ) -> Result<FamiliesPagedResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetFamiliesPaged {
+            start_after,
+            limit,
+        })
+        .await
+    }
+
+    async fn get_family_membership(
+        &self,
+        node_id: NodeId,
+    ) -> Result<NodeFamilyMembershipResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetFamilyMembership { node_id })
+            .await
+    }
+
+    async fn get_family_members_paged(
+        &self,
+        family_id: NodeFamilyId,
+        start_after: Option<NodeId>,
+        limit: Option<u32>,
+    ) -> Result<FamilyMembersPagedResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetFamilyMembersPaged {
+            family_id,
+            start_after,
+            limit,
+        })
+        .await
+    }
+
+    async fn get_pending_invitation(
+        &self,
+        family_id: NodeFamilyId,
+        node_id: NodeId,
+    ) -> Result<PendingFamilyInvitationResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetPendingInvitation {
+            family_id,
+            node_id,
+        })
+        .await
+    }
+
+    async fn get_pending_invitations_for_family_paged(
+        &self,
+        family_id: NodeFamilyId,
+        start_after: Option<NodeId>,
+        limit: Option<u32>,
+    ) -> Result<PendingFamilyInvitationsPagedResponse, NyxdError> {
+        self.query_node_families_contract(
+            NodeFamiliesQueryMsg::GetPendingInvitationsForFamilyPaged {
+                family_id,
+                start_after,
+                limit,
+            },
+        )
+        .await
+    }
+
+    async fn get_pending_invitations_for_node_paged(
+        &self,
+        node_id: NodeId,
+        start_after: Option<NodeFamilyId>,
+        limit: Option<u32>,
+    ) -> Result<PendingInvitationsForNodePagedResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetPendingInvitationsForNodePaged {
+            node_id,
+            start_after,
+            limit,
+        })
+        .await
+    }
+
+    async fn get_all_pending_invitations_paged(
+        &self,
+        start_after: Option<(NodeFamilyId, NodeId)>,
+        limit: Option<u32>,
+    ) -> Result<PendingInvitationsPagedResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetAllPendingInvitationsPaged {
+            start_after,
+            limit,
+        })
+        .await
+    }
+
+    async fn get_past_invitations_for_family_paged(
+        &self,
+        family_id: NodeFamilyId,
+        start_after: Option<PastFamilyInvitationCursor>,
+        limit: Option<u32>,
+    ) -> Result<PastFamilyInvitationsPagedResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetPastInvitationsForFamilyPaged {
+            family_id,
+            start_after,
+            limit,
+        })
+        .await
+    }
+
+    async fn get_past_invitations_for_node_paged(
+        &self,
+        node_id: NodeId,
+        start_after: Option<PastFamilyInvitationForNodeCursor>,
+        limit: Option<u32>,
+    ) -> Result<PastFamilyInvitationsForNodePagedResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetPastInvitationsForNodePaged {
+            node_id,
+            start_after,
+            limit,
+        })
+        .await
+    }
+
+    async fn get_all_past_invitations_paged(
+        &self,
+        start_after: Option<GlobalPastFamilyInvitationCursor>,
+        limit: Option<u32>,
+    ) -> Result<AllPastFamilyInvitationsPagedResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetAllPastInvitationsPaged {
+            start_after,
+            limit,
+        })
+        .await
+    }
+
+    async fn get_past_members_for_family_paged(
+        &self,
+        family_id: NodeFamilyId,
+        start_after: Option<PastFamilyMemberCursor>,
+        limit: Option<u32>,
+    ) -> Result<PastFamilyMembersPagedResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetPastMembersForFamilyPaged {
+            family_id,
+            start_after,
+            limit,
+        })
+        .await
+    }
+
+    async fn get_past_members_for_node_paged(
+        &self,
+        node_id: NodeId,
+        start_after: Option<PastFamilyMemberForNodeCursor>,
+        limit: Option<u32>,
+    ) -> Result<PastFamilyMembersForNodePagedResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetPastMembersForNodePaged {
+            node_id,
+            start_after,
+            limit,
+        })
+        .await
+    }
+}
+
+// extension trait to the query client to deal with the paged queries
+// (it didn't feel appropriate to combine it with the existing trait)
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait PagedNodeFamiliesQueryClient: NodeFamiliesQueryClient {
+    async fn get_all_families(&self) -> Result<Vec<NodeFamily>, NyxdError> {
+        collect_paged!(self, get_families_paged, families)
+    }
+
+    async fn get_all_family_members(
+        &self,
+        family_id: NodeFamilyId,
+    ) -> Result<Vec<FamilyMemberRecord>, NyxdError> {
+        collect_paged!(self, get_family_members_paged, members, family_id)
+    }
+
+    async fn get_all_pending_invitations_for_family(
+        &self,
+        family_id: NodeFamilyId,
+    ) -> Result<Vec<PendingFamilyInvitationDetails>, NyxdError> {
+        collect_paged!(
+            self,
+            get_pending_invitations_for_family_paged,
+            invitations,
+            family_id
+        )
+    }
+
+    async fn get_all_pending_invitations_for_node(
+        &self,
+        node_id: NodeId,
+    ) -> Result<Vec<PendingFamilyInvitationDetails>, NyxdError> {
+        collect_paged!(
+            self,
+            get_pending_invitations_for_node_paged,
+            invitations,
+            node_id
+        )
+    }
+
+    async fn get_all_pending_invitations(
+        &self,
+    ) -> Result<Vec<PendingFamilyInvitationDetails>, NyxdError> {
+        collect_paged!(self, get_all_pending_invitations_paged, invitations)
+    }
+
+    async fn get_all_past_invitations_for_family(
+        &self,
+        family_id: NodeFamilyId,
+    ) -> Result<Vec<PastFamilyInvitation>, NyxdError> {
+        collect_paged!(
+            self,
+            get_past_invitations_for_family_paged,
+            invitations,
+            family_id
+        )
+    }
+
+    async fn get_all_past_invitations_for_node(
+        &self,
+        node_id: NodeId,
+    ) -> Result<Vec<PastFamilyInvitation>, NyxdError> {
+        collect_paged!(
+            self,
+            get_past_invitations_for_node_paged,
+            invitations,
+            node_id
+        )
+    }
+
+    async fn get_all_past_invitations(&self) -> Result<Vec<PastFamilyInvitation>, NyxdError> {
+        collect_paged!(self, get_all_past_invitations_paged, invitations)
+    }
+
+    async fn get_all_past_members_for_family(
+        &self,
+        family_id: NodeFamilyId,
+    ) -> Result<Vec<PastFamilyMember>, NyxdError> {
+        collect_paged!(self, get_past_members_for_family_paged, members, family_id)
+    }
+
+    async fn get_all_past_members_for_node(
+        &self,
+        node_id: NodeId,
+    ) -> Result<Vec<PastFamilyMember>, NyxdError> {
+        collect_paged!(self, get_past_members_for_node_paged, members, node_id)
+    }
+}
+
+#[async_trait]
+impl<T> PagedNodeFamiliesQueryClient for T where T: NodeFamiliesQueryClient {}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<C> NodeFamiliesQueryClient for C
+where
+    C: CosmWasmClient + NymContractsProvider + Send + Sync,
+{
+    async fn query_node_families_contract<T>(
+        &self,
+        query: NodeFamiliesQueryMsg,
+    ) -> Result<T, NyxdError>
+    where
+        for<'a> T: Deserialize<'a>,
+    {
+        let node_families_contract_address = &self
+            .node_families_contract_address()
+            .ok_or_else(|| NyxdError::unavailable_contract_address("node families contract"))?;
+        self.query_contract_smart(node_families_contract_address, &query)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nyxd::contract_traits::tests::IgnoreValue;
+    use node_families_contract_common::QueryMsg;
+
+    // it's enough that this compiles and clippy is happy about it
+    #[allow(dead_code)]
+    fn all_query_variants_are_covered<C: NodeFamiliesQueryClient + Send + Sync>(
+        client: C,
+        msg: NodeFamiliesQueryMsg,
+    ) {
+        match msg {
+            NodeFamiliesQueryMsg::GetFamilyById { family_id } => {
+                client.get_family_by_id(family_id).ignore()
+            }
+            NodeFamiliesQueryMsg::GetFamilyByOwner { owner } => {
+                client.get_family_by_owner(&owner.parse().unwrap()).ignore()
+            }
+            NodeFamiliesQueryMsg::GetFamilyByName { name } => {
+                client.get_family_by_name(name).ignore()
+            }
+            NodeFamiliesQueryMsg::GetFamiliesPaged { start_after, limit } => {
+                client.get_families_paged(start_after, limit).ignore()
+            }
+            NodeFamiliesQueryMsg::GetFamilyMembership { node_id } => {
+                client.get_family_membership(node_id).ignore()
+            }
+            NodeFamiliesQueryMsg::GetFamilyMembersPaged {
+                family_id,
+                start_after,
+                limit,
+            } => client
+                .get_family_members_paged(family_id, start_after, limit)
+                .ignore(),
+            NodeFamiliesQueryMsg::GetPendingInvitation { family_id, node_id } => {
+                client.get_pending_invitation(family_id, node_id).ignore()
+            }
+            NodeFamiliesQueryMsg::GetPendingInvitationsForFamilyPaged {
+                family_id,
+                start_after,
+                limit,
+            } => client
+                .get_pending_invitations_for_family_paged(family_id, start_after, limit)
+                .ignore(),
+            NodeFamiliesQueryMsg::GetPendingInvitationsForNodePaged {
+                node_id,
+                start_after,
+                limit,
+            } => client
+                .get_pending_invitations_for_node_paged(node_id, start_after, limit)
+                .ignore(),
+            NodeFamiliesQueryMsg::GetAllPendingInvitationsPaged { start_after, limit } => client
+                .get_all_pending_invitations_paged(start_after, limit)
+                .ignore(),
+            NodeFamiliesQueryMsg::GetPastInvitationsForFamilyPaged {
+                family_id,
+                start_after,
+                limit,
+            } => client
+                .get_past_invitations_for_family_paged(family_id, start_after, limit)
+                .ignore(),
+            NodeFamiliesQueryMsg::GetPastInvitationsForNodePaged {
+                node_id,
+                start_after,
+                limit,
+            } => client
+                .get_past_invitations_for_node_paged(node_id, start_after, limit)
+                .ignore(),
+            NodeFamiliesQueryMsg::GetAllPastInvitationsPaged { start_after, limit } => client
+                .get_all_past_invitations_paged(start_after, limit)
+                .ignore(),
+            NodeFamiliesQueryMsg::GetPastMembersForFamilyPaged {
+                family_id,
+                start_after,
+                limit,
+            } => client
+                .get_past_members_for_family_paged(family_id, start_after, limit)
+                .ignore(),
+            QueryMsg::GetPastMembersForNodePaged {
+                node_id,
+                start_after,
+                limit,
+            } => client
+                .get_past_members_for_node_paged(node_id, start_after, limit)
+                .ignore(),
+        };
+    }
+}

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/node_families_query_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/node_families_query_client.rs
@@ -9,12 +9,14 @@ use async_trait::async_trait;
 use cosmrs::AccountId;
 use serde::Deserialize;
 
-pub use node_families_contract_common::{
-    msg::QueryMsg as NodeFamiliesQueryMsg, AllPastFamilyInvitationsPagedResponse,
-    FamiliesPagedResponse, FamilyMemberRecord, FamilyMembersPagedResponse,
-    GlobalPastFamilyInvitationCursor, NodeFamily, NodeFamilyByNameResponse,
-    NodeFamilyByOwnerResponse, NodeFamilyId, NodeFamilyMembershipResponse, NodeFamilyResponse,
-    PastFamilyInvitation, PastFamilyInvitationCursor, PastFamilyInvitationForNodeCursor,
+use nym_mixnet_contract_common::NodeId;
+pub use nym_node_families_contract_common::{
+    msg::QueryMsg as NodeFamiliesQueryMsg, AllFamilyMembersPagedResponse,
+    AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse, FamilyMemberRecord,
+    FamilyMembersPagedResponse, GlobalPastFamilyInvitationCursor, NodeFamily,
+    NodeFamilyByNameResponse, NodeFamilyByOwnerResponse, NodeFamilyId,
+    NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitation,
+    PastFamilyInvitationCursor, PastFamilyInvitationForNodeCursor,
     PastFamilyInvitationsForNodePagedResponse, PastFamilyInvitationsPagedResponse,
     PastFamilyMember, PastFamilyMemberCursor, PastFamilyMemberForNodeCursor,
     PastFamilyMembersForNodePagedResponse, PastFamilyMembersPagedResponse,
@@ -22,7 +24,6 @@ pub use node_families_contract_common::{
     PendingFamilyInvitationsPagedResponse, PendingInvitationsForNodePagedResponse,
     PendingInvitationsPagedResponse,
 };
-use nym_mixnet_contract_common::NodeId;
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -88,6 +89,18 @@ pub trait NodeFamiliesQueryClient {
     ) -> Result<FamilyMembersPagedResponse, NyxdError> {
         self.query_node_families_contract(NodeFamiliesQueryMsg::GetFamilyMembersPaged {
             family_id,
+            start_after,
+            limit,
+        })
+        .await
+    }
+
+    async fn get_all_family_members_paged(
+        &self,
+        start_after: Option<NodeId>,
+        limit: Option<u32>,
+    ) -> Result<AllFamilyMembersPagedResponse, NyxdError> {
+        self.query_node_families_contract(NodeFamiliesQueryMsg::GetAllFamilyMembersPaged {
             start_after,
             limit,
         })
@@ -226,11 +239,15 @@ pub trait PagedNodeFamiliesQueryClient: NodeFamiliesQueryClient {
         collect_paged!(self, get_families_paged, families)
     }
 
-    async fn get_all_family_members(
+    async fn get_all_family_members_for_family(
         &self,
         family_id: NodeFamilyId,
     ) -> Result<Vec<FamilyMemberRecord>, NyxdError> {
         collect_paged!(self, get_family_members_paged, members, family_id)
+    }
+
+    async fn get_all_family_members(&self) -> Result<Vec<FamilyMemberRecord>, NyxdError> {
+        collect_paged!(self, get_all_family_members_paged, members)
     }
 
     async fn get_all_pending_invitations_for_family(
@@ -334,7 +351,7 @@ where
 mod tests {
     use super::*;
     use crate::nyxd::contract_traits::tests::IgnoreValue;
-    use node_families_contract_common::QueryMsg;
+    use nym_node_families_contract_common::QueryMsg;
 
     // it's enough that this compiles and clippy is happy about it
     #[allow(dead_code)]
@@ -364,6 +381,9 @@ mod tests {
                 limit,
             } => client
                 .get_family_members_paged(family_id, start_after, limit)
+                .ignore(),
+            NodeFamiliesQueryMsg::GetAllFamilyMembersPaged { start_after, limit } => client
+                .get_all_family_members_paged(start_after, limit)
                 .ignore(),
             NodeFamiliesQueryMsg::GetPendingInvitation { family_id, node_id } => {
                 client.get_pending_invitation(family_id, node_id).ignore()

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/node_families_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/node_families_signing_client.rs
@@ -8,8 +8,10 @@ use crate::nyxd::error::NyxdError;
 use crate::nyxd::{Fee, SigningCosmWasmClient};
 use crate::signing::signer::OfflineSigner;
 use async_trait::async_trait;
-use node_families_contract_common::{Config, ExecuteMsg as NodeFamiliesExecuteMsg, NodeFamilyId};
 use nym_mixnet_contract_common::NodeId;
+use nym_node_families_contract_common::{
+    Config, ExecuteMsg as NodeFamiliesExecuteMsg, NodeFamilyId,
+};
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -207,7 +209,7 @@ where
 mod tests {
     use super::*;
     use crate::nyxd::contract_traits::tests::IgnoreValue;
-    use node_families_contract_common::ExecuteMsg;
+    use nym_node_families_contract_common::ExecuteMsg;
 
     // it's enough that this compiles and clippy is happy about it
     #[allow(dead_code)]

--- a/common/client-libs/validator-client/src/nyxd/contract_traits/node_families_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/node_families_signing_client.rs
@@ -1,0 +1,252 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::nyxd::coin::Coin;
+use crate::nyxd::contract_traits::NymContractsProvider;
+use crate::nyxd::cosmwasm_client::types::ExecuteResult;
+use crate::nyxd::error::NyxdError;
+use crate::nyxd::{Fee, SigningCosmWasmClient};
+use crate::signing::signer::OfflineSigner;
+use async_trait::async_trait;
+use node_families_contract_common::{Config, ExecuteMsg as NodeFamiliesExecuteMsg, NodeFamilyId};
+use nym_mixnet_contract_common::NodeId;
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait NodeFamiliesSigningClient {
+    async fn execute_node_families_contract(
+        &self,
+        fee: Option<Fee>,
+        msg: NodeFamiliesExecuteMsg,
+        memo: String,
+        funds: Vec<Coin>,
+    ) -> Result<ExecuteResult, NyxdError>;
+
+    async fn update_node_families_config(
+        &self,
+        config: Config,
+        fee: Option<Fee>,
+    ) -> Result<ExecuteResult, NyxdError> {
+        self.execute_node_families_contract(
+            fee,
+            NodeFamiliesExecuteMsg::UpdateConfig { config },
+            "NodeFamiliesContract::UpdateConfig".to_string(),
+            vec![],
+        )
+        .await
+    }
+
+    async fn create_family(
+        &self,
+        name: String,
+        description: String,
+        fee: Option<Fee>,
+        creation_fee: Vec<Coin>,
+    ) -> Result<ExecuteResult, NyxdError> {
+        self.execute_node_families_contract(
+            fee,
+            NodeFamiliesExecuteMsg::CreateFamily { name, description },
+            "NodeFamiliesContract::CreateFamily".to_string(),
+            creation_fee,
+        )
+        .await
+    }
+
+    async fn disband_family(&self, fee: Option<Fee>) -> Result<ExecuteResult, NyxdError> {
+        self.execute_node_families_contract(
+            fee,
+            NodeFamiliesExecuteMsg::DisbandFamily {},
+            "NodeFamiliesContract::DisbandFamily".to_string(),
+            vec![],
+        )
+        .await
+    }
+
+    async fn invite_to_family(
+        &self,
+        node_id: NodeId,
+        validity_secs: Option<u64>,
+        fee: Option<Fee>,
+    ) -> Result<ExecuteResult, NyxdError> {
+        self.execute_node_families_contract(
+            fee,
+            NodeFamiliesExecuteMsg::InviteToFamily {
+                node_id,
+                validity_secs,
+            },
+            "NodeFamiliesContract::InviteToFamily".to_string(),
+            vec![],
+        )
+        .await
+    }
+
+    async fn revoke_family_invitation(
+        &self,
+        node_id: NodeId,
+        fee: Option<Fee>,
+    ) -> Result<ExecuteResult, NyxdError> {
+        self.execute_node_families_contract(
+            fee,
+            NodeFamiliesExecuteMsg::RevokeFamilyInvitation { node_id },
+            "NodeFamiliesContract::RevokeFamilyInvitation".to_string(),
+            vec![],
+        )
+        .await
+    }
+
+    async fn accept_family_invitation(
+        &self,
+        family_id: NodeFamilyId,
+        node_id: NodeId,
+        fee: Option<Fee>,
+    ) -> Result<ExecuteResult, NyxdError> {
+        self.execute_node_families_contract(
+            fee,
+            NodeFamiliesExecuteMsg::AcceptFamilyInvitation { family_id, node_id },
+            "NodeFamiliesContract::AcceptFamilyInvitation".to_string(),
+            vec![],
+        )
+        .await
+    }
+
+    async fn reject_family_invitation(
+        &self,
+        family_id: NodeFamilyId,
+        node_id: NodeId,
+        fee: Option<Fee>,
+    ) -> Result<ExecuteResult, NyxdError> {
+        self.execute_node_families_contract(
+            fee,
+            NodeFamiliesExecuteMsg::RejectFamilyInvitation { family_id, node_id },
+            "NodeFamiliesContract::RejectFamilyInvitation".to_string(),
+            vec![],
+        )
+        .await
+    }
+
+    async fn leave_family(
+        &self,
+        node_id: NodeId,
+        fee: Option<Fee>,
+    ) -> Result<ExecuteResult, NyxdError> {
+        self.execute_node_families_contract(
+            fee,
+            NodeFamiliesExecuteMsg::LeaveFamily { node_id },
+            "NodeFamiliesContract::LeaveFamily".to_string(),
+            vec![],
+        )
+        .await
+    }
+
+    async fn kick_from_family(
+        &self,
+        node_id: NodeId,
+        fee: Option<Fee>,
+    ) -> Result<ExecuteResult, NyxdError> {
+        self.execute_node_families_contract(
+            fee,
+            NodeFamiliesExecuteMsg::KickFromFamily { node_id },
+            "NodeFamiliesContract::KickFromFamily".to_string(),
+            vec![],
+        )
+        .await
+    }
+
+    /// Cross-contract callback fired by the mixnet contract on node unbonding.
+    /// Exposed for completeness; the families contract rejects this call from
+    /// any sender other than the configured mixnet contract address.
+    async fn on_nym_node_unbond(
+        &self,
+        node_id: NodeId,
+        fee: Option<Fee>,
+    ) -> Result<ExecuteResult, NyxdError> {
+        self.execute_node_families_contract(
+            fee,
+            NodeFamiliesExecuteMsg::OnNymNodeUnbond { node_id },
+            "NodeFamiliesContract::OnNymNodeUnbond".to_string(),
+            vec![],
+        )
+        .await
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<C> NodeFamiliesSigningClient for C
+where
+    C: SigningCosmWasmClient + NymContractsProvider + Sync,
+    NyxdError: From<<Self as OfflineSigner>::Error>,
+{
+    async fn execute_node_families_contract(
+        &self,
+        fee: Option<Fee>,
+        msg: NodeFamiliesExecuteMsg,
+        memo: String,
+        funds: Vec<Coin>,
+    ) -> Result<ExecuteResult, NyxdError> {
+        let node_families_contract_address = &self
+            .node_families_contract_address()
+            .ok_or_else(|| NyxdError::unavailable_contract_address("node families contract"))?;
+
+        let fee = fee.unwrap_or(Fee::Auto(Some(self.simulated_gas_multiplier())));
+
+        let signer_address = &self.signer_addresses()[0];
+        self.execute(
+            signer_address,
+            node_families_contract_address,
+            &msg,
+            fee,
+            memo,
+            funds,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nyxd::contract_traits::tests::IgnoreValue;
+    use node_families_contract_common::ExecuteMsg;
+
+    // it's enough that this compiles and clippy is happy about it
+    #[allow(dead_code)]
+    fn all_execute_variants_are_covered<C: NodeFamiliesSigningClient + Send + Sync>(
+        client: C,
+        msg: NodeFamiliesExecuteMsg,
+    ) {
+        match msg {
+            NodeFamiliesExecuteMsg::UpdateConfig { config } => {
+                client.update_node_families_config(config, None).ignore()
+            }
+            NodeFamiliesExecuteMsg::CreateFamily { name, description } => client
+                .create_family(name, description, None, vec![])
+                .ignore(),
+            NodeFamiliesExecuteMsg::DisbandFamily {} => client.disband_family(None).ignore(),
+            NodeFamiliesExecuteMsg::InviteToFamily {
+                node_id,
+                validity_secs,
+            } => client
+                .invite_to_family(node_id, validity_secs, None)
+                .ignore(),
+            NodeFamiliesExecuteMsg::RevokeFamilyInvitation { node_id } => {
+                client.revoke_family_invitation(node_id, None).ignore()
+            }
+            NodeFamiliesExecuteMsg::AcceptFamilyInvitation { family_id, node_id } => client
+                .accept_family_invitation(family_id, node_id, None)
+                .ignore(),
+            NodeFamiliesExecuteMsg::RejectFamilyInvitation { family_id, node_id } => client
+                .reject_family_invitation(family_id, node_id, None)
+                .ignore(),
+            NodeFamiliesExecuteMsg::LeaveFamily { node_id } => {
+                client.leave_family(node_id, None).ignore()
+            }
+            NodeFamiliesExecuteMsg::KickFromFamily { node_id } => {
+                client.kick_from_family(node_id, None).ignore()
+            }
+            ExecuteMsg::OnNymNodeUnbond { node_id } => {
+                client.on_nym_node_unbond(node_id, None).ignore()
+            }
+        };
+    }
+}

--- a/common/client-libs/validator-client/src/nyxd/mod.rs
+++ b/common/client-libs/validator-client/src/nyxd/mod.rs
@@ -286,6 +286,10 @@ impl<C, S> NyxdClient<C, S> {
         self.config.contracts.multisig_contract_address = Some(address);
     }
 
+    pub fn set_node_families_contract_address(&mut self, address: AccountId) {
+        self.config.contracts.node_families_contract_address = Some(address);
+    }
+
     pub fn set_simulated_gas_multiplier(&mut self, multiplier: f32) {
         self.config.simulated_gas_multiplier = multiplier;
     }
@@ -302,6 +306,13 @@ impl<C, S> NymContractsProvider for NyxdClient<C, S> {
 
     fn performance_contract_address(&self) -> Option<&AccountId> {
         self.config.contracts.performance_contract_address.as_ref()
+    }
+
+    fn node_families_contract_address(&self) -> Option<&AccountId> {
+        self.config
+            .contracts
+            .node_families_contract_address
+            .as_ref()
     }
 
     fn ecash_contract_address(&self) -> Option<&AccountId> {

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/mixnode.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/mixnode.rs
@@ -190,6 +190,10 @@ impl NodeRewarding {
         truncate_reward(self.operator, denom)
     }
 
+    pub fn delegations_with_reward(&self, denom: impl Into<String>) -> Coin {
+        truncate_reward(self.delegates, denom)
+    }
+
     pub fn pending_delegator_reward(&self, delegation: &Delegation) -> StdResult<Coin> {
         let delegator_reward = self.determine_delegation_reward(delegation)?;
         Ok(truncate_reward(delegator_reward, &delegation.amount.denom))

--- a/common/cosmwasm-smart-contracts/node-families-contract/Cargo.toml
+++ b/common/cosmwasm-smart-contracts/node-families-contract/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "node-families-contract-common"
+name = "nym-node-families-contract-common"
 description = "Common crate for Nym's node families contract"
 version.workspace = true
 authors.workspace = true

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/msg.rs
@@ -10,9 +10,9 @@ use nym_mixnet_contract_common::NodeId;
 
 #[cfg(feature = "schema")]
 use crate::{
-    AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse, FamilyMembersPagedResponse,
-    NodeFamilyByNameResponse, NodeFamilyByOwnerResponse, NodeFamilyMembershipResponse,
-    NodeFamilyResponse, PastFamilyInvitationsForNodePagedResponse,
+    AllFamilyMembersPagedResponse, AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse,
+    FamilyMembersPagedResponse, NodeFamilyByNameResponse, NodeFamilyByOwnerResponse,
+    NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationsForNodePagedResponse,
     PastFamilyInvitationsPagedResponse, PastFamilyMembersForNodePagedResponse,
     PastFamilyMembersPagedResponse, PendingFamilyInvitationResponse,
     PendingFamilyInvitationsPagedResponse, PendingInvitationsForNodePagedResponse,
@@ -114,6 +114,15 @@ pub enum QueryMsg {
     #[cfg_attr(feature = "schema", returns(FamilyMembersPagedResponse))]
     GetFamilyMembersPaged {
         family_id: NodeFamilyId,
+        start_after: Option<NodeId>,
+        limit: Option<u32>,
+    },
+
+    /// Page through every current family member across all families, in
+    /// ascending [`NodeId`] order. Each entry carries the membership record
+    /// (which in turn names the family the node belongs to).
+    #[cfg_attr(feature = "schema", returns(AllFamilyMembersPagedResponse))]
+    GetAllFamilyMembersPaged {
         start_after: Option<NodeId>,
         limit: Option<u32>,
     },

--- a/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
+++ b/common/cosmwasm-smart-contracts/node-families-contract/src/types.rs
@@ -229,6 +229,18 @@ pub struct FamilyMembersPagedResponse {
     pub start_next_after: Option<NodeId>,
 }
 
+/// Response to [`QueryMsg::GetAllFamilyMembersPaged`](crate::QueryMsg::GetAllFamilyMembersPaged).
+#[cw_serde]
+pub struct AllFamilyMembersPagedResponse {
+    /// The members on this page, in ascending [`NodeId`] order across every
+    /// family.
+    pub members: Vec<FamilyMemberRecord>,
+
+    /// Cursor (last `node_id`) to pass as `start_after` on the next call,
+    /// or `None` if this page is empty (treat as end-of-list).
+    pub start_next_after: Option<NodeId>,
+}
+
 /// Response to [`QueryMsg::GetPendingInvitationsForFamilyPaged`](crate::QueryMsg::GetPendingInvitationsForFamilyPaged).
 #[cw_serde]
 pub struct PendingFamilyInvitationsPagedResponse {

--- a/common/http-api-common/src/response/mod.rs
+++ b/common/http-api-common/src/response/mod.rs
@@ -132,6 +132,41 @@ where
 #[derive(Default, Debug, Serialize, Deserialize, Copy, Clone)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "lowercase")]
+pub enum OutputV2 {
+    #[default]
+    Json,
+    Yaml,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, Copy, Clone)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::IntoParams, utoipa::ToSchema))]
+#[serde(default)]
+pub struct OutputParamsV2 {
+    pub output: Option<OutputV2>,
+}
+
+impl OutputParamsV2 {
+    pub fn get_output(&self) -> OutputV2 {
+        self.output.unwrap_or_default()
+    }
+
+    pub fn to_response<T: Serialize>(self, data: T) -> FormattedResponse<T> {
+        self.get_output().to_response(data)
+    }
+}
+
+impl OutputV2 {
+    pub fn to_response<T: Serialize>(self, data: T) -> FormattedResponse<T> {
+        match self {
+            OutputV2::Json => FormattedResponse::Json(Json::from(data)),
+            OutputV2::Yaml => FormattedResponse::Yaml(Yaml::from(data)),
+        }
+    }
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, Copy, Clone)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "lowercase")]
 pub enum Output {
     #[default]
     Json,

--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -22,6 +22,10 @@ pub const VESTING_CONTRACT_ADDRESS: &str =
 pub const PERFORMANCE_CONTRACT_ADDRESS: &str = "";
 // /\ TODO: this has to be updated once the contract is deployed
 
+// \/ TODO: this has to be updated once the contract is deployed
+pub const NODE_FAMILIES_CONTRACT_ADDRESS: &str = "";
+// /\ TODO: this has to be updated once the contract is deployed
+
 pub const ECASH_CONTRACT_ADDRESS: &str =
     "n1r7s6aksyc6pqardx88k3rkgfagwvj4z4zum9mmz2sfk3zm2mha0sd4dnun";
 pub const GROUP_CONTRACT_ADDRESS: &str =

--- a/common/network-defaults/src/network.rs
+++ b/common/network-defaults/src/network.rs
@@ -39,6 +39,8 @@ pub struct NymContracts {
     pub vesting_contract_address: Option<String>,
     #[serde(default)]
     pub performance_contract_address: Option<String>,
+    #[serde(default)]
+    pub node_families_contract_address: Option<String>,
     pub ecash_contract_address: Option<String>,
     pub group_contract_address: Option<String>,
     pub multisig_contract_address: Option<String>,
@@ -198,6 +200,9 @@ impl NymNetworkDetails {
                 vesting_contract_address: parse_optional_str(mainnet::VESTING_CONTRACT_ADDRESS),
                 performance_contract_address: parse_optional_str(
                     mainnet::PERFORMANCE_CONTRACT_ADDRESS,
+                ),
+                node_families_contract_address: parse_optional_str(
+                    mainnet::NODE_FAMILIES_CONTRACT_ADDRESS,
                 ),
                 ecash_contract_address: parse_optional_str(mainnet::ECASH_CONTRACT_ADDRESS),
                 group_contract_address: parse_optional_str(mainnet::GROUP_CONTRACT_ADDRESS),

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1176,28 +1176,13 @@ dependencies = [
  "cw-storage-plus",
  "cw-utils",
  "cw2",
- "node-families-contract-common",
  "nym-contracts-common",
  "nym-contracts-common-testing",
  "nym-crypto",
  "nym-mixnet-contract",
  "nym-mixnet-contract-common",
+ "nym-node-families-contract-common",
  "serde",
-]
-
-[[package]]
-name = "node-families-contract-common"
-version = "1.20.5"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-controllers",
- "cw-utils",
- "nym-contracts-common",
- "nym-mixnet-contract-common",
- "schemars",
- "serde",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1396,12 +1381,12 @@ dependencies = [
  "cw-storage-plus",
  "cw2",
  "easy-addr",
- "node-families-contract-common",
  "nym-contracts-common",
  "nym-contracts-common-testing",
  "nym-crypto",
  "nym-mixnet-contract",
  "nym-mixnet-contract-common",
+ "nym-node-families-contract-common",
  "nym-vesting-contract-common",
  "rand",
  "rand_chacha",
@@ -1472,6 +1457,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-node-families-contract-common"
+version = "1.20.5"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers",
+ "cw-utils",
+ "nym-contracts-common",
+ "nym-mixnet-contract-common",
+ "schemars",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "nym-pemstore"
 version = "1.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,12 +1493,12 @@ dependencies = [
  "cw-storage-plus",
  "cw2",
  "node-families",
- "node-families-contract-common",
  "nym-contracts-common",
  "nym-contracts-common-testing",
  "nym-crypto",
  "nym-mixnet-contract",
  "nym-mixnet-contract-common",
+ "nym-node-families-contract-common",
  "nym-performance-contract-common",
  "serde",
 ]

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -77,7 +77,7 @@ nym-vesting-contract-common = "1.20.4"
 contracts-common = { version = "1.20.4", package = "nym-contracts-common" }
 mixnet-contract-common = { version = "1.20.4", package = "nym-mixnet-contract-common" }
 vesting-contract-common = { version = "1.20.4", package = "nym-vesting-contract-common" }
-node-families-contract-common = { version = "1.20.4", package = "node-families-contract-common" }
+nym-node-families-contract-common = { version = "1.20.4", package = "nym-node-families-contract-common" }
 
 # Internal contract workspace members (for cross-contract testing)
 cw3-flex-multisig = { version = "2.0.0", path = "multisig/cw3-flex-multisig" }
@@ -105,4 +105,4 @@ nym-contracts-common-testing = { path = "../common/cosmwasm-smart-contracts/cont
 nym-contracts-common = { path = "../common/cosmwasm-smart-contracts/contracts-common" }
 nym-ecash-contract-common = { path = "../common/cosmwasm-smart-contracts/ecash-contract" }
 nym-mixnet-contract-common = { path = "../common/cosmwasm-smart-contracts/mixnet-contract" }
-node-families-contract-common = { path = "../common/cosmwasm-smart-contracts/node-families-contract" }
+nym-node-families-contract-common = { path = "../common/cosmwasm-smart-contracts/node-families-contract" }

--- a/contracts/mixnet/Cargo.toml
+++ b/contracts/mixnet/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 mixnet-contract-common = { workspace = true }
 vesting-contract-common = { workspace = true }
-node-families-contract-common = { workspace = true }
+nym-node-families-contract-common = { workspace = true }
 nym-contracts-common = { workspace = true }
 nym-contracts-common-testing = { workspace = true, optional = true }
 

--- a/contracts/mixnet/src/nodes/transactions.rs
+++ b/contracts/mixnet/src/nodes/transactions.rs
@@ -28,8 +28,8 @@ use mixnet_contract_common::{
     NodeCostParams, NymNodeBondingPayload, NymNodeDetails, PendingEpochEventKind,
     PendingIntervalEventKind,
 };
-use node_families_contract_common::msg::ExecuteMsg as NodeFamiliesExecuteMsg;
 use nym_contracts_common::signing::{MessageSignature, SigningPurpose};
+use nym_node_families_contract_common::msg::ExecuteMsg as NodeFamiliesExecuteMsg;
 use serde::Serialize;
 
 pub fn try_add_nym_node(

--- a/contracts/node-families/Cargo.toml
+++ b/contracts/node-families/Cargo.toml
@@ -30,7 +30,7 @@ cosmwasm-schema = { workspace = true, optional = true }
 cw-utils = { workspace = true }
 
 nym-contracts-common = { workspace = true }
-node-families-contract-common = { workspace = true }
+nym-node-families-contract-common = { workspace = true }
 nym-mixnet-contract-common = { workspace = true }
 
 # Optional deps activated by the `testable-node-families-contract` feature so
@@ -49,7 +49,7 @@ nym-mixnet-contract = { workspace = true, features = ["testable-mixnet-contract"
 nym-crypto = { workspace = true, features = ["asymmetric"] }
 
 [features]
-schema-gen = ["node-families-contract-common/schema", "cosmwasm-schema"]
+schema-gen = ["nym-node-families-contract-common/schema", "cosmwasm-schema"]
 testable-node-families-contract = [
     "nym-contracts-common-testing",
     "nym-mixnet-contract",

--- a/contracts/node-families/src/bin/schema.rs
+++ b/contracts/node-families/src/bin/schema.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use cosmwasm_schema::write_api;
-use node_families_contract_common::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use nym_node_families_contract_common::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
 fn main() {
     write_api! {

--- a/contracts/node-families/src/contract.rs
+++ b/contracts/node-families/src/contract.rs
@@ -4,8 +4,9 @@
 //! CosmWasm entry points for the node families contract.
 
 use crate::queries::{
-    query_all_past_invitations_paged, query_all_pending_invitations_paged, query_families_paged,
-    query_family_by_id, query_family_by_name, query_family_by_owner, query_family_members_paged,
+    query_all_family_members_paged, query_all_past_invitations_paged,
+    query_all_pending_invitations_paged, query_families_paged, query_family_by_id,
+    query_family_by_name, query_family_by_owner, query_family_members_paged,
     query_family_membership, query_past_invitations_for_family_paged,
     query_past_invitations_for_node_paged, query_past_members_for_family_paged,
     query_past_members_for_node_paged, query_pending_invitation,
@@ -20,10 +21,10 @@ use crate::transactions::{
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
 };
-use node_families_contract_common::{
+use nym_contracts_common::set_build_information;
+use nym_node_families_contract_common::{
     ExecuteMsg, InstantiateMsg, MigrateMsg, NodeFamiliesContractError, QueryMsg,
 };
-use nym_contracts_common::set_build_information;
 
 const CONTRACT_NAME: &str = "crate:nym-node-families-contract";
 
@@ -117,6 +118,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, NodeFamilies
             start_after,
             limit,
         )?)?),
+        QueryMsg::GetAllFamilyMembersPaged { start_after, limit } => Ok(to_json_binary(
+            &query_all_family_members_paged(deps, start_after, limit)?,
+        )?),
         QueryMsg::GetPendingInvitation { family_id, node_id } => Ok(to_json_binary(
             &query_pending_invitation(deps, env, family_id, node_id)?,
         )?),
@@ -217,7 +221,7 @@ mod tests {
         use super::*;
         use cosmwasm_std::coin;
         use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
-        use node_families_contract_common::Config;
+        use nym_node_families_contract_common::Config;
 
         fn mock_config() -> Config {
             Config {

--- a/contracts/node-families/src/helpers.rs
+++ b/contracts/node-families/src/helpers.rs
@@ -3,8 +3,8 @@
 
 use crate::storage::NodeFamiliesStorage;
 use cosmwasm_std::{Addr, Deps};
-use node_families_contract_common::NodeFamiliesContractError;
 use nym_mixnet_contract_common::{MixnetContractQuerier, NodeId};
+use nym_node_families_contract_common::NodeFamiliesContractError;
 
 /// Normalise a family name into the canonical form used as the unique-index key.
 ///

--- a/contracts/node-families/src/queries.rs
+++ b/contracts/node-families/src/queries.rs
@@ -5,10 +5,11 @@ use crate::helpers::normalise_family_name;
 use crate::storage::{retrieval_limits, NodeFamiliesStorage};
 use cosmwasm_std::{Deps, Env, Order, StdResult};
 use cw_storage_plus::Bound;
-use node_families_contract_common::{
-    AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse, FamilyMemberRecord,
-    FamilyMembersPagedResponse, GlobalPastFamilyInvitationCursor, NodeFamiliesContractError,
-    NodeFamilyByNameResponse, NodeFamilyByOwnerResponse, NodeFamilyId,
+use nym_mixnet_contract_common::NodeId;
+use nym_node_families_contract_common::{
+    AllFamilyMembersPagedResponse, AllPastFamilyInvitationsPagedResponse, FamiliesPagedResponse,
+    FamilyMemberRecord, FamilyMembersPagedResponse, GlobalPastFamilyInvitationCursor,
+    NodeFamiliesContractError, NodeFamilyByNameResponse, NodeFamilyByOwnerResponse, NodeFamilyId,
     NodeFamilyMembershipResponse, NodeFamilyResponse, PastFamilyInvitationCursor,
     PastFamilyInvitationForNodeCursor, PastFamilyInvitationsForNodePagedResponse,
     PastFamilyInvitationsPagedResponse, PastFamilyMemberCursor, PastFamilyMemberForNodeCursor,
@@ -17,7 +18,6 @@ use node_families_contract_common::{
     PendingFamilyInvitationsPagedResponse, PendingInvitationsForNodePagedResponse,
     PendingInvitationsPagedResponse,
 };
-use nym_mixnet_contract_common::NodeId;
 
 /// Resolve a single family by its id. Returns `family: None` if no family
 /// with that id exists.
@@ -147,6 +147,50 @@ pub fn query_family_members_paged(
 
     Ok(FamilyMembersPagedResponse {
         family_id,
+        members,
+        start_next_after,
+    })
+}
+
+/// Page through every current family member across all families, in ascending
+/// [`NodeId`] order. Each entry carries the [`FamilyMembership`](node_families_contract_common::FamilyMembership)
+/// record, which names the family the node belongs to.
+///
+/// Cost is O(page size) — full range scan over the primary `family_members`
+/// map without any prefix filter. Since each node belongs to at most one
+/// family, [`NodeId`] alone is sufficient as a pagination cursor.
+///
+/// `start_after` is exclusive — pass the previous page's `start_next_after`
+/// to fetch the next page; pass `None` to start from the lowest-id member.
+/// `limit` defaults to [`retrieval_limits::FAMILY_MEMBERS_DEFAULT_LIMIT`]
+/// and is clamped to [`retrieval_limits::FAMILY_MEMBERS_MAX_LIMIT`].
+pub fn query_all_family_members_paged(
+    deps: Deps,
+    start_after: Option<NodeId>,
+    limit: Option<u32>,
+) -> Result<AllFamilyMembersPagedResponse, NodeFamiliesContractError> {
+    let limit = limit
+        .unwrap_or(retrieval_limits::FAMILY_MEMBERS_DEFAULT_LIMIT)
+        .min(retrieval_limits::FAMILY_MEMBERS_MAX_LIMIT) as usize;
+
+    let start = start_after.map(Bound::exclusive);
+
+    let storage = NodeFamiliesStorage::new();
+    let members = storage
+        .family_members
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|res| {
+            res.map(|(node_id, membership)| FamilyMemberRecord {
+                node_id,
+                membership,
+            })
+        })
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let start_next_after = members.last().map(|record| record.node_id);
+
+    Ok(AllFamilyMembersPagedResponse {
         members,
         start_next_after,
     })
@@ -1076,6 +1120,206 @@ mod tests {
     }
 
     #[cfg(test)]
+    mod all_family_members_paged {
+        use super::*;
+
+        #[test]
+        fn empty_when_no_families_exist() {
+            let tester = init_contract_tester();
+
+            let res = query_all_family_members_paged(tester.deps(), None, None).unwrap();
+            assert!(res.members.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn empty_when_families_have_no_members() {
+            let mut tester = init_contract_tester();
+            tester.add_dummy_family();
+            tester.add_dummy_family();
+
+            let res = query_all_family_members_paged(tester.deps(), None, None).unwrap();
+            assert!(res.members.is_empty());
+            assert!(res.start_next_after.is_none());
+        }
+
+        #[test]
+        fn returns_members_from_every_family() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            let f3 = tester.add_dummy_family();
+
+            tester.add_to_family(f1.id, 10);
+            tester.add_to_family(f2.id, 20);
+            tester.add_to_family(f3.id, 30);
+
+            let res = query_all_family_members_paged(tester.deps(), None, None).unwrap();
+            let pairs: Vec<_> = res
+                .members
+                .iter()
+                .map(|m| (m.node_id, m.membership.family_id))
+                .collect();
+            assert_eq!(pairs, vec![(10, f1.id), (20, f2.id), (30, f3.id)]);
+        }
+
+        #[test]
+        fn members_returned_in_ascending_node_id_order_across_families() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+
+            // interleaved so insertion order does not match the requested ordering
+            tester.add_to_family(f2.id, 30);
+            tester.add_to_family(f1.id, 10);
+            tester.add_to_family(f2.id, 20);
+            tester.add_to_family(f1.id, 40);
+
+            let res = query_all_family_members_paged(tester.deps(), None, None).unwrap();
+            let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
+            assert_eq!(ids, vec![10, 20, 30, 40]);
+        }
+
+        #[test]
+        fn member_record_carries_correct_family_and_joined_at() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+
+            tester.add_to_family(f1.id, 7);
+            tester.add_to_family(f2.id, 99);
+            let expected_joined_at = tester.env().block.time.seconds();
+
+            let res = query_all_family_members_paged(tester.deps(), None, None).unwrap();
+            let by_node: std::collections::HashMap<_, _> = res
+                .members
+                .into_iter()
+                .map(|m| (m.node_id, m.membership))
+                .collect();
+
+            let m7 = &by_node[&7];
+            assert_eq!(m7.family_id, f1.id);
+            assert_eq!(m7.joined_at, expected_joined_at);
+
+            let m99 = &by_node[&99];
+            assert_eq!(m99.family_id, f2.id);
+            assert_eq!(m99.joined_at, expected_joined_at);
+        }
+
+        #[test]
+        fn limit_caps_page_size() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            for n in [10, 11, 12] {
+                tester.add_to_family(f.id, n);
+            }
+
+            let res = query_all_family_members_paged(tester.deps(), None, Some(2)).unwrap();
+            let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
+            assert_eq!(ids, vec![10, 11]);
+            assert_eq!(res.start_next_after, Some(11));
+        }
+
+        #[test]
+        fn start_after_is_exclusive() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            for n in [10, 11, 12] {
+                tester.add_to_family(f.id, n);
+            }
+
+            let res = query_all_family_members_paged(tester.deps(), Some(10), None).unwrap();
+            let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
+            assert_eq!(ids, vec![11, 12]);
+            assert_eq!(res.start_next_after, Some(12));
+        }
+
+        #[test]
+        fn paginates_through_all_members_across_families() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+
+            tester.add_to_family(f1.id, 10);
+            tester.add_to_family(f2.id, 11);
+            tester.add_to_family(f1.id, 12);
+            tester.add_to_family(f2.id, 13);
+            tester.add_to_family(f1.id, 14);
+
+            let p1 = query_all_family_members_paged(tester.deps(), None, Some(2)).unwrap();
+            assert_eq!(
+                p1.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
+                vec![10, 11]
+            );
+            assert_eq!(p1.start_next_after, Some(11));
+
+            let p2 = query_all_family_members_paged(tester.deps(), p1.start_next_after, Some(2))
+                .unwrap();
+            assert_eq!(
+                p2.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
+                vec![12, 13]
+            );
+            assert_eq!(p2.start_next_after, Some(13));
+
+            let p3 = query_all_family_members_paged(tester.deps(), p2.start_next_after, Some(2))
+                .unwrap();
+            assert_eq!(
+                p3.members.iter().map(|m| m.node_id).collect::<Vec<_>>(),
+                vec![14]
+            );
+            assert_eq!(p3.start_next_after, Some(14));
+
+            let p4 = query_all_family_members_paged(tester.deps(), p3.start_next_after, Some(2))
+                .unwrap();
+            assert!(p4.members.is_empty());
+            assert!(p4.start_next_after.is_none());
+        }
+
+        #[test]
+        fn limit_is_clamped_to_max() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            let total = retrieval_limits::FAMILY_MEMBERS_MAX_LIMIT + 5;
+            tester.add_n_family_members(f.id, total);
+
+            let res = query_all_family_members_paged(tester.deps(), None, Some(u32::MAX)).unwrap();
+            assert_eq!(
+                res.members.len(),
+                retrieval_limits::FAMILY_MEMBERS_MAX_LIMIT as usize
+            );
+        }
+
+        #[test]
+        fn default_limit_applied_when_unspecified() {
+            let mut tester = init_contract_tester();
+            let f = tester.add_dummy_family();
+            let total = retrieval_limits::FAMILY_MEMBERS_DEFAULT_LIMIT + 5;
+            tester.add_n_family_members(f.id, total);
+
+            let res = query_all_family_members_paged(tester.deps(), None, None).unwrap();
+            assert_eq!(
+                res.members.len(),
+                retrieval_limits::FAMILY_MEMBERS_DEFAULT_LIMIT as usize
+            );
+        }
+
+        #[test]
+        fn excludes_node_after_it_leaves_family() {
+            let mut tester = init_contract_tester();
+            let f1 = tester.add_dummy_family();
+            let f2 = tester.add_dummy_family();
+            tester.add_to_family(f1.id, 10);
+            tester.add_to_family(f2.id, 11);
+
+            tester.remove_from_family(10);
+
+            let res = query_all_family_members_paged(tester.deps(), None, None).unwrap();
+            let ids: Vec<_> = res.members.iter().map(|m| m.node_id).collect();
+            assert_eq!(ids, vec![11]);
+        }
+    }
+
+    #[cfg(test)]
     mod pending_invitations_for_family_paged {
         use super::*;
 
@@ -1384,7 +1628,7 @@ mod tests {
     #[cfg(test)]
     mod past_invitations_for_family_paged {
         use super::*;
-        use node_families_contract_common::FamilyInvitationStatus;
+        use nym_node_families_contract_common::FamilyInvitationStatus;
 
         #[test]
         fn empty_when_family_has_no_archive_entries() {
@@ -1830,7 +2074,7 @@ mod tests {
     #[cfg(test)]
     mod past_invitations_for_node_paged {
         use super::*;
-        use node_families_contract_common::FamilyInvitationStatus;
+        use nym_node_families_contract_common::FamilyInvitationStatus;
 
         #[test]
         fn empty_when_node_has_no_archive_entries() {

--- a/contracts/node-families/src/storage/mod.rs
+++ b/contracts/node-families/src/storage/mod.rs
@@ -11,12 +11,12 @@ use crate::storage::storage_indexes::{
 use cosmwasm_std::{Addr, Coin, DepsMut, Env, Order, StdResult, Storage};
 use cw_controllers::Admin;
 use cw_storage_plus::{IndexedMap, Item, Map};
-use node_families_contract_common::constants::storage_keys;
-use node_families_contract_common::{
+use nym_mixnet_contract_common::NodeId;
+use nym_node_families_contract_common::constants::storage_keys;
+use nym_node_families_contract_common::{
     Config, FamilyInvitation, FamilyInvitationStatus, FamilyMembership, NodeFamiliesContractError,
     NodeFamily, NodeFamilyId, PastFamilyInvitation, PastFamilyMember,
 };
-use nym_mixnet_contract_common::NodeId;
 
 pub(crate) mod retrieval_limits;
 mod storage_indexes;

--- a/contracts/node-families/src/storage/storage_indexes.rs
+++ b/contracts/node-families/src/storage/storage_indexes.rs
@@ -4,12 +4,12 @@
 use crate::storage::FamilyMember;
 use cosmwasm_std::Addr;
 use cw_storage_plus::{Index, IndexList, MultiIndex, UniqueIndex};
-use node_families_contract_common::constants::storage_keys;
-use node_families_contract_common::{
+use nym_mixnet_contract_common::NodeId;
+use nym_node_families_contract_common::constants::storage_keys;
+use nym_node_families_contract_common::{
     FamilyInvitation, FamilyMembership, NodeFamily, NodeFamilyId, PastFamilyInvitation,
     PastFamilyMember,
 };
-use nym_mixnet_contract_common::NodeId;
 
 /// Secondary indexes over [`NodeFamily`]. Enforces one-family-per-owner and
 /// globally-unique family names via `UniqueIndex`es on `owner` and `name`.

--- a/contracts/node-families/src/testing.rs
+++ b/contracts/node-families/src/testing.rs
@@ -10,11 +10,6 @@ use crate::helpers::normalise_family_name;
 use crate::storage::NodeFamiliesStorage;
 use cosmwasm_std::{coin, Addr, Coin, Storage};
 use mixnet_contract::testable_mixnet_contract::{EmbeddedMixnetContractExt, MixnetContract};
-use node_families_contract_common::constants::storage_keys;
-use node_families_contract_common::{
-    Config, ExecuteMsg, FamilyInvitation, InstantiateMsg, MigrateMsg, NodeFamiliesContractError,
-    NodeFamily, NodeFamilyId, QueryMsg,
-};
 use nym_contracts_common_testing::{
     AdminExt, ArbitraryContractStorageReader, ArbitraryContractStorageWriter, BankExt, ChainOpts,
     CommonStorageKeys, ContractFn, ContractOpts, ContractTester, ContractTesterBuilder, DenomExt,
@@ -22,6 +17,11 @@ use nym_contracts_common_testing::{
 };
 use nym_mixnet_contract_common::ContractState;
 use nym_mixnet_contract_common::NodeId;
+use nym_node_families_contract_common::constants::storage_keys;
+use nym_node_families_contract_common::{
+    Config, ExecuteMsg, FamilyInvitation, InstantiateMsg, MigrateMsg, NodeFamiliesContractError,
+    NodeFamily, NodeFamilyId, QueryMsg,
+};
 
 pub struct NodeFamiliesContract;
 

--- a/contracts/node-families/src/transactions.rs
+++ b/contracts/node-families/src/transactions.rs
@@ -9,9 +9,9 @@ use crate::helpers::{
 };
 use crate::storage::NodeFamiliesStorage;
 use cosmwasm_std::{BankMsg, DepsMut, Env, Event, MessageInfo, Response};
-use node_families_contract_common::constants::events;
-use node_families_contract_common::{Config, NodeFamiliesContractError, NodeFamilyId};
 use nym_mixnet_contract_common::NodeId;
+use nym_node_families_contract_common::constants::events;
+use nym_node_families_contract_common::{Config, NodeFamiliesContractError, NodeFamilyId};
 
 /// Replace the contract's runtime [`Config`]. Restricted to the contract admin.
 pub(crate) fn try_update_config(
@@ -1103,7 +1103,7 @@ mod tests {
     mod revoke_family_invitation {
         use super::*;
         use crate::testing::NodeFamiliesContractTesterExt;
-        use node_families_contract_common::FamilyInvitationStatus;
+        use nym_node_families_contract_common::FamilyInvitationStatus;
 
         #[test]
         fn happy_path_removes_pending_and_archives_revoked() -> anyhow::Result<()> {
@@ -1237,7 +1237,7 @@ mod tests {
         use super::*;
         use crate::testing::NodeFamiliesContractTesterExt;
         use mixnet_contract::testable_mixnet_contract::EmbeddedMixnetContractExt;
-        use node_families_contract_common::FamilyInvitationStatus;
+        use nym_node_families_contract_common::FamilyInvitationStatus;
 
         #[test]
         fn happy_path_records_membership_and_archives_accepted() -> anyhow::Result<()> {
@@ -1484,7 +1484,7 @@ mod tests {
         use super::*;
         use crate::testing::NodeFamiliesContractTesterExt;
         use mixnet_contract::testable_mixnet_contract::EmbeddedMixnetContractExt;
-        use node_families_contract_common::FamilyInvitationStatus;
+        use nym_node_families_contract_common::FamilyInvitationStatus;
 
         #[test]
         fn happy_path_removes_pending_and_archives_rejected() -> anyhow::Result<()> {
@@ -1961,7 +1961,7 @@ mod tests {
         use crate::testing::NodeFamiliesContractTesterExt;
         use cosmwasm_std::Addr;
         use mixnet_contract::testable_mixnet_contract::EmbeddedMixnetContractExt;
-        use node_families_contract_common::FamilyInvitationStatus;
+        use nym_node_families_contract_common::FamilyInvitationStatus;
 
         fn mixnet_addr(tester: &impl NodeFamiliesContractTesterExt) -> Addr {
             NodeFamiliesStorage::new()

--- a/contracts/performance/Cargo.toml
+++ b/contracts/performance/Cargo.toml
@@ -41,7 +41,7 @@ nym-crypto = { workspace = true, features = ["asymmetric", "rand"] }
 # real contract. We instantiate the families contract alongside so the call
 # lands somewhere that knows how to handle it.
 node-families = { workspace = true, features = ["testable-node-families-contract"] }
-node-families-contract-common = { workspace = true }
+nym-node-families-contract-common = { workspace = true }
 
 [features]
 schema-gen = ["nym-performance-contract-common/schema", "cosmwasm-schema"]

--- a/contracts/performance/src/testing/mod.rs
+++ b/contracts/performance/src/testing/mod.rs
@@ -9,9 +9,6 @@ use cosmwasm_std::{
 };
 use mixnet_contract::testable_mixnet_contract::{EmbeddedMixnetContractExt, MixnetContract};
 use node_families_contract::testing::NodeFamiliesContract;
-use node_families_contract_common::{
-    Config as NodeFamiliesConfig, InstantiateMsg as NodeFamiliesInstantiateMsg,
-};
 use nym_contracts_common::Percent;
 use nym_contracts_common_testing::{
     addr, AdminExt, ArbitraryContractStorageReader, ArbitraryContractStorageWriter, BankExt,
@@ -20,6 +17,9 @@ use nym_contracts_common_testing::{
     TEST_DENOM,
 };
 use nym_mixnet_contract_common::{ContractState, EpochId};
+use nym_node_families_contract_common::{
+    Config as NodeFamiliesConfig, InstantiateMsg as NodeFamiliesInstantiateMsg,
+};
 use nym_performance_contract_common::constants::storage_keys;
 use nym_performance_contract_common::{
     ExecuteMsg, InstantiateMsg, MigrateMsg, NodeId, NodePerformance, NodeResults,

--- a/nym-api/Cargo.toml
+++ b/nym-api/Cargo.toml
@@ -104,6 +104,7 @@ nym-serde-helpers = { workspace = true, features = ["date"] }
 nym-ticketbooks-merkle = { workspace = true }
 nym-statistics-common = { workspace = true }
 nym-ecash-signer-check = { workspace = true }
+nym-node-families-contract-common = { workspace = true }
 
 
 [features]

--- a/nym-api/nym-api-requests/src/models/mod.rs
+++ b/nym-api/nym-api-requests/src/models/mod.rs
@@ -15,6 +15,7 @@ pub mod legacy;
 pub mod mixnet;
 pub mod network;
 pub mod network_monitor;
+pub mod node_families;
 pub mod node_status;
 pub mod schema_helpers;
 pub mod utility;

--- a/nym-api/nym-api-requests/src/models/node_families.rs
+++ b/nym-api/nym-api-requests/src/models/node_families.rs
@@ -2,49 +2,100 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use cosmwasm_std::Coin;
-use nym_mixnet_contract_common::NodeId;
+use nym_mixnet_contract_common::{NodeId, NodeRewarding};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use time::OffsetDateTime;
 
+/// Pending family invitation as exposed by the nym-api node-families endpoints.
 #[derive(Serialize, Deserialize)]
 pub struct PendingFamilyInvitation {
+    /// Node the invitation is addressed to.
     pub node_id: NodeId,
 
+    /// Block-time after which the invitation can no longer be accepted.
     #[serde(with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,
-
-    pub expired: bool,
 }
 
+/// Per-node stake snapshot derived from the mixnet contract's rewarding state.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct NodeStakeInformation {
+    /// Operator bond + all delegations, with accrued rewards applied.
+    pub stake: Coin,
+
+    /// Operator pledge component of `stake`.
+    pub bond: Coin,
+
+    /// Delegations component of `stake`.
+    pub delegations: Coin,
+
+    /// Number of unique delegators backing this node.
+    pub delegators: usize,
+}
+
+impl From<&NodeRewarding> for NodeStakeInformation {
+    fn from(rewarding: &NodeRewarding) -> Self {
+        let denom = &rewarding.cost_params.interval_operating_cost.denom;
+
+        let bond = rewarding.operator_pledge_with_reward(denom);
+        let delegations = rewarding.delegations_with_reward(denom);
+        let mut stake = bond.clone();
+        stake.amount += delegations.amount;
+
+        NodeStakeInformation {
+            stake,
+            bond,
+            delegations,
+            delegators: rewarding.unique_delegations as usize,
+        }
+    }
+}
+
+/// Family member view as exposed by the nym-api node-families endpoints.
 #[derive(Serialize, Deserialize)]
 pub struct NodeFamilyMember {
     pub node_id: NodeId,
 
+    /// Block-time at which the node joined the family.
     #[serde(with = "time::serde::rfc3339")]
     pub joined_at: OffsetDateTime,
-    pub stake: Coin,
-    pub bond: Coin,
-    pub delegations: Coin,
-    pub delegators: usize,
+
+    /// Stake/bond/delegation snapshot; `None` if the node was not in the
+    /// mixnet-contract cache at refresh time.
+    pub stake_information: Option<NodeStakeInformation>,
 }
 
+/// Family view as exposed by the nym-api node-families endpoints, carrying
+/// current members, pending invitations and aggregated stats.
 #[derive(Serialize, Deserialize)]
 pub struct NodeFamily {
+    /// Unique family identifier assigned by the contract.
     pub id: u32,
+
+    /// Display name (canonical form — see `normalise_family_name`).
     pub name: String,
+
+    /// Free-form family description.
     pub description: String,
+
+    /// Owner address (cosmos `Addr` rendered as a string).
     pub owner: String,
 
+    /// Average age of members, approximated from the mean bonding height.
     #[serde(with = "humantime_serde")]
     pub average_node_age: Duration,
 
-    pub total_stake: Coin,
+    /// Sum of member stakes; `None` when no member has reportable stake.
+    pub total_stake: Option<Coin>,
 
+    /// Block-time the family was created.
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
 
+    /// Current members of the family.
     pub members: Vec<NodeFamilyMember>,
 
+    /// Outstanding invitations issued by the family owner.
     pub pending_invitations: Vec<PendingFamilyInvitation>,
 }

--- a/nym-api/nym-api-requests/src/models/node_families.rs
+++ b/nym-api/nym-api-requests/src/models/node_families.rs
@@ -82,7 +82,7 @@ pub struct NodeFamily {
     /// Owner address (cosmos `Addr` rendered as a string).
     pub owner: String,
 
-    /// Average age of members, approximated from the mean bonding height.
+    /// Time-weighted average age of members.
     #[serde(with = "humantime_serde")]
     pub average_node_age: Duration,
 

--- a/nym-api/nym-api-requests/src/models/node_families.rs
+++ b/nym-api/nym-api-requests/src/models/node_families.rs
@@ -1,33 +1,39 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use super::CoinSchema;
 use cosmwasm_std::Coin;
 use nym_mixnet_contract_common::{NodeId, NodeRewarding};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use time::OffsetDateTime;
+use utoipa::ToSchema;
 
 /// Pending family invitation as exposed by the nym-api node-families endpoints.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct PendingFamilyInvitation {
     /// Node the invitation is addressed to.
     pub node_id: NodeId,
 
     /// Block-time after which the invitation can no longer be accepted.
     #[serde(with = "time::serde::rfc3339")]
+    #[schema(value_type = String)]
     pub expires_at: OffsetDateTime,
 }
 
 /// Per-node stake snapshot derived from the mixnet contract's rewarding state.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct NodeStakeInformation {
     /// Operator bond + all delegations, with accrued rewards applied.
+    #[schema(value_type = CoinSchema)]
     pub stake: Coin,
 
     /// Operator pledge component of `stake`.
+    #[schema(value_type = CoinSchema)]
     pub bond: Coin,
 
     /// Delegations component of `stake`.
+    #[schema(value_type = CoinSchema)]
     pub delegations: Coin,
 
     /// Number of unique delegators backing this node.
@@ -53,12 +59,13 @@ impl From<&NodeRewarding> for NodeStakeInformation {
 }
 
 /// Family member view as exposed by the nym-api node-families endpoints.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct NodeFamilyMember {
     pub node_id: NodeId,
 
     /// Block-time at which the node joined the family.
     #[serde(with = "time::serde::rfc3339")]
+    #[schema(value_type = String)]
     pub joined_at: OffsetDateTime,
 
     /// Stake/bond/delegation snapshot; `None` if the node was not in the
@@ -68,7 +75,7 @@ pub struct NodeFamilyMember {
 
 /// Family view as exposed by the nym-api node-families endpoints, carrying
 /// current members, pending invitations and aggregated stats.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct NodeFamily {
     /// Unique family identifier assigned by the contract.
     pub id: u32,
@@ -84,13 +91,16 @@ pub struct NodeFamily {
 
     /// Time-weighted average age of members.
     #[serde(with = "humantime_serde")]
+    #[schema(value_type = String)]
     pub average_node_age: Duration,
 
     /// Sum of member stakes; `None` when no member has reportable stake.
+    #[schema(value_type = Option<CoinSchema>)]
     pub total_stake: Option<Coin>,
 
     /// Block-time the family was created.
     #[serde(with = "time::serde::rfc3339")]
+    #[schema(value_type = String)]
     pub created_at: OffsetDateTime,
 
     /// Current members of the family.

--- a/nym-api/nym-api-requests/src/models/node_families.rs
+++ b/nym-api/nym-api-requests/src/models/node_families.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use cosmwasm_std::Coin;
+use nym_mixnet_contract_common::NodeId;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use time::OffsetDateTime;
+
+#[derive(Serialize, Deserialize)]
+pub struct PendingFamilyInvitation {
+    pub node_id: NodeId,
+
+    #[serde(with = "time::serde::rfc3339")]
+    pub expires_at: OffsetDateTime,
+
+    pub expired: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NodeFamilyMember {
+    pub node_id: NodeId,
+
+    #[serde(with = "time::serde::rfc3339")]
+    pub joined_at: OffsetDateTime,
+    pub stake: Coin,
+    pub bond: Coin,
+    pub delegations: Coin,
+    pub delegators: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NodeFamily {
+    pub id: u32,
+    pub name: String,
+    pub description: String,
+    pub owner: String,
+
+    #[serde(with = "humantime_serde")]
+    pub average_node_age: Duration,
+
+    pub total_stake: Coin,
+
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+
+    pub members: Vec<NodeFamilyMember>,
+
+    pub pending_invitations: Vec<PendingFamilyInvitation>,
+}

--- a/nym-api/nym-api-requests/src/models/node_families.rs
+++ b/nym-api/nym-api-requests/src/models/node_families.rs
@@ -109,3 +109,22 @@ pub struct NodeFamily {
     /// Outstanding invitations issued by the family owner.
     pub pending_invitations: Vec<PendingFamilyInvitation>,
 }
+
+/// Response wrapper for endpoints that look up a single family. `family` is
+/// `None` when the lookup did not match (rather than returning a 404).
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct NodeFamilyResponse {
+    pub family: Option<NodeFamily>,
+}
+
+/// Response wrapper for endpoints that look up the family a given node
+/// belongs to. `family` is `None` when the node is not currently a member of
+/// any cached family.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct NodeFamilyForNodeResponse {
+    /// The node the lookup was performed for.
+    pub node_id: NodeId,
+
+    /// The family this node belongs to, if any.
+    pub family: Option<NodeFamily>,
+}

--- a/nym-api/nym-api-requests/src/models/node_families.rs
+++ b/nym-api/nym-api-requests/src/models/node_families.rs
@@ -89,7 +89,7 @@ pub struct NodeFamily {
     /// Owner address (cosmos `Addr` rendered as a string).
     pub owner: String,
 
-    /// Time-weighted average age of members.
+    /// Average age of members.
     #[serde(with = "humantime_serde")]
     #[schema(value_type = String)]
     pub average_node_age: Duration,

--- a/nym-api/src/ecash/tests/mod.rs
+++ b/nym-api/src/ecash/tests/mod.rs
@@ -5,25 +5,11 @@ use crate::ecash::api_routes::handlers::ecash_routes;
 use crate::ecash::error::{EcashError, Result};
 use crate::ecash::keys::KeyPairWithEpoch;
 use crate::ecash::state::EcashState;
-use crate::mixnet_contract_cache::cache::MixnetContractCache;
-use crate::network::models::NetworkDetails;
-use crate::node_describe_cache::cache::DescribedNodes;
 use crate::node_families::cache::NodeFamiliesCacheData;
-use crate::node_status_api::handlers::unstable;
-use crate::node_status_api::NodeStatusCache;
-use crate::status::ApiStatusState;
 use crate::support::caching::cache::SharedCache;
-use crate::support::caching::refresher::RefreshRequester;
 use crate::support::config;
-use crate::support::http::state::chain_status::ChainStatusCache;
-use crate::support::http::state::contract_details::ContractDetailsCache;
-use crate::support::http::state::force_refresh::ForcedRefresh;
-use crate::support::http::state::mixnet_contract_cache::MixnetContractCacheState;
-use crate::support::http::state::node_annotations_cache::NodeAnnotationsCache;
-use crate::support::http::state::AppState;
 use crate::support::nyxd::Client;
 use crate::support::storage::NymApiStorage;
-use crate::unstable_routes::v1::account::cache::AddressInfoCache;
 use async_trait::async_trait;
 use axum::Router;
 use axum_test::http::StatusCode;
@@ -79,8 +65,6 @@ use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
-use tempfile::{tempdir, TempDir};
 use time::Date;
 use tokio::sync::RwLock;
 
@@ -89,7 +73,8 @@ pub(crate) mod helpers;
 mod issued_ticketbooks;
 
 const TEST_COIN_DENOM: &str = "unym";
-const TEST_REWARDING_VALIDATOR_ADDRESS: &str = "n19lc9u84cz0yz3fww5283nucc9yvr8gsjmgeul0";
+pub(crate) const TEST_REWARDING_VALIDATOR_ADDRESS: &str =
+    "n19lc9u84cz0yz3fww5283nucc9yvr8gsjmgeul0";
 
 #[derive(Default, Debug)]
 struct InternalCounters {
@@ -1272,134 +1257,124 @@ struct TestFixture {
     chain_state: SharedFakeChain,
     epoch: Arc<AtomicU64>,
     ecash_clients: Arc<RwLock<HashMap<EpochId, Vec<EcashApiClient>>>>,
+}
 
-    _tmp_dir: TempDir,
+/// Test-only bundle returned by [`build_dummy_ecash_state`]. Carries the
+/// constructed [`EcashState`] plus the test handles the caller may want to
+/// poke at directly (chain state, registered ecash clients, epoch counter).
+pub(crate) struct DummyEcashBundle {
+    pub ecash_state: EcashState,
+    pub chain_state: SharedFakeChain,
+    pub ecash_clients: Arc<RwLock<HashMap<EpochId, Vec<EcashApiClient>>>>,
+    /// A real [`Client`] (not the [`DummyClient`]) suitable for the
+    /// `nyxd_client` field on [`AppState`]. Built from a global env-var dance
+    /// (see body), which is required because `AppState` is not generic.
+    pub real_client: Client,
+    pub epoch: Arc<AtomicU64>,
+}
+
+/// Build a self-contained [`EcashState`] suitable for handler tests. Pulls
+/// every dependency it needs (coconut keypair, identity, fake chain, dummy
+/// comm channel, etc.) from a deterministic RNG seed so callers get
+/// reproducible setups.
+pub(crate) async fn build_dummy_ecash_state(
+    config: &config::Config,
+    storage: NymApiStorage,
+    rng_seed: [u8; 32],
+) -> DummyEcashBundle {
+    let mut rng = crate::ecash::tests::fixtures::test_rng(rng_seed);
+    let coconut_keypair = ttp_keygen(1, 1).unwrap().remove(0);
+    let identity = ed25519::KeyPair::new(&mut rng);
+    let epoch = Arc::new(AtomicU64::new(1));
+    let address = AccountId::from_str(TEST_REWARDING_VALIDATOR_ADDRESS).unwrap();
+    let comm_channel = DummyCommunicationChannel::new_single_dummy(
+        coconut_keypair.verification_key().clone(),
+        address.clone(),
+    )
+    .with_epoch(epoch.clone());
+    let ecash_clients = comm_channel.clients_arc();
+
+    let staged_key_pair = crate::ecash::keys::KeyPair::new();
+    staged_key_pair
+        .set(KeyPairWithEpoch {
+            keys: coconut_keypair,
+            issued_for_epoch: 1,
+        })
+        .await;
+    staged_key_pair.validate();
+
+    let chain_state = SharedFakeChain::default();
+    let nyxd_client = DummyClient::new(address, chain_state.clone());
+
+    let ecash_contract = chain_state
+        .lock()
+        .unwrap()
+        .ecash_contract
+        .address
+        .clone()
+        .as_str()
+        .parse()
+        .unwrap();
+
+    let ecash_state = EcashState::new(
+        config,
+        ecash_contract,
+        nyxd_client,
+        identity,
+        staged_key_pair,
+        comm_channel,
+        storage,
+        &ShutdownManager::empty_mock(),
+    );
+
+    // ideally this would have been generic, but that's way too much work
+    // since then `AppState` would have had to be made generic
+    // also, this is such a disgusting workaround to make it 'work'. yuck
+    let mut dummy = NymNetworkDetails::new_empty();
+    dummy.endpoints = vec![ValidatorDetails::new(
+        "http://127.0.0.1:26657",
+        Some("http://why-do-we-even-need-api-url-set-here.wtf"),
+        None,
+    )];
+    dummy.export_to_env();
+    let real_client = Client::new(config).unwrap();
+
+    DummyEcashBundle {
+        ecash_state,
+        chain_state,
+        ecash_clients,
+        real_client,
+        epoch,
+    }
 }
 
 impl TestFixture {
-    fn build_app_state(
-        storage: NymApiStorage,
-        ecash_state: EcashState,
-        nyxd_client: Client,
-        tmp_dir: &TempDir,
-    ) -> AppState {
-        let mixnet_contract_paths = tmp_dir.path().join("mixnet_contract");
-        let node_annotations_paths = tmp_dir.path().join("node_annotations");
-
-        let mixnet_contract_cache_state =
-            MixnetContractCache::new(&mixnet_contract_paths, Duration::from_secs(42));
-        let mixnet_contract_cache =
-            MixnetContractCacheState::new(mixnet_contract_cache_state, RefreshRequester::default());
-
-        let node_status_cache_state =
-            NodeStatusCache::new(&node_annotations_paths, Duration::from_secs(42));
-        let node_annotations_cache =
-            NodeAnnotationsCache::new(node_status_cache_state, RefreshRequester::default());
-
-        AppState {
-            nyxd_client,
-            chain_status_cache: ChainStatusCache::new(Duration::from_secs(42)),
-            ecash_signers_cache: Default::default(),
-            address_info_cache: AddressInfoCache::new(Duration::from_secs(42), 1000),
-            forced_refresh: ForcedRefresh::new(true),
-            mixnet_contract_cache,
-            node_families_cache: SharedCache::<NodeFamiliesCacheData>::new(),
-            node_annotations_cache,
-            storage,
-            described_nodes_cache: SharedCache::<DescribedNodes>::new(),
-            network_details: NetworkDetails::new(
-                "localhost".to_string(),
-                NymNetworkDetails::new_empty(),
-            ),
-            node_info_cache: unstable::NodeInfoCache::default(),
-            contract_info_cache: ContractDetailsCache::new(Duration::from_secs(42)),
-            api_status: ApiStatusState::new(None),
-            ecash_state: Arc::new(ecash_state),
-        }
-    }
-
     async fn new() -> Self {
-        let mut rng = crate::ecash::tests::fixtures::test_rng([69u8; 32]);
-        let coconut_keypair = ttp_keygen(1, 1).unwrap().remove(0);
-        let identity = ed25519::KeyPair::new(&mut rng);
-        let epoch = Arc::new(AtomicU64::new(1));
-        let address = AccountId::from_str(TEST_REWARDING_VALIDATOR_ADDRESS).unwrap();
-        let comm_channel = DummyCommunicationChannel::new_single_dummy(
-            coconut_keypair.verification_key().clone(),
-            address.clone(),
-        )
-        .with_epoch(epoch.clone());
-        let ecash_clients = comm_channel.clients_arc();
-
-        // TODO: it's AWFUL to test with actual storage, we should somehow abstract it away
-        let tmp_dir = tempdir().unwrap();
-        let storage = NymApiStorage::init(tmp_dir.path().join("TESTING_STORAGE.db"))
-            .await
-            .unwrap();
-
-        let staged_key_pair = crate::ecash::keys::KeyPair::new();
-        staged_key_pair
-            .set(KeyPairWithEpoch {
-                keys: coconut_keypair,
-                issued_for_epoch: 1,
-            })
-            .await;
-        staged_key_pair.validate();
-
-        let chain_state = SharedFakeChain::default();
-        let nyxd_client = DummyClient::new(address, chain_state.clone());
-
-        let ecash_contract = chain_state
-            .lock()
-            .unwrap()
-            .ecash_contract
-            .address
-            .clone()
-            .as_str()
-            .parse()
-            .unwrap();
+        let storage = NymApiStorage::init_in_memory().await.unwrap();
 
         let mut config = config::Config::new("test");
         config.ecash_signer.enabled = true;
 
-        let ecash_state = EcashState::new(
-            &config,
-            ecash_contract,
-            nyxd_client,
-            identity,
-            staged_key_pair,
-            comm_channel,
+        let bundle = build_dummy_ecash_state(&config, storage.clone(), [69u8; 32]).await;
+
+        let app_state = crate::support::http::state::test_helpers::build_app_state(
             storage.clone(),
-            &ShutdownManager::empty_mock(),
+            bundle.ecash_state,
+            bundle.real_client,
+            SharedCache::<NodeFamiliesCacheData>::new(),
         );
 
-        // ideally this would have been generic, but that's way too much work
-        // since then `AppState` would have had to be made generic
-        // also, this is such a disgusting workaround to make it 'work'. yuck
-        let mut dummy = NymNetworkDetails::new_empty();
-        dummy.endpoints = vec![ValidatorDetails::new(
-            "http://127.0.0.1:26657",
-            Some("http://why-do-we-even-need-api-url-set-here.wtf"),
-            None,
-        )];
-        dummy.export_to_env();
-        let another_fake_nyxd_client = Client::new(&config).unwrap();
-
         TestFixture {
-            axum: TestServer::new(Router::new().nest("/v1/ecash", ecash_routes()).with_state(
-                Self::build_app_state(
-                    storage.clone(),
-                    ecash_state,
-                    another_fake_nyxd_client,
-                    &tmp_dir,
-                ),
-            ))
+            axum: TestServer::new(
+                Router::new()
+                    .nest("/v1/ecash", ecash_routes())
+                    .with_state(app_state),
+            )
             .unwrap(),
             storage,
-            chain_state,
-            epoch,
-            ecash_clients,
-            _tmp_dir: tmp_dir,
+            chain_state: bundle.chain_state,
+            epoch: bundle.epoch,
+            ecash_clients: bundle.ecash_clients,
         }
     }
 
@@ -1575,11 +1550,8 @@ mod credential_tests {
 
         let nyxd_client = DummyClient::new(address.clone(), Default::default());
         let key_pair = ttp_keygen(1, 1).unwrap().remove(0);
-        let tmp_dir = tempdir().unwrap();
 
-        let storage = NymApiStorage::init(tmp_dir.path().join("storage.db"))
-            .await
-            .unwrap();
+        let storage = NymApiStorage::init_in_memory().await.unwrap();
         let comm_channel = DummyCommunicationChannel::new_single_dummy(
             key_pair.verification_key().clone(),
             address,

--- a/nym-api/src/ecash/tests/mod.rs
+++ b/nym-api/src/ecash/tests/mod.rs
@@ -8,6 +8,7 @@ use crate::ecash::state::EcashState;
 use crate::mixnet_contract_cache::cache::MixnetContractCache;
 use crate::network::models::NetworkDetails;
 use crate::node_describe_cache::cache::DescribedNodes;
+use crate::node_families::cache::NodeFamiliesCacheData;
 use crate::node_status_api::handlers::unstable;
 use crate::node_status_api::NodeStatusCache;
 use crate::status::ApiStatusState;
@@ -1302,6 +1303,7 @@ impl TestFixture {
             address_info_cache: AddressInfoCache::new(Duration::from_secs(42), 1000),
             forced_refresh: ForcedRefresh::new(true),
             mixnet_contract_cache,
+            node_families_cache: SharedCache::<NodeFamiliesCacheData>::new(),
             node_annotations_cache,
             storage,
             described_nodes_cache: SharedCache::<DescribedNodes>::new(),

--- a/nym-api/src/main.rs
+++ b/nym-api/src/main.rs
@@ -17,6 +17,7 @@ pub(crate) mod mixnet_contract_cache;
 pub(crate) mod network;
 mod network_monitor;
 pub(crate) mod node_describe_cache;
+mod node_families;
 mod node_performance;
 pub(crate) mod node_status_api;
 pub(crate) mod nym_nodes;

--- a/nym-api/src/node_families/cache/mod.rs
+++ b/nym-api/src/node_families/cache/mod.rs
@@ -8,6 +8,7 @@ use nym_api_requests::models::node_families::{
 use nym_mixnet_contract_common::{NodeId, NymNodeDetails};
 use nym_node_families_contract_common::{FamilyMemberRecord, NodeFamilyId};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::time::Duration;
 use time::OffsetDateTime;
 
@@ -88,7 +89,8 @@ pub(crate) struct CachedFamily {
     /// Owner address (cosmos `Addr` rendered as a string).
     pub(crate) owner: String,
 
-    /// Average age of members, approximated from the mean bonding height.
+    /// Time-weighted average age of members, computed from cached per-height
+    /// block timestamps.
     #[serde(with = "humantime_serde")]
     pub(crate) average_node_age: Duration,
 
@@ -109,10 +111,14 @@ pub(crate) struct CachedFamily {
 
 /// Full nym-api node-families cache snapshot — combined families-contract
 /// state plus mixnet-contract stake/bond information.
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize)]
 pub(crate) struct NodeFamiliesCacheData {
     /// Every family known to the contract, with members and pending invitations.
     pub(crate) families: Vec<CachedFamily>,
+
+    /// Persistent block-height → block-time cache used by the refresher when
+    /// computing per-member age. Survives restarts via the on-disk cache file.
+    pub(crate) block_timestamps: HashMap<u64, OffsetDateTime>,
 }
 
 /// Intermediate accumulator used while folding contract data into a

--- a/nym-api/src/node_families/cache/mod.rs
+++ b/nym-api/src/node_families/cache/mod.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use cosmwasm_std::Coin;
-use nym_mixnet_contract_common::{NodeId, NodeRewarding, NymNodeDetails};
+use nym_api_requests::models::node_families::{
+    NodeFamily, NodeFamilyMember, NodeStakeInformation, PendingFamilyInvitation,
+};
+use nym_mixnet_contract_common::{NodeId, NymNodeDetails};
 use nym_node_families_contract_common::{FamilyMemberRecord, NodeFamilyId};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -10,41 +13,22 @@ use time::OffsetDateTime;
 
 pub(crate) mod refresher;
 
-#[derive(Serialize, Deserialize)]
-pub(crate) struct NodeStakeInformation {
-    pub stake: Coin,
-    pub bond: Coin,
-    pub delegations: Coin,
-    pub delegators: usize,
-}
-
-impl From<&NodeRewarding> for NodeStakeInformation {
-    fn from(rewarding: &NodeRewarding) -> Self {
-        let denom = &rewarding.cost_params.interval_operating_cost.denom;
-
-        let bond = rewarding.operator_pledge_with_reward(denom);
-        let delegations = rewarding.delegations_with_reward(denom);
-        let mut stake = bond.clone();
-        stake.amount += delegations.amount;
-
-        Self {
-            stake,
-            bond,
-            delegations,
-            delegators: rewarding.unique_delegations as usize,
-        }
-    }
-}
-
+/// Cached view of a single family member, joining the contract membership
+/// record with mixnet-contract node details (bond height + stake).
 #[derive(Serialize, Deserialize)]
 pub(crate) struct CachedFamilyMember {
     pub(crate) node_id: NodeId,
 
+    /// Block-time at which the node joined the family.
     #[serde(with = "time::serde::rfc3339")]
     pub(crate) joined_at: OffsetDateTime,
 
+    /// Bonding height from the mixnet contract; `None` if the node is no
+    /// longer in the mixnet cache snapshot.
     pub(crate) bonding_height: Option<u64>,
 
+    /// Stake/bond/delegation snapshot; `None` if the node is no longer in the
+    /// mixnet cache snapshot.
     pub(crate) node_stake_information: Option<NodeStakeInformation>,
 }
 
@@ -63,14 +47,15 @@ impl CachedFamilyMember {
     }
 }
 
+/// Cached pending invitation entry for a family.
 #[derive(Serialize, Deserialize)]
 pub(crate) struct CachedFamilyInvitation {
+    /// Node the invitation is addressed to.
     pub(crate) node_id: NodeId,
 
+    /// Block-time after which the invitation can no longer be accepted.
     #[serde(with = "time::serde::rfc3339")]
     pub(crate) expires_at: OffsetDateTime,
-
-    pub(crate) expired: bool,
 }
 
 impl From<nym_node_families_contract_common::PendingFamilyInvitationDetails>
@@ -83,43 +68,77 @@ impl From<nym_node_families_contract_common::PendingFamilyInvitationDetails>
                 invitation.invitation.expires_at as i64,
             )
             .unwrap_or(OffsetDateTime::UNIX_EPOCH),
-            expired: invitation.expired,
         }
     }
 }
 
+/// Cached family record with its current members, pending invitations and
+/// aggregated stats (`average_node_age`, `total_stake`).
 #[derive(Serialize, Deserialize)]
 pub(crate) struct CachedFamily {
+    /// Unique family identifier assigned by the contract.
     pub(crate) id: NodeFamilyId,
+
+    /// Display name (canonical form — see `normalise_family_name`).
     pub(crate) name: String,
+
+    /// Free-form family description.
     pub(crate) description: String,
+
+    /// Owner address (cosmos `Addr` rendered as a string).
     pub(crate) owner: String,
 
+    /// Average age of members, approximated from the mean bonding height.
     #[serde(with = "humantime_serde")]
     pub(crate) average_node_age: Duration,
+
+    /// Sum of member stakes; `None` when no member has reportable stake (e.g.
+    /// all bonds unbonding).
     pub(crate) total_stake: Option<Coin>,
 
+    /// Block-time the family was created.
     #[serde(with = "time::serde::rfc3339")]
     pub(crate) created_at: OffsetDateTime,
+
+    /// Current members of the family.
     pub(crate) members: Vec<CachedFamilyMember>,
 
+    /// Outstanding invitations issued by the family owner.
     pub(crate) pending_invitations: Vec<CachedFamilyInvitation>,
 }
 
-// families contract + mixnet contract combined
+/// Full nym-api node-families cache snapshot — combined families-contract
+/// state plus mixnet-contract stake/bond information.
 #[derive(Serialize, Deserialize)]
 pub(crate) struct NodeFamiliesCacheData {
+    /// Every family known to the contract, with members and pending invitations.
     pub(crate) families: Vec<CachedFamily>,
 }
 
+/// Intermediate accumulator used while folding contract data into a
+/// [`CachedFamily`]; finalised via [`Self::build`] once `average_node_age` is
+/// known.
 pub(crate) struct CachedFamilyBuilder {
+    /// Unique family identifier assigned by the contract.
     pub(crate) id: NodeFamilyId,
+
+    /// Display name (canonical form — see `normalise_family_name`).
     pub(crate) name: String,
+
+    /// Free-form family description.
     pub(crate) description: String,
+
+    /// Owner address (cosmos `Addr` rendered as a string).
     pub(crate) owner: String,
 
+    /// Block-time the family was created.
     pub(crate) created_at: OffsetDateTime,
+
+    /// Members accumulated as the refresher iterates the contract response.
     pub(crate) members: Vec<CachedFamilyMember>,
+
+    /// Pending invitations accumulated as the refresher iterates the contract
+    /// response.
     pub(crate) pending_invitations: Vec<CachedFamilyInvitation>,
 }
 
@@ -140,6 +159,8 @@ impl CachedFamilyBuilder {
         }
     }
 
+    /// Sum the per-member stake into a single family total. Returns `None` if
+    /// no member has a known stake.
     pub(crate) fn total_family_stake(&self) -> Option<Coin> {
         self.members
             .iter()
@@ -149,6 +170,41 @@ impl CachedFamilyBuilder {
                 updated.amount += e.amount;
                 updated
             })
+    }
+}
+
+impl From<&CachedFamilyInvitation> for PendingFamilyInvitation {
+    fn from(value: &CachedFamilyInvitation) -> Self {
+        PendingFamilyInvitation {
+            node_id: value.node_id,
+            expires_at: value.expires_at,
+        }
+    }
+}
+
+impl From<&CachedFamilyMember> for NodeFamilyMember {
+    fn from(value: &CachedFamilyMember) -> Self {
+        NodeFamilyMember {
+            node_id: value.node_id,
+            joined_at: value.joined_at,
+            stake_information: value.node_stake_information.clone(),
+        }
+    }
+}
+
+impl From<&CachedFamily> for NodeFamily {
+    fn from(value: &CachedFamily) -> Self {
+        NodeFamily {
+            id: value.id,
+            name: value.name.clone(),
+            description: value.description.clone(),
+            owner: value.owner.clone(),
+            average_node_age: value.average_node_age,
+            total_stake: value.total_stake.clone(),
+            created_at: value.created_at,
+            members: value.members.iter().map(Into::into).collect(),
+            pending_invitations: value.pending_invitations.iter().map(Into::into).collect(),
+        }
     }
 }
 

--- a/nym-api/src/node_families/cache/mod.rs
+++ b/nym-api/src/node_families/cache/mod.rs
@@ -8,7 +8,7 @@ use nym_api_requests::models::node_families::{
 use nym_mixnet_contract_common::{NodeId, NymNodeDetails};
 use nym_node_families_contract_common::{FamilyMemberRecord, NodeFamilyId};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::time::Duration;
 use time::OffsetDateTime;
 
@@ -113,8 +113,15 @@ pub(crate) struct CachedFamily {
 /// state plus mixnet-contract stake/bond information.
 #[derive(Default, Serialize, Deserialize)]
 pub(crate) struct NodeFamiliesCacheData {
-    /// Every family known to the contract, with members and pending invitations.
-    pub(crate) families: Vec<CachedFamily>,
+    /// Every family known to the contract, keyed by family id. `BTreeMap` so
+    /// iteration order is deterministic across refreshes (stable list
+    /// endpoint output, deterministic on-disk bincode).
+    pub(crate) families: BTreeMap<NodeFamilyId, CachedFamily>,
+
+    /// Secondary index: member node id → family id. Built alongside
+    /// `families` during refresh; lets `by-node` lookups avoid an O(families
+    /// × members) scan.
+    pub(crate) family_by_member: HashMap<NodeId, NodeFamilyId>,
 
     /// Persistent block-height → block-time cache used by the refresher when
     /// computing per-member age. Survives restarts via the on-disk cache file.

--- a/nym-api/src/node_families/cache/mod.rs
+++ b/nym-api/src/node_families/cache/mod.rs
@@ -1,0 +1,169 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use cosmwasm_std::Coin;
+use nym_mixnet_contract_common::{NodeId, NodeRewarding, NymNodeDetails};
+use nym_node_families_contract_common::{FamilyMemberRecord, NodeFamilyId};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use time::OffsetDateTime;
+
+pub(crate) mod refresher;
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct NodeStakeInformation {
+    pub stake: Coin,
+    pub bond: Coin,
+    pub delegations: Coin,
+    pub delegators: usize,
+}
+
+impl From<&NodeRewarding> for NodeStakeInformation {
+    fn from(rewarding: &NodeRewarding) -> Self {
+        let denom = &rewarding.cost_params.interval_operating_cost.denom;
+
+        let bond = rewarding.operator_pledge_with_reward(denom);
+        let delegations = rewarding.delegations_with_reward(denom);
+        let mut stake = bond.clone();
+        stake.amount += delegations.amount;
+
+        Self {
+            stake,
+            bond,
+            delegations,
+            delegators: rewarding.unique_delegations as usize,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct CachedFamilyMember {
+    pub(crate) node_id: NodeId,
+
+    #[serde(with = "time::serde::rfc3339")]
+    pub(crate) joined_at: OffsetDateTime,
+
+    pub(crate) bonding_height: Option<u64>,
+
+    pub(crate) node_stake_information: Option<NodeStakeInformation>,
+}
+
+impl CachedFamilyMember {
+    pub(crate) fn new(
+        record: FamilyMemberRecord,
+        node_information: Option<&NymNodeDetails>,
+    ) -> Self {
+        CachedFamilyMember {
+            node_id: record.node_id,
+            joined_at: OffsetDateTime::from_unix_timestamp(record.membership.joined_at as i64)
+                .unwrap_or(OffsetDateTime::UNIX_EPOCH),
+            bonding_height: node_information.map(|n| n.bond_information.bonding_height),
+            node_stake_information: node_information.map(|n| (&n.rewarding_details).into()),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct CachedFamilyInvitation {
+    pub(crate) node_id: NodeId,
+
+    #[serde(with = "time::serde::rfc3339")]
+    pub(crate) expires_at: OffsetDateTime,
+
+    pub(crate) expired: bool,
+}
+
+impl From<nym_node_families_contract_common::PendingFamilyInvitationDetails>
+    for CachedFamilyInvitation
+{
+    fn from(invitation: nym_node_families_contract_common::PendingFamilyInvitationDetails) -> Self {
+        CachedFamilyInvitation {
+            node_id: invitation.invitation.node_id,
+            expires_at: OffsetDateTime::from_unix_timestamp(
+                invitation.invitation.expires_at as i64,
+            )
+            .unwrap_or(OffsetDateTime::UNIX_EPOCH),
+            expired: invitation.expired,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct CachedFamily {
+    pub(crate) id: NodeFamilyId,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) owner: String,
+
+    #[serde(with = "humantime_serde")]
+    pub(crate) average_node_age: Duration,
+    pub(crate) total_stake: Option<Coin>,
+
+    #[serde(with = "time::serde::rfc3339")]
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) members: Vec<CachedFamilyMember>,
+
+    pub(crate) pending_invitations: Vec<CachedFamilyInvitation>,
+}
+
+// families contract + mixnet contract combined
+#[derive(Serialize, Deserialize)]
+pub(crate) struct NodeFamiliesCacheData {
+    pub(crate) families: Vec<CachedFamily>,
+}
+
+pub(crate) struct CachedFamilyBuilder {
+    pub(crate) id: NodeFamilyId,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) owner: String,
+
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) members: Vec<CachedFamilyMember>,
+    pub(crate) pending_invitations: Vec<CachedFamilyInvitation>,
+}
+
+impl CachedFamilyBuilder {
+    pub(crate) fn build(self, average_node_age: Duration) -> CachedFamily {
+        let total_stake = self.total_family_stake();
+
+        CachedFamily {
+            id: self.id,
+            name: self.name,
+            description: self.description,
+            owner: self.owner,
+            created_at: self.created_at,
+            members: self.members,
+            pending_invitations: self.pending_invitations,
+            total_stake,
+            average_node_age,
+        }
+    }
+
+    pub(crate) fn total_family_stake(&self) -> Option<Coin> {
+        self.members
+            .iter()
+            .filter_map(|m| m.node_stake_information.as_ref().map(|s| s.stake.clone()))
+            .reduce(|acc, e| {
+                let mut updated = acc;
+                updated.amount += e.amount;
+                updated
+            })
+    }
+}
+
+// initial conversion with empty details
+impl From<nym_node_families_contract_common::NodeFamily> for CachedFamilyBuilder {
+    fn from(value: nym_node_families_contract_common::NodeFamily) -> Self {
+        CachedFamilyBuilder {
+            id: value.id,
+            name: value.name,
+            description: value.description,
+            owner: value.owner.to_string(),
+            created_at: OffsetDateTime::from_unix_timestamp(value.created_at as i64)
+                .unwrap_or(OffsetDateTime::UNIX_EPOCH),
+            members: Vec::new(),
+            pending_invitations: Vec::new(),
+        }
+    }
+}

--- a/nym-api/src/node_families/cache/mod.rs
+++ b/nym-api/src/node_families/cache/mod.rs
@@ -89,7 +89,7 @@ pub(crate) struct CachedFamily {
     /// Owner address (cosmos `Addr` rendered as a string).
     pub(crate) owner: String,
 
-    /// Time-weighted average age of members, computed from cached per-height
+    /// Average age of members, computed from cached per-height
     /// block timestamps.
     #[serde(with = "humantime_serde")]
     pub(crate) average_node_age: Duration,

--- a/nym-api/src/node_families/cache/refresher.rs
+++ b/nym-api/src/node_families/cache/refresher.rs
@@ -15,10 +15,13 @@ use std::time::Duration;
 use time::OffsetDateTime;
 use tracing::error;
 
+/// Periodic refresher feeding the [`NodeFamiliesCacheData`] cache from the
+/// node-families contract, joined with mixnet-contract stake snapshots.
 pub struct NodeFamiliesDataProvider {
+    /// Nyxd client used for contract queries and block timestamp lookups.
     nyxd_client: Client,
 
-    // source of stake/delegation information of nodes:
+    /// Source of per-node stake/delegation information.
     mixnet_contract_cache: MixnetContractCache,
 }
 
@@ -46,11 +49,13 @@ impl NodeFamiliesDataProvider {
         }
     }
 
+    /// Approximate average member age, derived from a single timestamp lookup
+    /// at the mean bonding height. Height-weighted (not time-weighted) so the
+    /// chain RPC count stays O(1) per family instead of O(members).
     async fn average_node_age(&self, members: &[CachedFamilyMember]) -> Duration {
         let mut known_heights = 0;
         let mut running_total = 0;
 
-        // figure out average bonding heights of each node in the family
         for bonding_height in members.iter().filter_map(|m| m.bonding_height) {
             known_heights += 1;
             running_total += bonding_height;
@@ -60,7 +65,6 @@ impl NodeFamiliesDataProvider {
             return Duration::ZERO;
         }
 
-        // determine average node age
         let block_height = running_total / known_heights;
         let Ok(timestamp) = self.nyxd_client.block_timestamp(block_height as u32).await else {
             error!("failed to retrieve block timestamp for block height: {block_height}");
@@ -71,6 +75,9 @@ impl NodeFamiliesDataProvider {
         (OffsetDateTime::now_utc() - t).unsigned_abs()
     }
 
+    /// Pull the full families/members/pending-invitations snapshot from the
+    /// node-families contract and join it with the latest mixnet-contract node
+    /// information for stake/bonding data.
     async fn refresh(&self) -> Result<NodeFamiliesCacheData, NyxdError> {
         // retrieve the base data from the contract
         let raw_families = self.nyxd_client.get_all_families().await?;

--- a/nym-api/src/node_families/cache/refresher.rs
+++ b/nym-api/src/node_families/cache/refresher.rs
@@ -2,18 +2,22 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::mixnet_contract_cache::cache::MixnetContractCache;
-use crate::node_families::cache::{
-    CachedFamily, CachedFamilyBuilder, CachedFamilyMember, NodeFamiliesCacheData,
-};
+use crate::node_families::cache::{CachedFamilyBuilder, CachedFamilyMember, NodeFamiliesCacheData};
+use crate::support::caching::cache::SharedCache;
 use crate::support::caching::refresher::CacheItemProvider;
 use crate::support::nyxd::Client;
 use async_trait::async_trait;
+use futures::{stream, StreamExt};
 use nym_validator_client::nyxd::contract_traits::PagedNodeFamiliesQueryClient;
 use nym_validator_client::nyxd::error::NyxdError;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use time::OffsetDateTime;
 use tracing::error;
+
+/// Maximum number of `block_timestamp` lookups in flight in parallel during a
+/// single refresh tick.
+const BLOCK_TIMESTAMP_FETCH_CONCURRENCY: usize = 8;
 
 /// Periodic refresher feeding the [`NodeFamiliesCacheData`] cache from the
 /// node-families contract, joined with mixnet-contract stake snapshots.
@@ -23,6 +27,11 @@ pub struct NodeFamiliesDataProvider {
 
     /// Source of per-node stake/delegation information.
     mixnet_contract_cache: MixnetContractCache,
+
+    /// Read-only handle to the cache this provider feeds. Used to recover the
+    /// previously-known block-height → block-time map (rehydrated from disk on
+    /// startup) so we only RPC heights we haven't already seen.
+    shared_cache: SharedCache<NodeFamiliesCacheData>,
 }
 
 #[async_trait]
@@ -42,37 +51,25 @@ impl CacheItemProvider for NodeFamiliesDataProvider {
 }
 
 impl NodeFamiliesDataProvider {
-    pub(crate) fn new(nyxd_client: Client, mixnet_contract_cache: MixnetContractCache) -> Self {
+    pub(crate) fn new(
+        nyxd_client: Client,
+        mixnet_contract_cache: MixnetContractCache,
+        shared_cache: SharedCache<NodeFamiliesCacheData>,
+    ) -> Self {
         NodeFamiliesDataProvider {
             nyxd_client,
             mixnet_contract_cache,
+            shared_cache,
         }
     }
 
-    /// Approximate average member age, derived from a single timestamp lookup
-    /// at the mean bonding height. Height-weighted (not time-weighted) so the
-    /// chain RPC count stays O(1) per family instead of O(members).
-    async fn average_node_age(&self, members: &[CachedFamilyMember]) -> Duration {
-        let mut known_heights = 0;
-        let mut running_total = 0;
-
-        for bonding_height in members.iter().filter_map(|m| m.bonding_height) {
-            known_heights += 1;
-            running_total += bonding_height;
-        }
-
-        if known_heights == 0 {
-            return Duration::ZERO;
-        }
-
-        let block_height = running_total / known_heights;
-        let Ok(timestamp) = self.nyxd_client.block_timestamp(block_height as u32).await else {
-            error!("failed to retrieve block timestamp for block height: {block_height}");
-            return Duration::ZERO;
+    /// Snapshot of the previously-cached block timestamps (rehydrated from
+    /// disk on startup). Empty if the cache hasn't been initialised yet.
+    async fn previous_block_timestamps(&self) -> HashMap<u64, OffsetDateTime> {
+        let Ok(prev) = self.shared_cache.get().await else {
+            return HashMap::new();
         };
-
-        let t: OffsetDateTime = timestamp.into();
-        (OffsetDateTime::now_utc() - t).unsigned_abs()
+        prev.block_timestamps.clone()
     }
 
     /// Pull the full families/members/pending-invitations snapshot from the
@@ -92,10 +89,10 @@ impl NodeFamiliesDataProvider {
             .map(|node| (node.node_id(), node))
             .collect::<HashMap<_, _>>();
 
-        let mut families: HashMap<_, CachedFamilyBuilder> = HashMap::new();
-        for family in raw_families {
-            families.insert(family.id, family.into());
-        }
+        let mut families: HashMap<_, CachedFamilyBuilder> = raw_families
+            .into_iter()
+            .map(|family| (family.id, family.into()))
+            .collect();
 
         // insert all member information into appropriate families
         for member_record in raw_members {
@@ -126,15 +123,80 @@ impl NodeFamiliesDataProvider {
             family.pending_invitations.push(invitation.into());
         }
 
-        let mut family_details = Vec::new();
+        let referenced_heights: HashSet<u64> = families
+            .values()
+            .flat_map(|f| f.members.iter().filter_map(|m| m.bonding_height))
+            .collect();
 
-        for family in families.into_values() {
-            let average_node_age = self.average_node_age(&family.members).await;
-            family_details.push(family.build(average_node_age))
-        }
+        let block_timestamps = self.resolve_block_timestamps(&referenced_heights).await;
+
+        let family_details = families
+            .into_values()
+            .map(|family| {
+                let average_node_age = average_node_age(&family.members, &block_timestamps);
+                family.build(average_node_age)
+            })
+            .collect();
 
         Ok(NodeFamiliesCacheData {
             families: family_details,
+            block_timestamps,
         })
     }
+
+    /// Build the block-height → block-time map for this refresh: keep entries
+    /// from the previous cache that we still need, parallel-fetch the rest.
+    async fn resolve_block_timestamps(
+        &self,
+        referenced_heights: &HashSet<u64>,
+    ) -> HashMap<u64, OffsetDateTime> {
+        let mut block_timestamps = self.previous_block_timestamps().await;
+
+        let to_fetch: Vec<u64> = referenced_heights
+            .iter()
+            .filter(|h| !block_timestamps.contains_key(h))
+            .copied()
+            .collect();
+
+        let fetched: Vec<(u64, OffsetDateTime)> = stream::iter(to_fetch)
+            .map(|h| async move {
+                match self.nyxd_client.block_timestamp(h as u32).await {
+                    Ok(t) => Some((h, OffsetDateTime::from(t))),
+                    Err(err) => {
+                        error!("failed to retrieve block timestamp for height {h}: {err}");
+                        None
+                    }
+                }
+            })
+            .buffer_unordered(BLOCK_TIMESTAMP_FETCH_CONCURRENCY)
+            .filter_map(|x| async move { x })
+            .collect()
+            .await;
+
+        block_timestamps.extend(fetched);
+        block_timestamps
+    }
+}
+
+/// Time-weighted average member age: for each member with a known bonding
+/// height we have a cached block-time, take `now - t` and average. Heights we
+/// failed to resolve are skipped rather than poisoning the average.
+fn average_node_age(
+    members: &[CachedFamilyMember],
+    block_timestamps: &HashMap<u64, OffsetDateTime>,
+) -> Duration {
+    let now = OffsetDateTime::now_utc();
+    let mut total_secs: i64 = 0;
+    let mut count: i64 = 0;
+    for height in members.iter().filter_map(|m| m.bonding_height) {
+        let Some(ts) = block_timestamps.get(&height) else {
+            continue;
+        };
+        total_secs += (now - *ts).whole_seconds();
+        count += 1;
+    }
+    if count == 0 {
+        return Duration::ZERO;
+    }
+    Duration::from_secs((total_secs / count).max(0) as u64)
 }

--- a/nym-api/src/node_families/cache/refresher.rs
+++ b/nym-api/src/node_families/cache/refresher.rs
@@ -15,10 +15,6 @@ use std::time::Duration;
 use time::OffsetDateTime;
 use tracing::error;
 
-/// Maximum number of `block_timestamp` lookups in flight in parallel during a
-/// single refresh tick.
-const BLOCK_TIMESTAMP_FETCH_CONCURRENCY: usize = 8;
-
 /// Periodic refresher feeding the [`NodeFamiliesCacheData`] cache from the
 /// node-families contract, joined with mixnet-contract stake snapshots.
 pub struct NodeFamiliesDataProvider {
@@ -32,6 +28,10 @@ pub struct NodeFamiliesDataProvider {
     /// previously-known block-height → block-time map (rehydrated from disk on
     /// startup) so we only RPC heights we haven't already seen.
     shared_cache: SharedCache<NodeFamiliesCacheData>,
+
+    /// Maximum number of `block_timestamp` lookups in flight in parallel during a
+    /// single refresh tick.
+    block_timestamp_fetch_concurrency: usize,
 }
 
 #[async_trait]
@@ -52,6 +52,7 @@ impl CacheItemProvider for NodeFamiliesDataProvider {
 
 impl NodeFamiliesDataProvider {
     pub(crate) fn new(
+        block_timestamp_fetch_concurrency: usize,
         nyxd_client: Client,
         mixnet_contract_cache: MixnetContractCache,
         shared_cache: SharedCache<NodeFamiliesCacheData>,
@@ -60,6 +61,7 @@ impl NodeFamiliesDataProvider {
             nyxd_client,
             mixnet_contract_cache,
             shared_cache,
+            block_timestamp_fetch_concurrency,
         }
     }
 
@@ -168,7 +170,7 @@ impl NodeFamiliesDataProvider {
                     }
                 }
             })
-            .buffer_unordered(BLOCK_TIMESTAMP_FETCH_CONCURRENCY)
+            .buffer_unordered(self.block_timestamp_fetch_concurrency)
             .filter_map(|x| async move { x })
             .collect()
             .await;

--- a/nym-api/src/node_families/cache/refresher.rs
+++ b/nym-api/src/node_families/cache/refresher.rs
@@ -8,9 +8,10 @@ use crate::support::caching::refresher::CacheItemProvider;
 use crate::support::nyxd::Client;
 use async_trait::async_trait;
 use futures::{stream, StreamExt};
+use nym_mixnet_contract_common::NodeId;
 use nym_validator_client::nyxd::contract_traits::PagedNodeFamiliesQueryClient;
 use nym_validator_client::nyxd::error::NyxdError;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Duration;
 use time::OffsetDateTime;
 use tracing::error;
@@ -95,6 +96,7 @@ impl NodeFamiliesDataProvider {
             .into_iter()
             .map(|family| (family.id, family.into()))
             .collect();
+        let mut family_by_member: HashMap<NodeId, _> = HashMap::new();
 
         // insert all member information into appropriate families
         for member_record in raw_members {
@@ -109,7 +111,8 @@ impl NodeFamiliesDataProvider {
             let node_info = nym_nodes.get(&node_id);
             family
                 .members
-                .push(CachedFamilyMember::new(member_record, node_info))
+                .push(CachedFamilyMember::new(member_record, node_info));
+            family_by_member.insert(node_id, family_id);
         }
 
         // insert all invitations into appropriate families
@@ -132,16 +135,18 @@ impl NodeFamiliesDataProvider {
 
         let block_timestamps = self.resolve_block_timestamps(&referenced_heights).await;
 
-        let family_details = families
+        let family_details: BTreeMap<_, _> = families
             .into_values()
             .map(|family| {
                 let average_node_age = average_node_age(&family.members, &block_timestamps);
-                family.build(average_node_age)
+                let built = family.build(average_node_age);
+                (built.id, built)
             })
             .collect();
 
         Ok(NodeFamiliesCacheData {
             families: family_details,
+            family_by_member,
             block_timestamps,
         })
     }

--- a/nym-api/src/node_families/cache/refresher.rs
+++ b/nym-api/src/node_families/cache/refresher.rs
@@ -1,0 +1,133 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::mixnet_contract_cache::cache::MixnetContractCache;
+use crate::node_families::cache::{
+    CachedFamily, CachedFamilyBuilder, CachedFamilyMember, NodeFamiliesCacheData,
+};
+use crate::support::caching::refresher::CacheItemProvider;
+use crate::support::nyxd::Client;
+use async_trait::async_trait;
+use nym_validator_client::nyxd::contract_traits::PagedNodeFamiliesQueryClient;
+use nym_validator_client::nyxd::error::NyxdError;
+use std::collections::HashMap;
+use std::time::Duration;
+use time::OffsetDateTime;
+use tracing::error;
+
+pub struct NodeFamiliesDataProvider {
+    nyxd_client: Client,
+
+    // source of stake/delegation information of nodes:
+    mixnet_contract_cache: MixnetContractCache,
+}
+
+#[async_trait]
+impl CacheItemProvider for NodeFamiliesDataProvider {
+    type Item = NodeFamiliesCacheData;
+    type Error = NyxdError;
+
+    async fn wait_until_ready(&self) {
+        self.mixnet_contract_cache
+            .naive_wait_for_initial_values()
+            .await
+    }
+
+    async fn try_refresh(&mut self) -> Result<Option<Self::Item>, Self::Error> {
+        self.refresh().await.map(Some)
+    }
+}
+
+impl NodeFamiliesDataProvider {
+    pub(crate) fn new(nyxd_client: Client, mixnet_contract_cache: MixnetContractCache) -> Self {
+        NodeFamiliesDataProvider {
+            nyxd_client,
+            mixnet_contract_cache,
+        }
+    }
+
+    async fn average_node_age(&self, members: &[CachedFamilyMember]) -> Duration {
+        let mut known_heights = 0;
+        let mut running_total = 0;
+
+        // figure out average bonding heights of each node in the family
+        for bonding_height in members.iter().filter_map(|m| m.bonding_height) {
+            known_heights += 1;
+            running_total += bonding_height;
+        }
+
+        if known_heights == 0 {
+            return Duration::ZERO;
+        }
+
+        // determine average node age
+        let block_height = running_total / known_heights;
+        let Ok(timestamp) = self.nyxd_client.block_timestamp(block_height as u32).await else {
+            error!("failed to retrieve block timestamp for block height: {block_height}");
+            return Duration::ZERO;
+        };
+
+        let t: OffsetDateTime = timestamp.into();
+        (OffsetDateTime::now_utc() - t).unsigned_abs()
+    }
+
+    async fn refresh(&self) -> Result<NodeFamiliesCacheData, NyxdError> {
+        // retrieve the base data from the contract
+        let raw_families = self.nyxd_client.get_all_families().await?;
+        let raw_members = self.nyxd_client.get_all_family_members().await?;
+        let pending_invites = self.nyxd_client.get_all_pending_invitations().await?;
+
+        let nym_nodes = self
+            .mixnet_contract_cache
+            .nym_nodes()
+            .await
+            .into_iter()
+            .map(|node| (node.node_id(), node))
+            .collect::<HashMap<_, _>>();
+
+        let mut families: HashMap<_, CachedFamilyBuilder> = HashMap::new();
+        for family in raw_families {
+            families.insert(family.id, family.into());
+        }
+
+        // insert all member information into appropriate families
+        for member_record in raw_members {
+            let family_id = member_record.membership.family_id;
+            let node_id = member_record.node_id;
+            let Some(family) = families.get_mut(&family_id) else {
+                error!(
+                    "node {node_id} belongs to family {family_id}, but this family does not exist!",
+                );
+                continue;
+            };
+            let node_info = nym_nodes.get(&node_id);
+            family
+                .members
+                .push(CachedFamilyMember::new(member_record, node_info))
+        }
+
+        // insert all invitations into appropriate families
+        for invitation in pending_invites {
+            let family_id = invitation.invitation.family_id;
+            let node_id = invitation.invitation.node_id;
+            let Some(family) = families.get_mut(&family_id) else {
+                error!(
+                    "node {node_id} has been invited to family {family_id}, but this family does not exist!",
+                );
+                continue;
+            };
+            family.pending_invitations.push(invitation.into());
+        }
+
+        let mut family_details = Vec::new();
+
+        for family in families.into_values() {
+            let average_node_age = self.average_node_age(&family.members).await;
+            family_details.push(family.build(average_node_age))
+        }
+
+        Ok(NodeFamiliesCacheData {
+            families: family_details,
+        })
+    }
+}

--- a/nym-api/src/node_families/cache/refresher.rs
+++ b/nym-api/src/node_families/cache/refresher.rs
@@ -185,7 +185,7 @@ impl NodeFamiliesDataProvider {
     }
 }
 
-/// Time-weighted average member age: for each member with a known bonding
+/// Average member age: for each member with a known bonding
 /// height we have a cached block-time, take `now - t` and average. Heights we
 /// failed to resolve are skipped rather than poisoning the average.
 fn average_node_age(
@@ -199,11 +199,15 @@ fn average_node_age(
         let Some(ts) = block_timestamps.get(&height) else {
             continue;
         };
-        total_secs += (now - *ts).whole_seconds();
+        let age = (now - *ts).whole_seconds();
+        if age < 0 {
+            continue;
+        }
+        total_secs += age;
         count += 1;
     }
     if count == 0 {
         return Duration::ZERO;
     }
-    Duration::from_secs((total_secs / count).max(0) as u64)
+    Duration::from_secs((total_secs / count) as u64)
 }

--- a/nym-api/src/node_families/handlers/mod.rs
+++ b/nym-api/src/node_families/handlers/mod.rs
@@ -1,0 +1,2 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only

--- a/nym-api/src/node_families/handlers/mod.rs
+++ b/nym-api/src/node_families/handlers/mod.rs
@@ -1,2 +1,131 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
+
+use crate::node_status_api::models::{AxumErrorResponse, AxumResult};
+use crate::support::http::helpers::PaginationRequestV2;
+use crate::support::http::state::AppState;
+use axum::extract::{Path, Query, State};
+use axum::routing::get;
+use axum::Router;
+use nym_api_requests::models::node_families::NodeFamily;
+use nym_api_requests::pagination::{PaginatedResponse, Pagination};
+use nym_http_api_common::{FormattedResponse, OutputParamsV2};
+use nym_mixnet_contract_common::NodeId;
+use nym_node_families_contract_common::NodeFamilyId;
+
+// /v1/node-families
+pub(crate) fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/", get(get_families))
+        .route("/{family_id}", get(get_family_by_id))
+        .route("/by-node/{node_id}", get(get_family_for_node))
+}
+
+#[utoipa::path(
+    tag = "Node Families",
+    get,
+    path = "",
+    context_path = "/v1/node-families",
+    responses(
+        (status = 200, content(
+            (PaginatedResponse<NodeFamily> = "application/json"),
+            (PaginatedResponse<NodeFamily> = "application/yaml"),
+            (PaginatedResponse<NodeFamily> = "application/bincode")
+        ))
+    ),
+    params(PaginationRequestV2)
+)]
+async fn get_families(
+    Query(pagination): Query<PaginationRequestV2>,
+    State(state): State<AppState>,
+) -> AxumResult<FormattedResponse<PaginatedResponse<NodeFamily>>> {
+    // TODO: paginate
+    let _ = pagination;
+    let output = pagination.output.unwrap_or_default();
+
+    let cache = state.node_families_cache.get().await?;
+    let families: Vec<NodeFamily> = cache.families.iter().map(Into::into).collect();
+
+    Ok(output.to_response(PaginatedResponse {
+        pagination: Pagination {
+            total: families.len(),
+            page: 0,
+            size: families.len(),
+        },
+        data: families,
+    }))
+}
+
+#[utoipa::path(
+    tag = "Node Families",
+    get,
+    path = "/{family_id}",
+    context_path = "/v1/node-families",
+    responses(
+        (status = 200, content(
+            (NodeFamily = "application/json"),
+            (NodeFamily = "application/yaml"),
+            (NodeFamily = "application/bincode")
+        )),
+        (status = 404, description = "no family with the requested id exists in the cache")
+    ),
+    params(
+        ("family_id" = u32, Path, description = "Identifier of the family"),
+        OutputParamsV2,
+    )
+)]
+async fn get_family_by_id(
+    Path(family_id): Path<NodeFamilyId>,
+    Query(output): Query<OutputParamsV2>,
+    State(state): State<AppState>,
+) -> AxumResult<FormattedResponse<NodeFamily>> {
+    let output = output.get_output();
+
+    let cache = state.node_families_cache.get().await?;
+    let family = cache
+        .families
+        .iter()
+        .find(|f| f.id == family_id)
+        .map(NodeFamily::from)
+        .ok_or_else(|| AxumErrorResponse::not_found(format!("family {family_id} not found")))?;
+
+    Ok(output.to_response(family))
+}
+
+#[utoipa::path(
+    tag = "Node Families",
+    get,
+    path = "/by-node/{node_id}",
+    context_path = "/v1/node-families",
+    responses(
+        (status = 200, content(
+            (NodeFamily = "application/json"),
+            (NodeFamily = "application/yaml"),
+            (NodeFamily = "application/bincode")
+        )),
+        (status = 404, description = "node is not a member of any cached family")
+    ),
+    params(
+        ("node_id" = u32, Path, description = "Identifier of the member node"),
+        OutputParamsV2,
+    )
+)]
+async fn get_family_for_node(
+    Path(node_id): Path<NodeId>,
+    Query(output): Query<OutputParamsV2>,
+    State(state): State<AppState>,
+) -> AxumResult<FormattedResponse<NodeFamily>> {
+    let output = output.get_output();
+
+    let cache = state.node_families_cache.get().await?;
+    let family = cache
+        .families
+        .iter()
+        .find(|f| f.members.iter().any(|m| m.node_id == node_id))
+        .map(NodeFamily::from)
+        .ok_or_else(|| {
+            AxumErrorResponse::not_found(format!("node {node_id} is not a member of any family"))
+        })?;
+
+    Ok(output.to_response(family))
+}

--- a/nym-api/src/node_families/handlers/mod.rs
+++ b/nym-api/src/node_families/handlers/mod.rs
@@ -23,8 +23,8 @@ const MAX_FAMILIES_PAGE_SIZE: u32 = 200;
 pub(crate) fn routes() -> Router<AppState> {
     Router::new()
         .route("/", get(get_families))
-        .route("/{family_id}", get(get_family_by_id))
-        .route("/by-node/{node_id}", get(get_family_for_node))
+        .route("/:family_id", get(get_family_by_id))
+        .route("/by-node/:node_id", get(get_family_for_node))
 }
 
 #[utoipa::path(

--- a/nym-api/src/node_families/handlers/mod.rs
+++ b/nym-api/src/node_families/handlers/mod.rs
@@ -1,17 +1,23 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::node_status_api::models::{AxumErrorResponse, AxumResult};
+use crate::node_status_api::models::AxumResult;
 use crate::support::http::helpers::PaginationRequestV2;
 use crate::support::http::state::AppState;
 use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use axum::Router;
-use nym_api_requests::models::node_families::NodeFamily;
+use nym_api_requests::models::node_families::{
+    NodeFamily, NodeFamilyForNodeResponse, NodeFamilyResponse,
+};
 use nym_api_requests::pagination::{PaginatedResponse, Pagination};
 use nym_http_api_common::{FormattedResponse, OutputParamsV2};
 use nym_mixnet_contract_common::NodeId;
 use nym_node_families_contract_common::NodeFamilyId;
+use std::cmp::min;
+
+const DEFAULT_FAMILIES_PAGE_SIZE: u32 = 50;
+const MAX_FAMILIES_PAGE_SIZE: u32 = 200;
 
 // /v1/node-families
 pub(crate) fn routes() -> Router<AppState> {
@@ -30,7 +36,6 @@ pub(crate) fn routes() -> Router<AppState> {
         (status = 200, content(
             (PaginatedResponse<NodeFamily> = "application/json"),
             (PaginatedResponse<NodeFamily> = "application/yaml"),
-            (PaginatedResponse<NodeFamily> = "application/bincode")
         ))
     ),
     params(PaginationRequestV2)
@@ -39,20 +44,35 @@ async fn get_families(
     Query(pagination): Query<PaginationRequestV2>,
     State(state): State<AppState>,
 ) -> AxumResult<FormattedResponse<PaginatedResponse<NodeFamily>>> {
-    // TODO: paginate
-    let _ = pagination;
+    let page = pagination.page.unwrap_or_default();
+    let per_page = min(
+        pagination.per_page.unwrap_or(DEFAULT_FAMILIES_PAGE_SIZE),
+        MAX_FAMILIES_PAGE_SIZE,
+    );
     let output = pagination.output.unwrap_or_default();
 
     let cache = state.node_families_cache.get().await?;
-    let families: Vec<NodeFamily> = cache.families.iter().map(Into::into).collect();
+    let total = cache.families.len();
+    let offset = (page as usize).saturating_mul(per_page as usize);
+
+    // BTreeMap ascending-id iteration is stable across refreshes, so paging
+    // by offset is well-defined: page N is the same window of ids on every
+    // call (until the underlying set changes).
+    let data: Vec<NodeFamily> = cache
+        .families
+        .values()
+        .skip(offset)
+        .take(per_page as usize)
+        .map(Into::into)
+        .collect();
 
     Ok(output.to_response(PaginatedResponse {
         pagination: Pagination {
-            total: families.len(),
-            page: 0,
-            size: families.len(),
+            total,
+            page,
+            size: data.len(),
         },
-        data: families,
+        data,
     }))
 }
 
@@ -63,11 +83,9 @@ async fn get_families(
     context_path = "/v1/node-families",
     responses(
         (status = 200, content(
-            (NodeFamily = "application/json"),
-            (NodeFamily = "application/yaml"),
-            (NodeFamily = "application/bincode")
-        )),
-        (status = 404, description = "no family with the requested id exists in the cache")
+            (NodeFamilyResponse = "application/json"),
+            (NodeFamilyResponse = "application/yaml"),
+        ))
     ),
     params(
         ("family_id" = u32, Path, description = "Identifier of the family"),
@@ -78,18 +96,13 @@ async fn get_family_by_id(
     Path(family_id): Path<NodeFamilyId>,
     Query(output): Query<OutputParamsV2>,
     State(state): State<AppState>,
-) -> AxumResult<FormattedResponse<NodeFamily>> {
+) -> AxumResult<FormattedResponse<NodeFamilyResponse>> {
     let output = output.get_output();
 
     let cache = state.node_families_cache.get().await?;
-    let family = cache
-        .families
-        .iter()
-        .find(|f| f.id == family_id)
-        .map(NodeFamily::from)
-        .ok_or_else(|| AxumErrorResponse::not_found(format!("family {family_id} not found")))?;
+    let family = cache.families.get(&family_id).map(NodeFamily::from);
 
-    Ok(output.to_response(family))
+    Ok(output.to_response(NodeFamilyResponse { family }))
 }
 
 #[utoipa::path(
@@ -99,11 +112,9 @@ async fn get_family_by_id(
     context_path = "/v1/node-families",
     responses(
         (status = 200, content(
-            (NodeFamily = "application/json"),
-            (NodeFamily = "application/yaml"),
-            (NodeFamily = "application/bincode")
-        )),
-        (status = 404, description = "node is not a member of any cached family")
+            (NodeFamilyForNodeResponse = "application/json"),
+            (NodeFamilyForNodeResponse = "application/yaml"),
+        ))
     ),
     params(
         ("node_id" = u32, Path, description = "Identifier of the member node"),
@@ -114,18 +125,15 @@ async fn get_family_for_node(
     Path(node_id): Path<NodeId>,
     Query(output): Query<OutputParamsV2>,
     State(state): State<AppState>,
-) -> AxumResult<FormattedResponse<NodeFamily>> {
+) -> AxumResult<FormattedResponse<NodeFamilyForNodeResponse>> {
     let output = output.get_output();
 
     let cache = state.node_families_cache.get().await?;
     let family = cache
-        .families
-        .iter()
-        .find(|f| f.members.iter().any(|m| m.node_id == node_id))
-        .map(NodeFamily::from)
-        .ok_or_else(|| {
-            AxumErrorResponse::not_found(format!("node {node_id} is not a member of any family"))
-        })?;
+        .family_by_member
+        .get(&node_id)
+        .and_then(|family_id| cache.families.get(family_id))
+        .map(NodeFamily::from);
 
-    Ok(output.to_response(family))
+    Ok(output.to_response(NodeFamilyForNodeResponse { node_id, family }))
 }

--- a/nym-api/src/node_families/mod.rs
+++ b/nym-api/src/node_families/mod.rs
@@ -1,5 +1,35 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use crate::mixnet_contract_cache::cache::MixnetContractCache;
+use crate::node_families::cache::refresher::NodeFamiliesDataProvider;
+use crate::node_families::cache::NodeFamiliesCacheData;
+use crate::support::caching::cache::SharedCache;
+use crate::support::caching::refresher::CacheRefresher;
+use crate::support::{config, nyxd};
+use nym_validator_client::nyxd::error::NyxdError;
+use std::path::PathBuf;
+
 pub(crate) mod cache;
 pub(crate) mod handlers;
+
+pub(crate) fn build_refresher(
+    config: &config::NodeFamiliesCache,
+    mixnet_contract_cache: &MixnetContractCache,
+    node_families_cache: &SharedCache<NodeFamiliesCacheData>,
+    nyxd_client: nyxd::Client,
+    on_disk_file: PathBuf,
+) -> CacheRefresher<NodeFamiliesCacheData, NyxdError> {
+    CacheRefresher::new_with_initial_value(
+        Box::new(NodeFamiliesDataProvider::new(
+            config.debug.node_families_block_timestamp_fetch_concurrency,
+            nyxd_client,
+            mixnet_contract_cache.clone(),
+            node_families_cache.clone(),
+        )),
+        config.debug.caching_interval,
+        node_families_cache.clone(),
+    )
+    .named("node-families-cache-refresher")
+    .with_persistent_cache(on_disk_file)
+}

--- a/nym-api/src/node_families/mod.rs
+++ b/nym-api/src/node_families/mod.rs
@@ -12,6 +12,8 @@ use std::path::PathBuf;
 
 pub(crate) mod cache;
 pub(crate) mod handlers;
+#[cfg(test)]
+mod tests;
 
 pub(crate) fn build_refresher(
     config: &config::NodeFamiliesCache,

--- a/nym-api/src/node_families/mod.rs
+++ b/nym-api/src/node_families/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+pub(crate) mod cache;
+pub(crate) mod handlers;

--- a/nym-api/src/node_families/tests.rs
+++ b/nym-api/src/node_families/tests.rs
@@ -1,0 +1,253 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::ecash::tests::build_dummy_ecash_state;
+use crate::node_families::cache::{CachedFamily, CachedFamilyMember, NodeFamiliesCacheData};
+use crate::node_families::handlers;
+use crate::support::caching::cache::SharedCache;
+use crate::support::config;
+use crate::support::http::state::test_helpers::build_app_state;
+use crate::support::storage::NymApiStorage;
+use axum::Router;
+use axum_test::http::StatusCode;
+use axum_test::TestServer;
+use cosmwasm_std::Coin;
+use nym_api_requests::models::node_families::{
+    NodeFamily, NodeFamilyForNodeResponse, NodeFamilyResponse, NodeStakeInformation,
+};
+use nym_api_requests::pagination::PaginatedResponse;
+use nym_mixnet_contract_common::NodeId;
+use nym_node_families_contract_common::NodeFamilyId;
+use std::collections::{BTreeMap, HashMap};
+use std::time::Duration;
+use time::OffsetDateTime;
+
+struct NodeFamiliesTestFixture {
+    axum: TestServer,
+    cache: SharedCache<NodeFamiliesCacheData>,
+}
+
+impl NodeFamiliesTestFixture {
+    /// Build a test server with the node-families router mounted and an empty
+    /// (but initialised) shared cache. Use [`seed`] to populate it.
+    async fn new() -> Self {
+        let storage = NymApiStorage::init_in_memory().await.unwrap();
+
+        let cache = SharedCache::<NodeFamiliesCacheData>::new_with_value(Default::default());
+
+        // node-families handlers don't read `AppState.ecash_state`, but
+        // `AppState` requires one; we just need a valid construction.
+        let mut cfg = config::Config::new("test");
+        cfg.ecash_signer.enabled = false;
+        let bundle = build_dummy_ecash_state(&cfg, storage.clone(), [7u8; 32]).await;
+
+        let app_state = build_app_state(
+            storage,
+            bundle.ecash_state,
+            bundle.real_client,
+            cache.clone(),
+        );
+
+        let server = TestServer::new(
+            Router::new()
+                .nest("/v1/node-families", handlers::routes())
+                .with_state(app_state),
+        )
+        .unwrap();
+
+        NodeFamiliesTestFixture {
+            axum: server,
+            cache,
+        }
+    }
+
+    /// Replace the cached data with the provided snapshot.
+    async fn seed(&self, data: NodeFamiliesCacheData) {
+        // try_overwrite_old_value swaps the entire cached value
+        self.cache
+            .try_overwrite_old_value(data, "node-families-test")
+            .await
+            .ok();
+    }
+}
+
+// ---------- fixtures ----------
+
+fn stake_coin(amount: u128) -> Coin {
+    Coin::new(amount, "unym")
+}
+
+fn member(node_id: NodeId, with_stake: Option<u128>) -> CachedFamilyMember {
+    CachedFamilyMember {
+        node_id,
+        joined_at: OffsetDateTime::UNIX_EPOCH,
+        bonding_height: Some(1),
+        node_stake_information: with_stake.map(|amt| NodeStakeInformation {
+            stake: stake_coin(amt),
+            bond: stake_coin(amt),
+            delegations: stake_coin(0),
+            delegators: 0,
+        }),
+    }
+}
+
+fn family(id: NodeFamilyId, name: &str, members: Vec<CachedFamilyMember>) -> CachedFamily {
+    CachedFamily {
+        id,
+        name: name.to_string(),
+        description: format!("{name} description"),
+        owner: format!("n1owner{id}"),
+        average_node_age: Duration::ZERO,
+        total_stake: None,
+        created_at: OffsetDateTime::UNIX_EPOCH,
+        members,
+        pending_invitations: Vec::new(),
+    }
+}
+
+fn snapshot(families: Vec<CachedFamily>) -> NodeFamiliesCacheData {
+    let mut family_by_member: HashMap<NodeId, NodeFamilyId> = HashMap::new();
+    let mut families_map: BTreeMap<NodeFamilyId, CachedFamily> = BTreeMap::new();
+    for family in families {
+        for m in &family.members {
+            family_by_member.insert(m.node_id, family.id);
+        }
+        families_map.insert(family.id, family);
+    }
+    NodeFamiliesCacheData {
+        families: families_map,
+        family_by_member,
+        block_timestamps: HashMap::new(),
+    }
+}
+
+// ---------- /v1/node-families (list) ----------
+
+#[tokio::test]
+async fn list_returns_empty_when_cache_has_no_families() {
+    let fx = NodeFamiliesTestFixture::new().await;
+
+    let res = fx.axum.get("/v1/node-families").await;
+    assert_eq!(res.status_code(), StatusCode::OK);
+    let body: PaginatedResponse<NodeFamily> = res.json();
+    assert_eq!(body.pagination.total, 0);
+    assert_eq!(body.pagination.size, 0);
+    assert_eq!(body.pagination.page, 0);
+    assert!(body.data.is_empty());
+}
+
+#[tokio::test]
+async fn list_returns_every_seeded_family() {
+    let fx = NodeFamiliesTestFixture::new().await;
+    fx.seed(snapshot(vec![
+        family(1, "alpha", vec![member(10, Some(100))]),
+        family(2, "beta", vec![member(20, None)]),
+    ]))
+    .await;
+
+    let res = fx.axum.get("/v1/node-families").await;
+    let body: PaginatedResponse<NodeFamily> = res.json();
+    assert_eq!(body.pagination.total, 2);
+    let ids: Vec<_> = body.data.iter().map(|f| f.id).collect();
+    assert_eq!(ids, vec![1, 2]);
+}
+
+#[tokio::test]
+async fn list_paginates_by_offset_in_ascending_id_order() {
+    let fx = NodeFamiliesTestFixture::new().await;
+    let families: Vec<_> = (1u32..=5)
+        .map(|i| family(i, &format!("f{i}"), vec![]))
+        .collect();
+    fx.seed(snapshot(families)).await;
+
+    // page 0 / per_page 2 → ids [1, 2]
+    let res = fx.axum.get("/v1/node-families?page=0&per_page=2").await;
+    let page0: PaginatedResponse<NodeFamily> = res.json();
+    assert_eq!(page0.pagination.total, 5);
+    assert_eq!(page0.pagination.page, 0);
+    assert_eq!(page0.pagination.size, 2);
+    assert_eq!(
+        page0.data.iter().map(|f| f.id).collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+
+    // page 1 / per_page 2 → ids [3, 4]
+    let res = fx.axum.get("/v1/node-families?page=1&per_page=2").await;
+    let page1: PaginatedResponse<NodeFamily> = res.json();
+    assert_eq!(
+        page1.data.iter().map(|f| f.id).collect::<Vec<_>>(),
+        vec![3, 4]
+    );
+
+    // page 2 / per_page 2 → just id 5 on the last page
+    let res = fx.axum.get("/v1/node-families?page=2&per_page=2").await;
+    let page2: PaginatedResponse<NodeFamily> = res.json();
+    assert_eq!(page2.pagination.size, 1);
+    assert_eq!(page2.data.iter().map(|f| f.id).collect::<Vec<_>>(), vec![5]);
+
+    // page 3 / per_page 2 → past the end; data empty but total still reported
+    let res = fx.axum.get("/v1/node-families?page=3&per_page=2").await;
+    let page3: PaginatedResponse<NodeFamily> = res.json();
+    assert_eq!(page3.pagination.total, 5);
+    assert_eq!(page3.pagination.size, 0);
+    assert!(page3.data.is_empty());
+}
+
+// ---------- /v1/node-families/{family_id} ----------
+
+#[tokio::test]
+async fn get_family_by_id_returns_some_on_hit() {
+    let fx = NodeFamiliesTestFixture::new().await;
+    fx.seed(snapshot(vec![family(7, "seven", vec![])])).await;
+
+    let res = fx.axum.get("/v1/node-families/7").await;
+    assert_eq!(res.status_code(), StatusCode::OK);
+    let body: NodeFamilyResponse = res.json();
+    let family = body.family.expect("family should be present");
+    assert_eq!(family.id, 7);
+    assert_eq!(family.name, "seven");
+}
+
+#[tokio::test]
+async fn get_family_by_id_returns_none_on_miss() {
+    let fx = NodeFamiliesTestFixture::new().await;
+    fx.seed(snapshot(vec![family(1, "alpha", vec![])])).await;
+
+    let res = fx.axum.get("/v1/node-families/999").await;
+    // still 200 — `family: None` signals absence
+    assert_eq!(res.status_code(), StatusCode::OK);
+    let body: NodeFamilyResponse = res.json();
+    assert!(body.family.is_none());
+}
+
+// ---------- /v1/node-families/by-node/{node_id} ----------
+
+#[tokio::test]
+async fn get_family_for_node_returns_some_on_hit() {
+    let fx = NodeFamiliesTestFixture::new().await;
+    fx.seed(snapshot(vec![family(
+        3,
+        "gamma",
+        vec![member(42, None), member(43, None)],
+    )]))
+    .await;
+
+    let res = fx.axum.get("/v1/node-families/by-node/42").await;
+    let body: NodeFamilyForNodeResponse = res.json();
+    assert_eq!(body.node_id, 42);
+    let family = body.family.expect("expected to find the family");
+    assert_eq!(family.id, 3);
+}
+
+#[tokio::test]
+async fn get_family_for_node_returns_none_on_miss() {
+    let fx = NodeFamiliesTestFixture::new().await;
+    fx.seed(snapshot(vec![family(1, "alpha", vec![member(10, None)])]))
+        .await;
+
+    let res = fx.axum.get("/v1/node-families/by-node/9999").await;
+    assert_eq!(res.status_code(), StatusCode::OK);
+    let body: NodeFamilyForNodeResponse = res.json();
+    assert_eq!(body.node_id, 9999);
+    assert!(body.family.is_none());
+}

--- a/nym-api/src/support/cli/run.rs
+++ b/nym-api/src/support/cli/run.rs
@@ -13,6 +13,7 @@ use crate::key_rotation::KeyRotationController;
 use crate::mixnet_contract_cache::cache::MixnetContractCache;
 use crate::network::models::NetworkDetails;
 use crate::node_describe_cache::cache::DescribedNodes;
+use crate::node_families::cache::NodeFamiliesCacheData;
 use crate::node_performance::provider::contract_provider::ContractPerformanceProvider;
 use crate::node_performance::provider::legacy_storage_provider::LegacyStoragePerformanceProvider;
 use crate::node_performance::provider::NodePerformanceProvider;
@@ -36,7 +37,7 @@ use crate::support::storage::NymApiStorage;
 use crate::unstable_routes::v1::account::cache::AddressInfoCache;
 use crate::{
     ecash, epoch_operations, mixnet_contract_cache, network_monitor, node_describe_cache,
-    node_performance, node_status_api, signers_cache,
+    node_families, node_performance, node_status_api, signers_cache,
 };
 use anyhow::{bail, Context};
 use nym_config::defaults::NymNetworkDetails;
@@ -188,6 +189,19 @@ async fn start_nym_api_tasks(mut config: Config) -> anyhow::Result<ShutdownManag
         described_path,
     );
 
+    // NODE FAMILIES
+    let node_families_path = storage_cfg.cache_file("node_families");
+    let ttl = config.node_families_cache.debug.caching_interval;
+    let node_families_cache =
+        SharedCache::<NodeFamiliesCacheData>::new_with_persistent(&node_families_path, ttl, None);
+    let node_families_cache_refresher = node_families::build_refresher(
+        &config.node_families_cache,
+        &mixnet_contract_cache_state.clone(),
+        &node_families_cache,
+        nyxd_client.clone(),
+        node_families_path,
+    );
+
     // NODES ANNOTATIONS
     let annotations_path = storage_cfg.cache_file("node_annotations");
     let ttl = config.node_status_api.debug.caching_interval;
@@ -316,6 +330,8 @@ async fn start_nym_api_tasks(mut config: Config) -> anyhow::Result<ShutdownManag
         &shutdown_manager,
     );
 
+    node_families_cache_refresher.start(shutdown_manager.clone_shutdown_token());
+
     // start dkg task
     if config.ecash_signer.enabled {
         let dkg_bte_keypair = load_bte_keypair(&config.ecash_signer)?;
@@ -395,6 +411,7 @@ async fn start_nym_api_tasks(mut config: Config) -> anyhow::Result<ShutdownManag
         ),
         forced_refresh: ForcedRefresh::new(config.describe_cache.debug.allow_illegal_ips),
         mixnet_contract_cache,
+        node_families_cache,
         node_annotations_cache,
         storage,
         described_nodes_cache,

--- a/nym-api/src/support/config/mod.rs
+++ b/nym-api/src/support/config/mod.rs
@@ -52,6 +52,11 @@ const DEFAULT_PER_NODE_TEST_PACKETS: usize = 3;
 
 const DEFAULT_NODE_STATUS_CACHE_REFRESH_INTERVAL: Duration = Duration::from_secs(305);
 const DEFAULT_MIXNET_CACHE_REFRESH_INTERVAL: Duration = Duration::from_secs(150);
+const DEFAULT_NODE_FAMILIES_CACHE_REFRESH_INTERVAL: Duration = Duration::from_secs(600);
+
+/// Maximum number of `block_timestamp` lookups in flight in parallel during a
+/// single refresh tick.
+const DEFAULT_NODE_FAMILIES_BLOCK_TIMESTAMP_FETCH_CONCURRENCY: usize = 8;
 const DEFAULT_PERFORMANCE_CONTRACT_POLLING_INTERVAL: Duration = Duration::from_secs(150);
 const DEFAULT_PERFORMANCE_CONTRACT_FALLBACK_EPOCHS: u32 = 12;
 const DEFAULT_PERFORMANCE_CONTRACT_RETAINED_EPOCHS: usize = 25;
@@ -121,6 +126,9 @@ pub struct Config {
     #[serde(default)]
     pub mixnet_contract_cache: MixnetContractCache,
 
+    #[serde(default)]
+    pub node_families_cache: NodeFamiliesCache,
+
     pub node_status_api: NodeStatusAPI,
 
     #[serde(alias = "topology_cacher")]
@@ -156,6 +164,7 @@ impl Config {
             performance_provider: Default::default(),
             network_monitor: NetworkMonitor::new_default(id.as_ref()),
             mixnet_contract_cache: Default::default(),
+            node_families_cache: Default::default(),
             node_status_api: NodeStatusAPI::new_default(id.as_ref()),
             describe_cache: Default::default(),
             contracts_info_cache: Default::default(),
@@ -385,6 +394,40 @@ impl Default for MixnetContractCacheDebug {
     fn default() -> Self {
         MixnetContractCacheDebug {
             caching_interval: DEFAULT_MIXNET_CACHE_REFRESH_INTERVAL,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct NodeFamiliesCache {
+    #[serde(default)]
+    pub debug: NodeFamiliesCacheDebug,
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for NodeFamiliesCache {
+    fn default() -> Self {
+        NodeFamiliesCache {
+            debug: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(default)]
+pub struct NodeFamiliesCacheDebug {
+    #[serde(with = "humantime_serde")]
+    pub caching_interval: Duration,
+
+    pub node_families_block_timestamp_fetch_concurrency: usize,
+}
+
+impl Default for NodeFamiliesCacheDebug {
+    fn default() -> Self {
+        NodeFamiliesCacheDebug {
+            caching_interval: DEFAULT_NODE_FAMILIES_CACHE_REFRESH_INTERVAL,
+            node_families_block_timestamp_fetch_concurrency:
+                DEFAULT_NODE_FAMILIES_BLOCK_TIMESTAMP_FETCH_CONCURRENCY,
         }
     }
 }

--- a/nym-api/src/support/http/helpers.rs
+++ b/nym-api/src/support/http/helpers.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use nym_http_api_common::Output;
+use nym_http_api_common::{Output, OutputV2};
 use nym_mixnet_contract_common::NodeId;
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
@@ -10,6 +10,14 @@ use utoipa::{IntoParams, ToSchema};
 #[into_params(parameter_in = Query)]
 pub struct PaginationRequest {
     pub output: Option<Output>,
+    pub page: Option<u32>,
+    pub per_page: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug, ToSchema, IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct PaginationRequestV2 {
+    pub output: Option<OutputV2>,
     pub page: Option<u32>,
     pub per_page: Option<u32>,
 }

--- a/nym-api/src/support/http/router.rs
+++ b/nym-api/src/support/http/router.rs
@@ -5,6 +5,7 @@ use crate::circulating_supply_api::handlers::circulating_supply_routes;
 use crate::ecash::api_routes::handlers::ecash_routes;
 use crate::mixnet_contract_cache::handlers::{epoch_routes, legacy_nodes_routes};
 use crate::network::handlers::nym_network_routes;
+use crate::node_families::handlers as node_families_handlers;
 use crate::node_status_api::handlers::status_routes;
 use crate::support::http::openapi::ApiDoc;
 use crate::support::http::state::AppState;
@@ -49,6 +50,7 @@ impl RouterBuilder {
             .nest("/network", nym_network_routes())
             .nest("/api-status", status::handlers::api_status_routes())
             .nest("/nym-nodes", nym_nodes::handlers::v1::routes())
+            .nest("/node-families", node_families_handlers::routes())
             .nest("/ecash", ecash_routes())
             .nest("/unstable", unstable_routes_v1())
             .nest("/legacy", legacy_nodes_routes()); // CORS layer needs to be "outside" of routes

--- a/nym-api/src/support/http/state/contract_details.rs
+++ b/nym-api/src/support/http/state/contract_details.rs
@@ -55,6 +55,7 @@ async fn refresh(nyxd_client: &Client) -> Result<CachedContractsInfo, NyxdError>
     let multisig = query_guard!(client_guard, multisig_contract_address());
     let ecash = query_guard!(client_guard, ecash_contract_address());
     let performance = query_guard!(client_guard, performance_contract_address());
+    let node_families = query_guard!(client_guard, node_families_contract_address());
 
     for (address, name) in [
         (mixnet, "nym-mixnet-contract"),
@@ -64,6 +65,7 @@ async fn refresh(nyxd_client: &Client) -> Result<CachedContractsInfo, NyxdError>
         (multisig, "nym-cw3-multisig-contract"),
         (ecash, "nym-ecash-contract"),
         (performance, "nym-performance-contract"),
+        (node_families, "nym-node-families-contract"),
     ] {
         let (cw2, build_info) = if let Some(address) = address {
             let cw2 = query_guard!(client_guard, try_get_cw2_contract_version(address).await);

--- a/nym-api/src/support/http/state/mod.rs
+++ b/nym-api/src/support/http/state/mod.rs
@@ -34,6 +34,8 @@ pub(crate) mod force_refresh;
 pub(crate) mod helpers;
 pub(crate) mod mixnet_contract_cache;
 pub(crate) mod node_annotations_cache;
+#[cfg(test)]
+pub(crate) mod test_helpers;
 
 #[derive(Clone)]
 pub(crate) struct AppState {

--- a/nym-api/src/support/http/state/mod.rs
+++ b/nym-api/src/support/http/state/mod.rs
@@ -5,6 +5,7 @@ use crate::ecash::state::EcashState;
 use crate::mixnet_contract_cache::cache::MixnetContractCache;
 use crate::network::models::NetworkDetails;
 use crate::node_describe_cache::cache::DescribedNodes;
+use crate::node_families::cache::NodeFamiliesCacheData;
 use crate::node_status_api::handlers::unstable;
 use crate::node_status_api::models::AxumErrorResponse;
 use crate::node_status_api::NodeStatusCache;
@@ -58,6 +59,9 @@ pub(crate) struct AppState {
 
     /// Holds cached state of the Nym Mixnet contract, e.g. bonded nym-nodes, rewarded set, current interval.
     pub(crate) mixnet_contract_cache: MixnetContractCacheState,
+
+    /// Hold cached state of node families, e.g. membership, invitations, age, etc.
+    pub(crate) node_families_cache: SharedCache<NodeFamiliesCacheData>,
 
     /// Holds processed information on network nodes, i.e. performance, config scores, etc.
     // TODO: also perhaps redundant?

--- a/nym-api/src/support/http/state/test_helpers.rs
+++ b/nym-api/src/support/http/state/test_helpers.rs
@@ -1,0 +1,67 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Shared test-only helpers for assembling an [`AppState`] without going
+//! through the full nym-api startup path.
+
+use crate::ecash::state::EcashState;
+use crate::mixnet_contract_cache::cache::MixnetContractCache;
+use crate::network::models::NetworkDetails;
+use crate::node_describe_cache::cache::DescribedNodes;
+use crate::node_families::cache::NodeFamiliesCacheData;
+use crate::node_status_api::handlers::unstable;
+use crate::node_status_api::NodeStatusCache;
+use crate::status::ApiStatusState;
+use crate::support::caching::cache::SharedCache;
+use crate::support::caching::refresher::RefreshRequester;
+use crate::support::http::state::chain_status::ChainStatusCache;
+use crate::support::http::state::contract_details::ContractDetailsCache;
+use crate::support::http::state::force_refresh::ForcedRefresh;
+use crate::support::http::state::mixnet_contract_cache::MixnetContractCacheState;
+use crate::support::http::state::node_annotations_cache::NodeAnnotationsCache;
+use crate::support::http::state::AppState;
+use crate::support::nyxd::Client;
+use crate::support::storage::NymApiStorage;
+use crate::unstable_routes::v1::account::cache::AddressInfoCache;
+use nym_config::defaults::NymNetworkDetails;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Construct a default test [`AppState`]. All caches start empty
+/// (in-memory `SharedCache::new()` for the disk-backed ones); seed
+/// `node_families_cache` upstream of this call if the test needs data.
+pub(crate) fn build_app_state(
+    storage: NymApiStorage,
+    ecash_state: EcashState,
+    nyxd_client: Client,
+    node_families_cache: SharedCache<NodeFamiliesCacheData>,
+) -> AppState {
+    let mixnet_contract_cache: MixnetContractCache = SharedCache::new().into();
+    let mixnet_contract_cache =
+        MixnetContractCacheState::new(mixnet_contract_cache, RefreshRequester::default());
+
+    let node_status_cache: NodeStatusCache = SharedCache::new().into();
+    let node_annotations_cache =
+        NodeAnnotationsCache::new(node_status_cache, RefreshRequester::default());
+
+    AppState {
+        nyxd_client,
+        chain_status_cache: ChainStatusCache::new(Duration::from_secs(42)),
+        ecash_signers_cache: Default::default(),
+        address_info_cache: AddressInfoCache::new(Duration::from_secs(42), 1000),
+        forced_refresh: ForcedRefresh::new(true),
+        mixnet_contract_cache,
+        node_families_cache,
+        node_annotations_cache,
+        storage,
+        described_nodes_cache: SharedCache::<DescribedNodes>::new(),
+        network_details: NetworkDetails::new(
+            "localhost".to_string(),
+            NymNetworkDetails::new_empty(),
+        ),
+        node_info_cache: unstable::NodeInfoCache::default(),
+        contract_info_cache: ContractDetailsCache::new(Duration::from_secs(42)),
+        api_status: ApiStatusState::new(None),
+        ecash_state: Arc::new(ecash_state),
+    }
+}

--- a/nym-api/src/support/nyxd/mod.rs
+++ b/nym-api/src/support/nyxd/mod.rs
@@ -206,6 +206,7 @@ impl Client {
         Ok(time)
     }
 
+    /// Tendermint block timestamp at the given height.
     pub(crate) async fn block_timestamp(&self, height: u32) -> Result<TendermintTime, NyxdError> {
         let time = nyxd_query!(self, get_block_timestamp(Some(height)).await?);
 

--- a/nym-api/src/support/nyxd/mod.rs
+++ b/nym-api/src/support/nyxd/mod.rs
@@ -33,13 +33,15 @@ use nym_mixnet_contract_common::{
     ExecuteMsg, GatewayBond, HistoricalNymNodeVersionEntry, IdentityKey, KeyRotationState,
     NymNodeDetails, RewardedSet, RoleAssignment,
 };
+use nym_node_families_contract_common::msg::QueryMsg as NodeFamiliesQueryMsg;
 use nym_validator_client::coconut::EcashApiError;
 use nym_validator_client::nyxd::contract_traits::mixnet_query_client::MixnetQueryClientExt;
 use nym_validator_client::nyxd::contract_traits::performance_query_client::{
     LastSubmission, NodePerformance,
 };
 use nym_validator_client::nyxd::contract_traits::{
-    PagedDkgQueryClient, PagedPerformanceQueryClient, PerformanceQueryClient,
+    NodeFamiliesQueryClient, PagedDkgQueryClient, PagedPerformanceQueryClient,
+    PerformanceQueryClient,
 };
 use nym_validator_client::nyxd::error::NyxdError;
 use nym_validator_client::nyxd::Coin;
@@ -200,6 +202,12 @@ impl Client {
     #[allow(dead_code)]
     pub(crate) async fn current_block_timestamp(&self) -> Result<TendermintTime, NyxdError> {
         let time = nyxd_query!(self, get_current_block_timestamp().await?);
+
+        Ok(time)
+    }
+
+    pub(crate) async fn block_timestamp(&self, height: u32) -> Result<TendermintTime, NyxdError> {
+        let time = nyxd_query!(self, get_block_timestamp(Some(height)).await?);
 
         Ok(time)
     }
@@ -693,5 +701,18 @@ impl DkgQueryClient for Client {
         for<'a> T: Deserialize<'a>,
     {
         nyxd_query!(self, query_dkg_contract(query).await)
+    }
+}
+
+#[async_trait]
+impl NodeFamiliesQueryClient for Client {
+    async fn query_node_families_contract<T>(
+        &self,
+        query: NodeFamiliesQueryMsg,
+    ) -> std::result::Result<T, NyxdError>
+    where
+        for<'a> T: Deserialize<'a>,
+    {
+        nyxd_query!(self, query_node_families_contract(query).await)
     }
 }

--- a/nym-api/src/support/storage/mod.rs
+++ b/nym-api/src/support/storage/mod.rs
@@ -82,6 +82,33 @@ impl NymApiStorage {
             .max_connections(25)
             .acquire_timeout(Duration::from_secs(60));
 
+        Self::from_options(connect_opts, pool_opts).await
+    }
+
+    /// Build a [`NymApiStorage`] backed by an in-memory SQLite database. The
+    /// pool is pinned to a single connection so every query sees the same DB
+    /// (the standard "private :memory:" gotcha — multiple connections to
+    /// `:memory:` produce independent DBs unless shared-cache is used).
+    ///
+    /// Intended for tests; migrations run identically to the file-backed
+    /// constructor.
+    #[cfg(test)]
+    pub async fn init_in_memory() -> Result<Self, NymApiStorageError> {
+        let connect_opts = sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(":memory:")
+            .create_if_missing(true);
+
+        let pool_opts = sqlx::sqlite::SqlitePoolOptions::new()
+            .min_connections(1)
+            .max_connections(1);
+
+        Self::from_options(connect_opts, pool_opts).await
+    }
+
+    async fn from_options(
+        connect_opts: sqlx::sqlite::SqliteConnectOptions,
+        pool_opts: sqlx::sqlite::SqlitePoolOptions,
+    ) -> Result<Self, NymApiStorageError> {
         let connection_pool = match pool_opts.connect_with(connect_opts).await {
             Ok(db) => db,
             Err(err) => {
@@ -97,12 +124,10 @@ impl NymApiStorage {
 
         info!("Database migration finished!");
 
-        let storage = NymApiStorage {
+        Ok(NymApiStorage {
             manager: StorageManager { connection_pool },
             db_id_cache: Arc::new(Default::default()),
-        };
-
-        Ok(storage)
+        })
     }
 
     pub(crate) async fn get_mixnode_database_id(

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -4495,6 +4495,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "node-families-contract-common"
+version = "1.20.5"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers",
+ "cw-utils",
+ "nym-contracts-common",
+ "nym-mixnet-contract-common",
+ "schemars",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5124,6 +5139,7 @@ dependencies = [
  "flate2",
  "futures",
  "itertools 0.14.0",
+ "node-families-contract-common",
  "nym-api-requests",
  "nym-coconut-dkg-common",
  "nym-compact-ecash",

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -4495,21 +4495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "node-families-contract-common"
-version = "1.20.5"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-controllers",
- "cw-utils",
- "nym-contracts-common",
- "nym-mixnet-contract-common",
- "schemars",
- "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4976,6 +4961,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-node-families-contract-common"
+version = "1.20.5"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers",
+ "cw-utils",
+ "nym-contracts-common",
+ "nym-mixnet-contract-common",
+ "schemars",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "nym-node-requests"
 version = "1.20.5"
 dependencies = [
@@ -5139,7 +5139,6 @@ dependencies = [
  "flate2",
  "futures",
  "itertools 0.14.0",
- "node-families-contract-common",
  "nym-api-requests",
  "nym-coconut-dkg-common",
  "nym-compact-ecash",
@@ -5151,6 +5150,7 @@ dependencies = [
  "nym-mixnet-contract-common",
  "nym-multisig-contract-common",
  "nym-network-defaults",
+ "nym-node-families-contract-common",
  "nym-performance-contract-common",
  "nym-serde-helpers",
  "nym-vesting-contract-common",

--- a/nym-wallet/nym-wallet-types/src/network/sandbox.rs
+++ b/nym-wallet/nym-wallet-types/src/network/sandbox.rs
@@ -28,6 +28,10 @@ pub(crate) const COCONUT_DKG_CONTRACT_ADDRESS: &str =
 pub(crate) const PERFORMANCE_CONTRACT_ADDRESS: &str = "";
 // /\ TODO: this has to be updated once the contract is deployed
 
+// \/ TODO: this has to be updated once the contract is deployed
+pub(crate) const NODE_FAMILIES_CONTRACT_ADDRESS: &str = "";
+// /\ TODO: this has to be updated once the contract is deployed
+
 // -- Constructor functions --
 
 pub(crate) fn validators() -> Vec<ValidatorDetails> {
@@ -51,6 +55,7 @@ pub(crate) fn network_details() -> nym_network_defaults::NymNetworkDetails {
             mixnet_contract_address: parse_optional_str(MIXNET_CONTRACT_ADDRESS),
             vesting_contract_address: parse_optional_str(VESTING_CONTRACT_ADDRESS),
             performance_contract_address: parse_optional_str(PERFORMANCE_CONTRACT_ADDRESS),
+            node_families_contract_address: parse_optional_str(NODE_FAMILIES_CONTRACT_ADDRESS),
             ecash_contract_address: parse_optional_str(ECASH_CONTRACT_ADDRESS),
             group_contract_address: parse_optional_str(GROUP_CONTRACT_ADDRESS),
             multisig_contract_address: parse_optional_str(MULTISIG_CONTRACT_ADDRESS),


### PR DESCRIPTION
Closes:
[NYM-1203](https://nymtech.atlassian.net/browse/NYM-1203)
[NYM-1204](https://nymtech.atlassian.net/browse/NYM-1204)
[NYM-1205](https://nymtech.atlassian.net/browse/NYM-1205)


## Summary

Adds a cached node-families view to nym-api, exposing read-only HTTP endpoints that combine on-chain families-contract state with mixnet-contract stake/bond data. Refresh is periodic and persistent across restarts.

## Endpoints (all under `/v1/node-families`)

| Method | Path | Returns |
|---|---|---|
| `GET` | `/` | `PaginatedResponse<NodeFamily>` (page/per_page) |
| `GET` | `/{family_id}` | `NodeFamilyResponse { family: Option<NodeFamily> }` |
| `GET` | `/by-node/{node_id}` | `NodeFamilyForNodeResponse { node_id, family: Option<NodeFamily> }` |

Each `NodeFamily` payload includes `id`, `name`, `description`, `owner`, `created_at`, `members` (with per-member stake info), `pending_invitations`, `total_stake`, and a time-weighted `average_node_age`. Lookup endpoints return
a wrapper with `Option<NodeFamily>` instead of 404 so callers can treat "not found" as a normal response.

## Notable internals

- **Cache shape**: `BTreeMap<NodeFamilyId, CachedFamily>` + side index  `HashMap<NodeId, NodeFamilyId>`, giving O(log n) family lookup and O(1) member-to-family lookup. BTreeMap ordering keeps the list endpoint stable across refreshes.
- **Refresher**: pulls families/members/pending invitations from the node-families contract in one tick, joins per-member stake from the mixnet contract cache, and persists to disk via the existing `CacheRefresher` pipeline (bincode dump, rehydrated on startup).
- **Block-timestamp cache**: `HashMap<u64, OffsetDateTime>` stored alongside the families. The refresher parallel-fetches only heights it hasn't seen before, so `average_node_age` becomes pure arithmetic on cached timestamps; survives restarts.
- **Validator-client traits**: `NodeFamiliesQueryClient`, `PagedNodeFamiliesQueryClient`, `NodeFamiliesSigningClient` - mirrors the performance-contract pattern.
- **New contract query**: `GetAllFamilyMembersPaged` (global cross-family scan, used by the refresher).

[NYM-1203]: https://nymtech.atlassian.net/browse/NYM-1203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NYM-1204]: https://nymtech.atlassian.net/browse/NYM-1204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NYM-1205]: https://nymtech.atlassian.net/browse/NYM-1205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6774)
<!-- Reviewable:end -->
