### PR TITLE
Handle Rate Limit Challenge Response

### DIFF
--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -139,7 +139,7 @@
 //! ```
 #![warn(missing_docs)]
 
-use http::header::USER_AGENT;
+use http::header::{HeaderName, USER_AGENT};
 pub use inventory;
 pub use reqwest::{self, ClientBuilder as ReqwestClientBuilder, StatusCode};
 use std::error::Error;
@@ -1173,7 +1173,15 @@ impl ApiClientCore for Client {
             };
 
             match response {
-                Ok(resp) => return Ok(resp),
+                Ok(resp) => {
+                    // Check if the response includes a rate limit error from the vercel API
+                    if is_http_rate_limit_err(&resp) {
+                        // if we have multiple urls, update to the next
+                        self.maybe_rotate_hosts(Some(url.clone()));
+                    }
+
+                    return Ok(resp);
+                }
                 Err(err) => {
                     #[cfg(target_arch = "wasm32")]
                     let is_network_err = err.is_timeout();
@@ -1226,17 +1234,36 @@ impl ApiClientCore for Client {
     }
 }
 
+const VERCEL_CHALLENGE_HEADER: HeaderName = HeaderName::from_static("x-vercel-mitigated");
+const VERCEL_CHALLENGE_VALUE: &[u8] = b"challenge";
+const VERCEL_CONTENT_TYPE: &[u8] = b"text/html";
+
+/// Check for Rate Limit challenge response from the vercel API
+pub(crate) fn is_http_rate_limit_err(resp: &Response) -> bool {
+    let status = resp.status() == StatusCode::FORBIDDEN;
+    let header = resp
+        .headers()
+        .iter()
+        .any(|(h, v)| h == VERCEL_CHALLENGE_HEADER && v.as_bytes() == VERCEL_CHALLENGE_VALUE);
+    let content_type = resp
+        .headers()
+        .iter()
+        .any(|(h, v)| h == CONTENT_TYPE && v.as_bytes() == VERCEL_CONTENT_TYPE);
+
+    status && header && content_type
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 const MAX_ERR_SOURCE_ITERATIONS: usize = 4;
 
-/// This functions attempts to check the error returned by reqwest to see if
-/// rotating host informtion (for clients with mutliple hosts defined) could be
-/// helpful. This looks for situations where the error could plausibly be caused
-/// by a network adversary, or where rotating to an equival hostname might help.
+/// This functions attempts to check the error returned by reqwest to see if rotating host
+/// information (for clients with multiple hosts defined) could be helpful. This looks for
+/// situations where the error could plausibly be caused by a network adversary, or where rotating
+/// to an equivalent hostname might help.
 ///
-/// For example --> NetworkUnreachable will not be helped by rotating domains,
-/// but ConnectionReset might be caused by a network adversary blocking by SNI
-/// which could possibly benefit from rotating domains.
+/// For example --> NetworkUnreachable will not be helped by rotating domains, but ConnectionReset
+/// might be caused by a network adversary blocking by SNI which could possibly benefit from
+/// rotating domains.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn might_be_network_interference(err: &reqwest::Error) -> bool {
     if err.is_timeout() {

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -139,7 +139,7 @@
 //! ```
 #![warn(missing_docs)]
 
-use http::header::{HeaderName, USER_AGENT};
+use http::header::USER_AGENT;
 pub use inventory;
 pub use reqwest::{self, ClientBuilder as ReqwestClientBuilder, StatusCode};
 use std::error::Error;
@@ -1176,6 +1176,7 @@ impl ApiClientCore for Client {
                 Ok(resp) => {
                     // Check if the response includes a rate limit error from the vercel API
                     if is_http_rate_limit_err(&resp) {
+                        warn!("encountered vercel rate limit error for {}", url.as_str());
                         // if we have multiple urls, update to the next
                         self.maybe_rotate_hosts(Some(url.clone()));
                     }
@@ -1234,21 +1235,22 @@ impl ApiClientCore for Client {
     }
 }
 
-const VERCEL_CHALLENGE_HEADER: HeaderName = HeaderName::from_static("x-vercel-mitigated");
+const VERCEL_CHALLENGE_HEADER: &str = "x-vercel-mitigated";
 const VERCEL_CHALLENGE_VALUE: &[u8] = b"challenge";
-const VERCEL_CONTENT_TYPE: &[u8] = b"text/html";
 
 /// Check for Rate Limit challenge response from the vercel API
 pub(crate) fn is_http_rate_limit_err(resp: &Response) -> bool {
     let status = resp.status() == StatusCode::FORBIDDEN;
     let header = resp
         .headers()
-        .iter()
-        .any(|(h, v)| h == VERCEL_CHALLENGE_HEADER && v.as_bytes() == VERCEL_CHALLENGE_VALUE);
+        .get(VERCEL_CHALLENGE_HEADER)
+        .is_some_and(|v| v.as_bytes() == VERCEL_CHALLENGE_VALUE);
     let content_type = resp
         .headers()
-        .iter()
-        .any(|(h, v)| h == CONTENT_TYPE && v.as_bytes() == VERCEL_CONTENT_TYPE);
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<Mime>().ok())
+        .is_some_and(|mime_type| mime_type == mime::TEXT_HTML_UTF_8);
 
     status && header && content_type
 }
@@ -1724,6 +1726,13 @@ where
         decode_raw_response(&headers, full)
     } else if res.status() == StatusCode::NOT_FOUND {
         Err(HttpClientError::NotFound { url: Box::new(url) })
+    } else if is_http_rate_limit_err(&res) {
+        Err(HttpClientError::EndpointFailure {
+            url: Box::new(url),
+            status,
+            headers: Box::new(HeaderMap::new()),
+            error: String::from("received vercel rate limit challenge response"),
+        })
     } else {
         let Ok(plaintext) = res.text().await else {
             return Err(HttpClientError::RequestFailure {

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1250,7 +1250,9 @@ pub(crate) fn is_http_rate_limit_err(resp: &Response) -> bool {
         .get(CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.parse::<Mime>().ok())
-        .is_some_and(|mime_type| mime_type == mime::TEXT_HTML_UTF_8);
+        .is_some_and(|mime_type| {
+            mime_type.type_() == mime::TEXT && mime_type.subtype() == mime::HTML
+        });
 
     status && header && content_type
 }

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -1732,7 +1732,7 @@ where
         Err(HttpClientError::EndpointFailure {
             url: Box::new(url),
             status,
-            headers: Box::new(HeaderMap::new()),
+            headers: Box::new(headers),
             error: String::from("received vercel rate limit challenge response"),
         })
     } else {


### PR DESCRIPTION
## Description

JIRA-NYM-1312

When requests are challenged by the WAF they return an HTTP error. Thejhttp client was configured such that HTTP errors would not result in a rotation of the client URL that was being tried. The thinking being that if we were able to complete a TLS handshake and proceed to the HTTP phase then the censorship was not an issue and instead there was an application level issue that should be handled elsewhere (i.e. this is a bug, not censorship). So domains were not rotated.

So the API url is not rotated challenge response errors and so subsequent retries will likely result in more errors. We should handle this response and rotate to the next Url if one is available.

## Solution

If a response is received without a client error, but matching the http response signature of the rate limit challenge we rotate the url (if more than one is available). 

The response is still passed through for the parser / application to handle though. Meaning that (for expected `application/json`  payloads) the parsing will fail and return an `EndpointError`. However given that this is a known matched error we no longer capture the plaintext of the error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6786)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of provider rate-limit/challenge responses and automatic rotation to alternative hosts to maintain request reliability.
  * Returns a clearer, consistent failure when a rate-limit challenge is encountered, preventing silent fall-through and improving error visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym/pull/6786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->