### PR TITLE
Fix test for url rotation

### DIFF
--- a/common/http-api-client/src/fronted.rs
+++ b/common/http-api-client/src/fronted.rs
@@ -342,6 +342,8 @@ mod tests {
         )
         .unwrap(); // fastly
 
+        // use non-shared client and no-hickory so that we aren't reliant on a shared http client
+        // that could be impacted by independent interleaved tests.
         let client = ClientBuilder::new_with_urls(vec![url1, url2])
             .expect("bad url")
             .non_shared()
@@ -370,7 +372,7 @@ mod tests {
             .await;
         assert!(result.is_err());
 
-        // Check that the host configuration updated the front on error.
+        // Check that the host configuration updated the front on error (tls error wring host)
         assert_eq!(
             client.current_url().as_str(),
             "https://fake-domain.nymtech.net/",
@@ -390,7 +392,8 @@ mod tests {
             .await;
         assert!(result.is_err());
 
-        // Check that the host configuration updated the domain and front on error.
+        // Check that the host configuration updated the domain and front on error (tls error
+        // untrusted root)
         assert_eq!(
             client.current_url().as_str(),
             "https://validator.global.ssl.fastly.net/",

--- a/common/http-api-client/src/fronted.rs
+++ b/common/http-api-client/src/fronted.rs
@@ -324,6 +324,9 @@ mod tests {
     }
 
     #[tokio::test]
+    // NOTE THIS TEST IS DISABLED BECAUSE IT INTERACTS WITH LIVE NETWORK AND EXPECTS
+    // SPECIFIC BEHAVIOR. Keeping in case logic changes and needs tested locally.
+    #[cfg(any())] // #[ignore] we run --ignore in CI/CD assuming it just means slow -_-
     async fn fallback_on_failure() {
         let url1 = Url::new(
             "https://fake-domain.nymtech.net",
@@ -366,7 +369,6 @@ mod tests {
             )
             .await;
         assert!(result.is_err());
-        tracing::debug!("{result:?}");
 
         // Check that the host configuration updated the front on error.
         assert_eq!(

--- a/common/http-api-client/src/fronted.rs
+++ b/common/http-api-client/src/fronted.rs
@@ -328,8 +328,8 @@ mod tests {
         let url1 = Url::new(
             "https://fake-domain.nymtech.net",
             Some(vec![
-                "https://fake-front-1.nymtech.net",
-                "https://fake-front-2.nymtech.net",
+                "https://wrong.host.badssl.com/",
+                "https://untrusted-root.badssl.com/",
             ]),
         )
         .unwrap();
@@ -341,6 +341,8 @@ mod tests {
 
         let client = ClientBuilder::new_with_urls(vec![url1, url2])
             .expect("bad url")
+            .non_shared()
+            .no_hickory_dns()
             .with_fronting(Some(FrontPolicy::Always))
             .build()
             .expect("failed to build client");
@@ -352,7 +354,7 @@ mod tests {
         );
         assert_eq!(
             client.current_url().front_str(),
-            Some("fake-front-1.nymtech.net"),
+            Some("wrong.host.badssl.com"),
         );
 
         let result = client
@@ -364,6 +366,7 @@ mod tests {
             )
             .await;
         assert!(result.is_err());
+        tracing::debug!("{result:?}");
 
         // Check that the host configuration updated the front on error.
         assert_eq!(
@@ -372,7 +375,7 @@ mod tests {
         );
         assert_eq!(
             client.current_url().front_str(),
-            Some("fake-front-2.nymtech.net"),
+            Some("untrusted-root.badssl.com"),
         );
 
         let result = client


### PR DESCRIPTION
Test failing for url rotation due to behavior changes. (see this https://github.com/nymtech/nym/actions/runs/26297851743/job/77415114613?pr=6779)

This PR both fixes the test so that it should be predictable, but also disables it since it relies on live network resources behaving predictably at test time. I am leaving the test in for local testing if we need to make changes to the logic that it relates to.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6817)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated fronting fallback test to use realistic TLS test domains and to validate a specific sequential fallback between front hosts.
  * Change is confined to the test suite and adjusts expected outcomes for fallback behavior; no production-visible functionality was modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym/pull/6817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->