### PR TITLE
bugfix: fix axum 0.8 migration in mix-stress testing endpoints

### DIFF
--- a/nym-api/src/nym_nodes/handlers/v2.rs
+++ b/nym-api/src/nym_nodes/handlers/v2.rs
@@ -15,7 +15,7 @@ use tower_http::compression::CompressionLayer;
 pub(crate) fn routes() -> Router<AppState> {
     Router::new()
         .route("/described", get(get_described_nodes))
-        .route("/annotation/:node_id", get(get_node_annotation))
+        .route("/annotation/{node_id}", get(get_node_annotation))
         .layer(CompressionLayer::new())
 }
 

--- a/nym-api/src/nym_nodes/handlers/v3.rs
+++ b/nym-api/src/nym_nodes/handlers/v3.rs
@@ -169,7 +169,7 @@ async fn known_network_monitor(
 fn stress_testing_routes() -> Router<AppState> {
     Router::new()
         .route("/batch-submit", post(batch_submit_stress_testing_results))
-        .route("/known-monitors/:identity_key", get(known_network_monitor))
+        .route("/known-monitors/{identity_key}", get(known_network_monitor))
 }
 
 /// Build the `/v3/nym-nodes` subtree hosting the v3 network-monitor endpoints.

--- a/nym-api/src/support/http/router.rs
+++ b/nym-api/src/support/http/router.rs
@@ -167,3 +167,17 @@ impl ApiHttpServer {
         .await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Axum 0.8 panics inside `.route(...)` when given the legacy `:param`
+    /// path syntax. That panic never fires at `cargo check` time, so a regression
+    /// only surfaces when nym-api boots. This test exercises the whole route tree
+    /// to catch such regressions in CI.
+    #[test]
+    fn default_router_builds_without_panic() {
+        let _ = RouterBuilder::with_default_routes(false, None);
+    }
+}

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator-requests/src/lib.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator-requests/src/lib.rs
@@ -61,9 +61,9 @@ pub mod routes {
         pub mod results {
             use super::*;
 
-            pub const TESTRUN_BY_ID: &str = "/testrun/:id";
-            pub const NYM_NODE_BY_NODE_ID: &str = "/nym-node/:node_id";
-            pub const NYM_NODE_TESTRUNS: &str = "/nym-node/:node_id/testruns";
+            pub const TESTRUN_BY_ID: &str = "/testrun/{id}";
+            pub const NYM_NODE_BY_NODE_ID: &str = "/nym-node/{node_id}";
+            pub const NYM_NODE_TESTRUNS: &str = "/nym-node/{node_id}/testruns";
             pub const TESTRUNS_IN_PROGRESS: &str = "/testruns-in-progress";
             pub const TESTRUNS: &str = "/testruns";
             pub const NYM_NODES: &str = "/nym-nodes";

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/http/api/v1/mod.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/http/api/v1/mod.rs
@@ -27,3 +27,20 @@ pub(crate) fn routes(
                 .route_layer(metrics_and_results_auth),
         )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use zeroize::Zeroizing;
+
+    /// Axum 0.8 panics inside `.route(...)` when given the legacy `:param`
+    /// path syntax. That panic never fires at `cargo check` time, so a regression
+    /// only surfaces when the orchestrator boots. This test exercises the whole
+    /// v1 route tree to catch such regressions in CI.
+    #[test]
+    fn v1_router_builds_without_panic() {
+        let dummy_auth = || AuthLayer::new(Arc::new(Zeroizing::new(String::new())));
+        let _ = routes(dummy_auth(), dummy_auth());
+    }
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6824)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP route parameter syntax across API endpoints to prevent runtime errors during router initialization

* **Tests**
  * Added regression tests to validate router construction and HTTP route building, catching potential startup failures related to route syntax incompatibilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym/pull/6824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->