### PR TITLE
[DOCs/operatos]: Release notes/v2026.10-waterloo

### DIFF
--- a/documentation/docs/.npmrc
+++ b/documentation/docs/.npmrc
@@ -1,0 +1,1 @@
+strict-dep-builds=false

--- a/documentation/docs/components/outputs/api-scraping-outputs/nodes-count.json
+++ b/documentation/docs/components/outputs/api-scraping-outputs/nodes-count.json
@@ -1,6 +1,6 @@
 {
-  "nodes": 723,
-  "locations": 76,
-  "mixnodes": 249,
-  "exit_gateways": 466
+  "nodes": 683,
+  "locations": 78,
+  "mixnodes": 243,
+  "exit_gateways": 432
 }

--- a/documentation/docs/components/outputs/api-scraping-outputs/nodes-count.json
+++ b/documentation/docs/components/outputs/api-scraping-outputs/nodes-count.json
@@ -1,6 +1,6 @@
 {
-  "nodes": 683,
+  "nodes": 682,
   "locations": 78,
-  "mixnodes": 243,
+  "mixnodes": 242,
   "exit_gateways": 432
 }

--- a/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
+++ b/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
@@ -1,1 +1,1 @@
-Wednesday, May 20th 2026, 06:27:43 UTC
+Wednesday, May 27th 2026, 11:22:09 UTC

--- a/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
+++ b/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
@@ -1,1 +1,1 @@
-Wednesday, May 27th 2026, 11:22:09 UTC
+Wednesday, May 27th 2026, 11:42:58 UTC

--- a/documentation/docs/components/outputs/command-outputs/node-api-check-query-help.md
+++ b/documentation/docs/components/outputs/command-outputs/node-api-check-query-help.md
@@ -11,7 +11,7 @@ options:
   --no_routing_history  Display node stats without routing history
   --no_verloc_metrics   Display node stats without verloc metrics
   -m, --markdown        Display results in markdown format
-  -o [OUTPUT], --output [OUTPUT]
+  -o, --output [OUTPUT]
                         Save results to file (in current dir or supply with
                         path without filename)
 ```

--- a/documentation/docs/components/outputs/command-outputs/nym-node-cli-install-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-node-cli-install-help.md
@@ -15,8 +15,7 @@ usage: nym-node-cli install [-h] [-V] [-d BRANCH] [-v]
 options:
   -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
-  -d BRANCH, --dev BRANCH
-                        Define github branch (default: develop)
+  -d, --dev BRANCH      Define github branch (default: develop)
   -v, --verbose         Show full error tracebacks
   --mode {mixnode,entry-gateway,exit-gateway}
                         Node mode: 'mixnode', 'entry-gateway', or 'exit-

--- a/documentation/docs/components/outputs/command-outputs/nym-node-run-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-node-run-help.md
@@ -4,87 +4,115 @@ Start this nym-node
 Usage: nym-node run [OPTIONS]
 
 Options:
-      --id <ID>                                                              Id of the nym-node to use [env: NYMNODE_ID=] [default: default-nym-node]
-      --config-file <CONFIG_FILE>                                            Path to a configuration file of this node [env: NYMNODE_CONFIG=]
-      --accept-operator-terms-and-conditions                                 Explicitly specify whether you agree with the terms and conditions of a nym node operator as defined at
-                                                                             <https://nymtech.net/terms-and-conditions/operators/v1.0.0> [env: NYMNODE_ACCEPT_OPERATOR_TERMS=]
-      --deny-init                                                            Forbid a new node from being initialised if configuration file for the provided specification doesn't already exist [env:
-                                                                             NYMNODE_DENY_INIT=]
-      --init-only                                                            If this is a brand new nym-node, specify whether it should only be initialised without actually running the subprocesses [env:
-                                                                             NYMNODE_INIT_ONLY=]
-      --local                                                                Flag specifying this node will be running in a local setting [env: NYMNODE_LOCAL=]
-      --mode [<MODE>...]                                                     Specifies the current mode(s) of this nym-node [env: NYMNODE_MODE=] [possible values: mixnode, entry-gateway, exit-gateway,
-                                                                             exit-providers-only]
-      --modes <MODES>                                                        Specifies the current mode(s) of this nym-node as a single flag [env: NYMNODE_MODES=] [possible values: mixnode, entry-gateway,
-                                                                             exit-gateway, exit-providers-only]
-  -w, --write-changes                                                        If this node has been initialised before, specify whether to write any new changes to the config file [env:
-                                                                             NYMNODE_WRITE_CONFIG_CHANGES=]
-      --bonding-information-output <BONDING_INFORMATION_OUTPUT>              Specify output file for bonding information of this nym-node, i.e. its encoded keys. NOTE: the required bonding information is still a
-                                                                             subject to change and this argument should be treated only as a preview of future features [env: NYMNODE_BONDING_INFORMATION_OUTPUT=]
-  -o, --output <OUTPUT>                                                      Specify the output format of the bonding information (`text` or `json`) [env: NYMNODE_OUTPUT=] [default: text] [possible values: text,
-                                                                             json]
-      --public-ips <PUBLIC_IPS>                                              Comma separated list of public ip addresses that will be announced to the nym-api and subsequently to the clients. In nearly all
-                                                                             circumstances, it's going to be identical to the address you're going to use for bonding [env: NYMNODE_PUBLIC_IPS=]
-      --hostname <HOSTNAME>                                                  Optional hostname associated with this gateway that will be announced to the nym-api and subsequently to the clients [env:
-                                                                             NYMNODE_HOSTNAME=]
-      --location <LOCATION>                                                  Optional **physical** location of this node's server. Either full country name (e.g. 'Poland'), two-letter alpha2 (e.g. 'PL'),
-                                                                             three-letter alpha3 (e.g. 'POL') or three-digit numeric-3 (e.g. '616') can be provided [env: NYMNODE_LOCATION=]
-      --http-bind-address <HTTP_BIND_ADDRESS>                                Socket address this node will use for binding its http API. default: `[::]:8080` [env: NYMNODE_HTTP_BIND_ADDRESS=]
-      --landing-page-assets-path <LANDING_PAGE_ASSETS_PATH>                  Path to assets directory of custom landing page of this node [env: NYMNODE_HTTP_LANDING_ASSETS=]
-      --http-access-token <HTTP_ACCESS_TOKEN>                                An optional bearer token for accessing certain http endpoints. Currently only used for prometheus metrics [env:
-                                                                             NYMNODE_HTTP_ACCESS_TOKEN=]
-      --expose-system-info <EXPOSE_SYSTEM_INFO>                              Specify whether basic system information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_SYSTEM_INFO=] [possible values:
-                                                                             true, false]
-      --expose-system-hardware <EXPOSE_SYSTEM_HARDWARE>                      Specify whether basic system hardware information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_SYSTEM_HARDWARE=]
-                                                                             [possible values: true, false]
-      --expose-crypto-hardware <EXPOSE_CRYPTO_HARDWARE>                      Specify whether detailed system crypto hardware information should be exposed. default: true [env:
-                                                                             NYMNODE_HTTP_EXPOSE_CRYPTO_HARDWARE=] [possible values: true, false]
-      --mixnet-bind-address <MIXNET_BIND_ADDRESS>                            Address this node will bind to for listening for mixnet packets default: `[::]:1789` [env: NYMNODE_MIXNET_BIND_ADDRESS=]
-      --mixnet-announce-port <MIXNET_ANNOUNCE_PORT>                          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node is behind a
-                                                                             proxy [env: NYMNODE_MIXNET_ANNOUNCE_PORT=]
-      --nym-api-urls <NYM_API_URLS>                                          Addresses to nym APIs from which the node gets the view of the network [env: NYMNODE_NYM_APIS=]
-      --nyxd-urls <NYXD_URLS>                                                Addresses to nyxd chain endpoint which the node will use for chain interactions [env: NYMNODE_NYXD=]
-      --enable-console-logging <ENABLE_CONSOLE_LOGGING>                      Specify whether running statistics of this node should be logged to the console [env: NYMNODE_ENABLE_CONSOLE_LOGGING=] [possible
-                                                                             values: true, false]
-      --wireguard-enabled <WIREGUARD_ENABLED>                                Specifies whether the wireguard service is enabled on this node [env: NYMNODE_WG_ENABLED=] [possible values: true, false]
-      --wireguard-bind-address <WIREGUARD_BIND_ADDRESS>                      Socket address this node will use for binding its wireguard interface. default: `[::]:51822` [env: NYMNODE_WG_BIND_ADDRESS=]
-      --wireguard-tunnel-announced-port <WIREGUARD_TUNNEL_ANNOUNCED_PORT>    Tunnel port announced to external clients wishing to connect to the wireguard interface. Useful in the instances where the node is
-                                                                             behind a proxy [env: NYMNODE_WG_ANNOUNCED_PORT=]
-      --wireguard-private-network-prefix <WIREGUARD_PRIVATE_NETWORK_PREFIX>  The prefix denoting the maximum number of the clients that can be connected via Wireguard. The maximum value for IPv4 is 32 and for
-                                                                             IPv6 is 128 [env: NYMNODE_WG_PRIVATE_NETWORK_PREFIX=]
-      --wireguard-userspace <WIREGUARD_USERSPACE>                            Use userspace implementation of WireGuard (wireguard-go) instead of kernel module. Useful in containerized environments without kernel
-                                                                             WireGuard support [env: NYMNODE_WG_USERSPACE=] [possible values: true, false]
-      --verloc-bind-address <VERLOC_BIND_ADDRESS>                            Socket address this node will use for binding its verloc API. default: `[::]:1790` [env: NYMNODE_VERLOC_BIND_ADDRESS=]
-      --verloc-announce-port <VERLOC_ANNOUNCE_PORT>                          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node is behind a
-                                                                             proxy [env: NYMNODE_VERLOC_ANNOUNCE_PORT=]
-      --entry-bind-address <ENTRY_BIND_ADDRESS>                              Socket address this node will use for binding its client websocket API. default: `[::]:9000` [env: NYMNODE_ENTRY_BIND_ADDRESS=]
-      --announce-ws-port <ANNOUNCE_WS_PORT>                                  Custom announced port for listening for websocket client traffic. If unspecified, the value from the `bind_address` will be used
-                                                                             instead [env: NYMNODE_ENTRY_ANNOUNCE_WS_PORT=]
-      --announce-wss-port <ANNOUNCE_WSS_PORT>                                If applicable, announced port for listening for secure websocket client traffic [env: NYMNODE_ENTRY_ANNOUNCE_WSS_PORT=]
-      --enforce-zk-nyms <ENFORCE_ZK_NYMS>                                    Indicates whether this gateway is accepting only coconut credentials for accessing the mixnet or if it also accepts non-paying clients
-                                                                             [env: NYMNODE_ENFORCE_ZK_NYMS=] [possible values: true, false]
-      --mnemonic <MNEMONIC>                                                  Custom cosmos wallet mnemonic used for zk-nym redemption. If no value is provided, a fresh mnemonic is going to be generated [env:
-                                                                             NYMNODE_MNEMONIC=]
-      --upgrade-mode-attestation-url <UPGRADE_MODE_ATTESTATION_URL>          Endpoint to query to retrieve current upgrade mode attestation. This argument should never be set outside testnets and local networks
-                                                                             [env: NYMNODE_UPGRADE_MODE_ATTESTATION_URL=]
-      --upgrade-mode-attester-public-key <UPGRADE_MODE_ATTESTER_PUBLIC_KEY>  Expected public key of the entity signing the published attestation. This argument should never be set outside testnets and local
-                                                                             networks [env: NYMNODE_UPGRADE_MODE_ATTESTER_PUBKEY=]
-      --upstream-exit-policy-url <UPSTREAM_EXIT_POLICY_URL>                  Specifies the url for an upstream source of the exit policy used by this node [env: NYMNODE_UPSTREAM_EXIT_POLICY=]
-      --open-proxy <OPEN_PROXY>                                              Specifies whether this exit node should run in 'open-proxy' mode and thus would attempt to resolve **ANY** request it receives [env:
-                                                                             NYMNODE_OPEN_PROXY=] [possible values: true, false]
-      --nr-allow-local-ips <NR_ALLOW_LOCAL_IPS>                              Allow the network requester to forward traffic to non-globally-routable addresses. Intended for local development, private-network
-                                                                             deployments, and testnet scenarios. Not recommended on production exit gateway unless you know what you're doing [env:
-                                                                             NYMNODE_NR_ALLOW_LOCAL_IPS=] [possible values: true, false]
-      --ipr-allow-local-ips <IPR_ALLOW_LOCAL_IPS>                            Allow the IP packet router to forward traffic to non-globally-routable addresses. Intended for local development, private-network
-                                                                             deployments, and testnet scenarios. Not recommended on production exit gateway unless you know what you're doing [env:
-                                                                             NYMNODE_IPR_ALLOW_LOCAL_IPS=] [possible values: true, false]
-      --lp-control-bind-address <LP_CONTROL_BIND_ADDRESS>                    Bind address for the TCP LP control traffic. default: `[::]:41264` [env: NYMNODE_LP_CONTROL_BIND_ADDRESS=]
-      --lp-control-announce-port <LP_CONTROL_ANNOUNCE_PORT>                  Custom announced port for listening for the TCP LP control traffic. If unspecified, the value from the `lp_control_bind_address` will
-                                                                             be used instead [env: NYMNODE_LP_CONTROL_ANNOUNCE_PORT=]
-      --lp-data-bind-address <LP_DATA_BIND_ADDRESS>                          Bind address for the UDP LP data traffic. default: `[::]:51264` [env: NYMNODE_LP_DATA_BIND_ADDRESS=]
-      --lp-data-announce-port <LP_DATA_ANNOUNCE_PORT>                        Custom announced port for listening for the UDP LP data traffic. If unspecified, the value from the `lp_data_bind_address` will be
-                                                                             used instead [env: NYMNODE_LP_DATA_ANNOUNCE_PORT=]
-      --lp-use-mock-ecash <LP_USE_MOCK_ECASH>                                Use mock ecash manager for LP testing. WARNING: Only use this for local testing! Never enable in production. When enabled, the LP
-                                                                             listener will accept any credential without blockchain verification [env: NYMNODE_LP_USE_MOCK_ECASH=] [possible values: true, false]
-  -h, --help                                                                 Print help
+      --id <ID>
+          Id of the nym-node to use [env: NYMNODE_ID=] [default: default-nym-node]
+      --config-file <CONFIG_FILE>
+          Path to a configuration file of this node [env: NYMNODE_CONFIG=]
+      --accept-operator-terms-and-conditions
+          Explicitly specify whether you agree with the terms and conditions of a nym node operator as defined at <https://nymtech.net/terms-and-conditions/operators/v1.0.0> [env:
+          NYMNODE_ACCEPT_OPERATOR_TERMS=]
+      --deny-init
+          Forbid a new node from being initialised if configuration file for the provided specification doesn't already exist [env: NYMNODE_DENY_INIT=]
+      --init-only
+          If this is a brand new nym-node, specify whether it should only be initialised without actually running the subprocesses [env: NYMNODE_INIT_ONLY=]
+      --local
+          Flag specifying this node will be running in a local setting [env: NYMNODE_LOCAL=]
+      --mode [<MODE>...]
+          Specifies the current mode(s) of this nym-node [env: NYMNODE_MODE=] [possible values: mixnode, entry-gateway, exit-gateway, exit-providers-only]
+      --modes <MODES>
+          Specifies the current mode(s) of this nym-node as a single flag [env: NYMNODE_MODES=] [possible values: mixnode, entry-gateway, exit-gateway, exit-providers-only]
+  -w, --write-changes
+          If this node has been initialised before, specify whether to write any new changes to the config file [env: NYMNODE_WRITE_CONFIG_CHANGES=]
+      --bonding-information-output <BONDING_INFORMATION_OUTPUT>
+          Specify output file for bonding information of this nym-node, i.e. its encoded keys. NOTE: the required bonding information is still a subject to change and this argument should be
+          treated only as a preview of future features [env: NYMNODE_BONDING_INFORMATION_OUTPUT=]
+  -o, --output <OUTPUT>
+          Specify the output format of the bonding information (`text` or `json`) [env: NYMNODE_OUTPUT=] [default: text] [possible values: text, json]
+      --public-ips <PUBLIC_IPS>
+          Comma separated list of public ip addresses that will be announced to the nym-api and subsequently to the clients. In nearly all circumstances, it's going to be identical to the
+          address you're going to use for bonding [env: NYMNODE_PUBLIC_IPS=]
+      --hostname <HOSTNAME>
+          Optional hostname associated with this gateway that will be announced to the nym-api and subsequently to the clients [env: NYMNODE_HOSTNAME=]
+      --location <LOCATION>
+          Optional **physical** location of this node's server. Either full country name (e.g. 'Poland'), two-letter alpha2 (e.g. 'PL'), three-letter alpha3 (e.g. 'POL') or three-digit
+          numeric-3 (e.g. '616') can be provided [env: NYMNODE_LOCATION=]
+      --http-bind-address <HTTP_BIND_ADDRESS>
+          Socket address this node will use for binding its http API. default: `[::]:8080` [env: NYMNODE_HTTP_BIND_ADDRESS=]
+      --landing-page-assets-path <LANDING_PAGE_ASSETS_PATH>
+          Path to assets directory of custom landing page of this node [env: NYMNODE_HTTP_LANDING_ASSETS=]
+      --http-access-token <HTTP_ACCESS_TOKEN>
+          An optional bearer token for accessing certain http endpoints. Currently only used for prometheus metrics [env: NYMNODE_HTTP_ACCESS_TOKEN=]
+      --expose-system-info <EXPOSE_SYSTEM_INFO>
+          Specify whether basic system information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_SYSTEM_INFO=] [possible values: true, false]
+      --expose-system-hardware <EXPOSE_SYSTEM_HARDWARE>
+          Specify whether basic system hardware information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_SYSTEM_HARDWARE=] [possible values: true, false]
+      --expose-crypto-hardware <EXPOSE_CRYPTO_HARDWARE>
+          Specify whether detailed system crypto hardware information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_CRYPTO_HARDWARE=] [possible values: true, false]
+      --mixnet-bind-address <MIXNET_BIND_ADDRESS>
+          Address this node will bind to for listening for mixnet packets default: `[::]:1789` [env: NYMNODE_MIXNET_BIND_ADDRESS=]
+      --mixnet-announce-port <MIXNET_ANNOUNCE_PORT>
+          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node is behind a proxy [env: NYMNODE_MIXNET_ANNOUNCE_PORT=]
+      --nym-api-urls <NYM_API_URLS>
+          Addresses to nym APIs from which the node gets the view of the network [env: NYMNODE_NYM_APIS=]
+      --nyxd-urls <NYXD_URLS>
+          Addresses to nyxd chain endpoint which the node will use for chain interactions [env: NYMNODE_NYXD=]
+      --enable-console-logging <ENABLE_CONSOLE_LOGGING>
+          Specify whether running statistics of this node should be logged to the console [env: NYMNODE_ENABLE_CONSOLE_LOGGING=] [possible values: true, false]
+      --wireguard-enabled <WIREGUARD_ENABLED>
+          Specifies whether the wireguard service is enabled on this node [env: NYMNODE_WG_ENABLED=] [possible values: true, false]
+      --wireguard-bind-address <WIREGUARD_BIND_ADDRESS>
+          Socket address this node will use for binding its wireguard interface. default: `[::]:51822` [env: NYMNODE_WG_BIND_ADDRESS=]
+      --wireguard-tunnel-announced-port <WIREGUARD_TUNNEL_ANNOUNCED_PORT>
+          Tunnel port announced to external clients wishing to connect to the wireguard interface. Useful in the instances where the node is behind a proxy [env: NYMNODE_WG_ANNOUNCED_PORT=]
+      --wireguard-private-network-prefix <WIREGUARD_PRIVATE_NETWORK_PREFIX>
+          The prefix denoting the maximum number of the clients that can be connected via Wireguard. The maximum value for IPv4 is 32 and for IPv6 is 128 [env:
+          NYMNODE_WG_PRIVATE_NETWORK_PREFIX=]
+      --wireguard-userspace <WIREGUARD_USERSPACE>
+          Use userspace implementation of WireGuard (wireguard-go) instead of kernel module. Useful in containerized environments without kernel WireGuard support [env: NYMNODE_WG_USERSPACE=]
+          [possible values: true, false]
+      --verloc-bind-address <VERLOC_BIND_ADDRESS>
+          Socket address this node will use for binding its verloc API. default: `[::]:1790` [env: NYMNODE_VERLOC_BIND_ADDRESS=]
+      --verloc-announce-port <VERLOC_ANNOUNCE_PORT>
+          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node is behind a proxy [env: NYMNODE_VERLOC_ANNOUNCE_PORT=]
+      --entry-bind-address <ENTRY_BIND_ADDRESS>
+          Socket address this node will use for binding its client websocket API. default: `[::]:9000` [env: NYMNODE_ENTRY_BIND_ADDRESS=]
+      --announce-ws-port <ANNOUNCE_WS_PORT>
+          Custom announced port for listening for websocket client traffic. If unspecified, the value from the `bind_address` will be used instead [env: NYMNODE_ENTRY_ANNOUNCE_WS_PORT=]
+      --announce-wss-port <ANNOUNCE_WSS_PORT>
+          If applicable, announced port for listening for secure websocket client traffic [env: NYMNODE_ENTRY_ANNOUNCE_WSS_PORT=]
+      --enforce-zk-nyms <ENFORCE_ZK_NYMS>
+          Indicates whether this gateway is accepting only coconut credentials for accessing the mixnet or if it also accepts non-paying clients [env: NYMNODE_ENFORCE_ZK_NYMS=] [possible
+          values: true, false]
+      --mnemonic <MNEMONIC>
+          Custom cosmos wallet mnemonic used for zk-nym redemption. If no value is provided, a fresh mnemonic is going to be generated [env: NYMNODE_MNEMONIC=]
+      --upgrade-mode-attestation-url <UPGRADE_MODE_ATTESTATION_URL>
+          Endpoint to query to retrieve current upgrade mode attestation. This argument should never be set outside testnets and local networks [env: NYMNODE_UPGRADE_MODE_ATTESTATION_URL=]
+      --upgrade-mode-attester-public-key <UPGRADE_MODE_ATTESTER_PUBLIC_KEY>
+          Expected public key of the entity signing the published attestation. This argument should never be set outside testnets and local networks [env:
+          NYMNODE_UPGRADE_MODE_ATTESTER_PUBKEY=]
+      --upstream-exit-policy-url <UPSTREAM_EXIT_POLICY_URL>
+          Specifies the url for an upstream source of the exit policy used by this node [env: NYMNODE_UPSTREAM_EXIT_POLICY=]
+      --open-proxy <OPEN_PROXY>
+          Specifies whether this exit node should run in 'open-proxy' mode and thus would attempt to resolve **ANY** request it receives [env: NYMNODE_OPEN_PROXY=] [possible values: true,
+          false]
+      --nr-allow-local-ips <NR_ALLOW_LOCAL_IPS>
+          Allow the network requester to forward traffic to non-globally-routable addresses. Intended for local development, private-network deployments, and testnet scenarios. Not
+          recommended on production exit gateway unless you know what you're doing [env: NYMNODE_NR_ALLOW_LOCAL_IPS=] [possible values: true, false]
+      --ipr-allow-local-ips <IPR_ALLOW_LOCAL_IPS>
+          Allow the IP packet router to forward traffic to non-globally-routable addresses. Intended for local development, private-network deployments, and testnet scenarios. Not recommended
+          on production exit gateway unless you know what you're doing [env: NYMNODE_IPR_ALLOW_LOCAL_IPS=] [possible values: true, false]
+      --lp-control-bind-address <LP_CONTROL_BIND_ADDRESS>
+          Bind address for the TCP LP control traffic. default: `[::]:41264` [env: NYMNODE_LP_CONTROL_BIND_ADDRESS=]
+      --lp-control-announce-port <LP_CONTROL_ANNOUNCE_PORT>
+          Custom announced port for listening for the TCP LP control traffic. If unspecified, the value from the `lp_control_bind_address` will be used instead [env:
+          NYMNODE_LP_CONTROL_ANNOUNCE_PORT=]
+      --lp-data-bind-address <LP_DATA_BIND_ADDRESS>
+          Bind address for the UDP LP data traffic. default: `[::]:51264` [env: NYMNODE_LP_DATA_BIND_ADDRESS=]
+      --lp-data-announce-port <LP_DATA_ANNOUNCE_PORT>
+          Custom announced port for listening for the UDP LP data traffic. If unspecified, the value from the `lp_data_bind_address` will be used instead [env: NYMNODE_LP_DATA_ANNOUNCE_PORT=]
+      --lp-use-mock-ecash <LP_USE_MOCK_ECASH>
+          Use mock ecash manager for LP testing. WARNING: Only use this for local testing! Never enable in production. When enabled, the LP listener will accept any credential without
+          blockchain verification [env: NYMNODE_LP_USE_MOCK_ECASH=] [possible values: true, false]
+  -h, --help
+          Print help
 ```

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -64,11 +64,8 @@ This page displays a full list of all the changes during our release cycle from 
 - [`nym-node`](nodes/nym-node.mdx) version `1.32.0`
 
 ```sh
-
-
+NODE VERSION HERE ! ! ! !
 ```
-
-
 
 ### Operators Tools
 

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -72,7 +72,7 @@ NODE VERSION HERE ! ! ! !
 <Callout type="error" emoji="🚨">
 **Two breaking issues requiring attention:**
 
-1. We ask all operators to **migrate away from WorkTitans B.V. ([AS209847](https://ipinfo.io/AS209847))**, also known as _the.hosting_, _PQ-Hosting_ and _Stark Industries_! Please read the [info below]()
+1. We ask all operators to **migrate away from WorkTitans B.V. ([AS209847](https://ipinfo.io/AS209847))**, also known as _the.hosting_, _PQ-Hosting_ and _Stark Industries_! Please read the [info below](#migrate-away-from-thehosting).
 
 1. [**Security steps required**](/operators/troubleshooting/vps-isp#security-patch-copyfail--dirtyfrag): Several critical [Linux kernel vulnerabilities](https://ubuntu.com/blog/copy-fail-vulnerability-fixes-available) had been disclosed. Check out your servers and if needed apply required mitigations!
 </Callout>

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -64,7 +64,16 @@ This page displays a full list of all the changes during our release cycle from 
 - [`nym-node`](nodes/nym-node.mdx) version `1.32.0`
 
 ```sh
-NODE VERSION HERE ! ! ! !
+nym-node
+Binary Name:        nym-node
+Build Timestamp:    2026-05-27T12:46:38.359447083Z
+Build Version:      1.32.0
+Commit SHA:         25eba09b92cff648cd37bdd7f0921e710eed25f5
+Commit Date:        2026-05-27T11:00:31.000000000+02:00
+Commit Branch:      HEAD
+rustc Version:      1.91.1
+rustc Channel:      stable
+cargo Profile:      release
 ```
 
 ### Operators Tools

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -135,7 +135,7 @@ ansible-playbook deploy.yml -t ntm
 
 - [**New docs**](https://github.com/nymtech/nym/pull/6716): Max's leg work on [exit services documentation](/network/infrastructure/exit-services), [`Mixfetch`](/developers/mix-fetch) and [`smolmix`](/developers/smolmix)
 
-#### Migrate away from *The Hosting*
+#### Migrate away from The Hosting
 
 **WorkTitans B.V. ([AS209847](https://ipinfo.io/AS209847))**, also known as _the.hosting_, _PQ-Hosting_ and _Stark Industries_, has been [seized by Dutch authorities](https://securityaffairs.com/192602/intelligence/dutch-authorities-dismantle-hosting-network-allegedly-used-for-cyberattacks-and-disinformation.html). Infrastructure in the United States, Germany, the Netherlands and Austria was permanently lost — **nodes hosted there are gone and cannot be restored.**
 

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -149,7 +149,7 @@ This provider had been the most popular choice among Nym node operators for year
 - When researching alternatives, check [_The ISP List_](/operators/community-counsel/isp-list) and please submit a PR if you find anything outdated
 - We are in talks with several providers to establish mission-aligned partnerships and negotiate discounts on dedicated servers, will keep you updated
 
-This situation is a reminder of why we have [Operator Terms and Conditions with zero logging tollerance](/operators/nodes/nym-node/setup#terms--conditions) and do active steps to reinforce the security model described in our [latest Operators Town Hall](https://www.youtube.com/watch?v=j8WWBY8ewXE).
+This situation is a reminder of why we have [Operator Terms and Conditions with zero logging tolerance](/operators/nodes/nym-node/setup#terms--conditions) and do active steps to reinforce the security model described in our [latest Operators Town Hall](https://www.youtube.com/watch?v=j8WWBY8ewXE).
 
 #### Operators UX Improvements
 

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -153,11 +153,13 @@ This situation is a reminder of why we have [Operator Terms and Conditions with 
 
 #### Operators UX Improvements
 
-- [NTM: Split IPv4 / IPv6 uplinks](https://github.com/nymtech/nym/pull/6640): Now NTM can work with different uplink interfaces for IPv4 and IPv6
+- [**NTM: Split IPv4 / IPv6 uplinks**](https://github.com/nymtech/nym/pull/6640): Now NTM can work with different uplink interfaces for IPv4 and IPv6
 
-- [Nym Node CLI: Split IPv4 / IPv6 uplinks](https://github.com/nymtech/nym/pull/6743): `nym-node-cli.py` uplinks sync up with NTM
+- [**Nym Node CLI: Split IPv4 / IPv6 uplinks**](https://github.com/nymtech/nym/pull/6743): `nym-node-cli.py` uplinks sync up with NTM
 
-- [NTM & Nym Node CLI: Alternative SSH port](https://github.com/nymtech/nym/pull/6633): Operators can use these tools with `HOST_SSH_PORT` allowing them to define any alternative port instead of only using hard-coded 22
+- [**NTM & Nym Node CLI: Alternative SSH port**](https://github.com/nymtech/nym/pull/6633): Operators can use these tools with `HOST_SSH_PORT` allowing them to define any alternative port instead of only using hard-coded 22
+
+- [**Token Rewards SpectreDAO Explorer page**](https://explorer.nym.spectredao.net/rewards): The most favorite Nym explorer of the year is shipping another feature, showing rewards and much more in a nice GUI
 
 ### Features
 

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -58,7 +58,19 @@ This page displays a full list of all the changes during our release cycle from 
 
 <VarInfo />
 
-## Operators Tools
+## `v2026.10-waterloo`
+
+- [Release Binaries](https://github.com/nymtech/nym/releases/tag/nym-binaries-v2026.10-waterloo)
+- [`nym-node`](nodes/nym-node.mdx) version `1.32.0`
+
+```sh
+
+
+```
+
+
+
+### Operators Tools
 
 As the upcoming platform release has been posponed, we prepared this indenpendent release of tools and updates important for node operators. 
 
@@ -121,13 +133,71 @@ ansible-playbook deploy.yml -t ntm
 
 - [**New docs**](https://github.com/nymtech/nym/pull/6716): Max's leg work on [exit services documentation](/network/infrastructure/exit-services), [`Mixfetch`](/developers/mix-fetch) and [`smolmix`](/developers/smolmix)
 
-### Operators UX Improvements
+#### Operators UX Improvements
 
 - [NTM: Split IPv4 / IPv6 uplinks](https://github.com/nymtech/nym/pull/6640): Now NTM can work with different uplink interfaces for IPv4 and IPv6
 
 - [Nym Node CLI: Split IPv4 / IPv6 uplinks](https://github.com/nymtech/nym/pull/6743): `nym-node-cli.py` uplinks sync up with NTM
 
 - [NTM & Nym Node CLI: Alternative SSH port](https://github.com/nymtech/nym/pull/6633): Operators can use these tools with `HOST_SSH_PORT` allowing them to define any alternative port instead of only using hard-coded 22
+
+### Features
+
+- [Re-order default API urls for network details - Waterloo release](https://github.com/nymtech/nym/pull/6799): 
+
+- [Add workflows for NM3](https://github.com/nymtech/nym/pull/6729): Added automated GitHub Actions workflows to streamline deployment of network monitor components to the container registry with optional release versioning
+
+- [Credential proxy pool](https://github.com/nymtech/nym/pull/6726)
+
+- [NMv3 updated performance calculation](https://github.com/nymtech/nym/pull/6714): Wire stress-testing scores submitted by the network-monitor orchestrator into nym-api's node performance calculation, behind a config gate and an availability guard so an orchestrator outage cannot silently slash every node's score.
+ 
+- [NMv3: submission of stress testing result into nym-api](https://github.com/nymtech/nym/pull/6709): Allow the network monitor orchestrator to submit stress-testing results to the nym-api over a signed, authenticated channel.
+
+- [NMv3: Prometheus metrics for network monitor](https://github.com/nymtech/nym/pull/6693): Wires up a `/v1/metrics/prometheus` scrape endpoint for the v3 orchestrator, along with the metric variants it exposes and the call-site instrumentation that feeds them. The handle follows the existing nym-node wrapper pattern: a singleton `PROMETHEUS_METRICS` backed by `nym_metrics`, with every variant pre-registered at startup so scrapes never see a missing series.
+
+- [NMv3: add read-only results API to orchestrator](https://github.com/nymtech/nym/pull/6689): Read in detail summary [here]((https://github.com/nymtech/nym/pull/6689))
+
+- [NMv3: Eviction of stale testrun data](https://github.com/nymtech/nym/pull/6685): Read in detail summary [here](https://github.com/nymtech/nym/pull/6685)
+
+- [Nym Wallet: deps updates, clipboard/updater/, icon, polishing...](https://github.com/nymtech/nym/pull/6681): Rolls together desktop wallet UX polish, and operational fixes we have been carrying in the branch. The goal is safer defaults, less noisy background behaviour.
+
+- [NMv3: Wire up testrun assignment and result submission flow](https://github.com/nymtech/nym/pull/6680): Read in detail summary [here](https://github.com/nymtech/nym/pull/6680)
+
+- [NMv3: Support multiple network monitor agents per host](https://github.com/nymtech/nym/pull/6679): Read in detail summary [here](https://github.com/nymtech/nym/pull/6679)
+
+- [NMv3 agent announcement](https://github.com/nymtech/nym/pull/6673): Read in detail summary [here](https://github.com/nymtech/nym/pull/6673)
+
+- [Add node refresher for periodic scraping of bonded nym-node details](https://github.com/nymtech/nym/pull/6626)
+
+- [NMv3 orchestrator queue](https://github.com/nymtech/nym/pull/6597): This PR bootstraps the orchestrator side of the v3 network monitor. It introduces the persistent storage layer, configuration, CLI wiring, and the initial NetworkMonitorOrchestrator struct - everything needed before the actual scheduling and HTTP server logic lands in follow-up PRs.
+
+- [Network monitor agent - standalone node stress-testing](https://github.com/nymtech/nym/pull/6582): Introduces the nym-network-monitor-agent binary. The agent can connect to a single mixnode and run a controlled stress test against it without requiring an orchestrator, making it useful for manual diagnostics as well as the foundation for the future automated pipeline.
+
+- [Propagate NM agent noise keys to `nym-node` routing](https://github.com/nymtech/nym/pull/6577): Network Monitor agents need to perform Noise protocol handshakes with `nym-node`s, just like any other `nym-node` on the network. Previously the contract stored only the agent's IP address, and the noise key map in `nym-node` only tracked keys for `nym-api`-sourced nodes. This PR closes the gap end-to-end: from on-chain registration through to live packet routing.
+
+- [Start mix stress testing topic branch](https://github.com/nymtech/nym/pull/6575)
+
+- [NMv3 agents subscription](https://github.com/nymtech/nym/pull/6567): This PR introduces real-time blockchain monitoring for network monitor agent authorizations and implements replay protection bypass for authorized network monitor (NM) agents. This allows NM agents to perform node stress testing, while maintaining security for regular traffic.
+
+### Bugfix
+
+- [IPR v8\<\-\>v9 mismatch on Waterloo](https://github.com/nymtech/nym/pull/6772)
+
+
+
+
+
+### Refactors & Maintenance
+
+- [Migrate to hickory `0.26.1`](https://github.com/nymtech/nym/pull/6751): Migrate to hickory `0.26.1`. Fixes recent CVEs reported over GitHub
+
+- [Made sphinx version threshold assertion a compile time check](https://github.com/nymtech/nym/pull/6718)
+
+
+
+
+
+
 
 ## `v2026.9-venaco`
 

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -175,7 +175,7 @@ This situation is a reminder of why we have [Operator Terms and Conditions with 
 
 - [NMv3: Prometheus metrics for network monitor](https://github.com/nymtech/nym/pull/6693): Wires up a `/v1/metrics/prometheus` scrape endpoint for the v3 orchestrator, along with the metric variants it exposes and the call-site instrumentation that feeds them. The handle follows the existing nym-node wrapper pattern: a singleton `PROMETHEUS_METRICS` backed by `nym_metrics`, with every variant pre-registered at startup so scrapes never see a missing series.
 
-- [NMv3: add read-only results API to orchestrator](https://github.com/nymtech/nym/pull/6689): Read in detail summary [here]((https://github.com/nymtech/nym/pull/6689))
+- [NMv3: add read-only results API to orchestrator](https://github.com/nymtech/nym/pull/6689): Read in detail summary [here](https://github.com/nymtech/nym/pull/6689)
 
 - [NMv3: Eviction of stale testrun data](https://github.com/nymtech/nym/pull/6685): Read in detail summary [here](https://github.com/nymtech/nym/pull/6685)
 

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -72,11 +72,16 @@ This page displays a full list of all the changes during our release cycle from 
 
 ### Operators Tools
 
-As the upcoming platform release has been posponed, we prepared this indenpendent release of tools and updates important for node operators. 
-
 <Callout type="error" emoji="🚨">
-[**Security steps required**](/operators/troubleshooting/vps-isp#security-patch-copyfail--dirtyfrag): Several critical [Linux kernel vulnerabilities](https://ubuntu.com/blog/copy-fail-vulnerability-fixes-available) had been disclosed. Check out your servers and if needed apply required mitigations!
+**Two breaking issues requiring attention:**
+
+1. We ask all operators to **migrate away from WorkTitans B.V. ([AS209847](https://ipinfo.io/AS209847))**, also known as _the.hosting_, _PQ-Hosting_ and _Stark Industries_! Please read the [info below]()
+
+1. [**Security steps required**](/operators/troubleshooting/vps-isp#security-patch-copyfail--dirtyfrag): Several critical [Linux kernel vulnerabilities](https://ubuntu.com/blog/copy-fail-vulnerability-fixes-available) had been disclosed. Check out your servers and if needed apply required mitigations!
 </Callout>
+
+- [**New Nym Wallet `v1.2.20`**](https://github.com/nymtech/nym/releases/tag/nym-wallet-v1.2.20) 
+
 
 - [**NIP-11 - NTM updated: Telegram voice and video call works now!**](https://github.com/nymtech/nym/pull/6807) Please re-run [Nym network tunnel manager](https://raw.githubusercontent.com/nymtech/nym/refs/heads/develop/scripts/nym-node-setup/network-tunnel-manager.sh) (NTM) on your hosting servers:
 
@@ -133,6 +138,22 @@ ansible-playbook deploy.yml -t ntm
 
 - [**New docs**](https://github.com/nymtech/nym/pull/6716): Max's leg work on [exit services documentation](/network/infrastructure/exit-services), [`Mixfetch`](/developers/mix-fetch) and [`smolmix`](/developers/smolmix)
 
+#### Migrate away from *the.Hosting*
+
+**WorkTitans B.V. ([AS209847](https://ipinfo.io/AS209847))**, also known as _the.hosting_, _PQ-Hosting_ and _Stark Industries_, has been [seized by Dutch authorities](https://securityaffairs.com/192602/intelligence/dutch-authorities-dismantle-hosting-network-allegedly-used-for-cyberattacks-and-disinformation.html). Infrastructure in the United States, Germany, the Netherlands and Austria was permanently lost — **nodes hosted there are gone and cannot be restored.**
+
+This provider had been the most popular choice among Nym node operators for years, combining solid services, broad location coverage, good port speeds, unlimited bandwidth and crypto payments. Despite this, it repeatedly proved unreliable and put operations at risk in terms of reliability, security and privacy.
+
+##### Action Steps
+
+- **All operators must move away from [the.hosting](https://the.hosting/en/) (WorkTitans B.V., [AS209847](https://ipinfo.io/AS209847)) as soon as possible**
+- **If your nodes are under SGP, this is a requirement — please act within one month**
+- **If this affects your locations or grant size, contact us before purchasing new servers**
+- When researching alternatives, check [_The ISP List_](https://nym.com/docs/operators/community-counsel/isp-list) and please submit a PR if you find anything outdated
+- We are in talks with several providers to establish mission-aligned partnerships and negotiate discounts on dedicated servers, will keep you updated
+
+This situation is a reminder of why we have [Operator Terms and Conditions with zero logging tollerance](/operators/nodes/nym-node/setup#terms--conditions) and do active steps to reinforce the security model described in our [latest Operators Town Hall](https://www.youtube.com/watch?v=j8WWBY8ewXE).
+
 #### Operators UX Improvements
 
 - [NTM: Split IPv4 / IPv6 uplinks](https://github.com/nymtech/nym/pull/6640): Now NTM can work with different uplink interfaces for IPv4 and IPv6
@@ -179,24 +200,17 @@ ansible-playbook deploy.yml -t ntm
 
 - [NMv3 agents subscription](https://github.com/nymtech/nym/pull/6567): This PR introduces real-time blockchain monitoring for network monitor agent authorizations and implements replay protection bypass for authorized network monitor (NM) agents. This allows NM agents to perform node stress testing, while maintaining security for regular traffic.
 
+- [NMv3 agents contract](https://github.com/nymtech/nym/pull/6555): This PR introduces the smart contract storing information about ip addresses of the authorised NM agents.
+
 ### Bugfix
 
 - [IPR v8\<\-\>v9 mismatch on Waterloo](https://github.com/nymtech/nym/pull/6772)
-
-
-
-
 
 ### Refactors & Maintenance
 
 - [Migrate to hickory `0.26.1`](https://github.com/nymtech/nym/pull/6751): Migrate to hickory `0.26.1`. Fixes recent CVEs reported over GitHub
 
 - [Made sphinx version threshold assertion a compile time check](https://github.com/nymtech/nym/pull/6718)
-
-
-
-
-
 
 
 ## `v2026.9-venaco`

--- a/documentation/docs/pages/operators/changelog.mdx
+++ b/documentation/docs/pages/operators/changelog.mdx
@@ -72,7 +72,7 @@ NODE VERSION HERE ! ! ! !
 <Callout type="error" emoji="🚨">
 **Two breaking issues requiring attention:**
 
-1. We ask all operators to **migrate away from WorkTitans B.V. ([AS209847](https://ipinfo.io/AS209847))**, also known as _the.hosting_, _PQ-Hosting_ and _Stark Industries_! Please read the [info below](#migrate-away-from-thehosting).
+1. We ask all operators to **migrate away from WorkTitans B.V. ([AS209847](https://ipinfo.io/AS209847))**, also known as _the.hosting_, _PQ-Hosting_ and _Stark Industries_! Please read the [info below](#migrate-away-from-the-hosting).
 
 1. [**Security steps required**](/operators/troubleshooting/vps-isp#security-patch-copyfail--dirtyfrag): Several critical [Linux kernel vulnerabilities](https://ubuntu.com/blog/copy-fail-vulnerability-fixes-available) had been disclosed. Check out your servers and if needed apply required mitigations!
 </Callout>
@@ -135,7 +135,7 @@ ansible-playbook deploy.yml -t ntm
 
 - [**New docs**](https://github.com/nymtech/nym/pull/6716): Max's leg work on [exit services documentation](/network/infrastructure/exit-services), [`Mixfetch`](/developers/mix-fetch) and [`smolmix`](/developers/smolmix)
 
-#### Migrate away from *the.Hosting*
+#### Migrate away from *The Hosting*
 
 **WorkTitans B.V. ([AS209847](https://ipinfo.io/AS209847))**, also known as _the.hosting_, _PQ-Hosting_ and _Stark Industries_, has been [seized by Dutch authorities](https://securityaffairs.com/192602/intelligence/dutch-authorities-dismantle-hosting-network-allegedly-used-for-cyberattacks-and-disinformation.html). Infrastructure in the United States, Germany, the Netherlands and Austria was permanently lost — **nodes hosted there are gone and cannot be restored.**
 
@@ -146,7 +146,7 @@ This provider had been the most popular choice among Nym node operators for year
 - **All operators must move away from [the.hosting](https://the.hosting/en/) (WorkTitans B.V., [AS209847](https://ipinfo.io/AS209847)) as soon as possible**
 - **If your nodes are under SGP, this is a requirement — please act within one month**
 - **If this affects your locations or grant size, contact us before purchasing new servers**
-- When researching alternatives, check [_The ISP List_](https://nym.com/docs/operators/community-counsel/isp-list) and please submit a PR if you find anything outdated
+- When researching alternatives, check [_The ISP List_](/operators/community-counsel/isp-list) and please submit a PR if you find anything outdated
 - We are in talks with several providers to establish mission-aligned partnerships and negotiate discounts on dedicated servers, will keep you updated
 
 This situation is a reminder of why we have [Operator Terms and Conditions with zero logging tollerance](/operators/nodes/nym-node/setup#terms--conditions) and do active steps to reinforce the security model described in our [latest Operators Town Hall](https://www.youtube.com/watch?v=j8WWBY8ewXE).

--- a/documentation/docs/pages/operators/nodes/nym-node/setup.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/setup.mdx
@@ -19,16 +19,7 @@ This documentation page provides a guide on how to set up and run a [NYM NODE](.
 ## Current version
 
 ```sh
-nym-node
-Binary Name:        nym-node
-Build Timestamp:    2026-05-06T05:19:51.973494120Z
-Build Version:      1.31.0
-Commit SHA:         f84de25302e886d4bd97a898885c569724c002a7
-Commit Date:        2026-05-06T07:16:42.000000000+02:00
-Commit Branch:      HEAD
-rustc Version:      1.91.1
-rustc Channel:      stable
-cargo Profile:      release
+NODE VERSION HERE ! ! !
 ```
 
 Detailed version archive and release notes is documented [here](../../changelog.mdx).

--- a/documentation/docs/pages/operators/nodes/nym-node/setup.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/setup.mdx
@@ -19,7 +19,16 @@ This documentation page provides a guide on how to set up and run a [NYM NODE](.
 ## Current version
 
 ```sh
-NODE VERSION HERE ! ! !
+nym-node
+Binary Name:        nym-node
+Build Timestamp:    2026-05-27T12:46:38.359447083Z
+Build Version:      1.32.0
+Commit SHA:         25eba09b92cff648cd37bdd7f0921e710eed25f5
+Commit Date:        2026-05-27T11:00:31.000000000+02:00
+Commit Branch:      HEAD
+rustc Version:      1.91.1
+rustc Channel:      stable
+cargo Profile:      release
 ```
 
 Detailed version archive and release notes is documented [here](../../changelog.mdx).


### PR DESCRIPTION
Routine changelog for platform release, this time with a lot of content:

**Operators**

- New wallet
- New feat/page 'Rewards' in SpectreDAO explorer
- CVE mitigation steps
- Callout to migrate away from the.hosting
- Many UX improvements
- @mfahampshire network updates
- NIP-11 NTM update

**Dev**

- NMv3 everything
- Stress testing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6827)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated network node-count metrics snapshot.
  * Updated a displayed UTC timestamp.
  * Clarified CLI help option formatting (output and install flags) and reformatted command help for readability.
  * Added v2026.10-waterloo release with migration guidance, operator UX improvements, features, and fixes.
  * Updated node setup build metadata to new release values.
  * Adjusted documentation package npm config to disable strict dependency builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nymtech/nym/pull/6827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->