### PR TITLE
[DOCs/operators]: New operators menu

### DIFF
--- a/documentation/docs/components/outputs/api-scraping-outputs/nodes-count.json
+++ b/documentation/docs/components/outputs/api-scraping-outputs/nodes-count.json
@@ -1,6 +1,6 @@
 {
-  "nodes": 682,
-  "locations": 76,
-  "mixnodes": 239,
-  "exit_gateways": 435
+  "nodes": 677,
+  "locations": 77,
+  "mixnodes": 240,
+  "exit_gateways": 429
 }

--- a/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
+++ b/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
@@ -1,1 +1,1 @@
-Thursday, June 4th 2026, 09:20:29 UTC
+Thursday, June 4th 2026, 11:40:35 UTC

--- a/documentation/docs/pages/operators/_meta.json
+++ b/documentation/docs/pages/operators/_meta.json
@@ -3,17 +3,23 @@
   "changelog": "Changelog",
   "release-cycle": "Release Cycle",
   "variables": "Variables & Parameters",
-  "sandbox": "Sandbox Testnet",
-  "binaries": "Binaries",
+  "---1": {
+    "type": "separator"
+  },
   "nodes": "Nodes & Validators Guides",
+  "binaries": "Binaries",
   "orchestration" : "Orchestration",
   "performance-and-testing": "Performance Measurement",
   "tools": "Tools",
   "troubleshooting": "Troubleshooting",
+  "---2": {
+    "type": "separator"
+  },
+  "sandbox": "Sandbox Testnet",  
   "tokenomics": "Tokenomics",
   "faq": "FAQ",
   "community-counsel": "Community Counsel",
-  "---": {
+  "---3": {
     "type": "separator"
   },
   "archive": "Archive",

--- a/documentation/docs/pages/styles.css
+++ b/documentation/docs/pages/styles.css
@@ -537,3 +537,15 @@ html:not(.dark) .landing-card {
     margin-bottom: 1.5rem;
   }
 }
+
+
+/* Bold pages/operators/nodes sidebar item */
+html.dark .nextra-sidebar-container a[href="/docs/operators/nodes"] {
+  color: var(--textPrimary) !important;
+  font-weight: 700;
+}
+
+html:not(.dark) .nextra-sidebar-container a[href="/docs/operators/nodes"] {
+  color: #111 !important;
+  font-weight: 700;
+}


### PR DESCRIPTION
Re-shuffle operators menu and adding bold for the main part.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6853)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized operators documentation navigation structure and hierarchy.
  * Updated node network statistics (nodes, locations, mixnodes, exit gateways counts).
  * Updated timestamp information in documentation.

* **Style**
  * Enhanced sidebar styling with dark and light mode support for operators documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->