### PR TITLE
Safe account removal in password wallets and more reliable network switching

### DIFF
--- a/nym-wallet/src-tauri/src/error.rs
+++ b/nym-wallet/src-tauri/src/error.rs
@@ -110,6 +110,12 @@ pub enum BackendError {
     WalletDifferentPasswordDetected,
     #[error("Unexpected mnemonic account for login")]
     WalletUnexpectedMnemonicAccount,
+    #[error(
+        "Cannot remove the only stored account. Back up and remove the wallet file to reset entirely."
+    )]
+    WalletCannotRemoveLastAccount,
+    #[error("Switch to another account before removing the active account")]
+    WalletCannotRemoveActiveAccount,
     #[error("Failed to derive address from mnemonic")]
     FailedToDeriveAddress,
     #[error("Built-in HD derivation path constant failed to parse (internal error)")]

--- a/nym-wallet/src-tauri/src/main.rs
+++ b/nym-wallet/src-tauri/src/main.rs
@@ -53,6 +53,7 @@ fn main() {
             mixnet::account::create_password,
             mixnet::account::does_password_file_exist,
             mixnet::account::get_balance,
+            mixnet::account::get_wallet_storage_paths,
             mixnet::account::list_accounts,
             mixnet::account::logout,
             mixnet::account::remove_account_for_password,

--- a/nym-wallet/src-tauri/src/operations/mixnet/account.rs
+++ b/nym-wallet/src-tauri/src/operations/mixnet/account.rs
@@ -541,6 +541,45 @@ async fn set_state_with_all_accounts(
     Ok(())
 }
 
+fn resolve_active_account_id(
+    state: &crate::state::WalletStateInner,
+) -> Option<wallet_storage::AccountId> {
+    let client = state.current_client().ok()?;
+    let current_address = client.nyxd.address();
+    let network = state.current_network();
+    state.get_all_accounts().find_map(|account| {
+        if account.addresses.get(&network).map(|a| a.as_ref()) == Some(current_address.as_ref()) {
+            Some(account.id.clone())
+        } else {
+            None
+        }
+    })
+}
+
+fn validate_account_removal_request(
+    stored_login: &wallet_storage::StoredLogin,
+    account_id: &wallet_storage::AccountId,
+    active_account_id: Option<&wallet_storage::AccountId>,
+) -> Result<(), BackendError> {
+    match stored_login {
+        wallet_storage::StoredLogin::Mnemonic(_) => {
+            Err(BackendError::WalletUnexpectedMnemonicAccount)
+        }
+        wallet_storage::StoredLogin::Multiple(accounts) => {
+            if accounts.get_account(account_id).is_none() {
+                return Err(BackendError::WalletNoSuchAccountIdInWalletLogin);
+            }
+            if accounts.len() <= 1 {
+                return Err(BackendError::WalletCannotRemoveLastAccount);
+            }
+            if active_account_id == Some(account_id) {
+                return Err(BackendError::WalletCannotRemoveActiveAccount);
+            }
+            Ok(())
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn remove_account_for_password(
     password: UserPassword,
@@ -551,6 +590,12 @@ pub async fn remove_account_for_password(
     // Currently we only support a single, default, id in the wallet
     let login_id = wallet_storage::LoginId::new(DEFAULT_LOGIN_ID.to_string());
     let account_id = wallet_storage::AccountId::new(account_id.to_string());
+    let stored_login = wallet_storage::load_existing_login(&login_id, &password)?;
+    let active_account_id = {
+        let r_state = state.read().await;
+        resolve_active_account_id(&r_state)
+    };
+    validate_account_removal_request(&stored_login, &account_id, active_account_id.as_ref())?;
     wallet_storage::remove_account_from_login(&login_id, &account_id, &password)?;
 
     // Load to reset the internal state
@@ -648,6 +693,38 @@ fn _show_mnemonic_for_account_in_password(
     Ok(mnemonic)
 }
 
+#[tauri::command]
+pub fn get_wallet_storage_paths() -> Result<WalletStoragePaths, BackendError> {
+    use crate::platform_constants::CONFIG_DIR_NAME;
+
+    let wallet_file_path = wallet_storage::wallet_login_filepath()?;
+    let storage_directory = wallet_file_path
+        .parent()
+        .ok_or(BackendError::UnknownStorageDirectory)?
+        .to_string_lossy()
+        .into_owned();
+    let wallet_file = wallet_file_path.to_string_lossy().into_owned();
+    let config_directory = dirs::config_dir()
+        .map(|dir| dir.join(CONFIG_DIR_NAME))
+        .ok_or(BackendError::UnknownStorageDirectory)?
+        .to_string_lossy()
+        .into_owned();
+
+    Ok(WalletStoragePaths {
+        wallet_file,
+        storage_directory,
+        config_directory,
+    })
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WalletStoragePaths {
+    pub wallet_file: String,
+    pub storage_directory: String,
+    pub config_directory: String,
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -736,5 +813,41 @@ mod tests {
                 WalletAccount::new("42".into(), MnemonicAccount::new(expected_mn4, hd_path)),
             ]
         );
+    }
+
+    #[test]
+    fn validate_account_removal_request_blocks_last_and_active_account() {
+        use wallet_storage::account_data::{
+            MnemonicAccount, MultipleAccounts, StoredLogin, WalletAccount,
+        };
+
+        let hd_path: DerivationPath = COSMOS_DERIVATION_PATH.parse().unwrap();
+        let mnemonic = bip39::Mnemonic::generate(12).unwrap();
+        let account_id = wallet_storage::AccountId::new("default".to_string());
+        let single = StoredLogin::Multiple(MultipleAccounts::from(vec![WalletAccount::new(
+            account_id.clone(),
+            MnemonicAccount::new(mnemonic.clone(), hd_path.clone()),
+        )]));
+
+        assert!(matches!(
+            validate_account_removal_request(&single, &account_id, None),
+            Err(BackendError::WalletCannotRemoveLastAccount)
+        ));
+
+        let second_id = wallet_storage::AccountId::new("other".to_string());
+        let mnemonic2 = bip39::Mnemonic::generate(12).unwrap();
+        let multiple = StoredLogin::Multiple(MultipleAccounts::from(vec![
+            WalletAccount::new(
+                account_id.clone(),
+                MnemonicAccount::new(mnemonic, hd_path.clone()),
+            ),
+            WalletAccount::new(second_id.clone(), MnemonicAccount::new(mnemonic2, hd_path)),
+        ]));
+
+        assert!(matches!(
+            validate_account_removal_request(&multiple, &account_id, Some(&account_id)),
+            Err(BackendError::WalletCannotRemoveActiveAccount)
+        ));
+        assert!(validate_account_removal_request(&multiple, &second_id, Some(&account_id)).is_ok());
     }
 }

--- a/nym-wallet/src/components/Accounts/AccountItem.tsx
+++ b/nym-wallet/src/components/Accounts/AccountItem.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import EditIcon from '@mui/icons-material/Create';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import {
   Box,
@@ -16,6 +17,11 @@ import {
 import { useClipboard } from 'use-clipboard-copy';
 import { AccountsContext } from 'src/context';
 import { AccountAvatar } from './AccountAvatar';
+import {
+  canRemoveAccount,
+  getAccountRemovalBlockMessage,
+  getAccountRemovalBlockReason,
+} from 'src/utils/accountRemovalPolicy';
 
 export const AccountItem = ({
   name,
@@ -26,11 +32,17 @@ export const AccountItem = ({
   address: string;
   onSelectAccount: () => void;
 }) => {
-  const { selectedAccount, setDialogToDisplay, setAccountMnemonic, handleAccountToEdit } = useContext(AccountsContext);
+  const { selectedAccount, accounts, setDialogToDisplay, setAccountMnemonic, handleAccountToEdit, handleAccountToDelete } =
+    useContext(AccountsContext);
   const { copy, copied } = useClipboard({ copiedTimeout: 1000 });
   const theme = useTheme();
 
   const isSelected = selectedAccount?.id === name;
+  const removalBlockReason = getAccountRemovalBlockReason(accounts ?? [], selectedAccount?.id, name);
+  const removalAllowed = canRemoveAccount(accounts ?? [], selectedAccount?.id, name);
+  const removalTooltip = removalAllowed
+    ? 'Remove this account from your saved wallet'
+    : getAccountRemovalBlockMessage(removalBlockReason ?? 'active_account');
 
   return (
     <ListItem
@@ -57,6 +69,29 @@ export const AccountItem = ({
               }}
             />
           )}
+          <Tooltip title={removalTooltip}>
+            <span>
+              <IconButton
+                sx={{
+                  color: theme.palette.mode === 'dark' ? 'nym.text.dark' : theme.palette.text.primary,
+                  backgroundColor: alpha(theme.palette.text.primary, 0.05),
+                  '&:hover': {
+                    backgroundColor: alpha(theme.palette.error.main, 0.12),
+                    color: theme.palette.error.main,
+                  },
+                  width: 30,
+                  height: 30,
+                }}
+                disabled={!removalAllowed}
+                onClick={() => {
+                  handleAccountToDelete(name);
+                  setDialogToDisplay('Delete');
+                }}
+              >
+                <DeleteOutlineIcon fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
           <IconButton
             sx={{
               mr: 1.5,

--- a/nym-wallet/src/components/Accounts/AccountItem.tsx
+++ b/nym-wallet/src/components/Accounts/AccountItem.tsx
@@ -16,12 +16,12 @@ import {
 } from '@mui/material';
 import { useClipboard } from 'use-clipboard-copy';
 import { AccountsContext } from 'src/context';
-import { AccountAvatar } from './AccountAvatar';
 import {
   canRemoveAccount,
   getAccountRemovalBlockMessage,
   getAccountRemovalBlockReason,
 } from 'src/utils/accountRemovalPolicy';
+import { AccountAvatar } from './AccountAvatar';
 
 export const AccountItem = ({
   name,
@@ -32,8 +32,14 @@ export const AccountItem = ({
   address: string;
   onSelectAccount: () => void;
 }) => {
-  const { selectedAccount, accounts, setDialogToDisplay, setAccountMnemonic, handleAccountToEdit, handleAccountToDelete } =
-    useContext(AccountsContext);
+  const {
+    selectedAccount,
+    accounts,
+    setDialogToDisplay,
+    setAccountMnemonic,
+    handleAccountToEdit,
+    handleAccountToDelete,
+  } = useContext(AccountsContext);
   const { copy, copied } = useClipboard({ copiedTimeout: 1000 });
   const theme = useTheme();
 

--- a/nym-wallet/src/components/Accounts/Accounts.tsx
+++ b/nym-wallet/src/components/Accounts/Accounts.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from 'react';
 import { AccountsContext, AppContext } from 'src/context';
 import { EditAccountModal } from './modals/EditAccountModal';
+import { DeleteAccountModal } from './modals/DeleteAccountModal';
 import { AddAccountModal } from './modals/AddAccountModal';
 import { AccountsModal } from './modals/AccountsModal';
 import { MnemonicModal } from './modals/MnemonicModal';
@@ -16,6 +17,7 @@ export const Accounts = () => {
       <AccountsModal />
       <AddAccountModal />
       <EditAccountModal />
+      <DeleteAccountModal />
       <MnemonicModal />
     </>
   ) : null;

--- a/nym-wallet/src/components/Accounts/modals/DeleteAccountModal.tsx
+++ b/nym-wallet/src/components/Accounts/modals/DeleteAccountModal.tsx
@@ -24,14 +24,8 @@ import { StyledBackButton } from 'src/components/StyledBackButton';
 import { ConfirmPasswordModal } from './ConfirmPasswordModal';
 
 export const DeleteAccountModal = () => {
-  const {
-    accountToDelete,
-    dialogToDisplay,
-    setDialogToDisplay,
-    handleRemoveAccount,
-    handleAccountToDelete,
-    setError,
-  } = useContext(AccountsContext);
+  const { accountToDelete, dialogToDisplay, setDialogToDisplay, handleRemoveAccount, handleAccountToDelete, setError } =
+    useContext(AccountsContext);
 
   const [backupConfirmed, setBackupConfirmed] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -118,14 +112,14 @@ export const DeleteAccountModal = () => {
         </DialogTitle>
         <DialogContent sx={{ px: 3, pb: 1 }}>
           <Alert severity="warning" sx={{ mb: 2 }}>
-            This permanently removes &quot;{accountToDelete?.id}&quot; from your saved wallet. Your password login
-            and other stored accounts are kept, but this action cannot be undone.
+            This permanently removes &quot;{accountToDelete?.id}&quot; from your saved wallet. Your password login and
+            other stored accounts are kept, but this action cannot be undone.
           </Alert>
 
           {pathsLoadError ? (
             <Alert severity="error" sx={{ mb: 2 }}>
-              Could not load wallet file locations: {pathsLoadError}. Do not continue unless you already know where
-              your wallet file is stored.
+              Could not load wallet file locations: {pathsLoadError}. Do not continue unless you already know where your
+              wallet file is stored.
             </Alert>
           ) : (
             <Box

--- a/nym-wallet/src/components/Accounts/modals/DeleteAccountModal.tsx
+++ b/nym-wallet/src/components/Accounts/modals/DeleteAccountModal.tsx
@@ -1,0 +1,186 @@
+import React, { useContext, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  IconButton,
+  Paper,
+  Typography,
+} from '@mui/material';
+import { Close } from '@mui/icons-material';
+import { useTheme } from '@mui/material/styles';
+import { AccountsContext } from 'src/context';
+import { getWalletStoragePaths } from 'src/requests';
+import { formatWalletBackupReminder } from 'src/utils/walletBackupReminder';
+import { canProceedToAccountRemovalPassword } from 'src/utils/deleteAccountModalPolicy';
+import { mapAccountRemovalError } from 'src/utils/accountRemovalErrors';
+import { StyledBackButton } from 'src/components/StyledBackButton';
+import { ConfirmPasswordModal } from './ConfirmPasswordModal';
+
+export const DeleteAccountModal = () => {
+  const {
+    accountToDelete,
+    dialogToDisplay,
+    setDialogToDisplay,
+    handleRemoveAccount,
+    handleAccountToDelete,
+    setError,
+  } = useContext(AccountsContext);
+
+  const [backupConfirmed, setBackupConfirmed] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [backupReminder, setBackupReminder] = useState<string>();
+  const [pathsLoadError, setPathsLoadError] = useState<string>();
+
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (dialogToDisplay !== 'Delete' || !accountToDelete) {
+      return;
+    }
+
+    setBackupConfirmed(false);
+    setShowConfirmPassword(false);
+    setPathsLoadError(undefined);
+    setBackupReminder(undefined);
+
+    getWalletStoragePaths()
+      .then((paths) => setBackupReminder(formatWalletBackupReminder(paths)))
+      .catch((e) => setPathsLoadError(String(e)));
+  }, [dialogToDisplay, accountToDelete]);
+
+  const handleClose = () => {
+    handleAccountToDelete(undefined);
+    setDialogToDisplay('Accounts');
+    setBackupConfirmed(false);
+    setShowConfirmPassword(false);
+    setError(undefined);
+  };
+
+  const onConfirmPassword = async (password: string) => {
+    if (!accountToDelete) {
+      return;
+    }
+    try {
+      await handleRemoveAccount({ account: accountToDelete, password });
+      setShowConfirmPassword(false);
+      handleClose();
+    } catch (e) {
+      setError(mapAccountRemovalError(e));
+    }
+  };
+
+  const canContinue = canProceedToAccountRemovalPassword({
+    backupConfirmed,
+    backupReminder,
+    pathsLoadError,
+  });
+
+  if (showConfirmPassword && accountToDelete) {
+    return (
+      <ConfirmPasswordModal
+        modalTitle="Confirm account removal"
+        accountName={accountToDelete.id}
+        buttonTitle="Remove account permanently"
+        onClose={() => {
+          setShowConfirmPassword(false);
+          setError(undefined);
+        }}
+        onConfirm={onConfirmPassword}
+      />
+    );
+  }
+
+  return (
+    <Dialog
+      open={dialogToDisplay === 'Delete' && Boolean(accountToDelete)}
+      onClose={handleClose}
+      fullWidth
+      maxWidth="sm"
+      PaperProps={{
+        style: { border: `1px solid ${theme.palette.nym.nymWallet.modal.border}` },
+      }}
+    >
+      <Paper>
+        <DialogTitle>
+          <Box display="flex" justifyContent="space-between" alignItems="center">
+            <Typography variant="h6">Remove account</Typography>
+            <IconButton onClick={handleClose}>
+              <Close />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+        <DialogContent sx={{ px: 3, pb: 1 }}>
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            This permanently removes &quot;{accountToDelete?.id}&quot; from your saved wallet. Your password login
+            and other stored accounts are kept, but this action cannot be undone.
+          </Alert>
+
+          {pathsLoadError ? (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              Could not load wallet file locations: {pathsLoadError}. Do not continue unless you already know where
+              your wallet file is stored.
+            </Alert>
+          ) : (
+            <Box
+              sx={{
+                mb: 2,
+                p: 2,
+                borderRadius: 1,
+                bgcolor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.04)' : 'grey.50',
+                border: `1px solid ${theme.palette.divider}`,
+              }}
+            >
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                Back up before you continue
+              </Typography>
+              <Typography
+                component="pre"
+                variant="body2"
+                sx={{
+                  whiteSpace: 'pre-wrap',
+                  fontFamily: 'monospace',
+                  fontSize: '0.8rem',
+                  m: 0,
+                }}
+              >
+                {backupReminder ?? 'Loading wallet file locations...'}
+              </Typography>
+            </Box>
+          )}
+
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={backupConfirmed}
+                onChange={(e) => setBackupConfirmed(e.target.checked)}
+                color="primary"
+              />
+            }
+            label="I have backed up my wallet file and understand this removal is permanent"
+          />
+        </DialogContent>
+        <DialogActions sx={{ p: 3, gap: 2 }}>
+          <StyledBackButton onBack={handleClose} />
+          <Button
+            fullWidth
+            disableElevation
+            variant="contained"
+            color="error"
+            size="large"
+            disabled={!canContinue}
+            onClick={() => setShowConfirmPassword(true)}
+          >
+            Continue to remove
+          </Button>
+        </DialogActions>
+      </Paper>
+    </Dialog>
+  );
+};

--- a/nym-wallet/src/components/Accounts/modals/DeleteAccountModal.tsx
+++ b/nym-wallet/src/components/Accounts/modals/DeleteAccountModal.tsx
@@ -24,8 +24,15 @@ import { StyledBackButton } from 'src/components/StyledBackButton';
 import { ConfirmPasswordModal } from './ConfirmPasswordModal';
 
 export const DeleteAccountModal = () => {
-  const { accountToDelete, dialogToDisplay, setDialogToDisplay, handleRemoveAccount, handleAccountToDelete, setError } =
-    useContext(AccountsContext);
+  const {
+    accountToDelete,
+    dialogToDisplay,
+    setDialogToDisplay,
+    handleRemoveAccount,
+    handleAccountToDelete,
+    setError,
+    error,
+  } = useContext(AccountsContext);
 
   const [backupConfirmed, setBackupConfirmed] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -63,10 +70,10 @@ export const DeleteAccountModal = () => {
     }
     try {
       await handleRemoveAccount({ account: accountToDelete, password });
-      setShowConfirmPassword(false);
       handleClose();
     } catch (e) {
       setError(mapAccountRemovalError(e));
+      setShowConfirmPassword(false);
     }
   };
 
@@ -82,10 +89,7 @@ export const DeleteAccountModal = () => {
         modalTitle="Confirm account removal"
         accountName={accountToDelete.id}
         buttonTitle="Remove account permanently"
-        onClose={() => {
-          setShowConfirmPassword(false);
-          setError(undefined);
-        }}
+        onClose={handleClose}
         onConfirm={onConfirmPassword}
       />
     );
@@ -111,6 +115,11 @@ export const DeleteAccountModal = () => {
           </Box>
         </DialogTitle>
         <DialogContent sx={{ px: 3, pb: 1 }}>
+          {error ? (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          ) : null}
           <Alert severity="warning" sx={{ mb: 2 }}>
             This permanently removes &quot;{accountToDelete?.id}&quot; from your saved wallet. Your password login and
             other stored accounts are kept, but this action cannot be undone.

--- a/nym-wallet/src/components/Accounts/modals/DeleteAccountModal.tsx
+++ b/nym-wallet/src/components/Accounts/modals/DeleteAccountModal.tsx
@@ -18,7 +18,10 @@ import { useTheme } from '@mui/material/styles';
 import { AccountsContext } from 'src/context';
 import { getWalletStoragePaths } from 'src/requests';
 import { formatWalletBackupReminder } from 'src/utils/walletBackupReminder';
-import { canProceedToAccountRemovalPassword } from 'src/utils/deleteAccountModalPolicy';
+import {
+  canProceedToAccountRemovalPassword,
+  formatWalletPathsLoadBlockedMessage,
+} from 'src/utils/deleteAccountModalPolicy';
 import { mapAccountRemovalError } from 'src/utils/accountRemovalErrors';
 import { StyledBackButton } from 'src/components/StyledBackButton';
 import { ConfirmPasswordModal } from './ConfirmPasswordModal';
@@ -127,8 +130,7 @@ export const DeleteAccountModal = () => {
 
           {pathsLoadError ? (
             <Alert severity="error" sx={{ mb: 2 }}>
-              Could not load wallet file locations: {pathsLoadError}. Do not continue unless you already know where your
-              wallet file is stored.
+              {formatWalletPathsLoadBlockedMessage(pathsLoadError)}
             </Alert>
           ) : (
             <Box

--- a/nym-wallet/src/components/NetworkSelector.tsx
+++ b/nym-wallet/src/components/NetworkSelector.tsx
@@ -77,16 +77,16 @@ export const NetworkSelector = () => {
         <List>
           <ListSubheader sx={{ backgroundColor: 'transparent' }}>Network selection</ListSubheader>
           {networks.map(({ name, networkName }) => (
-              <NetworkItem
-                key={networkName}
-                title={name}
-                isSelected={networkName === network}
-                onSelect={() => {
-                  handleClose();
-                  switchNetwork(networkName);
-                }}
-              />
-            ))}
+            <NetworkItem
+              key={networkName}
+              title={name}
+              isSelected={networkName === network}
+              onSelect={() => {
+                handleClose();
+                switchNetwork(networkName);
+              }}
+            />
+          ))}
         </List>
       </Popover>
     </>

--- a/nym-wallet/src/components/NetworkSelector.tsx
+++ b/nym-wallet/src/components/NetworkSelector.tsx
@@ -3,6 +3,7 @@ import { Button, List, ListItemButton, ListItemIcon, ListItemText, ListSubheader
 import { ArrowDropDown, Check } from '@mui/icons-material';
 import { Network } from 'src/types';
 import { AppContext } from '../context/main';
+import { formatNetworkSelectorLabel } from '../utils/networkSelectorLabel';
 import { headerControlPillSx } from './headerControlPillSx';
 
 const networks: { networkName: Network; name: string }[] = [
@@ -63,7 +64,7 @@ export const NetworkSelector = () => {
         disableElevation
         endIcon={<ArrowDropDown sx={{ color: 'text.primary' }} />}
       >
-        {networks.find((n) => n.networkName === network)?.name}
+        {formatNetworkSelectorLabel(network, networks)}
       </Button>
       <Popover
         open={Boolean(anchorEl)}

--- a/nym-wallet/src/components/NetworkSelector.tsx
+++ b/nym-wallet/src/components/NetworkSelector.tsx
@@ -3,13 +3,11 @@ import { Button, List, ListItemButton, ListItemIcon, ListItemText, ListSubheader
 import { ArrowDropDown, Check } from '@mui/icons-material';
 import { Network } from 'src/types';
 import { AppContext } from '../context/main';
-import { config } from '../config';
 import { headerControlPillSx } from './headerControlPillSx';
 
 const networks: { networkName: Network; name: string }[] = [
   { networkName: 'MAINNET', name: 'Nym Mainnet' },
   { networkName: 'SANDBOX', name: 'Testnet Sandbox' },
-  { networkName: 'QA', name: 'QA' },
 ];
 
 const NetworkItem: FCWithChildren<{ title: string; isSelected: boolean; onSelect: () => void }> = ({
@@ -43,7 +41,7 @@ const NetworkItem: FCWithChildren<{ title: string; isSelected: boolean; onSelect
 );
 
 export const NetworkSelector = () => {
-  const { network, switchNetwork, appEnv } = useContext(AppContext);
+  const { network, switchNetwork } = useContext(AppContext);
 
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
@@ -78,16 +76,7 @@ export const NetworkSelector = () => {
       >
         <List>
           <ListSubheader sx={{ backgroundColor: 'transparent' }}>Network selection</ListSubheader>
-          {networks
-            .filter(({ networkName }) => {
-              // show all networks when in dev more or the user wants QA mode enabled
-              if (config.IS_DEV_MODE || appEnv?.ENABLE_QA_MODE) {
-                return true;
-              }
-              // otherwise, filter out QA
-              return networkName !== 'QA';
-            })
-            .map(({ name, networkName }) => (
+          {networks.map(({ name, networkName }) => (
               <NetworkItem
                 key={networkName}
                 title={name}

--- a/nym-wallet/src/context/accounts.tsx
+++ b/nym-wallet/src/context/accounts.tsx
@@ -1,11 +1,6 @@
 import React, { createContext, Dispatch, SetStateAction, useContext, useEffect, useMemo, useState } from 'react';
 import { AccountEntry } from '@nymproject/types';
-import {
-  addAccount as addAccountRequest,
-  removeAccount,
-  renameAccount,
-  showMnemonicForAccount,
-} from 'src/requests';
+import { addAccount as addAccountRequest, removeAccount, renameAccount, showMnemonicForAccount } from 'src/requests';
 import { useSnackbar } from 'notistack';
 import { performAccountRemoval } from 'src/utils/accountRemovalFlow';
 import { AppContext } from './main';

--- a/nym-wallet/src/context/accounts.tsx
+++ b/nym-wallet/src/context/accounts.tsx
@@ -1,13 +1,20 @@
 import React, { createContext, Dispatch, SetStateAction, useContext, useEffect, useMemo, useState } from 'react';
 import { AccountEntry } from '@nymproject/types';
-import { addAccount as addAccountRequest, renameAccount, showMnemonicForAccount } from 'src/requests';
+import {
+  addAccount as addAccountRequest,
+  removeAccount,
+  renameAccount,
+  showMnemonicForAccount,
+} from 'src/requests';
 import { useSnackbar } from 'notistack';
+import { performAccountRemoval } from 'src/utils/accountRemovalFlow';
 import { AppContext } from './main';
 
 type TAccounts = {
   accounts?: AccountEntry[];
   selectedAccount?: AccountEntry;
   accountToEdit?: AccountEntry;
+  accountToDelete?: AccountEntry;
   dialogToDisplay?: TAccountsDialog;
   isLoading: boolean;
   error?: string;
@@ -18,6 +25,7 @@ type TAccounts = {
   setDialogToDisplay: (dialog?: TAccountsDialog) => void;
   handleSelectAccount: (data: { accountName: string; password: string }) => Promise<boolean>;
   handleAccountToEdit: (accountId: string | undefined) => void;
+  handleAccountToDelete: (accountId: string | undefined) => void;
   handleEditAccount: ({
     account,
     newAccountName,
@@ -27,11 +35,12 @@ type TAccounts = {
     newAccountName: string;
     password: string;
   }) => Promise<void>;
+  handleRemoveAccount: ({ account, password }: { account: AccountEntry; password: string }) => Promise<void>;
   handleImportAccount: (account: AccountEntry) => void;
   handleGetAccountMnemonic: (data: { password: string; accountName: string }) => void;
 };
 
-export type TAccountsDialog = 'Accounts' | 'Add' | 'Edit' | 'Import' | 'Mnemonic';
+export type TAccountsDialog = 'Accounts' | 'Add' | 'Edit' | 'Delete' | 'Import' | 'Mnemonic';
 export type TAccountMnemonic = { value?: string; accountName?: string };
 
 export const AccountsContext = createContext({} as TAccounts);
@@ -40,6 +49,7 @@ export const AccountsProvider: FCWithChildren = ({ children }) => {
   const [accounts, setAccounts] = useState<AccountEntry[]>([]);
   const [selectedAccount, setSelectedAccount] = useState<AccountEntry>();
   const [accountToEdit, setAccountToEdit] = useState<AccountEntry>();
+  const [accountToDelete, setAccountToDelete] = useState<AccountEntry>();
   const [dialogToDisplay, setDialogToDisplay] = useState<TAccountsDialog>();
   const [accountMnemonic, setAccountMnemonic] = useState<TAccountMnemonic>({
     value: undefined,
@@ -47,7 +57,7 @@ export const AccountsProvider: FCWithChildren = ({ children }) => {
   });
   const [error, setError] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
-  const { onAccountChange, storedAccounts } = useContext(AppContext);
+  const { onAccountChange, storedAccounts, reloadStoredAccounts } = useContext(AppContext);
   const { enqueueSnackbar } = useSnackbar();
 
   const handleAddAccount = async ({
@@ -101,10 +111,25 @@ export const AccountsProvider: FCWithChildren = ({ children }) => {
     }
   };
 
+  const handleRemoveAccount = async ({ account, password }: { account: AccountEntry; password: string }) => {
+    setIsLoading(true);
+    try {
+      const updatedAccounts = await performAccountRemoval({ account, password, removeAccount, reloadStoredAccounts });
+      setAccounts(updatedAccounts);
+      enqueueSnackbar('Account removed from saved wallet', { variant: 'success' });
+      setDialogToDisplay('Accounts');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const handleImportAccount = (account: AccountEntry) => setAccounts((accs) => [...(accs ? [...accs] : []), account]);
 
   const handleAccountToEdit = (accountName: string | undefined) =>
     setAccountToEdit(accounts?.find((acc) => acc.id === accountName));
+
+  const handleAccountToDelete = (accountName: string | undefined) =>
+    setAccountToDelete(accounts?.find((acc) => acc.id === accountName));
 
   const handleSelectAccount = async ({ accountName, password }: { accountName: string; password: string }) => {
     try {
@@ -149,6 +174,7 @@ export const AccountsProvider: FCWithChildren = ({ children }) => {
           accounts,
           selectedAccount,
           accountToEdit,
+          accountToDelete,
           dialogToDisplay,
           accountMnemonic,
           setDialogToDisplay,
@@ -156,12 +182,14 @@ export const AccountsProvider: FCWithChildren = ({ children }) => {
           isLoading,
           handleAddAccount,
           handleEditAccount,
+          handleRemoveAccount,
           handleAccountToEdit,
+          handleAccountToDelete,
           handleSelectAccount,
           handleImportAccount,
           handleGetAccountMnemonic,
         }),
-        [accounts, selectedAccount, accountToEdit, dialogToDisplay, isLoading, error, accountMnemonic],
+        [accounts, selectedAccount, accountToEdit, accountToDelete, dialogToDisplay, isLoading, error, accountMnemonic],
       )}
     >
       {children}

--- a/nym-wallet/src/context/main.tsx
+++ b/nym-wallet/src/context/main.tsx
@@ -27,6 +27,7 @@ import {
   didNetworkRefreshSucceed,
   resolveNetworkSwitchOutcome,
   selectNetworkForPersistence,
+  shouldClearWalletUiStateOnNetworkSwitchCommit,
 } from '../utils/networkSwitchExecution';
 import { toDisplay } from '../utils';
 
@@ -380,8 +381,6 @@ export const AppProvider: FCWithChildren = ({ children }) => {
       setNetwork(_network);
       return;
     }
-    userBalance.clearAll();
-    setMixnodeDetails(null);
     let refreshSucceeded = false;
     try {
       // loadAccount swallows backend errors and returns undefined, so a thrown
@@ -391,11 +390,10 @@ export const AppProvider: FCWithChildren = ({ children }) => {
     } catch (e) {
       Console.error(e as string);
     }
-    if (!refreshSucceeded) {
-      enqueueSnackbar('Error switching network', { variant: 'error' });
-    }
     const outcome = resolveNetworkSwitchOutcome(network, _network, refreshSucceeded, true);
-    if (outcome.status === 'committed') {
+    if (shouldClearWalletUiStateOnNetworkSwitchCommit(outcome)) {
+      userBalance.clearAll();
+      setMixnodeDetails(null);
       setNetwork(outcome.network);
       await keepState(outcome.network);
     }

--- a/nym-wallet/src/context/main.tsx
+++ b/nym-wallet/src/context/main.tsx
@@ -22,6 +22,8 @@ import { createSignInWindow, getReactState, setReactState } from '../requests/ap
 import { fetchNymPriceDeduped, getNetworkOverviewEndpoints, clearNymPriceCache } from '../api/networkOverview';
 import { signInAndNavigateToBalance } from '../utils/signInAndNavigateToBalance';
 import { dedupeInflightByKey } from '../utils/dedupeInflightByKey';
+import { shouldRefreshAccountOnManualNetworkSwitch } from '../utils/networkSwitchPolicy';
+import { didNetworkRefreshSucceed, resolveNetworkSwitchOutcome } from '../utils/networkSwitchExecution';
 import { toDisplay } from '../utils';
 
 export const urls = (networkName?: Network) =>
@@ -71,7 +73,7 @@ export type TAppContext = {
   handleCloseReceiveModal: () => void;
   setIsLoading: (isLoading: boolean) => void;
   setError: (value?: string) => void;
-  switchNetwork: (network: Network) => void;
+  switchNetwork: (network: Network) => void | Promise<void>;
   getBondDetails: () => Promise<void>;
   handleShowAdmin: () => void;
   logIn: (opts: { type: TLoginType; value: string }) => void;
@@ -79,6 +81,7 @@ export type TAppContext = {
   signInWithPassword: (password: string) => void;
   logOut: () => void;
   keepState: () => Promise<void>;
+  reloadStoredAccounts: () => Promise<AccountEntry[]>;
   printBalance: string;
   printVestedBalance?: string; // spendable vested token
   mixnetContractParams?: TauriContractStateParams;
@@ -175,9 +178,10 @@ export const AppProvider: FCWithChildren = ({ children }) => {
       }
     });
 
-  const loadStoredAccounts = async () => {
+  const loadStoredAccounts = async (): Promise<AccountEntry[]> => {
     const accounts = await listAccounts();
     setStoredAccounts(accounts);
+    return accounts;
   };
 
   const getBondDetails = async () => {
@@ -190,11 +194,12 @@ export const AppProvider: FCWithChildren = ({ children }) => {
     }
   };
 
-  const refreshAccount = async (_network: Network) => {
-    await loadAccount(_network);
+  const refreshAccount = async (_network: Network): Promise<Account | undefined> => {
+    const client = await loadAccount(_network);
     if (loginType === 'password') {
       await loadStoredAccounts();
     }
+    return client;
   };
 
   const getModeFromStorage = async () => {
@@ -362,7 +367,35 @@ export const AppProvider: FCWithChildren = ({ children }) => {
 
   const handleShowAdmin = () => setShowAdmin((show) => !show);
   const handleShowTerminal = () => setShowTerminal((show) => !show);
-  const switchNetwork = (_network: Network) => setNetwork(_network);
+  const switchNetwork = async (_network: Network) => {
+    if (_network === network) {
+      return;
+    }
+    const hasActiveSession = shouldRefreshAccountOnManualNetworkSwitch(Boolean(clientDetails));
+    if (!hasActiveSession) {
+      setNetwork(_network);
+      return;
+    }
+    userBalance.clearAll();
+    setMixnodeDetails(null);
+    let refreshSucceeded = false;
+    try {
+      // loadAccount swallows backend errors and returns undefined, so a thrown
+      // error alone is not a reliable success signal; require a loaded client.
+      const client = await refreshAccount(_network);
+      refreshSucceeded = didNetworkRefreshSucceed(client);
+    } catch (e) {
+      Console.error(e as string);
+    }
+    if (!refreshSucceeded) {
+      enqueueSnackbar('Error switching network', { variant: 'error' });
+    }
+    const outcome = resolveNetworkSwitchOutcome(network, _network, refreshSucceeded, true);
+    if (outcome.status === 'committed') {
+      setNetwork(outcome.network);
+      await keepState();
+    }
+  };
   const handleShowSendModal = () => setShowSendModal(true);
   const handleShowReceiveModal = () => setShowReceiveModal(true);
   const handleCloseSendModal = () => setShowSendModal(false);
@@ -403,6 +436,7 @@ export const AppProvider: FCWithChildren = ({ children }) => {
       logIn,
       logOut,
       keepState,
+      reloadStoredAccounts: loadStoredAccounts,
       onAccountChange,
       showSendModal,
       showReceiveModal,

--- a/nym-wallet/src/context/main.tsx
+++ b/nym-wallet/src/context/main.tsx
@@ -23,7 +23,11 @@ import { fetchNymPriceDeduped, getNetworkOverviewEndpoints, clearNymPriceCache }
 import { signInAndNavigateToBalance } from '../utils/signInAndNavigateToBalance';
 import { dedupeInflightByKey } from '../utils/dedupeInflightByKey';
 import { shouldRefreshAccountOnManualNetworkSwitch } from '../utils/networkSwitchPolicy';
-import { didNetworkRefreshSucceed, resolveNetworkSwitchOutcome } from '../utils/networkSwitchExecution';
+import {
+  didNetworkRefreshSucceed,
+  resolveNetworkSwitchOutcome,
+  selectNetworkForPersistence,
+} from '../utils/networkSwitchExecution';
 import { toDisplay } from '../utils';
 
 export const urls = (networkName?: Network) =>
@@ -80,7 +84,7 @@ export type TAppContext = {
   handleShowTerminal: () => void;
   signInWithPassword: (password: string) => void;
   logOut: () => void;
-  keepState: () => Promise<void>;
+  keepState: (persistedNetwork?: Network) => Promise<void>;
   reloadStoredAccounts: () => Promise<AccountEntry[]>;
   printBalance: string;
   printVestedBalance?: string; // spendable vested token
@@ -148,12 +152,12 @@ export const AppProvider: FCWithChildren = ({ children }) => {
     initFromRustState();
   }, []);
 
-  const keepState = async () => {
+  const keepState = async (persistedNetwork?: Network) => {
     const state: RustState = {
-      network,
+      network: selectNetworkForPersistence(network, persistedNetwork),
       loginType,
     };
-    setReactState(JSON.stringify(state));
+    await setReactState(JSON.stringify(state));
   };
 
   const clearState = () => {
@@ -393,7 +397,7 @@ export const AppProvider: FCWithChildren = ({ children }) => {
     const outcome = resolveNetworkSwitchOutcome(network, _network, refreshSucceeded, true);
     if (outcome.status === 'committed') {
       setNetwork(outcome.network);
-      await keepState();
+      await keepState(outcome.network);
     }
   };
   const handleShowSendModal = () => setShowSendModal(true);

--- a/nym-wallet/src/context/mocks/accounts.tsx
+++ b/nym-wallet/src/context/mocks/accounts.tsx
@@ -9,6 +9,7 @@ export const MockAccountsProvider: FCWithChildren = ({ children }) => {
     address: 'abc123',
   });
   const [accountToEdit, setAccountToEdit] = useState<AccountEntry>();
+  const [accountToDelete, setAccountToDelete] = useState<AccountEntry>();
   const [dialogToDisplay, setDialogToDisplay] = useState<TAccountsDialog>();
   const [accountMnemonic, setAccountMnemonic] = useState<TAccountMnemonic>({
     value: undefined,
@@ -55,6 +56,14 @@ export const MockAccountsProvider: FCWithChildren = ({ children }) => {
   const handleAccountToEdit = (accountName: string | undefined) =>
     setAccountToEdit(accounts?.find((acc) => acc.id === accountName));
 
+  const handleAccountToDelete = (accountName: string | undefined) =>
+    setAccountToDelete(accounts?.find((acc) => acc.id === accountName));
+
+  const handleRemoveAccount = async ({ account }: { account: AccountEntry; password: string }) => {
+    setAccounts((accs) => accs.filter((acc) => acc.id !== account.id));
+    setDialogToDisplay('Accounts');
+  };
+
   const handleSelectAccount = async ({ accountName }: { accountName: string; password: string }) => {
     const match = accounts?.find((acc) => acc.id === accountName);
     setSelectedAccount(match);
@@ -81,6 +90,7 @@ export const MockAccountsProvider: FCWithChildren = ({ children }) => {
           accounts,
           selectedAccount,
           accountToEdit,
+          accountToDelete,
           dialogToDisplay,
           accountMnemonic,
           setDialogToDisplay,
@@ -88,12 +98,14 @@ export const MockAccountsProvider: FCWithChildren = ({ children }) => {
           isLoading,
           handleAddAccount,
           handleEditAccount,
+          handleRemoveAccount,
           handleAccountToEdit,
+          handleAccountToDelete,
           handleSelectAccount,
           handleImportAccount,
           handleGetAccountMnemonic,
         }),
-        [accounts, selectedAccount, accountToEdit, dialogToDisplay, isLoading, error, accountMnemonic],
+        [accounts, selectedAccount, accountToEdit, accountToDelete, dialogToDisplay, isLoading, error, accountMnemonic],
       )}
     >
       {children}

--- a/nym-wallet/src/context/mocks/main.tsx
+++ b/nym-wallet/src/context/mocks/main.tsx
@@ -66,6 +66,7 @@ export const MockMainContextProvider: FCWithChildren = ({ children }) => {
       handleCloseSendModal: () => undefined,
       handleCloseReceiveModal: () => undefined,
       keepState: async () => undefined,
+      reloadStoredAccounts: async () => [],
       printBalance: '100.0000 NYMT',
       printVestedBalance: undefined,
       mixnetContractParams: undefined,

--- a/nym-wallet/src/requests/account.ts
+++ b/nym-wallet/src/requests/account.ts
@@ -42,7 +42,12 @@ export const addAccount = async ({
 }) => invokeWrapper<AccountEntry>('add_account_for_password', { mnemonic, password, accountId: accountName });
 
 export const removeAccount = async ({ password, accountName }: { password: string; accountName: string }) =>
-  invokeWrapper<void>('remove_account_for_password', { password, innerId: accountName });
+  invokeWrapper<void>('remove_account_for_password', { password, accountId: accountName });
+
+export const getWalletStoragePaths = async () =>
+  invokeWrapper<{ walletFile: string; storageDirectory: string; configDirectory: string }>(
+    'get_wallet_storage_paths',
+  );
 
 export const listAccounts = async () => invokeWrapper<AccountEntry[]>('list_accounts');
 

--- a/nym-wallet/src/requests/account.ts
+++ b/nym-wallet/src/requests/account.ts
@@ -45,9 +45,7 @@ export const removeAccount = async ({ password, accountName }: { password: strin
   invokeWrapper<void>('remove_account_for_password', { password, accountId: accountName });
 
 export const getWalletStoragePaths = async () =>
-  invokeWrapper<{ walletFile: string; storageDirectory: string; configDirectory: string }>(
-    'get_wallet_storage_paths',
-  );
+  invokeWrapper<{ walletFile: string; storageDirectory: string; configDirectory: string }>('get_wallet_storage_paths');
 
 export const listAccounts = async () => invokeWrapper<AccountEntry[]>('list_accounts');
 

--- a/nym-wallet/src/utils/accountRemovalErrors.test.ts
+++ b/nym-wallet/src/utils/accountRemovalErrors.test.ts
@@ -6,14 +6,16 @@ describe('mapAccountRemovalError', () => {
   });
 
   it('maps last-account errors', () => {
-    expect(mapAccountRemovalError('Cannot remove the only stored account. Back up and remove the wallet file to reset entirely.')).toContain(
-      'only stored account',
-    );
+    expect(
+      mapAccountRemovalError(
+        'Cannot remove the only stored account. Back up and remove the wallet file to reset entirely.',
+      ),
+    ).toContain('only stored account');
   });
 
   it('maps active-account errors', () => {
-    expect(
-      mapAccountRemovalError('Switch to another account before removing the active account'),
-    ).toContain('Switch to another account');
+    expect(mapAccountRemovalError('Switch to another account before removing the active account')).toContain(
+      'Switch to another account',
+    );
   });
 });

--- a/nym-wallet/src/utils/accountRemovalErrors.test.ts
+++ b/nym-wallet/src/utils/accountRemovalErrors.test.ts
@@ -18,4 +18,10 @@ describe('mapAccountRemovalError', () => {
       'Switch to another account',
     );
   });
+
+  it('maps backend errors thrown as Error without an Error: prefix', () => {
+    expect(mapAccountRemovalError(new Error('Switch to another account before removing the active account'))).toBe(
+      'Switch to another account before removing this one.',
+    );
+  });
 });

--- a/nym-wallet/src/utils/accountRemovalErrors.test.ts
+++ b/nym-wallet/src/utils/accountRemovalErrors.test.ts
@@ -1,0 +1,19 @@
+import { mapAccountRemovalError } from './accountRemovalErrors';
+
+describe('mapAccountRemovalError', () => {
+  it('maps legacy mnemonic wallet errors', () => {
+    expect(mapAccountRemovalError('Unexpected mnemonic account for login')).toContain('legacy single-account');
+  });
+
+  it('maps last-account errors', () => {
+    expect(mapAccountRemovalError('Cannot remove the only stored account. Back up and remove the wallet file to reset entirely.')).toContain(
+      'only stored account',
+    );
+  });
+
+  it('maps active-account errors', () => {
+    expect(
+      mapAccountRemovalError('Switch to another account before removing the active account'),
+    ).toContain('Switch to another account');
+  });
+});

--- a/nym-wallet/src/utils/accountRemovalErrors.ts
+++ b/nym-wallet/src/utils/accountRemovalErrors.ts
@@ -1,5 +1,12 @@
 export function mapAccountRemovalError(error: unknown): string {
-  const message = typeof error === 'string' ? error : String(error);
+  let message: string;
+  if (error instanceof Error) {
+    message = error.message;
+  } else if (typeof error === 'string') {
+    message = error;
+  } else {
+    message = String(error);
+  }
 
   if (message.includes('Unexpected mnemonic account') || message.includes('WalletUnexpectedMnemonicAccount')) {
     return 'This wallet uses a legacy single-account format. Add another account first, then try again.';

--- a/nym-wallet/src/utils/accountRemovalErrors.ts
+++ b/nym-wallet/src/utils/accountRemovalErrors.ts
@@ -4,10 +4,7 @@ export function mapAccountRemovalError(error: unknown): string {
   if (message.includes('Unexpected mnemonic account') || message.includes('WalletUnexpectedMnemonicAccount')) {
     return 'This wallet uses a legacy single-account format. Add another account first, then try again.';
   }
-  if (
-    message.includes('Cannot remove the only stored account') ||
-    message.includes('WalletCannotRemoveLastAccount')
-  ) {
+  if (message.includes('Cannot remove the only stored account') || message.includes('WalletCannotRemoveLastAccount')) {
     return 'You cannot remove your only stored account here. To reset the wallet entirely, sign out and remove your saved wallet file after backing it up.';
   }
   if (

--- a/nym-wallet/src/utils/accountRemovalErrors.ts
+++ b/nym-wallet/src/utils/accountRemovalErrors.ts
@@ -1,0 +1,21 @@
+export function mapAccountRemovalError(error: unknown): string {
+  const message = typeof error === 'string' ? error : String(error);
+
+  if (message.includes('Unexpected mnemonic account') || message.includes('WalletUnexpectedMnemonicAccount')) {
+    return 'This wallet uses a legacy single-account format. Add another account first, then try again.';
+  }
+  if (
+    message.includes('Cannot remove the only stored account') ||
+    message.includes('WalletCannotRemoveLastAccount')
+  ) {
+    return 'You cannot remove your only stored account here. To reset the wallet entirely, sign out and remove your saved wallet file after backing it up.';
+  }
+  if (
+    message.includes('Switch to another account before removing the active account') ||
+    message.includes('WalletCannotRemoveActiveAccount')
+  ) {
+    return 'Switch to another account before removing this one.';
+  }
+
+  return message;
+}

--- a/nym-wallet/src/utils/accountRemovalFlow.test.ts
+++ b/nym-wallet/src/utils/accountRemovalFlow.test.ts
@@ -12,7 +12,7 @@ describe('performAccountRemoval', () => {
 
     expect(removeAccount).toHaveBeenCalledWith({ password: 'pw', accountName: 'Account 2' });
     expect(reloadStoredAccounts).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(remaining);
+    expect(result).toStrictEqual(remaining);
   });
 
   it('does not reload the account list when the IPC removal fails', async () => {

--- a/nym-wallet/src/utils/accountRemovalFlow.test.ts
+++ b/nym-wallet/src/utils/accountRemovalFlow.test.ts
@@ -1,0 +1,36 @@
+import { performAccountRemoval } from './accountRemovalFlow';
+
+const account = { id: 'Account 2', address: 'addr2' };
+
+describe('performAccountRemoval', () => {
+  it('removes via IPC then reloads and returns the refreshed account list', async () => {
+    const remaining = [{ id: 'Account 1', address: 'addr1' }];
+    const removeAccount = jest.fn().mockResolvedValue(undefined);
+    const reloadStoredAccounts = jest.fn().mockResolvedValue(remaining);
+
+    const result = await performAccountRemoval({ account, password: 'pw', removeAccount, reloadStoredAccounts });
+
+    expect(removeAccount).toHaveBeenCalledWith({ password: 'pw', accountName: 'Account 2' });
+    expect(reloadStoredAccounts).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(remaining);
+  });
+
+  it('does not reload the account list when the IPC removal fails', async () => {
+    const removeAccount = jest.fn().mockRejectedValue('Switch to another account before removing the active account');
+    const reloadStoredAccounts = jest.fn().mockResolvedValue([]);
+
+    await expect(
+      performAccountRemoval({ account, password: 'pw', removeAccount, reloadStoredAccounts }),
+    ).rejects.toThrow('Switch to another account');
+    expect(reloadStoredAccounts).not.toHaveBeenCalled();
+  });
+
+  it('maps a legacy mnemonic backend error to user-facing copy', async () => {
+    const removeAccount = jest.fn().mockRejectedValue('Unexpected mnemonic account for login');
+    const reloadStoredAccounts = jest.fn();
+
+    await expect(
+      performAccountRemoval({ account, password: 'pw', removeAccount, reloadStoredAccounts }),
+    ).rejects.toThrow('legacy single-account');
+  });
+});

--- a/nym-wallet/src/utils/accountRemovalFlow.ts
+++ b/nym-wallet/src/utils/accountRemovalFlow.ts
@@ -1,0 +1,26 @@
+import { AccountEntry } from '@nymproject/types';
+import { mapAccountRemovalError } from './accountRemovalErrors';
+
+/**
+ * Orchestrates the local + remote effects of removing a stored account so the sequence is testable
+ * outside React: remove via IPC, then reload the stored accounts and return the refreshed list.
+ * Backend errors are surfaced as a user-facing message via `mapAccountRemovalError`.
+ */
+export async function performAccountRemoval({
+  account,
+  password,
+  removeAccount,
+  reloadStoredAccounts,
+}: {
+  account: AccountEntry;
+  password: string;
+  removeAccount: (args: { password: string; accountName: string }) => Promise<void>;
+  reloadStoredAccounts: () => Promise<AccountEntry[]>;
+}): Promise<AccountEntry[]> {
+  try {
+    await removeAccount({ password, accountName: account.id });
+    return await reloadStoredAccounts();
+  } catch (e) {
+    throw new Error(mapAccountRemovalError(e));
+  }
+}

--- a/nym-wallet/src/utils/accountRemovalPolicy.test.ts
+++ b/nym-wallet/src/utils/accountRemovalPolicy.test.ts
@@ -1,8 +1,4 @@
-import {
-  canRemoveAccount,
-  getAccountRemovalBlockMessage,
-  getAccountRemovalBlockReason,
-} from './accountRemovalPolicy';
+import { canRemoveAccount, getAccountRemovalBlockMessage, getAccountRemovalBlockReason } from './accountRemovalPolicy';
 
 const accounts = [
   { id: 'Account 1', address: 'addr1' },

--- a/nym-wallet/src/utils/accountRemovalPolicy.test.ts
+++ b/nym-wallet/src/utils/accountRemovalPolicy.test.ts
@@ -1,0 +1,30 @@
+import {
+  canRemoveAccount,
+  getAccountRemovalBlockMessage,
+  getAccountRemovalBlockReason,
+} from './accountRemovalPolicy';
+
+const accounts = [
+  { id: 'Account 1', address: 'addr1' },
+  { id: 'Account 2', address: 'addr2' },
+];
+
+describe('accountRemovalPolicy', () => {
+  it('allows removing a non-active account when multiple accounts exist', () => {
+    expect(canRemoveAccount(accounts, 'Account 1', 'Account 2')).toBe(true);
+    expect(getAccountRemovalBlockReason(accounts, 'Account 1', 'Account 2')).toBeNull();
+  });
+
+  it('blocks removing the active account', () => {
+    expect(canRemoveAccount(accounts, 'Account 1', 'Account 1')).toBe(false);
+    expect(getAccountRemovalBlockReason(accounts, 'Account 1', 'Account 1')).toBe('active_account');
+    expect(getAccountRemovalBlockMessage('active_account')).toContain('Switch to another account');
+  });
+
+  it('blocks removing the only stored account', () => {
+    const single = [{ id: 'Account 1', address: 'addr1' }];
+    expect(canRemoveAccount(single, 'Account 1', 'Account 1')).toBe(false);
+    expect(getAccountRemovalBlockReason(single, 'Account 1', 'Account 1')).toBe('last_account');
+    expect(getAccountRemovalBlockMessage('last_account')).toContain('only stored account');
+  });
+});

--- a/nym-wallet/src/utils/accountRemovalPolicy.ts
+++ b/nym-wallet/src/utils/accountRemovalPolicy.ts
@@ -1,5 +1,6 @@
 import { AccountEntry } from '@nymproject/types';
 
+/** Advisory UI pre-check only; backend removal rules in `remove_account_for_password` are authoritative. */
 export type AccountRemovalBlockReason = 'active_account' | 'last_account';
 
 export function getAccountRemovalBlockReason(

--- a/nym-wallet/src/utils/accountRemovalPolicy.ts
+++ b/nym-wallet/src/utils/accountRemovalPolicy.ts
@@ -1,0 +1,32 @@
+import { AccountEntry } from '@nymproject/types';
+
+export type AccountRemovalBlockReason = 'active_account' | 'last_account';
+
+export function getAccountRemovalBlockReason(
+  accounts: AccountEntry[],
+  selectedAccountId: string | undefined,
+  targetAccountId: string,
+): AccountRemovalBlockReason | null {
+  if (accounts.length <= 1) {
+    return 'last_account';
+  }
+  if (selectedAccountId === targetAccountId) {
+    return 'active_account';
+  }
+  return null;
+}
+
+export function canRemoveAccount(
+  accounts: AccountEntry[],
+  selectedAccountId: string | undefined,
+  targetAccountId: string,
+): boolean {
+  return getAccountRemovalBlockReason(accounts, selectedAccountId, targetAccountId) === null;
+}
+
+export function getAccountRemovalBlockMessage(reason: AccountRemovalBlockReason): string {
+  if (reason === 'last_account') {
+    return 'You cannot remove your only stored account here. To reset the wallet entirely, sign out and remove your saved wallet file after backing it up.';
+  }
+  return 'Switch to another account before removing this one.';
+}

--- a/nym-wallet/src/utils/deleteAccountModalPolicy.test.ts
+++ b/nym-wallet/src/utils/deleteAccountModalPolicy.test.ts
@@ -1,0 +1,30 @@
+import { canProceedToAccountRemovalPassword } from './deleteAccountModalPolicy';
+
+describe('canProceedToAccountRemovalPassword', () => {
+  it('requires backup acknowledgement and loaded paths', () => {
+    expect(
+      canProceedToAccountRemovalPassword({
+        backupConfirmed: true,
+        backupReminder: '~/saved-wallet.json',
+      }),
+    ).toBe(true);
+  });
+
+  it('allows proceed when paths failed to load but backup is acknowledged', () => {
+    expect(
+      canProceedToAccountRemovalPassword({
+        backupConfirmed: true,
+        pathsLoadError: 'IPC unavailable',
+      }),
+    ).toBe(true);
+  });
+
+  it('blocks proceed without backup acknowledgement even if paths errored', () => {
+    expect(
+      canProceedToAccountRemovalPassword({
+        backupConfirmed: false,
+        pathsLoadError: 'IPC unavailable',
+      }),
+    ).toBe(false);
+  });
+});

--- a/nym-wallet/src/utils/deleteAccountModalPolicy.test.ts
+++ b/nym-wallet/src/utils/deleteAccountModalPolicy.test.ts
@@ -1,4 +1,4 @@
-import { canProceedToAccountRemovalPassword } from './deleteAccountModalPolicy';
+import { canProceedToAccountRemovalPassword, formatWalletPathsLoadBlockedMessage } from './deleteAccountModalPolicy';
 
 describe('canProceedToAccountRemovalPassword', () => {
   it('requires backup acknowledgement and loaded paths', () => {
@@ -26,5 +26,13 @@ describe('canProceedToAccountRemovalPassword', () => {
         pathsLoadError: 'IPC unavailable',
       }),
     ).toBe(false);
+  });
+});
+
+describe('formatWalletPathsLoadBlockedMessage', () => {
+  it('states that removal is disabled until paths load', () => {
+    expect(formatWalletPathsLoadBlockedMessage('IPC unavailable')).toContain(
+      'disabled until these paths can be loaded',
+    );
   });
 });

--- a/nym-wallet/src/utils/deleteAccountModalPolicy.test.ts
+++ b/nym-wallet/src/utils/deleteAccountModalPolicy.test.ts
@@ -10,13 +10,13 @@ describe('canProceedToAccountRemovalPassword', () => {
     ).toBe(true);
   });
 
-  it('allows proceed when paths failed to load but backup is acknowledged', () => {
+  it('blocks proceed when backup paths failed to load even if backup is acknowledged', () => {
     expect(
       canProceedToAccountRemovalPassword({
         backupConfirmed: true,
         pathsLoadError: 'IPC unavailable',
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('blocks proceed without backup acknowledgement even if paths errored', () => {

--- a/nym-wallet/src/utils/deleteAccountModalPolicy.ts
+++ b/nym-wallet/src/utils/deleteAccountModalPolicy.ts
@@ -7,8 +7,8 @@ export function canProceedToAccountRemovalPassword({
   backupReminder?: string;
   pathsLoadError?: string;
 }): boolean {
-  if (!backupConfirmed) {
+  if (!backupConfirmed || pathsLoadError) {
     return false;
   }
-  return Boolean(backupReminder) || Boolean(pathsLoadError);
+  return Boolean(backupReminder);
 }

--- a/nym-wallet/src/utils/deleteAccountModalPolicy.ts
+++ b/nym-wallet/src/utils/deleteAccountModalPolicy.ts
@@ -12,3 +12,7 @@ export function canProceedToAccountRemovalPassword({
   }
   return Boolean(backupReminder);
 }
+
+export function formatWalletPathsLoadBlockedMessage(pathsLoadError: string): string {
+  return `Could not load wallet file locations: ${pathsLoadError}. Account removal is disabled until these paths can be loaded.`;
+}

--- a/nym-wallet/src/utils/deleteAccountModalPolicy.ts
+++ b/nym-wallet/src/utils/deleteAccountModalPolicy.ts
@@ -1,0 +1,14 @@
+export function canProceedToAccountRemovalPassword({
+  backupConfirmed,
+  backupReminder,
+  pathsLoadError,
+}: {
+  backupConfirmed: boolean;
+  backupReminder?: string;
+  pathsLoadError?: string;
+}): boolean {
+  if (!backupConfirmed) {
+    return false;
+  }
+  return Boolean(backupReminder) || Boolean(pathsLoadError);
+}

--- a/nym-wallet/src/utils/deleteAccountModalRecovery.test.ts
+++ b/nym-wallet/src/utils/deleteAccountModalRecovery.test.ts
@@ -1,0 +1,15 @@
+import { resolveDeleteModalRecovery } from './deleteAccountModalRecovery';
+
+describe('resolveDeleteModalRecovery', () => {
+  it('returns to the warning step after a failed removal so the user keeps cancel and back actions', () => {
+    expect(resolveDeleteModalRecovery('removal_failed')).toStrictEqual({ action: 'return_to_warning' });
+  });
+
+  it('exits the delete flow when password confirmation is cancelled', () => {
+    expect(resolveDeleteModalRecovery('confirm_password_cancel')).toStrictEqual({ action: 'exit_flow' });
+  });
+
+  it('exits the delete flow after a successful removal', () => {
+    expect(resolveDeleteModalRecovery('removal_succeeded')).toStrictEqual({ action: 'exit_flow' });
+  });
+});

--- a/nym-wallet/src/utils/deleteAccountModalRecovery.ts
+++ b/nym-wallet/src/utils/deleteAccountModalRecovery.ts
@@ -1,0 +1,11 @@
+export type DeleteAccountModalRecoveryEvent = 'confirm_password_cancel' | 'removal_failed' | 'removal_succeeded';
+
+export type DeleteAccountModalRecoveryOutcome = { action: 'exit_flow' } | { action: 'return_to_warning' };
+
+/** Password-step cancel always exits deletion so the user is never trapped behind a nested sheet. */
+export function resolveDeleteModalRecovery(event: DeleteAccountModalRecoveryEvent): DeleteAccountModalRecoveryOutcome {
+  if (event === 'removal_failed') {
+    return { action: 'return_to_warning' };
+  }
+  return { action: 'exit_flow' };
+}

--- a/nym-wallet/src/utils/networkSelectorLabel.test.ts
+++ b/nym-wallet/src/utils/networkSelectorLabel.test.ts
@@ -1,0 +1,20 @@
+import { formatNetworkSelectorLabel } from './networkSelectorLabel';
+
+const selectableNetworks = [
+  { networkName: 'MAINNET' as const, name: 'Nym Mainnet' },
+  { networkName: 'SANDBOX' as const, name: 'Testnet Sandbox' },
+];
+
+describe('formatNetworkSelectorLabel', () => {
+  it('uses the friendly label for supported networks', () => {
+    expect(formatNetworkSelectorLabel('MAINNET', selectableNetworks)).toBe('Nym Mainnet');
+  });
+
+  it('shows a readable legacy label when a persisted network is no longer selectable', () => {
+    expect(formatNetworkSelectorLabel('QA', selectableNetworks)).toBe('QA (unsupported)');
+  });
+
+  it('falls back to the first selectable network when no network is set', () => {
+    expect(formatNetworkSelectorLabel(undefined, selectableNetworks)).toBe('Nym Mainnet');
+  });
+});

--- a/nym-wallet/src/utils/networkSelectorLabel.ts
+++ b/nym-wallet/src/utils/networkSelectorLabel.ts
@@ -1,0 +1,18 @@
+import { Network } from '../types';
+
+export type SelectableNetwork = { networkName: Network; name: string };
+
+/** Display label for the header control; legacy persisted values stay readable after options are removed. */
+export function formatNetworkSelectorLabel(
+  network: Network | undefined,
+  selectableNetworks: readonly SelectableNetwork[],
+): string {
+  const match = selectableNetworks.find((entry) => entry.networkName === network);
+  if (match) {
+    return match.name;
+  }
+  if (network) {
+    return `${network} (unsupported)`;
+  }
+  return selectableNetworks[0]?.name ?? 'Network';
+}

--- a/nym-wallet/src/utils/networkSwitchExecution.test.ts
+++ b/nym-wallet/src/utils/networkSwitchExecution.test.ts
@@ -27,14 +27,16 @@ describe('selectNetworkForPersistence', () => {
 
 describe('resolveNetworkSwitchOutcome', () => {
   it('keeps the previous network when refresh fails for a logged-in session', () => {
-    expect(
-      resolveNetworkSwitchOutcome('MAINNET', 'SANDBOX', false, true),
-    ).toEqual({ status: 'failed', network: 'MAINNET' });
+    expect(resolveNetworkSwitchOutcome('MAINNET', 'SANDBOX', false, true)).toStrictEqual({
+      status: 'failed',
+      network: 'MAINNET',
+    });
   });
 
   it('commits the target network after refresh succeeds', () => {
-    expect(
-      resolveNetworkSwitchOutcome('MAINNET', 'SANDBOX', true, true),
-    ).toEqual({ status: 'committed', network: 'SANDBOX' });
+    expect(resolveNetworkSwitchOutcome('MAINNET', 'SANDBOX', true, true)).toStrictEqual({
+      status: 'committed',
+      network: 'SANDBOX',
+    });
   });
 });

--- a/nym-wallet/src/utils/networkSwitchExecution.test.ts
+++ b/nym-wallet/src/utils/networkSwitchExecution.test.ts
@@ -1,0 +1,26 @@
+import { didNetworkRefreshSucceed, resolveNetworkSwitchOutcome } from './networkSwitchExecution';
+
+describe('didNetworkRefreshSucceed', () => {
+  it('treats a missing loaded client as a failed switch (loadAccount swallows errors)', () => {
+    expect(didNetworkRefreshSucceed(undefined)).toBe(false);
+    expect(didNetworkRefreshSucceed(null)).toBe(false);
+  });
+
+  it('treats a loaded client as a successful switch', () => {
+    expect(didNetworkRefreshSucceed({ client_address: 'n1abc' })).toBe(true);
+  });
+});
+
+describe('resolveNetworkSwitchOutcome', () => {
+  it('keeps the previous network when refresh fails for a logged-in session', () => {
+    expect(
+      resolveNetworkSwitchOutcome('MAINNET', 'SANDBOX', false, true),
+    ).toEqual({ status: 'failed', network: 'MAINNET' });
+  });
+
+  it('commits the target network after refresh succeeds', () => {
+    expect(
+      resolveNetworkSwitchOutcome('MAINNET', 'SANDBOX', true, true),
+    ).toEqual({ status: 'committed', network: 'SANDBOX' });
+  });
+});

--- a/nym-wallet/src/utils/networkSwitchExecution.test.ts
+++ b/nym-wallet/src/utils/networkSwitchExecution.test.ts
@@ -2,6 +2,8 @@ import {
   didNetworkRefreshSucceed,
   resolveNetworkSwitchOutcome,
   selectNetworkForPersistence,
+  shouldClearWalletUiStateOnNetworkSwitchCommit,
+  shouldShowNetworkSwitchFailureToast,
 } from './networkSwitchExecution';
 
 describe('didNetworkRefreshSucceed', () => {
@@ -38,5 +40,18 @@ describe('resolveNetworkSwitchOutcome', () => {
       status: 'committed',
       network: 'SANDBOX',
     });
+  });
+});
+
+describe('shouldClearWalletUiStateOnNetworkSwitchCommit', () => {
+  it('clears wallet UI state only after a committed switch', () => {
+    expect(shouldClearWalletUiStateOnNetworkSwitchCommit({ status: 'failed', network: 'MAINNET' })).toBe(false);
+    expect(shouldClearWalletUiStateOnNetworkSwitchCommit({ status: 'committed', network: 'SANDBOX' })).toBe(true);
+  });
+});
+
+describe('shouldShowNetworkSwitchFailureToast', () => {
+  it('does not duplicate loadAccount error toasts', () => {
+    expect(shouldShowNetworkSwitchFailureToast()).toBe(false);
   });
 });

--- a/nym-wallet/src/utils/networkSwitchExecution.test.ts
+++ b/nym-wallet/src/utils/networkSwitchExecution.test.ts
@@ -1,4 +1,8 @@
-import { didNetworkRefreshSucceed, resolveNetworkSwitchOutcome } from './networkSwitchExecution';
+import {
+  didNetworkRefreshSucceed,
+  resolveNetworkSwitchOutcome,
+  selectNetworkForPersistence,
+} from './networkSwitchExecution';
 
 describe('didNetworkRefreshSucceed', () => {
   it('treats a missing loaded client as a failed switch (loadAccount swallows errors)', () => {
@@ -8,6 +12,16 @@ describe('didNetworkRefreshSucceed', () => {
 
   it('treats a loaded client as a successful switch', () => {
     expect(didNetworkRefreshSucceed({ client_address: 'n1abc' })).toBe(true);
+  });
+});
+
+describe('selectNetworkForPersistence', () => {
+  it('prefers the committed network over stale React state when persisting after a switch', () => {
+    expect(selectNetworkForPersistence('MAINNET', 'SANDBOX')).toBe('SANDBOX');
+  });
+
+  it('falls back to React state when no explicit network is provided', () => {
+    expect(selectNetworkForPersistence('MAINNET')).toBe('MAINNET');
   });
 });
 

--- a/nym-wallet/src/utils/networkSwitchExecution.ts
+++ b/nym-wallet/src/utils/networkSwitchExecution.ts
@@ -33,6 +33,16 @@ export function resolveNetworkSwitchOutcome(
   return { status: 'failed', network: previousNetwork ?? targetNetwork };
 }
 
+/** Defer balance/mixnode clears until the switch commits so a failed refresh does not zero the UI. */
+export function shouldClearWalletUiStateOnNetworkSwitchCommit(outcome: NetworkSwitchOutcome): boolean {
+  return outcome.status === 'committed';
+}
+
+/** loadAccount already surfaces load failures; switchNetwork should not enqueue a second toast. */
+export function shouldShowNetworkSwitchFailureToast(): boolean {
+  return false;
+}
+
 /** React setState is async; pass the committed network when persisting immediately after a switch. */
 export function selectNetworkForPersistence(
   reactStateNetwork: Network | undefined,

--- a/nym-wallet/src/utils/networkSwitchExecution.ts
+++ b/nym-wallet/src/utils/networkSwitchExecution.ts
@@ -32,3 +32,11 @@ export function resolveNetworkSwitchOutcome(
   }
   return { status: 'failed', network: previousNetwork ?? targetNetwork };
 }
+
+/** React setState is async; pass the committed network when persisting immediately after a switch. */
+export function selectNetworkForPersistence(
+  reactStateNetwork: Network | undefined,
+  explicitNetwork?: Network,
+): Network | undefined {
+  return explicitNetwork ?? reactStateNetwork;
+}

--- a/nym-wallet/src/utils/networkSwitchExecution.ts
+++ b/nym-wallet/src/utils/networkSwitchExecution.ts
@@ -1,0 +1,34 @@
+import { Network } from '../types';
+
+export type NetworkSwitchOutcome =
+  | { status: 'unchanged'; network: Network }
+  | { status: 'committed'; network: Network }
+  | { status: 'failed'; network: Network };
+
+/**
+ * `loadAccount` swallows backend errors and resolves to `undefined`, so the absence of a thrown
+ * error is NOT proof the Rust `switch_network` succeeded. A switch succeeded only when a client
+ * was actually loaded for the target network.
+ */
+export function didNetworkRefreshSucceed(loadedClient: unknown): boolean {
+  return Boolean(loadedClient);
+}
+
+/** Logged-in switches commit network state only after Rust refresh succeeds. */
+export function resolveNetworkSwitchOutcome(
+  previousNetwork: Network | undefined,
+  targetNetwork: Network,
+  refreshSucceeded: boolean,
+  hasActiveSession: boolean,
+): NetworkSwitchOutcome {
+  if (targetNetwork === previousNetwork) {
+    return { status: 'unchanged', network: previousNetwork ?? targetNetwork };
+  }
+  if (!hasActiveSession) {
+    return { status: 'committed', network: targetNetwork };
+  }
+  if (refreshSucceeded) {
+    return { status: 'committed', network: targetNetwork };
+  }
+  return { status: 'failed', network: previousNetwork ?? targetNetwork };
+}

--- a/nym-wallet/src/utils/networkSwitchPolicy.test.ts
+++ b/nym-wallet/src/utils/networkSwitchPolicy.test.ts
@@ -1,0 +1,11 @@
+import { shouldRefreshAccountOnManualNetworkSwitch } from './networkSwitchPolicy';
+
+describe('networkSwitchPolicy', () => {
+  it('requires backend refresh when user switches network while logged in', () => {
+    expect(shouldRefreshAccountOnManualNetworkSwitch(true)).toBe(true);
+  });
+
+  it('defers account load to the network effect when there is no active session', () => {
+    expect(shouldRefreshAccountOnManualNetworkSwitch(false)).toBe(false);
+  });
+});

--- a/nym-wallet/src/utils/networkSwitchPolicy.ts
+++ b/nym-wallet/src/utils/networkSwitchPolicy.ts
@@ -1,0 +1,4 @@
+/** Logged-in network changes must call Rust `switch_network`; the boot effect only loads when no session yet. */
+export function shouldRefreshAccountOnManualNetworkSwitch(hasActiveSession: boolean): boolean {
+  return hasActiveSession;
+}

--- a/nym-wallet/src/utils/walletBackupReminder.test.ts
+++ b/nym-wallet/src/utils/walletBackupReminder.test.ts
@@ -1,0 +1,17 @@
+import { formatWalletBackupReminder } from './walletBackupReminder';
+
+describe('walletBackupReminder', () => {
+  it('includes platform paths and permanent removal warning', () => {
+    const message = formatWalletBackupReminder({
+      walletFile: '/Users/me/Library/Application Support/nym-wallet/saved-wallet.json',
+      storageDirectory: '/Users/me/Library/Application Support/nym-wallet',
+      configDirectory: '/Users/me/Library/Application Support/nym-wallet',
+    });
+
+    expect(message).toContain('permanently deletes');
+    expect(message).toContain('cannot be undone');
+    expect(message).toContain('saved-wallet.json');
+    expect(message).toContain('backup');
+    expect(message).toContain('Wallet folder');
+  });
+});

--- a/nym-wallet/src/utils/walletBackupReminder.ts
+++ b/nym-wallet/src/utils/walletBackupReminder.ts
@@ -1,0 +1,22 @@
+export type WalletStoragePaths = {
+  walletFile: string;
+  storageDirectory: string;
+  configDirectory: string;
+};
+
+export function formatWalletBackupReminder(paths: WalletStoragePaths): string {
+  return [
+    'Removing a stored account permanently deletes its saved credentials from your wallet file. This cannot be undone.',
+    '',
+    'Before you continue, copy your wallet file and settings folder to a safe backup location. If removal fails or corrupts the file, you may lose access to your remaining accounts without a backup.',
+    '',
+    `Wallet file (required backup):`,
+    paths.walletFile,
+    '',
+    `Wallet folder (recommended backup):`,
+    paths.storageDirectory,
+    '',
+    `Wallet settings folder (recommended backup):`,
+    paths.configDirectory,
+  ].join('\n');
+}


### PR DESCRIPTION
- Users with a password-protected wallet and more than one saved account can remove an individual account from the accounts list, with clear warnings and a password confirmation step.
- Removal is blocked when it would be unsafe: you cannot remove the account you are currently using (switch first), and you cannot remove your only saved account from this screen (full wallet reset still requires signing out and removing the wallet file after a backup).
- Before removal, the app shows where the wallet file lives on disk and asks you to confirm you have backed up, so accidental data loss is less likely.
- The wallet backend now checks these rules before deleting anything, and shows clearer error messages if something goes wrong.

Bonus fix 🕺 
Fixed a bug where changing network (e.g. mainnet to sandbox) while logged in could leave the app on the wrong network or show stale balances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added account deletion UI with safeguards to prevent removing the last stored account or the currently active account.
  * Added a full “Delete Account” flow with backup confirmation, backup reminder, and password confirmation.
  * Added wallet storage location lookup to power the backup reminder during deletion.

* **Changes**
  * Improved user-facing account removal error messages and delete-flow recovery behavior.
  * Refined account removal handling to reload accounts after successful deletion.
  * Improved network switching refresh/commit behavior and simplified the Network Selector to Mainnet and Sandbox.

* **Tests**
  * Added/expanded coverage for deletion, error mapping, and network-switch logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->