### PR TITLE
[DOCs/operators]: Stress testing score

### DIFF
--- a/documentation/docs/components/operators/snippets/node-perf-mixnet.mdx
+++ b/documentation/docs/components/operators/snippets/node-perf-mixnet.mdx
@@ -3,10 +3,14 @@ import { Callout } from 'nextra/components';
 
 ## Mixnet: Node Performance Calculation
 
-Performance is a value between `0` and `1`. The final performance number is a result of multiplying [config score](#config-score-calculation) and [routing score](#routing-score-calculation).
+Performance is a value between `0` and `1`. The final performance number has different calculation for nodes serving as gateways and where the result is calculated by multiplying [config score](#config-score-calculation) and [routing score](#routing-score-calculation), where for nodes serving as mixnodes we added a new value [`stress_score`](#stress-testing-score-calculation) with a weight `0.3`. See the formulas below or directly in the code on Github ([here](https://github.com/nymtech/nym/blob/develop/nym-api/src/node_status_api/cache/refresher.rs#L254-L263) and [here](https://github.com/nymtech/nym/blob/develop/nym-api/src/node_status_api/cache/refresher.rs#L378-L390)).
 
 <Callout type="info" emoji="📌">
-> **node_performance = config_score \* routing_score**
+> **Gateways** <br/>
+> **performance = config_score * routing_score** <br/><br/>
+> **Mixnodes** <br/>
+> **performance = config_score * stress_weight * stress_score + (1.0 - stress_weight) * routing_score** <br/>
+> **stress_testing_score_weight = 0.3**
 </Callout>
 
 Performance value is an average of last 24h.
@@ -91,3 +95,31 @@ As you can see above, the algorithm is designed to give maximum selection score 
 ### Routing Score Calculation
 
 Routing score is measured by Nym Network Monitor which sends thousands of packages through different routes every 15 minutes and measures how many were dropped on the way. Test result represents percentage of packets succesfully returned which are then converted into floats bettween `0` and `1`.
+
+###  Stress Testing Score Calculation
+
+<Callout type="info" emoji="ℹ️">
+**This metric concernes only Nym nodes running in the mode `mixnode`.**
+</Callout>
+
+With a growing user base of NymVPN and ongoing SDK releases, there is a requirement to optimize the quality of Nym Mixnet to ensure reliable performance and low packet loss. 
+
+So far [`routing_score`](#routing-score) has been the most essential variable in the calculation of node performance. However, we found out that there are more vectors needed to evaluate quality of mixnode performance. 
+
+There is an additional metric only for mixnodes - *stress testing score*. Stress testing is a performance measurement, calculating how many packets sent together in a burst a node can handle without dropping them. 
+
+Such test is done by sending **1000 packets per second for 30 seconds, once every ~2 hours**.
+
+Not alike `routing_score` going over a whole route, stress testing measures exactly 1 node and therefore the result is exact for the given node. The route is simple:
+```
+nym_testing_agent -> mixnode -> nym_testing_agent
+```
+
+The value of stress testing score is denoted as `stress__score` and it's a float between 0-1 displaying percentage success of packets returning back to the agent. 
+
+This is the calculation formula for mixnodes:
+
+<Callout type="info" emoji="📌">
+> **performance = config_score * stress_weight * stress_score + (1.0 - stress_weight) * routing_score** <br/>
+> **stress_testing_score_weight = 0.3**
+</Callout>

--- a/documentation/docs/components/operators/snippets/node-perf-mixnet.mdx
+++ b/documentation/docs/components/operators/snippets/node-perf-mixnet.mdx
@@ -7,9 +7,9 @@ Performance is a value between `0` and `1`. The final performance number has dif
 
 <Callout type="info" emoji="📌">
 > **Gateways** <br/>
-> **performance = config_score * routing_score** <br/><br/>
+> **performance = config_score \* routing_score** <br/><br/>
 > **Mixnodes** <br/>
-> **performance = config_score * stress_weight * stress_score + (1.0 - stress_weight) * routing_score** <br/>
+> **performance = tress_weight \* stress_score + (1.0 - stress_weight) \* routing_score \* config_score** <br/>
 > **stress_testing_score_weight = 0.3**
 </Callout>
 
@@ -120,6 +120,6 @@ The value of stress testing score is denoted as `stress__score` and it's a float
 This is the calculation formula for mixnodes:
 
 <Callout type="info" emoji="📌">
-> **performance = config_score * stress_weight * stress_score + (1.0 - stress_weight) * routing_score** <br/>
+> **performance = tress_weight \* stress_score + (1.0 - stress_weight) \* routing_score \* config_score** <br/>
 > **stress_testing_score_weight = 0.3**
 </Callout>

--- a/documentation/docs/components/operators/snippets/node-perf-mixnet.mdx
+++ b/documentation/docs/components/operators/snippets/node-perf-mixnet.mdx
@@ -9,8 +9,8 @@ Performance is a value between `0` and `1`. The final performance number has dif
 > **Gateways** <br/>
 > **performance = config_score \* routing_score** <br/><br/>
 > **Mixnodes** <br/>
-> **performance = stress_weight \* stress_score + (1.0 - stress_weight) \* routing_score \* config_score** <br/>
-> **stress_testing_score_weight = 0.3**
+> **performance = stress_weight \* stress_score + ( 1.0 - stress_weight ) \* routing_score \* config_score** <br/>
+> **stress_weight = 0.3**
 </Callout>
 
 Performance value is an average of last 24h.
@@ -121,5 +121,5 @@ This is the calculation formula for mixnodes:
 
 <Callout type="info" emoji="📌">
 > **performance = stress_weight \* stress_score + (1.0 - stress_weight) \* routing_score \* config_score** <br/>
-> **stress_testing_score_weight = 0.3**
+> **stress_weight = 0.3**
 </Callout>

--- a/documentation/docs/components/operators/snippets/node-perf-mixnet.mdx
+++ b/documentation/docs/components/operators/snippets/node-perf-mixnet.mdx
@@ -99,7 +99,7 @@ Routing score is measured by Nym Network Monitor which sends thousands of packag
 ###  Stress Testing Score Calculation
 
 <Callout type="info" emoji="ℹ️">
-**This metric concernes only Nym nodes running in the mode `mixnode`.**
+**This metric applies only to Mixnodes (`nym-node` run in `--mode mixnode`).**
 </Callout>
 
 With a growing user base of NymVPN and ongoing SDK releases, there is a requirement to optimize the quality of Nym Mixnet to ensure reliable performance and low packet loss. 

--- a/documentation/docs/components/operators/snippets/node-perf-mixnet.mdx
+++ b/documentation/docs/components/operators/snippets/node-perf-mixnet.mdx
@@ -9,7 +9,7 @@ Performance is a value between `0` and `1`. The final performance number has dif
 > **Gateways** <br/>
 > **performance = config_score \* routing_score** <br/><br/>
 > **Mixnodes** <br/>
-> **performance = tress_weight \* stress_score + (1.0 - stress_weight) \* routing_score \* config_score** <br/>
+> **performance = stress_weight \* stress_score + (1.0 - stress_weight) \* routing_score \* config_score** <br/>
 > **stress_testing_score_weight = 0.3**
 </Callout>
 
@@ -120,6 +120,6 @@ The value of stress testing score is denoted as `stress__score` and it's a float
 This is the calculation formula for mixnodes:
 
 <Callout type="info" emoji="📌">
-> **performance = tress_weight \* stress_score + (1.0 - stress_weight) \* routing_score \* config_score** <br/>
+> **performance = stress_weight \* stress_score + (1.0 - stress_weight) \* routing_score \* config_score** <br/>
 > **stress_testing_score_weight = 0.3**
 </Callout>

--- a/documentation/docs/components/outputs/api-scraping-outputs/nodes-count.json
+++ b/documentation/docs/components/outputs/api-scraping-outputs/nodes-count.json
@@ -1,6 +1,6 @@
 {
   "nodes": 694,
-  "locations": 75,
-  "mixnodes": 238,
-  "exit_gateways": 448
+  "locations": 73,
+  "mixnodes": 234,
+  "exit_gateways": 452
 }

--- a/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
+++ b/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
@@ -1,1 +1,1 @@
-Saturday, June 13th 2026, 11:33:57 UTC
+Tuesday, June 16th 2026, 14:01:39 UTC

--- a/documentation/docs/components/outputs/command-outputs/nym-api-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-api-help.md
@@ -8,8 +8,13 @@ Commands:
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-  -c, --config-env-file <CONFIG_ENV_FILE>  Path pointing to an env file that configures the Nym API [env: NYMAPI_CONFIG_ENV_FILE_ARG=]
-      --no-banner                          A no-op flag included for consistency with other binaries (and compatibility with nymvisor, oops) [env: NYMAPI_NO_BANNER_ARG=]
-  -h, --help                               Print help
-  -V, --version                            Print version
+  -c, --config-env-file <CONFIG_ENV_FILE>
+          Path pointing to an env file that configures the Nym API [env: NYMAPI_CONFIG_ENV_FILE_ARG=]
+      --no-banner
+          A no-op flag included for consistency with other binaries (and compatibility with nymvisor,
+          oops) [env: NYMAPI_NO_BANNER_ARG=]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```

--- a/documentation/docs/components/outputs/command-outputs/nym-node-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-node-help.md
@@ -8,12 +8,18 @@ Commands:
   migrate                   Attempt to migrate an existing mixnode or gateway into a nym-node
   run                       Start this nym-node
   sign                      Use identity key of this node to sign provided message
-  unsafe-reset-sphinx-keys  UNSAFE: reset existing sphinx keys and attempt to generate fresh one for the current network state
+  unsafe-reset-sphinx-keys  UNSAFE: reset existing sphinx keys and attempt to generate fresh one for the
+                            current network state
   help                      Print this message or the help of the given subcommand(s)
 
 Options:
-  -c, --config-env-file <CONFIG_ENV_FILE>  Path pointing to an env file that configures the nym-node and overrides any preconfigured values [env: NYMNODE_CONFIG_ENV_FILE_ARG=]
-      --no-banner                          Flag used for disabling the printed banner in tty [env: NYMNODE_NO_BANNER=]
-  -h, --help                               Print help
-  -V, --version                            Print version
+  -c, --config-env-file <CONFIG_ENV_FILE>
+          Path pointing to an env file that configures the nym-node and overrides any preconfigured values
+          [env: NYMNODE_CONFIG_ENV_FILE_ARG=]
+      --no-banner
+          Flag used for disabling the printed banner in tty [env: NYMNODE_NO_BANNER=]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```

--- a/documentation/docs/components/outputs/command-outputs/nym-node-run-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-node-run-help.md
@@ -4,89 +4,159 @@ Start this nym-node
 Usage: nym-node run [OPTIONS]
 
 Options:
-      --id <ID>                                                              Id of the nym-node to use [env: NYMNODE_ID=] [default: default-nym-node]
-      --config-file <CONFIG_FILE>                                            Path to a configuration file of this node [env: NYMNODE_CONFIG=]
-      --accept-operator-terms-and-conditions                                 Explicitly specify whether you agree with the terms and conditions of a nym node operator as defined at
-                                                                             <https://nymtech.net/terms-and-conditions/operators/v1.0.0> [env: NYMNODE_ACCEPT_OPERATOR_TERMS=]
-      --deny-init                                                            Forbid a new node from being initialised if configuration file for the provided specification doesn't already exist [env:
-                                                                             NYMNODE_DENY_INIT=]
-      --init-only                                                            If this is a brand new nym-node, specify whether it should only be initialised without actually running the subprocesses [env:
-                                                                             NYMNODE_INIT_ONLY=]
-      --local                                                                Flag specifying this node will be running in a local setting [env: NYMNODE_LOCAL=]
-      --mode [<MODE>...]                                                     Specifies the current mode(s) of this nym-node [env: NYMNODE_MODE=] [possible values: mixnode, entry-gateway, exit-gateway,
-                                                                             exit-providers-only]
-      --modes <MODES>                                                        Specifies the current mode(s) of this nym-node as a single flag [env: NYMNODE_MODES=] [possible values: mixnode, entry-gateway,
-                                                                             exit-gateway, exit-providers-only]
-  -w, --write-changes                                                        If this node has been initialised before, specify whether to write any new changes to the config file [env:
-                                                                             NYMNODE_WRITE_CONFIG_CHANGES=]
-      --bonding-information-output <BONDING_INFORMATION_OUTPUT>              Specify output file for bonding information of this nym-node, i.e. its encoded keys. NOTE: the required bonding information is still a
-                                                                             subject to change and this argument should be treated only as a preview of future features [env: NYMNODE_BONDING_INFORMATION_OUTPUT=]
-  -o, --output <OUTPUT>                                                      Specify the output format of the bonding information (`text` or `json`) [env: NYMNODE_OUTPUT=] [default: text] [possible values: text,
-                                                                             json]
-      --public-ips <PUBLIC_IPS>                                              Comma separated list of public ip addresses that will be announced to the nym-api and subsequently to the clients. In nearly all
-                                                                             circumstances, it's going to be identical to the address you're going to use for bonding [env: NYMNODE_PUBLIC_IPS=]
-      --hostname <HOSTNAME>                                                  Optional hostname associated with this gateway that will be announced to the nym-api and subsequently to the clients [env:
-                                                                             NYMNODE_HOSTNAME=]
-      --location <LOCATION>                                                  Optional **physical** location of this node's server. Either full country name (e.g. 'Poland'), two-letter alpha2 (e.g. 'PL'),
-                                                                             three-letter alpha3 (e.g. 'POL') or three-digit numeric-3 (e.g. '616') can be provided [env: NYMNODE_LOCATION=]
-      --http-bind-address <HTTP_BIND_ADDRESS>                                Socket address this node will use for binding its http API. default: `[::]:8080` [env: NYMNODE_HTTP_BIND_ADDRESS=]
-      --landing-page-assets-path <LANDING_PAGE_ASSETS_PATH>                  Path to assets directory of custom landing page of this node [env: NYMNODE_HTTP_LANDING_ASSETS=]
-      --http-access-token <HTTP_ACCESS_TOKEN>                                An optional bearer token for accessing certain http endpoints. Currently only used for prometheus metrics [env:
-                                                                             NYMNODE_HTTP_ACCESS_TOKEN=]
-      --expose-system-info <EXPOSE_SYSTEM_INFO>                              Specify whether basic system information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_SYSTEM_INFO=] [possible values:
-                                                                             true, false]
-      --expose-system-hardware <EXPOSE_SYSTEM_HARDWARE>                      Specify whether basic system hardware information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_SYSTEM_HARDWARE=]
-                                                                             [possible values: true, false]
-      --expose-crypto-hardware <EXPOSE_CRYPTO_HARDWARE>                      Specify whether detailed system crypto hardware information should be exposed. default: true [env:
-                                                                             NYMNODE_HTTP_EXPOSE_CRYPTO_HARDWARE=] [possible values: true, false]
-      --nyxd-urls <NYXD_URLS>                                                Addresses to nyxd chain endpoint which the node will use for chain interactions [env: NYMNODE_NYXD=]
-      --nyxd-websocket-url <NYXD_WEBSOCKET_URL>                              Url to the websocket endpoint of a nyx validator, for example `wss://rpc.nymtech.net/websocket`. It is used for subscribing to new
-                                                                             block events [env: NYMNODE_NYXD_WEBSOCKET=]
-      --mixnet-bind-address <MIXNET_BIND_ADDRESS>                            Address this node will bind to for listening for mixnet packets default: `[::]:1789` [env: NYMNODE_MIXNET_BIND_ADDRESS=]
-      --mixnet-announce-port <MIXNET_ANNOUNCE_PORT>                          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node is behind a
-                                                                             proxy [env: NYMNODE_MIXNET_ANNOUNCE_PORT=]
-      --nym-api-urls <NYM_API_URLS>                                          Addresses to nym APIs from which the node gets the view of the network [env: NYMNODE_NYM_APIS=]
-      --enable-console-logging <ENABLE_CONSOLE_LOGGING>                      Specify whether running statistics of this node should be logged to the console [env: NYMNODE_ENABLE_CONSOLE_LOGGING=] [possible
-                                                                             values: true, false]
-      --wireguard-enabled <WIREGUARD_ENABLED>                                Specifies whether the wireguard service is enabled on this node [env: NYMNODE_WG_ENABLED=] [possible values: true, false]
-      --wireguard-bind-address <WIREGUARD_BIND_ADDRESS>                      Socket address this node will use for binding its wireguard interface. default: `[::]:51822` [env: NYMNODE_WG_BIND_ADDRESS=]
-      --wireguard-tunnel-announced-port <WIREGUARD_TUNNEL_ANNOUNCED_PORT>    Tunnel port announced to external clients wishing to connect to the wireguard interface. Useful in the instances where the node is
-                                                                             behind a proxy [env: NYMNODE_WG_ANNOUNCED_PORT=]
-      --wireguard-private-network-prefix <WIREGUARD_PRIVATE_NETWORK_PREFIX>  The prefix denoting the maximum number of the clients that can be connected via Wireguard. The maximum value for IPv4 is 32 and for
-                                                                             IPv6 is 128 [env: NYMNODE_WG_PRIVATE_NETWORK_PREFIX=]
-      --wireguard-userspace <WIREGUARD_USERSPACE>                            Use userspace implementation of WireGuard (wireguard-go) instead of kernel module. Useful in containerized environments without kernel
-                                                                             WireGuard support [env: NYMNODE_WG_USERSPACE=] [possible values: true, false]
-      --verloc-bind-address <VERLOC_BIND_ADDRESS>                            Socket address this node will use for binding its verloc API. default: `[::]:1790` [env: NYMNODE_VERLOC_BIND_ADDRESS=]
-      --verloc-announce-port <VERLOC_ANNOUNCE_PORT>                          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node is behind a
-                                                                             proxy [env: NYMNODE_VERLOC_ANNOUNCE_PORT=]
-      --entry-bind-address <ENTRY_BIND_ADDRESS>                              Socket address this node will use for binding its client websocket API. default: `[::]:9000` [env: NYMNODE_ENTRY_BIND_ADDRESS=]
-      --announce-ws-port <ANNOUNCE_WS_PORT>                                  Custom announced port for listening for websocket client traffic. If unspecified, the value from the `bind_address` will be used
-                                                                             instead [env: NYMNODE_ENTRY_ANNOUNCE_WS_PORT=]
-      --announce-wss-port <ANNOUNCE_WSS_PORT>                                If applicable, announced port for listening for secure websocket client traffic [env: NYMNODE_ENTRY_ANNOUNCE_WSS_PORT=]
-      --enforce-zk-nyms <ENFORCE_ZK_NYMS>                                    Indicates whether this gateway is accepting only coconut credentials for accessing the mixnet or if it also accepts non-paying clients
-                                                                             [env: NYMNODE_ENFORCE_ZK_NYMS=] [possible values: true, false]
-      --mnemonic <MNEMONIC>                                                  Custom cosmos wallet mnemonic used for zk-nym redemption. If no value is provided, a fresh mnemonic is going to be generated [env:
-                                                                             NYMNODE_MNEMONIC=]
-      --upgrade-mode-attestation-url <UPGRADE_MODE_ATTESTATION_URL>          Endpoint to query to retrieve current upgrade mode attestation. This argument should never be set outside testnets and local networks
-                                                                             [env: NYMNODE_UPGRADE_MODE_ATTESTATION_URL=]
-      --upgrade-mode-attester-public-key <UPGRADE_MODE_ATTESTER_PUBLIC_KEY>  Expected public key of the entity signing the published attestation. This argument should never be set outside testnets and local
-                                                                             networks [env: NYMNODE_UPGRADE_MODE_ATTESTER_PUBKEY=]
-      --upstream-exit-policy-url <UPSTREAM_EXIT_POLICY_URL>                  Specifies the url for an upstream source of the exit policy used by this node [env: NYMNODE_UPSTREAM_EXIT_POLICY=]
-      --open-proxy <OPEN_PROXY>                                              Specifies whether this exit node should run in 'open-proxy' mode and thus would attempt to resolve **ANY** request it receives [env:
-                                                                             NYMNODE_OPEN_PROXY=] [possible values: true, false]
-      --nr-allow-local-ips <NR_ALLOW_LOCAL_IPS>                              Allow the network requester to forward traffic to non-globally-routable addresses. Intended for local development, private-network
-                                                                             deployments, and testnet scenarios. Not recommended on production exit gateway unless you know what you're doing [env:
-                                                                             NYMNODE_NR_ALLOW_LOCAL_IPS=] [possible values: true, false]
-      --ipr-allow-local-ips <IPR_ALLOW_LOCAL_IPS>                            Allow the IP packet router to forward traffic to non-globally-routable addresses. Intended for local development, private-network
-                                                                             deployments, and testnet scenarios. Not recommended on production exit gateway unless you know what you're doing [env:
-                                                                             NYMNODE_IPR_ALLOW_LOCAL_IPS=] [possible values: true, false]
-      --lp-control-bind-address <LP_CONTROL_BIND_ADDRESS>                    Bind address for the TCP LP control traffic. default: `[::]:41264` [env: NYMNODE_LP_CONTROL_BIND_ADDRESS=]
-      --lp-control-announce-port <LP_CONTROL_ANNOUNCE_PORT>                  Custom announced port for listening for the TCP LP control traffic. If unspecified, the value from the `lp_control_bind_address` will
-                                                                             be used instead [env: NYMNODE_LP_CONTROL_ANNOUNCE_PORT=]
-      --lp-data-bind-address <LP_DATA_BIND_ADDRESS>                          Bind address for the UDP LP data traffic. default: `[::]:51264` [env: NYMNODE_LP_DATA_BIND_ADDRESS=]
-      --lp-data-announce-port <LP_DATA_ANNOUNCE_PORT>                        Custom announced port for listening for the UDP LP data traffic. If unspecified, the value from the `lp_data_bind_address` will be
-                                                                             used instead [env: NYMNODE_LP_DATA_ANNOUNCE_PORT=]
-      --lp-use-mock-ecash <LP_USE_MOCK_ECASH>                                Use mock ecash manager for LP testing. WARNING: Only use this for local testing! Never enable in production. When enabled, the LP
-                                                                             listener will accept any credential without blockchain verification [env: NYMNODE_LP_USE_MOCK_ECASH=] [possible values: true, false]
-  -h, --help                                                                 Print help
+      --id <ID>
+          Id of the nym-node to use [env: NYMNODE_ID=] [default: default-nym-node]
+      --config-file <CONFIG_FILE>
+          Path to a configuration file of this node [env: NYMNODE_CONFIG=]
+      --accept-operator-terms-and-conditions
+          Explicitly specify whether you agree with the terms and conditions of a nym node operator as
+          defined at <https://nymtech.net/terms-and-conditions/operators/v1.0.0> [env:
+          NYMNODE_ACCEPT_OPERATOR_TERMS=]
+      --deny-init
+          Forbid a new node from being initialised if configuration file for the provided specification
+          doesn't already exist [env: NYMNODE_DENY_INIT=]
+      --init-only
+          If this is a brand new nym-node, specify whether it should only be initialised without actually
+          running the subprocesses [env: NYMNODE_INIT_ONLY=]
+      --local
+          Flag specifying this node will be running in a local setting [env: NYMNODE_LOCAL=]
+      --mode [<MODE>...]
+          Specifies the current mode(s) of this nym-node [env: NYMNODE_MODE=] [possible values: mixnode,
+          entry-gateway, exit-gateway, exit-providers-only]
+      --modes <MODES>
+          Specifies the current mode(s) of this nym-node as a single flag [env: NYMNODE_MODES=] [possible
+          values: mixnode, entry-gateway, exit-gateway, exit-providers-only]
+  -w, --write-changes
+          If this node has been initialised before, specify whether to write any new changes to the config
+          file [env: NYMNODE_WRITE_CONFIG_CHANGES=]
+      --bonding-information-output <BONDING_INFORMATION_OUTPUT>
+          Specify output file for bonding information of this nym-node, i.e. its encoded keys. NOTE: the
+          required bonding information is still a subject to change and this argument should be treated
+          only as a preview of future features [env: NYMNODE_BONDING_INFORMATION_OUTPUT=]
+  -o, --output <OUTPUT>
+          Specify the output format of the bonding information (`text` or `json`) [env: NYMNODE_OUTPUT=]
+          [default: text] [possible values: text, json]
+      --public-ips <PUBLIC_IPS>
+          Comma separated list of public ip addresses that will be announced to the nym-api and
+          subsequently to the clients. In nearly all circumstances, it's going to be identical to the
+          address you're going to use for bonding [env: NYMNODE_PUBLIC_IPS=]
+      --hostname <HOSTNAME>
+          Optional hostname associated with this gateway that will be announced to the nym-api and
+          subsequently to the clients [env: NYMNODE_HOSTNAME=]
+      --location <LOCATION>
+          Optional **physical** location of this node's server. Either full country name (e.g. 'Poland'),
+          two-letter alpha2 (e.g. 'PL'), three-letter alpha3 (e.g. 'POL') or three-digit numeric-3 (e.g.
+          '616') can be provided [env: NYMNODE_LOCATION=]
+      --http-bind-address <HTTP_BIND_ADDRESS>
+          Socket address this node will use for binding its http API. default: `[::]:8080` [env:
+          NYMNODE_HTTP_BIND_ADDRESS=]
+      --landing-page-assets-path <LANDING_PAGE_ASSETS_PATH>
+          Path to assets directory of custom landing page of this node [env: NYMNODE_HTTP_LANDING_ASSETS=]
+      --http-access-token <HTTP_ACCESS_TOKEN>
+          An optional bearer token for accessing certain http endpoints. Currently only used for
+          prometheus metrics [env: NYMNODE_HTTP_ACCESS_TOKEN=]
+      --expose-system-info <EXPOSE_SYSTEM_INFO>
+          Specify whether basic system information should be exposed. default: true [env:
+          NYMNODE_HTTP_EXPOSE_SYSTEM_INFO=] [possible values: true, false]
+      --expose-system-hardware <EXPOSE_SYSTEM_HARDWARE>
+          Specify whether basic system hardware information should be exposed. default: true [env:
+          NYMNODE_HTTP_EXPOSE_SYSTEM_HARDWARE=] [possible values: true, false]
+      --expose-crypto-hardware <EXPOSE_CRYPTO_HARDWARE>
+          Specify whether detailed system crypto hardware information should be exposed. default: true
+          [env: NYMNODE_HTTP_EXPOSE_CRYPTO_HARDWARE=] [possible values: true, false]
+      --nyxd-urls <NYXD_URLS>
+          Addresses to nyxd chain endpoint which the node will use for chain interactions [env:
+          NYMNODE_NYXD=]
+      --nyxd-websocket-url <NYXD_WEBSOCKET_URL>
+          Url to the websocket endpoint of a nyx validator, for example `wss://rpc.nymtech.net/websocket`.
+          It is used for subscribing to new block events [env: NYMNODE_NYXD_WEBSOCKET=]
+      --mixnet-bind-address <MIXNET_BIND_ADDRESS>
+          Address this node will bind to for listening for mixnet packets default: `[::]:1789` [env:
+          NYMNODE_MIXNET_BIND_ADDRESS=]
+      --mixnet-announce-port <MIXNET_ANNOUNCE_PORT>
+          If applicable, custom port announced in the self-described API that other clients and nodes will
+          use. Useful when the node is behind a proxy [env: NYMNODE_MIXNET_ANNOUNCE_PORT=]
+      --nym-api-urls <NYM_API_URLS>
+          Addresses to nym APIs from which the node gets the view of the network [env: NYMNODE_NYM_APIS=]
+      --enable-console-logging <ENABLE_CONSOLE_LOGGING>
+          Specify whether running statistics of this node should be logged to the console [env:
+          NYMNODE_ENABLE_CONSOLE_LOGGING=] [possible values: true, false]
+      --wireguard-enabled <WIREGUARD_ENABLED>
+          Specifies whether the wireguard service is enabled on this node [env: NYMNODE_WG_ENABLED=]
+          [possible values: true, false]
+      --wireguard-bind-address <WIREGUARD_BIND_ADDRESS>
+          Socket address this node will use for binding its wireguard interface. default: `[::]:51822`
+          [env: NYMNODE_WG_BIND_ADDRESS=]
+      --wireguard-tunnel-announced-port <WIREGUARD_TUNNEL_ANNOUNCED_PORT>
+          Tunnel port announced to external clients wishing to connect to the wireguard interface. Useful
+          in the instances where the node is behind a proxy [env: NYMNODE_WG_ANNOUNCED_PORT=]
+      --wireguard-private-network-prefix <WIREGUARD_PRIVATE_NETWORK_PREFIX>
+          The prefix denoting the maximum number of the clients that can be connected via Wireguard. The
+          maximum value for IPv4 is 32 and for IPv6 is 128 [env: NYMNODE_WG_PRIVATE_NETWORK_PREFIX=]
+      --wireguard-userspace <WIREGUARD_USERSPACE>
+          Use userspace implementation of WireGuard (wireguard-go) instead of kernel module. Useful in
+          containerized environments without kernel WireGuard support [env: NYMNODE_WG_USERSPACE=]
+          [possible values: true, false]
+      --verloc-bind-address <VERLOC_BIND_ADDRESS>
+          Socket address this node will use for binding its verloc API. default: `[::]:1790` [env:
+          NYMNODE_VERLOC_BIND_ADDRESS=]
+      --verloc-announce-port <VERLOC_ANNOUNCE_PORT>
+          If applicable, custom port announced in the self-described API that other clients and nodes will
+          use. Useful when the node is behind a proxy [env: NYMNODE_VERLOC_ANNOUNCE_PORT=]
+      --entry-bind-address <ENTRY_BIND_ADDRESS>
+          Socket address this node will use for binding its client websocket API. default: `[::]:9000`
+          [env: NYMNODE_ENTRY_BIND_ADDRESS=]
+      --announce-ws-port <ANNOUNCE_WS_PORT>
+          Custom announced port for listening for websocket client traffic. If unspecified, the value from
+          the `bind_address` will be used instead [env: NYMNODE_ENTRY_ANNOUNCE_WS_PORT=]
+      --announce-wss-port <ANNOUNCE_WSS_PORT>
+          If applicable, announced port for listening for secure websocket client traffic [env:
+          NYMNODE_ENTRY_ANNOUNCE_WSS_PORT=]
+      --enforce-zk-nyms <ENFORCE_ZK_NYMS>
+          Indicates whether this gateway is accepting only coconut credentials for accessing the mixnet or
+          if it also accepts non-paying clients [env: NYMNODE_ENFORCE_ZK_NYMS=] [possible values: true,
+          false]
+      --mnemonic <MNEMONIC>
+          Custom cosmos wallet mnemonic used for zk-nym redemption. If no value is provided, a fresh
+          mnemonic is going to be generated [env: NYMNODE_MNEMONIC=]
+      --upgrade-mode-attestation-url <UPGRADE_MODE_ATTESTATION_URL>
+          Endpoint to query to retrieve current upgrade mode attestation. This argument should never be
+          set outside testnets and local networks [env: NYMNODE_UPGRADE_MODE_ATTESTATION_URL=]
+      --upgrade-mode-attester-public-key <UPGRADE_MODE_ATTESTER_PUBLIC_KEY>
+          Expected public key of the entity signing the published attestation. This argument should never
+          be set outside testnets and local networks [env: NYMNODE_UPGRADE_MODE_ATTESTER_PUBKEY=]
+      --upstream-exit-policy-url <UPSTREAM_EXIT_POLICY_URL>
+          Specifies the url for an upstream source of the exit policy used by this node [env:
+          NYMNODE_UPSTREAM_EXIT_POLICY=]
+      --open-proxy <OPEN_PROXY>
+          Specifies whether this exit node should run in 'open-proxy' mode and thus would attempt to
+          resolve **ANY** request it receives [env: NYMNODE_OPEN_PROXY=] [possible values: true, false]
+      --nr-allow-local-ips <NR_ALLOW_LOCAL_IPS>
+          Allow the network requester to forward traffic to non-globally-routable addresses. Intended for
+          local development, private-network deployments, and testnet scenarios. Not recommended on
+          production exit gateway unless you know what you're doing [env: NYMNODE_NR_ALLOW_LOCAL_IPS=]
+          [possible values: true, false]
+      --ipr-allow-local-ips <IPR_ALLOW_LOCAL_IPS>
+          Allow the IP packet router to forward traffic to non-globally-routable addresses. Intended for
+          local development, private-network deployments, and testnet scenarios. Not recommended on
+          production exit gateway unless you know what you're doing [env: NYMNODE_IPR_ALLOW_LOCAL_IPS=]
+          [possible values: true, false]
+      --lp-control-bind-address <LP_CONTROL_BIND_ADDRESS>
+          Bind address for the TCP LP control traffic. default: `[::]:41264` [env:
+          NYMNODE_LP_CONTROL_BIND_ADDRESS=]
+      --lp-control-announce-port <LP_CONTROL_ANNOUNCE_PORT>
+          Custom announced port for listening for the TCP LP control traffic. If unspecified, the value
+          from the `lp_control_bind_address` will be used instead [env: NYMNODE_LP_CONTROL_ANNOUNCE_PORT=]
+      --lp-data-bind-address <LP_DATA_BIND_ADDRESS>
+          Bind address for the UDP LP data traffic. default: `[::]:51264` [env:
+          NYMNODE_LP_DATA_BIND_ADDRESS=]
+      --lp-data-announce-port <LP_DATA_ANNOUNCE_PORT>
+          Custom announced port for listening for the UDP LP data traffic. If unspecified, the value from
+          the `lp_data_bind_address` will be used instead [env: NYMNODE_LP_DATA_ANNOUNCE_PORT=]
+      --lp-use-mock-ecash <LP_USE_MOCK_ECASH>
+          Use mock ecash manager for LP testing. WARNING: Only use this for local testing! Never enable in
+          production. When enabled, the LP listener will accept any credential without blockchain
+          verification [env: NYMNODE_LP_USE_MOCK_ECASH=] [possible values: true, false]
+  -h, --help
+          Print help
 ```

--- a/documentation/docs/components/outputs/command-outputs/nymvisor-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nymvisor-help.md
@@ -11,7 +11,10 @@ Commands:
   help               Print this message or the help of the given subcommand(s)
 
 Options:
-  -c, --config-env-file <CONFIG_ENV_FILE>  Path pointing to an env file that configures the nymvisor and overrides any preconfigured values
-  -h, --help                               Print help
-  -V, --version                            Print version
+  -c, --config-env-file <CONFIG_ENV_FILE>
+          Path pointing to an env file that configures the nymvisor and overrides any preconfigured values
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```

--- a/documentation/docs/pages/operators/tokenomics/mixnet-rewards.mdx
+++ b/documentation/docs/pages/operators/tokenomics/mixnet-rewards.mdx
@@ -21,7 +21,7 @@ import RewardsCalculator from 'components/operators/interactive/calculators/rewa
 # Nym Operators Rewards
 
 <Callout type="warning">
-**[Mixnet Node performance Calculation](#mixnet-node-performance-calculation) had been updated recently. Make sure to read the chapter *[Stress Testing Score Calculation](##stress-testing-score-calculation)* below carefully to fully understand tokenomics changes for Mixnodes!**
+**[Mixnet Node performance Calculation](#mixnet-node-performance-calculation) had been updated recently. Make sure to read the chapter *[Stress Testing Score Calculation](#stress-testing-score-calculation)* below carefully to fully understand tokenomics changes for Mixnodes!**
 </Callout>
 
 <TimeNow />

--- a/documentation/docs/pages/operators/tokenomics/mixnet-rewards.mdx
+++ b/documentation/docs/pages/operators/tokenomics/mixnet-rewards.mdx
@@ -21,7 +21,7 @@ import RewardsCalculator from 'components/operators/interactive/calculators/rewa
 # Nym Operators Rewards
 
 <Callout type="warning">
-**Nym Network Rewarded set selection had been upgraded recently. Make sure to read the chapter *[Rewarded Set Selection](#rewarded-set-selection)* below carefully to fully understand all requirements to be rewarded!**
+**[Mixnet Node performance Calculation](#mixnet-node-performance-calculation) had been updated recently. Make sure to read the chapter *[Stress Testing Score Calculation](##stress-testing-score-calculation)* below carefully to fully understand tokenomics changes for Mixnodes!**
 </Callout>
 
 <TimeNow />


### PR DESCRIPTION
This PR documents logic of a new metric for mixnodes - stress testing score.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated **“Mixnet: Node Performance Calculation”** with separate performance formulas for gateways vs mixnodes, including the mixnode stress-weighted approach (stress weight: `0.3`).
  * Added **“Stress Testing Score Calculation”** for mixnodes, documenting the burst-packet measurement method and the resulting stress score used in the formula.
  * Refreshed related mixnet tokenomics guidance to point readers to the updated performance sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->