### PR TITLE
update stats API IP

### DIFF
--- a/common/http-api-client/src/dns/constants.rs
+++ b/common/http-api-client/src/dns/constants.rs
@@ -58,7 +58,7 @@ pub const NYM_COM_DOMAIN: &str = "nym.com";
 pub const NYM_COM_IPS: &[IpAddr] = &[IpAddr::V4(Ipv4Addr::new(76, 76, 21, 22))];
 
 pub const NYM_STATS_API_DOMAIN: &str = "nym-statistics-api.nymtech.cc";
-pub const NYM_STATS_API_IPS: &[IpAddr] = &[IpAddr::V4(Ipv4Addr::new(195, 19, 29, 32))];
+pub const NYM_STATS_API_IPS: &[IpAddr] = &[IpAddr::V4(Ipv4Addr::new(185, 19, 29, 32))];
 
 pub const NYM_RPC_DOMAIN: &str = "rpc.nymtech.net";
 pub const NYM_RPC_IPS: &[IpAddr] = &[

--- a/common/http-api-client/src/dns/constants.rs
+++ b/common/http-api-client/src/dns/constants.rs
@@ -58,7 +58,7 @@ pub const NYM_COM_DOMAIN: &str = "nym.com";
 pub const NYM_COM_IPS: &[IpAddr] = &[IpAddr::V4(Ipv4Addr::new(76, 76, 21, 22))];
 
 pub const NYM_STATS_API_DOMAIN: &str = "nym-statistics-api.nymtech.cc";
-pub const NYM_STATS_API_IPS: &[IpAddr] = &[IpAddr::V4(Ipv4Addr::new(91, 92, 153, 96))];
+pub const NYM_STATS_API_IPS: &[IpAddr] = &[IpAddr::V4(Ipv4Addr::new(195, 19, 29, 32))];
 
 pub const NYM_RPC_DOMAIN: &str = "rpc.nymtech.net";
 pub const NYM_RPC_IPS: &[IpAddr] = &[


### PR DESCRIPTION
Stats API got migrated to a new ingress, the IP needs updating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  - Updated the network configuration for the statistics API endpoint to use a new IP address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->