### PR TITLE
Bandwidth controller step 1 : Standalone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5854,6 +5854,7 @@ dependencies = [
  "nym-wireguard-types",
  "semver 1.0.28",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5887,6 +5888,7 @@ dependencies = [
 name = "nym-bandwidth-controller"
 version = "1.21.1"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "log",
  "nym-credential-storage",
@@ -5897,7 +5899,12 @@ dependencies = [
  "nym-task",
  "nym-validator-client",
  "rand 0.8.6",
+ "strum 0.28.0",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -8007,10 +8014,10 @@ dependencies = [
  "nym-registration-common",
  "nym-sdk",
  "nym-test-utils",
- "nym-validator-client",
  "nym-wireguard-types",
  "rand 0.9.2",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5902,9 +5902,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-util",
  "tracing",
- "zeroize",
 ]
 
 [[package]]

--- a/common/bandwidth-controller/Cargo.toml
+++ b/common/bandwidth-controller/Cargo.toml
@@ -15,15 +15,27 @@ publish = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arc-swap = { workspace = true }
 async-trait = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+zeroize = { workspace = true }
 
 nym-credential-storage = { workspace = true }
 nym-credentials = { workspace = true }
 nym-credentials-interface = { workspace = true }
-nym-crypto = { workspace = true, features = ["rand", "asymmetric", "stream_cipher", "aes", "hashing"] }
+nym-crypto = { workspace = true, features = [
+    "rand",
+    "asymmetric",
+    "stream_cipher",
+    "aes",
+    "hashing",
+] }
 nym-ecash-time = { workspace = true }
 nym-task = { workspace = true }
 nym-validator-client = { workspace = true }
@@ -31,3 +43,6 @@ nym-validator-client = { workspace = true }
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.nym-validator-client]
 workspace = true
 features = ["http-client"]
+
+[lints]
+workspace = true

--- a/common/bandwidth-controller/Cargo.toml
+++ b/common/bandwidth-controller/Cargo.toml
@@ -19,12 +19,10 @@ arc-swap = { workspace = true }
 async-trait = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
-strum = { workspace = true }
+strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { workspace = true }
-zeroize = { workspace = true }
 
 nym-credential-storage = { workspace = true }
 nym-credentials = { workspace = true }

--- a/common/bandwidth-controller/src/controller.rs
+++ b/common/bandwidth-controller/src/controller.rs
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 - Nym Technologies SA <contact@nymtech.net>
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::BandwidthControllerError;
@@ -78,8 +78,8 @@ impl<St: Storage> BandwidthController<St> {
         self.storage
             .attempt_revert_ticketbook_withdrawal(
                 info.ticketbook_id,
-                info.used_tickets,
                 info.tickets_withdrawn,
+                info.used_tickets,
             )
             .await
             .map_err(BandwidthControllerError::credential_storage_error)

--- a/common/bandwidth-controller/src/controller.rs
+++ b/common/bandwidth-controller/src/controller.rs
@@ -1,0 +1,378 @@
+// Copyright 2021-2024 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::BandwidthControllerError;
+use crate::requests::{BandwidthControllerRequest, BandwidthControllerRequestSender};
+use crate::traits::CredentialPublicDataFetcher;
+use crate::{
+    BandwidthTicketProvider, PreparedCredential, PreparedCredentialMetadata, UPGRADE_MODE_JWT_TYPE,
+};
+use async_trait::async_trait;
+use log::error;
+use nym_credential_storage::models::RetrievedTicketbook;
+use nym_credential_storage::storage::Storage;
+use nym_credentials::ecash::bandwidth::CredentialSpendingData;
+use nym_credentials_interface::{
+    AnnotatedCoinIndexSignature, AnnotatedExpirationDateSignature, TicketType, VerificationKeyAuth,
+};
+use nym_crypto::asymmetric::ed25519;
+use nym_ecash_time::{Date, OffsetDateTime};
+use nym_task::ShutdownToken;
+use nym_validator_client::nym_api::EpochId;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+pub struct BandwidthController<St> {
+    storage: St,
+
+    // Channels used to receive commands from the outside.
+    request_channel: (
+        UnboundedSender<BandwidthControllerRequest>,
+        UnboundedReceiver<BandwidthControllerRequest>,
+    ),
+
+    // fetches the global ecash signing materials when they are missing locally
+    public_data_fetcher: Option<Box<dyn CredentialPublicDataFetcher>>,
+}
+
+impl<St: Storage> BandwidthController<St> {
+    pub fn new(storage: St) -> Self {
+        let request_channel = mpsc::unbounded_channel();
+        BandwidthController {
+            storage,
+            request_channel,
+            public_data_fetcher: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_credential_public_data_fetcher(
+        mut self,
+        fetcher: impl CredentialPublicDataFetcher + 'static,
+    ) -> Self {
+        self.public_data_fetcher = Some(Box::new(fetcher));
+        self
+    }
+
+    /// Get the request channel used to send request to the controller.
+    /// Request are handled only if the `BandwidthController` is running using `run`
+    pub fn get_request_sender(&self) -> BandwidthControllerRequestSender {
+        BandwidthControllerRequestSender::new(self.request_channel.0.clone())
+    }
+
+    /// Tries to retrieve one of the stored, unused credentials for the given type that hasn't yet expired.
+    pub async fn get_next_usable_ticketbook(
+        &self,
+        ticketbook_type: TicketType,
+        tickets: u32,
+    ) -> Result<Option<RetrievedTicketbook>, BandwidthControllerError> {
+        self.storage
+            .get_next_unspent_usable_ticketbook(ticketbook_type.to_string(), tickets)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)
+    }
+
+    pub async fn attempt_revert_ticket_usage(
+        &self,
+        info: PreparedCredentialMetadata,
+    ) -> Result<bool, BandwidthControllerError> {
+        self.storage
+            .attempt_revert_ticketbook_withdrawal(
+                info.ticketbook_id,
+                info.used_tickets,
+                info.tickets_withdrawn,
+            )
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)
+    }
+
+    pub async fn get_aggregate_verification_key(
+        &self,
+        epoch_id: EpochId,
+    ) -> Result<Option<VerificationKeyAuth>, BandwidthControllerError> {
+        self.storage
+            .get_master_verification_key(epoch_id)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)
+    }
+
+    pub async fn get_coin_index_signatures(
+        &self,
+        epoch_id: EpochId,
+    ) -> Result<Option<Vec<AnnotatedCoinIndexSignature>>, BandwidthControllerError> {
+        self.storage
+            .get_coin_index_signatures(epoch_id)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)
+    }
+
+    pub async fn get_expiration_date_signatures(
+        &self,
+        epoch_id: EpochId,
+        expiration_date: Date,
+    ) -> Result<Option<Vec<AnnotatedExpirationDateSignature>>, BandwidthControllerError> {
+        self.storage
+            .get_expiration_date_signatures(expiration_date, epoch_id)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)
+    }
+
+    /// Returns the master verification key for the epoch, fetching it via the configured public
+    /// data fetcher and persisting it if it isn't already in local storage.
+    async fn ensure_master_verification_key(
+        &self,
+        epoch_id: EpochId,
+    ) -> Result<VerificationKeyAuth, BandwidthControllerError> {
+        if let Some(key) = self.get_aggregate_verification_key(epoch_id).await? {
+            return Ok(key);
+        }
+        let Some(fetcher) = &self.public_data_fetcher else {
+            return Err(BandwidthControllerError::MissingVerificationKey { epoch_id });
+        };
+        let key = fetcher
+            .fetch_master_verification_key(epoch_id)
+            .await
+            .map_err(BandwidthControllerError::fetcher_error)?;
+        self.storage
+            .insert_master_verification_key(&key)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)?;
+        Ok(key.key)
+    }
+
+    /// Returns the coin index signatures for the epoch, fetching them via the configured public
+    /// data fetcher and persisting them if they aren't already in local storage.
+    async fn ensure_coin_index_signatures(
+        &self,
+        epoch_id: EpochId,
+    ) -> Result<Vec<AnnotatedCoinIndexSignature>, BandwidthControllerError> {
+        if let Some(signatures) = self.get_coin_index_signatures(epoch_id).await? {
+            return Ok(signatures);
+        }
+        let Some(fetcher) = &self.public_data_fetcher else {
+            return Err(BandwidthControllerError::MissingCoinIndexSignatures { epoch_id });
+        };
+        let signatures = fetcher
+            .fetch_coin_index_signatures(epoch_id)
+            .await
+            .map_err(BandwidthControllerError::fetcher_error)?;
+        self.storage
+            .insert_coin_index_signatures(&signatures)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)?;
+        Ok(signatures.signatures)
+    }
+
+    /// Returns the expiration date signatures for the epoch and expiration date, fetching them via
+    /// the configured public data fetcher and persisting them if they aren't already in local storage.
+    async fn ensure_expiration_date_signatures(
+        &self,
+        epoch_id: EpochId,
+        expiration_date: Date,
+    ) -> Result<Vec<AnnotatedExpirationDateSignature>, BandwidthControllerError> {
+        if let Some(signatures) = self
+            .get_expiration_date_signatures(epoch_id, expiration_date)
+            .await?
+        {
+            return Ok(signatures);
+        }
+        let Some(fetcher) = &self.public_data_fetcher else {
+            return Err(BandwidthControllerError::MissingExpirationDateSignatures { epoch_id });
+        };
+        let signatures = fetcher
+            .fetch_expiration_date_signatures(expiration_date, epoch_id)
+            .await
+            .map_err(BandwidthControllerError::fetcher_error)?;
+        self.storage
+            .insert_expiration_date_signatures(&signatures)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)?;
+        Ok(signatures.signatures)
+    }
+
+    /// Ensures all global ecash signing materials for the given epoch and expiration date are
+    /// present in local storage, fetching and persisting any that are missing.
+    pub async fn ensure_global_data(
+        &self,
+        epoch_id: EpochId,
+        expiration_date: Date,
+    ) -> Result<(), BandwidthControllerError> {
+        self.ensure_master_verification_key(epoch_id).await?;
+        self.ensure_coin_index_signatures(epoch_id).await?;
+        self.ensure_expiration_date_signatures(epoch_id, expiration_date)
+            .await?;
+        Ok(())
+    }
+
+    async fn prepare_ecash_ticket_inner(
+        &self,
+        provider_pk: [u8; 32],
+        spend_time: OffsetDateTime,
+        tickets_to_spend: u32,
+        mut retrieved_ticketbook: RetrievedTicketbook,
+    ) -> Result<CredentialSpendingData, BandwidthControllerError> {
+        let epoch_id = retrieved_ticketbook.ticketbook.epoch_id();
+        let expiration_date = retrieved_ticketbook.ticketbook.expiration_date();
+
+        let verification_key = self.ensure_master_verification_key(epoch_id).await?;
+        let expiration_signatures = self
+            .ensure_expiration_date_signatures(epoch_id, expiration_date)
+            .await?;
+        let coin_indices_signatures = self.ensure_coin_index_signatures(epoch_id).await?;
+
+        let pay_info = retrieved_ticketbook
+            .ticketbook
+            .generate_pay_info(provider_pk, spend_time);
+
+        let spend_request = retrieved_ticketbook.ticketbook.prepare_for_spending(
+            &verification_key,
+            pay_info.into(),
+            &coin_indices_signatures,
+            &expiration_signatures,
+            tickets_to_spend as u64,
+        )?;
+        Ok(spend_request)
+    }
+
+    pub async fn prepare_ecash_ticket(
+        &self,
+        ticketbook_type: TicketType,
+        provider_pk: [u8; 32],
+        tickets_to_spend: u32,
+        spend_time: OffsetDateTime,
+    ) -> Result<Option<PreparedCredential>, BandwidthControllerError> {
+        let Some(retrieved_ticketbook) = self
+            .get_next_usable_ticketbook(ticketbook_type, tickets_to_spend)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let ticketbook_id = retrieved_ticketbook.ticketbook_id;
+        let epoch_id = retrieved_ticketbook.ticketbook.epoch_id();
+
+        let used_tickets =
+            retrieved_ticketbook.ticketbook.spent_tickets() as u32 + tickets_to_spend;
+        let metadata = PreparedCredentialMetadata {
+            ticketbook_id,
+            tickets_withdrawn: tickets_to_spend,
+            used_tickets,
+        };
+
+        match self
+            .prepare_ecash_ticket_inner(
+                provider_pk,
+                spend_time,
+                tickets_to_spend,
+                retrieved_ticketbook,
+            )
+            .await
+        {
+            Ok(data) => Ok(Some(PreparedCredential {
+                data,
+                epoch_id,
+                metadata,
+            })),
+            Err(err) => {
+                error!("failed to prepare credential spending request. attempting to revert withdrawal...");
+                self.attempt_revert_ticket_usage(metadata).await?;
+                Err(err)
+            }
+        }
+    }
+
+    async fn get_upgrade_mode_token(&self) -> Result<Option<String>, BandwidthControllerError> {
+        let Some(emergency_credential) = self
+            .storage
+            .get_emergency_credential(UPGRADE_MODE_JWT_TYPE)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)?
+        else {
+            return Ok(None);
+        };
+        // upgrade mode credential is just a simple stringified JWT
+        let token = String::from_utf8(emergency_credential.data.content)
+            .map_err(|_| BandwidthControllerError::MalformedUpgradeModeToken)?;
+        Ok(Some(token))
+    }
+
+    /// Runs the controller event loop, handling incoming requests until the
+    /// request channel is closed or cancellation is requested.
+    pub async fn run(mut self, shutdown_token: ShutdownToken) {
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_token.cancelled() => {
+                    log::debug!("bandwidth controller received cancellation request; shutting down");
+                    break;
+                }
+                request = self.request_channel.1.recv() => match request {
+                    Some(request) => self.handle_request(request).await,
+                    None => {
+                        log::warn!("bandwidth controller request channel closed; this should never happened as we are owning a sender; shutting down");
+                        break;
+                    }
+                }
+            }
+        }
+
+        self.storage.close().await;
+    }
+
+    async fn handle_request(&mut self, request: BandwidthControllerRequest) {
+        match request {
+            BandwidthControllerRequest::EcashTicket(return_sender, request) => {
+                let credential_result = self
+                    .prepare_ecash_ticket(
+                        request.ticket_type,
+                        request.gateway_id.to_bytes(),
+                        request.tickets_to_spend,
+                        request.spend_time,
+                    )
+                    .await;
+                return_sender.send(credential_result)
+            }
+            BandwidthControllerRequest::UpgradeModeToken(return_sender) => {
+                return_sender.send(self.get_upgrade_mode_token().await)
+            }
+            BandwidthControllerRequest::AttemptRevertSpending(return_sender, metadata) => {
+                return_sender.send(self.attempt_revert_ticket_usage(metadata).await)
+            }
+        }
+    }
+}
+
+// So we can use the BC without making it run on its own if we don't need that
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<St: Storage> BandwidthTicketProvider for BandwidthController<St> {
+    async fn get_ecash_ticket(
+        &self,
+        ticket_type: TicketType,
+        gateway_id: ed25519::PublicKey,
+        tickets_to_spend: u32,
+        spend_time: OffsetDateTime,
+    ) -> Result<Option<PreparedCredential>, BandwidthControllerError> {
+        self.prepare_ecash_ticket(
+            ticket_type,
+            gateway_id.to_bytes(),
+            tickets_to_spend,
+            spend_time,
+        )
+        .await
+    }
+
+    async fn get_upgrade_mode_token(&self) -> Result<Option<String>, BandwidthControllerError> {
+        self.get_upgrade_mode_token().await
+    }
+
+    async fn attempt_revert_spending(
+        &self,
+        metadata: PreparedCredentialMetadata,
+    ) -> Result<bool, BandwidthControllerError> {
+        self.attempt_revert_ticket_usage(metadata).await
+    }
+
+    async fn close(&self) {
+        self.storage.close().await
+    }
+}

--- a/common/bandwidth-controller/src/error.rs
+++ b/common/bandwidth-controller/src/error.rs
@@ -28,9 +28,6 @@ pub enum BandwidthControllerError {
     #[error("No verification key for epoch : {epoch_id}")]
     MissingVerificationKey { epoch_id: EpochId },
 
-    #[error("No credential fetcher available")]
-    MissingCredentialFetcher,
-
     #[error("retrieved upgrade mode token is not a valid String")]
     MalformedUpgradeModeToken,
 

--- a/common/bandwidth-controller/src/error.rs
+++ b/common/bandwidth-controller/src/error.rs
@@ -1,13 +1,8 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use nym_credential_storage::error::StorageError;
 use nym_credentials::error::Error as CredentialsError;
-use nym_credentials_interface::CompactEcashError;
-use nym_crypto::asymmetric::ed25519::Ed25519RecoveryError;
-use nym_crypto::asymmetric::x25519::KeyRecoveryError;
-use nym_validator_client::coconut::EcashApiError;
-use nym_validator_client::error::ValidatorClientError;
+use nym_validator_client::{coconut::EcashApiError, nym_api::EpochId};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -21,39 +16,33 @@ pub enum BandwidthControllerError {
     #[error("There was a credential storage error - {0}")]
     CredentialStorageError(Box<dyn std::error::Error + Send + Sync>),
 
+    #[error("a credential/global-data fetcher failed - {0}")]
+    FetcherError(Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("No expiration date signatures for epoch : {epoch_id}")]
+    MissingExpirationDateSignatures { epoch_id: EpochId },
+
+    #[error("No coin index signatures for epoch : {epoch_id}")]
+    MissingCoinIndexSignatures { epoch_id: EpochId },
+
+    #[error("No verification key for epoch : {epoch_id}")]
+    MissingVerificationKey { epoch_id: EpochId },
+
+    #[error("No credential fetcher available")]
+    MissingCredentialFetcher,
+
     #[error("retrieved upgrade mode token is not a valid String")]
     MalformedUpgradeModeToken,
-
-    #[error("the credential storage does not contain any usable credentials")]
-    NoCredentialsAvailable,
-
-    // this should really be fully incorporated into the above, but messing with coconut is the last thing I want to do now
-    #[error(transparent)]
-    StorageError(#[from] StorageError),
-
-    #[error("Ecash error - {0}")]
-    EcashError(#[from] CompactEcashError),
-
-    #[error("Validator client error - {0}")]
-    ValidatorError(#[from] ValidatorClientError),
 
     #[error("Credential error - {0}")]
     CredentialError(#[from] CredentialsError),
 
-    #[error("Could not parse Ed25519 data")]
-    Ed25519ParseError(#[from] Ed25519RecoveryError),
-
-    #[error("Could not parse X25519 data")]
-    X25519ParseError(#[from] KeyRecoveryError),
-
-    #[error("The tx hash provided is not valid")]
-    InvalidTxHash,
+    // Internal error that should not happen, e.g. channel comms failing
+    #[error("internal error: {0}")]
+    Internal(String),
 
     #[error("Threshold not set yet")]
     NoThreshold,
-
-    #[error("can't handle recovering storage with revision {stored}. {expected} was expected")]
-    UnsupportedCredentialStorageRevision { stored: u8, expected: u8 },
 
     #[error("did not receive a valid response for aggregated data ({typ}) from ANY nym-api")]
     ExhaustedApiQueries { typ: String },
@@ -64,5 +53,13 @@ impl BandwidthControllerError {
         source: impl std::error::Error + Send + Sync + 'static,
     ) -> Self {
         BandwidthControllerError::CredentialStorageError(Box::new(source))
+    }
+
+    pub fn fetcher_error(source: Box<dyn std::error::Error + Send + Sync>) -> Self {
+        BandwidthControllerError::FetcherError(source)
+    }
+
+    pub fn internal(message: impl ToString) -> Self {
+        BandwidthControllerError::Internal(message.to_string())
     }
 }

--- a/common/bandwidth-controller/src/error.rs
+++ b/common/bandwidth-controller/src/error.rs
@@ -34,9 +34,12 @@ pub enum BandwidthControllerError {
     #[error("Credential error - {0}")]
     CredentialError(#[from] CredentialsError),
 
-    // Internal error that should not happen, e.g. channel comms failing
+    // Internal error that should not happen
     #[error("internal error: {0}")]
     Internal(String),
+
+    #[error("A channel we were using is closed")]
+    ChannelClosed,
 
     #[error("Threshold not set yet")]
     NoThreshold,

--- a/common/bandwidth-controller/src/fetcher/mod.rs
+++ b/common/bandwidth-controller/src/fetcher/mod.rs
@@ -1,6 +1,9 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
+use nym_ecash_time::OffsetDateTime;
 use nym_validator_client::coconut::{all_ecash_api_clients, EcashApiError};
 use nym_validator_client::nym_api::EpochId;
 use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
@@ -13,14 +16,25 @@ mod nyxd_public_data;
 struct EcashApiClientsCache {
     epoch_id: EpochId,
     clients: Vec<EcashApiClient>,
+    last_updated_at: OffsetDateTime,
 }
 
 impl EcashApiClientsCache {
+    const VALIDITY_DURATION: Duration = Duration::from_secs(30 * 60); // 30 minutes
+
+    fn is_stale(&self) -> bool {
+        self.last_updated_at + Self::VALIDITY_DURATION < OffsetDateTime::now_utc()
+    }
+
     async fn from_dkg_client<C>(query_client: &C, epoch_id: EpochId) -> Result<Self, EcashApiError>
     where
         C: DkgQueryClient + Send + Sync,
     {
         let clients = all_ecash_api_clients(query_client, epoch_id).await?;
-        Ok(EcashApiClientsCache { epoch_id, clients })
+        Ok(EcashApiClientsCache {
+            epoch_id,
+            clients,
+            last_updated_at: OffsetDateTime::now_utc(),
+        })
     }
 }

--- a/common/bandwidth-controller/src/fetcher/mod.rs
+++ b/common/bandwidth-controller/src/fetcher/mod.rs
@@ -1,0 +1,26 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use nym_validator_client::coconut::{all_ecash_api_clients, EcashApiError};
+use nym_validator_client::nym_api::EpochId;
+use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
+use nym_validator_client::EcashApiClient;
+
+pub use nyxd_public_data::NyxdGlobalDataFetcher;
+
+mod nyxd_public_data;
+
+struct EcashApiClientsCache {
+    epoch_id: EpochId,
+    clients: Vec<EcashApiClient>,
+}
+
+impl EcashApiClientsCache {
+    async fn from_dkg_client<C>(query_client: &C, epoch_id: EpochId) -> Result<Self, EcashApiError>
+    where
+        C: DkgQueryClient + Send + Sync,
+    {
+        let clients = all_ecash_api_clients(query_client, epoch_id).await?;
+        Ok(EcashApiClientsCache { epoch_id, clients })
+    }
+}

--- a/common/bandwidth-controller/src/fetcher/nyxd_public_data.rs
+++ b/common/bandwidth-controller/src/fetcher/nyxd_public_data.rs
@@ -1,0 +1,168 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use arc_swap::ArcSwapOption;
+use async_trait::async_trait;
+use log::warn;
+use nym_credentials::{
+    AggregatedCoinIndicesSignatures, AggregatedExpirationDateSignatures, EpochVerificationKey,
+};
+use nym_ecash_time::Date;
+use nym_validator_client::client::NymApiClientExt;
+use nym_validator_client::coconut::EcashApiError;
+use nym_validator_client::nym_api::EpochId;
+use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
+use nym_validator_client::EcashApiClient;
+use rand::prelude::SliceRandom;
+use rand::thread_rng;
+use std::fmt::Display;
+use std::future::Future;
+use std::sync::Arc;
+use thiserror::Error;
+
+use crate::fetcher::EcashApiClientsCache;
+use crate::traits::{CredentialPublicDataFetcher, FetcherError};
+
+/// In-repo [`CredentialPublicDataFetcher`] that retrieves the global ecash signing materials from the
+/// nym-apis using a nyxd query client.
+pub struct NyxdGlobalDataFetcher<C: DkgQueryClient + Send + Sync> {
+    client: C,
+
+    // Lock-free cache for the ecash api clients, lazily instantiated. `ArcSwapOption` lets us
+    // refresh it through `&self` (so the trait methods can stay `&self`) without a mutex.
+    ecash_api_clients: ArcSwapOption<EcashApiClientsCache>,
+}
+
+impl<C: DkgQueryClient + Send + Sync> NyxdGlobalDataFetcher<C> {
+    pub fn new(client: C) -> Self {
+        NyxdGlobalDataFetcher {
+            client,
+            ecash_api_clients: ArcSwapOption::empty(),
+        }
+    }
+
+    async fn ecash_api_clients(&self, epoch_id: EpochId) -> Result<Vec<EcashApiClient>, Error> {
+        // fast path: atomic load, return if cached for this epoch
+        if let Some(cache) = self.ecash_api_clients.load_full() {
+            if cache.epoch_id == epoch_id {
+                return Ok(cache.clients.clone());
+            }
+        }
+
+        // empty or stale - refresh and atomically swap in the new cache, then return it.
+        // a concurrent miss may fetch redundantly and the later store wins; harmless since
+        // the fetch is idempotent.
+        let cache = Arc::new(EcashApiClientsCache::from_dkg_client(&self.client, epoch_id).await?);
+        let clients = cache.clients.clone();
+        self.ecash_api_clients.store(Some(cache));
+        Ok(clients)
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<C: DkgQueryClient + Send + Sync> CredentialPublicDataFetcher for NyxdGlobalDataFetcher<C> {
+    async fn fetch_master_verification_key(
+        &self,
+        epoch_id: EpochId,
+    ) -> Result<EpochVerificationKey, FetcherError> {
+        let ecash_apis = self.ecash_api_clients(epoch_id).await?;
+        let master_vk = query_random_apis_until_success(
+            ecash_apis,
+            |api| async move { api.api_client.master_verification_key(Some(epoch_id)).await },
+            format!("aggregated verification key for epoch {epoch_id}"),
+        )
+        .await?
+        .key;
+
+        Ok(EpochVerificationKey {
+            epoch_id,
+            key: master_vk,
+        })
+    }
+
+    async fn fetch_coin_index_signatures(
+        &self,
+        epoch_id: EpochId,
+    ) -> Result<AggregatedCoinIndicesSignatures, FetcherError> {
+        let ecash_apis = self.ecash_api_clients(epoch_id).await?;
+        let index_sigs = query_random_apis_until_success(
+            ecash_apis,
+            |api| async move {
+                api.api_client
+                    .global_coin_indices_signatures(Some(epoch_id))
+                    .await
+            },
+            format!("aggregated coin index signatures for epoch {epoch_id}"),
+        )
+        .await?
+        .signatures;
+
+        Ok(AggregatedCoinIndicesSignatures {
+            epoch_id,
+            signatures: index_sigs,
+        })
+    }
+
+    async fn fetch_expiration_date_signatures(
+        &self,
+        expiration_date: Date,
+        epoch_id: EpochId,
+    ) -> Result<AggregatedExpirationDateSignatures, FetcherError> {
+        let ecash_apis = self.ecash_api_clients(epoch_id).await?;
+        let expiration_sigs = query_random_apis_until_success(
+            ecash_apis,
+            |api| async move {
+                api.api_client
+                    .global_expiration_date_signatures(Some(expiration_date), Some(epoch_id))
+                    .await
+            },
+            format!("aggregated expiration date signatures for date {expiration_date}"),
+        )
+        .await?
+        .signatures;
+
+        Ok(AggregatedExpirationDateSignatures {
+            epoch_id,
+            expiration_date,
+            signatures: expiration_sigs,
+        })
+    }
+}
+
+async fn query_random_apis_until_success<F, T, U, E>(
+    mut apis: Vec<EcashApiClient>,
+    f: F,
+    typ: impl Into<String>,
+) -> Result<T, Error>
+where
+    F: Fn(EcashApiClient) -> U,
+    U: Future<Output = Result<T, E>>,
+    E: Display,
+{
+    // try apis in pseudorandom way to remove any bias towards the first registered dealer
+    apis.shuffle(&mut thread_rng());
+
+    for api in apis {
+        let disp = api.to_string();
+        match f(api).await {
+            Ok(res) => return Ok(res),
+            Err(err) => {
+                warn!("failed to obtain valid response from API {disp}: {err}")
+            }
+        }
+    }
+    Err(Error::ExhaustedApiQueries { typ: typ.into() })
+}
+
+#[derive(Error, Debug)]
+enum Error {
+    #[error("Nyxd error: {0}")]
+    Nyxd(#[from] nym_validator_client::nyxd::error::NyxdError),
+
+    #[error("ecash api query failure: {0}")]
+    EcashApiError(#[from] EcashApiError),
+
+    #[error("did not receive a valid response for aggregated data ({typ}) from ANY nym-api")]
+    ExhaustedApiQueries { typ: String },
+}

--- a/common/bandwidth-controller/src/fetcher/nyxd_public_data.rs
+++ b/common/bandwidth-controller/src/fetcher/nyxd_public_data.rs
@@ -44,7 +44,7 @@ impl<C: DkgQueryClient + Send + Sync> NyxdGlobalDataFetcher<C> {
     async fn ecash_api_clients(&self, epoch_id: EpochId) -> Result<Vec<EcashApiClient>, Error> {
         // fast path: atomic load, return if cached for this epoch
         if let Some(cache) = self.ecash_api_clients.load_full() {
-            if cache.epoch_id == epoch_id {
+            if cache.epoch_id == epoch_id && !cache.is_stale() {
                 return Ok(cache.clients.clone());
             }
         }

--- a/common/bandwidth-controller/src/lib.rs
+++ b/common/bandwidth-controller/src/lib.rs
@@ -1,41 +1,30 @@
 // Copyright 2021-2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(clippy::expect_used)]
-#![warn(clippy::unwrap_used)]
-#![warn(clippy::todo)]
-#![warn(clippy::dbg_macro)]
-
-use crate::error::BandwidthControllerError;
-use crate::utils::{
-    get_aggregate_verification_key, get_coin_index_signatures, get_expiration_date_signatures,
-    ApiClientsWrapper,
-};
-use log::error;
-use nym_credential_storage::models::{EmergencyCredential, RetrievedTicketbook};
-use nym_credential_storage::storage::Storage;
 use nym_credentials::ecash::bandwidth::CredentialSpendingData;
-use nym_credentials_interface::{
-    AnnotatedCoinIndexSignature, AnnotatedExpirationDateSignature, TicketType, VerificationKeyAuth,
-};
-use nym_ecash_time::Date;
+use nym_credentials_interface::TicketType;
+use nym_crypto::asymmetric::ed25519;
+use nym_ecash_time::OffsetDateTime;
 use nym_validator_client::nym_api::EpochId;
-use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
 
-pub use traits::{BandwidthTicketProvider, DEFAULT_TICKETS_TO_SPEND};
+pub use controller::BandwidthController;
+pub use fetcher::NyxdGlobalDataFetcher;
+pub use traits::{BandwidthTicketProvider, FetcherError};
 
 pub mod acquire;
+mod controller;
 pub mod error;
+mod fetcher;
 pub mod mock;
+pub mod requests;
 mod traits;
 mod utils;
 
-#[derive(Debug)]
-pub struct BandwidthController<C, St> {
-    storage: St,
-    client: C,
-}
+pub const DEFAULT_TICKETS_TO_SPEND: u32 = 1;
 
+pub const UPGRADE_MODE_JWT_TYPE: &str = "UPGRADE_MODE_JWT";
+
+#[derive(Clone, Debug)]
 pub struct PreparedCredential {
     /// The cryptographic material required for spending the underlying credential.
     pub data: CredentialSpendingData,
@@ -48,7 +37,7 @@ pub struct PreparedCredential {
     pub metadata: PreparedCredentialMetadata,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct PreparedCredentialMetadata {
     /// The database id of the stored credential.
     pub ticketbook_id: i64,
@@ -60,175 +49,10 @@ pub struct PreparedCredentialMetadata {
     pub used_tickets: u32,
 }
 
-impl<C, St: Storage> BandwidthController<C, St> {
-    pub fn new(storage: St, client: C) -> Self {
-        BandwidthController { storage, client }
-    }
-
-    /// Tries to retrieve one of the stored, unused credentials for the given type that hasn't yet expired.
-    pub async fn get_next_usable_ticketbook(
-        &self,
-        ticketbook_type: TicketType,
-        tickets: u32,
-    ) -> Result<RetrievedTicketbook, BandwidthControllerError> {
-        let Some(ticketbook) = self
-            .storage
-            .get_next_unspent_usable_ticketbook(ticketbook_type.to_string(), tickets)
-            .await
-            .map_err(BandwidthControllerError::credential_storage_error)?
-        else {
-            return Err(BandwidthControllerError::NoCredentialsAvailable);
-        };
-
-        Ok(ticketbook)
-    }
-
-    pub async fn attempt_revert_ticket_usage(
-        &self,
-        info: PreparedCredentialMetadata,
-    ) -> Result<bool, BandwidthControllerError> {
-        self.storage
-            .attempt_revert_ticketbook_withdrawal(
-                info.ticketbook_id,
-                info.used_tickets,
-                info.tickets_withdrawn,
-            )
-            .await
-            .map_err(BandwidthControllerError::credential_storage_error)
-    }
-
-    async fn get_aggregate_verification_key(
-        &self,
-        epoch_id: EpochId,
-        ecash_apis: &mut ApiClientsWrapper<'_, C>,
-    ) -> Result<VerificationKeyAuth, BandwidthControllerError>
-    where
-        C: DkgQueryClient,
-    {
-        get_aggregate_verification_key(&self.storage, epoch_id, ecash_apis).await
-    }
-
-    async fn get_coin_index_signatures(
-        &self,
-        epoch_id: EpochId,
-        ecash_apis: &mut ApiClientsWrapper<'_, C>,
-    ) -> Result<Vec<AnnotatedCoinIndexSignature>, BandwidthControllerError>
-    where
-        C: DkgQueryClient,
-    {
-        get_coin_index_signatures(&self.storage, epoch_id, ecash_apis).await
-    }
-
-    async fn get_expiration_date_signatures(
-        &self,
-        epoch_id: EpochId,
-        expiration_date: Date,
-        ecash_apis: &mut ApiClientsWrapper<'_, C>,
-    ) -> Result<Vec<AnnotatedExpirationDateSignature>, BandwidthControllerError>
-    where
-        C: DkgQueryClient,
-    {
-        get_expiration_date_signatures(&self.storage, epoch_id, expiration_date, ecash_apis).await
-    }
-
-    async fn prepare_ecash_ticket_inner(
-        &self,
-        provider_pk: [u8; 32],
-        tickets_to_spend: u32,
-        mut retrieved_ticketbook: RetrievedTicketbook,
-    ) -> Result<CredentialSpendingData, BandwidthControllerError>
-    where
-        C: DkgQueryClient,
-    {
-        let epoch_id = retrieved_ticketbook.ticketbook.epoch_id();
-        let expiration_date = retrieved_ticketbook.ticketbook.expiration_date();
-        let mut api_clients = ApiClientsWrapper::new(&self.client, epoch_id);
-
-        let verification_key = self
-            .get_aggregate_verification_key(epoch_id, &mut api_clients)
-            .await?;
-        let expiration_signatures = self
-            .get_expiration_date_signatures(epoch_id, expiration_date, &mut api_clients)
-            .await?;
-        let coin_indices_signatures = self
-            .get_coin_index_signatures(epoch_id, &mut api_clients)
-            .await?;
-
-        let pay_info = retrieved_ticketbook
-            .ticketbook
-            .generate_pay_info(provider_pk);
-
-        let spend_request = retrieved_ticketbook.ticketbook.prepare_for_spending(
-            &verification_key,
-            pay_info.into(),
-            &coin_indices_signatures,
-            &expiration_signatures,
-            tickets_to_spend as u64,
-        )?;
-        Ok(spend_request)
-    }
-
-    pub async fn prepare_ecash_ticket(
-        &self,
-        ticketbook_type: TicketType,
-        provider_pk: [u8; 32],
-        tickets_to_spend: u32,
-    ) -> Result<PreparedCredential, BandwidthControllerError>
-    where
-        C: DkgQueryClient,
-    {
-        let retrieved_ticketbook = self
-            .get_next_usable_ticketbook(ticketbook_type, tickets_to_spend)
-            .await?;
-
-        let ticketbook_id = retrieved_ticketbook.ticketbook_id;
-        let epoch_id = retrieved_ticketbook.ticketbook.epoch_id();
-
-        let used_tickets =
-            retrieved_ticketbook.ticketbook.spent_tickets() as u32 + tickets_to_spend;
-        let metadata = PreparedCredentialMetadata {
-            ticketbook_id,
-            tickets_withdrawn: tickets_to_spend,
-            used_tickets,
-        };
-
-        match self
-            .prepare_ecash_ticket_inner(provider_pk, tickets_to_spend, retrieved_ticketbook)
-            .await
-        {
-            Ok(data) => Ok(PreparedCredential {
-                data,
-                epoch_id,
-                metadata,
-            }),
-            Err(err) => {
-                error!("failed to prepare credential spending request. attempting to revert withdrawal...");
-                self.attempt_revert_ticket_usage(metadata).await?;
-                Err(err)
-            }
-        }
-    }
-
-    pub async fn get_emergency_credential(
-        &self,
-        typ: &str,
-    ) -> Result<Option<EmergencyCredential>, BandwidthControllerError> {
-        self.storage
-            .get_emergency_credential(typ)
-            .await
-            .map_err(BandwidthControllerError::credential_storage_error)
-    }
-}
-
-impl<C, St> Clone for BandwidthController<C, St>
-where
-    C: Clone,
-    St: Clone,
-{
-    fn clone(&self) -> Self {
-        BandwidthController {
-            storage: self.storage.clone(),
-            client: self.client.clone(),
-        }
-    }
+#[derive(Copy, Clone, Debug)]
+pub struct EcashTicketRequest {
+    pub ticket_type: TicketType,
+    pub gateway_id: ed25519::PublicKey,
+    pub tickets_to_spend: u32,
+    pub spend_time: OffsetDateTime,
 }

--- a/common/bandwidth-controller/src/mock.rs
+++ b/common/bandwidth-controller/src/mock.rs
@@ -24,7 +24,8 @@ impl BandwidthTicketProvider for MockBandwidthController {
         ticket_type: TicketType,
         _gateway_id: PublicKey,
         tickets_to_spend: u32,
-    ) -> Result<PreparedCredential, BandwidthControllerError> {
+        _spend_time: OffsetDateTime,
+    ) -> Result<Option<PreparedCredential>, BandwidthControllerError> {
         assert_eq!(tickets_to_spend, 1);
 
         // This is a valid serialized CredentialSpendingData taken from integration tests
@@ -107,7 +108,7 @@ impl BandwidthTicketProvider for MockBandwidthController {
         // Update spend_date to today to pass validation
         credential.spend_date = OffsetDateTime::now_utc().date();
 
-        Ok(PreparedCredential {
+        Ok(Some(PreparedCredential {
             data: credential,
             epoch_id: 0,
             metadata: PreparedCredentialMetadata {
@@ -115,10 +116,19 @@ impl BandwidthTicketProvider for MockBandwidthController {
                 tickets_withdrawn: 1,
                 used_tickets: 0,
             },
-        })
+        }))
     }
 
     async fn get_upgrade_mode_token(&self) -> Result<Option<String>, BandwidthControllerError> {
         Ok(None)
     }
+
+    async fn attempt_revert_spending(
+        &self,
+        _: PreparedCredentialMetadata,
+    ) -> Result<bool, BandwidthControllerError> {
+        Ok(true)
+    }
+
+    async fn close(&self) {}
 }

--- a/common/bandwidth-controller/src/requests/mod.rs
+++ b/common/bandwidth-controller/src/requests/mod.rs
@@ -1,0 +1,56 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::{
+    error::BandwidthControllerError, EcashTicketRequest, PreparedCredential,
+    PreparedCredentialMetadata,
+};
+
+pub use sender::BandwidthControllerRequestSender;
+use tokio::sync::oneshot;
+
+mod sender;
+
+#[derive(strum::Display)]
+pub enum BandwidthControllerRequest {
+    EcashTicket(
+        ReturnSender<Option<PreparedCredential>, BandwidthControllerError>,
+        EcashTicketRequest,
+    ),
+
+    UpgradeModeToken(ReturnSender<Option<String>, BandwidthControllerError>),
+
+    AttemptRevertSpending(
+        ReturnSender<bool, BandwidthControllerError>,
+        PreparedCredentialMetadata,
+    ),
+}
+
+#[derive(Debug)]
+pub struct ReturnSender<T, E> {
+    sender: oneshot::Sender<Result<T, E>>,
+}
+
+impl<T, E> ReturnSender<T, E>
+where
+    T: std::fmt::Debug,
+    E: std::fmt::Debug,
+{
+    pub fn new() -> (Self, oneshot::Receiver<Result<T, E>>) {
+        let (sender, receiver) = oneshot::channel();
+        (Self { sender }, receiver)
+    }
+
+    pub fn send(self, response: Result<T, E>)
+    where
+        T: Send,
+        E: Send,
+    {
+        self.sender
+            .send(response)
+            .inspect_err(|err| {
+                tracing::error!("Failed to send response: {:#?}", err);
+            })
+            .ok();
+    }
+}

--- a/common/bandwidth-controller/src/requests/mod.rs
+++ b/common/bandwidth-controller/src/requests/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::{
     error::BandwidthControllerError, EcashTicketRequest, PreparedCredential,

--- a/common/bandwidth-controller/src/requests/mod.rs
+++ b/common/bandwidth-controller/src/requests/mod.rs
@@ -13,38 +13,30 @@ mod sender;
 
 #[derive(strum::Display)]
 pub enum BandwidthControllerRequest {
-    EcashTicket(
-        ReturnSender<Option<PreparedCredential>, BandwidthControllerError>,
-        EcashTicketRequest,
-    ),
+    EcashTicket(ReturnSender<Option<PreparedCredential>>, EcashTicketRequest),
 
-    UpgradeModeToken(ReturnSender<Option<String>, BandwidthControllerError>),
+    UpgradeModeToken(ReturnSender<Option<String>>),
 
-    AttemptRevertSpending(
-        ReturnSender<bool, BandwidthControllerError>,
-        PreparedCredentialMetadata,
-    ),
+    AttemptRevertSpending(ReturnSender<bool>, PreparedCredentialMetadata),
 }
 
 #[derive(Debug)]
-pub struct ReturnSender<T, E> {
-    sender: oneshot::Sender<Result<T, E>>,
+pub struct ReturnSender<T> {
+    sender: oneshot::Sender<Result<T, BandwidthControllerError>>,
 }
 
-impl<T, E> ReturnSender<T, E>
+impl<T> ReturnSender<T>
 where
     T: std::fmt::Debug,
-    E: std::fmt::Debug,
 {
-    pub fn new() -> (Self, oneshot::Receiver<Result<T, E>>) {
+    pub fn new() -> (Self, oneshot::Receiver<Result<T, BandwidthControllerError>>) {
         let (sender, receiver) = oneshot::channel();
         (Self { sender }, receiver)
     }
 
-    pub fn send(self, response: Result<T, E>)
+    pub fn send(self, response: Result<T, BandwidthControllerError>)
     where
         T: Send,
-        E: Send,
     {
         self.sender
             .send(response)

--- a/common/bandwidth-controller/src/requests/sender.rs
+++ b/common/bandwidth-controller/src/requests/sender.rs
@@ -1,0 +1,103 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use async_trait::async_trait;
+use nym_credentials_interface::TicketType;
+use nym_crypto::asymmetric::ed25519;
+use nym_ecash_time::OffsetDateTime;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::instrument;
+
+use crate::{
+    error::BandwidthControllerError,
+    requests::{BandwidthControllerRequest, ReturnSender},
+    BandwidthTicketProvider, EcashTicketRequest, PreparedCredential, PreparedCredentialMetadata,
+};
+
+#[derive(Clone)]
+pub struct BandwidthControllerRequestSender {
+    command_tx: UnboundedSender<BandwidthControllerRequest>,
+}
+
+// Basic set of commands that can be sent to the bandwidth controller
+
+impl BandwidthControllerRequestSender {
+    pub fn new(command_tx: UnboundedSender<BandwidthControllerRequest>) -> Self {
+        Self { command_tx }
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_ecash_ticket(
+        &self,
+        ticket_type: TicketType,
+        gateway_id: ed25519::PublicKey,
+        tickets_to_spend: u32,
+        spend_time: OffsetDateTime,
+    ) -> Result<Option<PreparedCredential>, BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::EcashTicket(
+                tx,
+                EcashTicketRequest {
+                    ticket_type,
+                    gateway_id,
+                    tickets_to_spend,
+                    spend_time,
+                },
+            ))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_upgrade_mode_token(&self) -> Result<Option<String>, BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::UpgradeModeToken(tx))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
+    }
+
+    #[instrument(skip(self))]
+    pub async fn attempt_revert_spending(
+        &self,
+        metadata: PreparedCredentialMetadata,
+    ) -> Result<bool, BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::AttemptRevertSpending(
+                tx, metadata,
+            ))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl BandwidthTicketProvider for BandwidthControllerRequestSender {
+    async fn get_ecash_ticket(
+        &self,
+        ticket_type: TicketType,
+        gateway_id: ed25519::PublicKey,
+        tickets_to_spend: u32,
+        spend_time: OffsetDateTime,
+    ) -> Result<Option<PreparedCredential>, BandwidthControllerError> {
+        self.get_ecash_ticket(ticket_type, gateway_id, tickets_to_spend, spend_time)
+            .await
+    }
+
+    async fn get_upgrade_mode_token(&self) -> Result<Option<String>, BandwidthControllerError> {
+        self.get_upgrade_mode_token().await
+    }
+
+    async fn attempt_revert_spending(
+        &self,
+        metadata: PreparedCredentialMetadata,
+    ) -> Result<bool, BandwidthControllerError> {
+        self.attempt_revert_spending(metadata).await
+    }
+
+    // No-op, the controller will close when stopped
+    async fn close(&self) {}
+}

--- a/common/bandwidth-controller/src/requests/sender.rs
+++ b/common/bandwidth-controller/src/requests/sender.rs
@@ -49,7 +49,7 @@ impl BandwidthControllerRequestSender {
         rx.await.map_err(BandwidthControllerError::internal)?
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), level = "debug")]
     pub async fn get_upgrade_mode_token(&self) -> Result<Option<String>, BandwidthControllerError> {
         let (tx, rx) = ReturnSender::new();
         self.command_tx
@@ -58,7 +58,7 @@ impl BandwidthControllerRequestSender {
         rx.await.map_err(BandwidthControllerError::internal)?
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), level = "debug")]
     pub async fn attempt_revert_spending(
         &self,
         metadata: PreparedCredentialMetadata,

--- a/common/bandwidth-controller/src/requests/sender.rs
+++ b/common/bandwidth-controller/src/requests/sender.rs
@@ -1,5 +1,5 @@
 // Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
 use nym_credentials_interface::TicketType;

--- a/common/bandwidth-controller/src/requests/sender.rs
+++ b/common/bandwidth-controller/src/requests/sender.rs
@@ -45,8 +45,9 @@ impl BandwidthControllerRequestSender {
                     spend_time,
                 },
             ))
-            .map_err(BandwidthControllerError::internal)?;
-        rx.await.map_err(BandwidthControllerError::internal)?
+            .map_err(|_| BandwidthControllerError::ChannelClosed)?;
+        rx.await
+            .map_err(|_| BandwidthControllerError::ChannelClosed)?
     }
 
     #[instrument(skip(self), level = "debug")]
@@ -54,8 +55,9 @@ impl BandwidthControllerRequestSender {
         let (tx, rx) = ReturnSender::new();
         self.command_tx
             .send(BandwidthControllerRequest::UpgradeModeToken(tx))
-            .map_err(BandwidthControllerError::internal)?;
-        rx.await.map_err(BandwidthControllerError::internal)?
+            .map_err(|_| BandwidthControllerError::ChannelClosed)?;
+        rx.await
+            .map_err(|_| BandwidthControllerError::ChannelClosed)?
     }
 
     #[instrument(skip(self), level = "debug")]
@@ -68,8 +70,9 @@ impl BandwidthControllerRequestSender {
             .send(BandwidthControllerRequest::AttemptRevertSpending(
                 tx, metadata,
             ))
-            .map_err(BandwidthControllerError::internal)?;
-        rx.await.map_err(BandwidthControllerError::internal)?
+            .map_err(|_| BandwidthControllerError::ChannelClosed)?;
+        rx.await
+            .map_err(|_| BandwidthControllerError::ChannelClosed)?
     }
 }
 

--- a/common/bandwidth-controller/src/requests/sender.rs
+++ b/common/bandwidth-controller/src/requests/sender.rs
@@ -26,7 +26,7 @@ impl BandwidthControllerRequestSender {
         Self { command_tx }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), level = "debug")]
     pub async fn get_ecash_ticket(
         &self,
         ticket_type: TicketType,

--- a/common/bandwidth-controller/src/traits.rs
+++ b/common/bandwidth-controller/src/traits.rs
@@ -2,16 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+
+use nym_credentials::ecash::bandwidth::serialiser::keys::EpochVerificationKey;
+use nym_credentials::ecash::bandwidth::serialiser::signatures::{
+    AggregatedCoinIndicesSignatures, AggregatedExpirationDateSignatures,
+};
 use nym_credentials_interface::TicketType;
 use nym_crypto::asymmetric::ed25519;
-use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
+use nym_ecash_time::{Date, OffsetDateTime};
+use nym_validator_client::nym_api::EpochId;
 
-use crate::{error::BandwidthControllerError, BandwidthController, PreparedCredential};
-
-pub const DEFAULT_TICKETS_TO_SPEND: u32 = 1;
-
-// TODO: this does not really belong here
-pub const UPGRADE_MODE_JWT_TYPE: &str = "UPGRADE_MODE_JWT";
+use crate::{error::BandwidthControllerError, PreparedCredential, PreparedCredentialMetadata};
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -21,45 +22,17 @@ pub trait BandwidthTicketProvider: Send + Sync {
         ticket_type: TicketType,
         gateway_id: ed25519::PublicKey,
         tickets_to_spend: u32,
-    ) -> Result<PreparedCredential, BandwidthControllerError>;
+        spend_time: OffsetDateTime,
+    ) -> Result<Option<PreparedCredential>, BandwidthControllerError>;
 
     async fn get_upgrade_mode_token(&self) -> Result<Option<String>, BandwidthControllerError>;
 
-    async fn close(&self) {}
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl<C, St> BandwidthTicketProvider for BandwidthController<C, St>
-where
-    C: DkgQueryClient,
-    St: nym_credential_storage::storage::Storage,
-{
-    async fn get_ecash_ticket(
+    async fn attempt_revert_spending(
         &self,
-        ticket_type: TicketType,
-        gateway_id: ed25519::PublicKey,
-        tickets_to_spend: u32,
-    ) -> Result<PreparedCredential, BandwidthControllerError> {
-        self.prepare_ecash_ticket(ticket_type, gateway_id.to_bytes(), tickets_to_spend)
-            .await
-    }
+        metadata: PreparedCredentialMetadata,
+    ) -> Result<bool, BandwidthControllerError>;
 
-    async fn get_upgrade_mode_token(&self) -> Result<Option<String>, BandwidthControllerError> {
-        let Some(emergency_credential) =
-            self.get_emergency_credential(UPGRADE_MODE_JWT_TYPE).await?
-        else {
-            return Ok(None);
-        };
-        // upgrade mode credential is just a simple stringified JWT
-        let token = String::from_utf8(emergency_credential.data.content)
-            .map_err(|_| BandwidthControllerError::MalformedUpgradeModeToken)?;
-        Ok(Some(token))
-    }
-
-    async fn close(&self) {
-        self.storage.close().await;
-    }
+    async fn close(&self);
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -70,9 +43,10 @@ impl<T: BandwidthTicketProvider + ?Sized + Send> BandwidthTicketProvider for Box
         ticket_type: TicketType,
         gateway_id: ed25519::PublicKey,
         tickets_to_spend: u32,
-    ) -> Result<PreparedCredential, BandwidthControllerError> {
+        spend_time: OffsetDateTime,
+    ) -> Result<Option<PreparedCredential>, BandwidthControllerError> {
         (**self)
-            .get_ecash_ticket(ticket_type, gateway_id, tickets_to_spend)
+            .get_ecash_ticket(ticket_type, gateway_id, tickets_to_spend, spend_time)
             .await
     }
 
@@ -80,7 +54,42 @@ impl<T: BandwidthTicketProvider + ?Sized + Send> BandwidthTicketProvider for Box
         (**self).get_upgrade_mode_token().await
     }
 
+    async fn attempt_revert_spending(
+        &self,
+        metadata: PreparedCredentialMetadata,
+    ) -> Result<bool, BandwidthControllerError> {
+        (**self).attempt_revert_spending(metadata).await
+    }
+
+    // For compatibility for now. Remove once BC is properly implemented in client repo
     async fn close(&self) {
         (**self).close().await;
     }
+}
+
+// This isn't an associated type because
+// a) it would make it dyn-incompatible and we want it
+// b) BandwidthController will pack everything its own variant anyway
+
+/// Error any fetcher implementation may return; the controller wraps it with context.
+pub type FetcherError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait CredentialPublicDataFetcher: Send + Sync {
+    async fn fetch_master_verification_key(
+        &self,
+        epoch_id: EpochId,
+    ) -> Result<EpochVerificationKey, FetcherError>;
+
+    async fn fetch_coin_index_signatures(
+        &self,
+        epoch_id: EpochId,
+    ) -> Result<AggregatedCoinIndicesSignatures, FetcherError>;
+
+    async fn fetch_expiration_date_signatures(
+        &self,
+        expiration_date: Date,
+        epoch_id: EpochId,
+    ) -> Result<AggregatedExpirationDateSignatures, FetcherError>;
 }

--- a/common/bandwidth-controller/src/utils.rs
+++ b/common/bandwidth-controller/src/utils.rs
@@ -12,9 +12,7 @@ use nym_credentials_interface::{
     AnnotatedCoinIndexSignature, AnnotatedExpirationDateSignature, VerificationKeyAuth,
 };
 use nym_ecash_time::Date;
-use nym_validator_client::coconut::all_ecash_api_clients;
 use nym_validator_client::nym_api::{EpochId, NymApiClientExt};
-use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
 use nym_validator_client::EcashApiClient;
 use rand::prelude::SliceRandom;
 use rand::thread_rng;
@@ -32,56 +30,6 @@ impl EcashClientsProvider for Vec<EcashApiClient> {
         &mut self,
     ) -> Result<Vec<EcashApiClient>, BandwidthControllerError> {
         Ok(self.clone())
-    }
-}
-
-impl<C> EcashClientsProvider for &mut ApiClientsWrapper<'_, C>
-where
-    C: DkgQueryClient,
-{
-    async fn try_get_ecash_clients(
-        &mut self,
-    ) -> Result<Vec<EcashApiClient>, BandwidthControllerError> {
-        self.clients().await
-    }
-}
-
-pub(crate) enum ApiClientsWrapper<'a, C> {
-    Uninitialised {
-        query_client: &'a C,
-        epoch_id: EpochId,
-    },
-    Cached {
-        clients: Vec<EcashApiClient>,
-    },
-}
-
-impl<'a, C> ApiClientsWrapper<'a, C> {
-    pub(crate) fn new(query_client: &'a C, epoch_id: EpochId) -> Self {
-        ApiClientsWrapper::Uninitialised {
-            query_client,
-            epoch_id,
-        }
-    }
-
-    async fn clients(&mut self) -> Result<Vec<EcashApiClient>, BandwidthControllerError>
-    where
-        C: DkgQueryClient,
-    {
-        match self {
-            ApiClientsWrapper::Uninitialised {
-                query_client,
-                epoch_id,
-            } => {
-                let clients = all_ecash_api_clients(*query_client, *epoch_id).await?;
-                *self = ApiClientsWrapper::Cached {
-                    clients: clients.clone(),
-                };
-
-                Ok(clients)
-            }
-            ApiClientsWrapper::Cached { clients } => Ok(clients.clone()),
-        }
     }
 }
 

--- a/common/client-core/src/client/base_client/mod.rs
+++ b/common/client-core/src/client/base_client/mod.rs
@@ -36,10 +36,11 @@ use crate::init::{
     types::{GatewaySetup, InitialisationResult},
 };
 use futures::channel::mpsc;
-use nym_bandwidth_controller::BandwidthController;
+use nym_bandwidth_controller::{
+    BandwidthController, BandwidthTicketProvider, NyxdGlobalDataFetcher,
+};
 use nym_client_core_config_types::{ForgetMe, RememberMe};
 use nym_client_core_gateways_storage::GatewayDetails;
-use nym_credential_storage::storage::Storage;
 use nym_crypto::asymmetric::{ed25519, x25519};
 use nym_crypto::hkdf::DerivationMaterial;
 use nym_gateway_client::client::config::GatewayClientConfig;
@@ -214,6 +215,7 @@ impl From<bool> for CredentialsToggle {
 pub struct BaseClientBuilder<C, S: MixnetClientStorage> {
     config: Config,
     client_store: S,
+    // when present, used to build a nyxd-backed public data fetcher for the bandwidth controller
     dkg_query_client: Option<C>,
 
     // Optional API URLs for domain fronting support
@@ -223,6 +225,7 @@ pub struct BaseClientBuilder<C, S: MixnetClientStorage> {
     wait_for_initial_topology: bool,
     custom_topology_provider: Option<Box<dyn TopologyProvider + Send + Sync>>,
     custom_gateway_transceiver: Option<Box<dyn GatewayTransceiver + Send>>,
+    custom_bandwidth_provider: Option<Box<dyn BandwidthTicketProvider>>,
     shutdown: Option<ShutdownTracker>,
     event_tx: Option<EventSender>,
     user_agent: Option<UserAgent>,
@@ -254,6 +257,7 @@ where
             wait_for_initial_topology: false,
             custom_topology_provider: None,
             custom_gateway_transceiver: None,
+            custom_bandwidth_provider: None,
             shutdown: None,
             event_tx: None,
             user_agent: None,
@@ -325,6 +329,15 @@ where
     #[must_use]
     pub fn with_gateway_transceiver(mut self, sender: Box<dyn GatewayTransceiver + Send>) -> Self {
         self.custom_gateway_transceiver = Some(sender);
+        self
+    }
+
+    #[must_use]
+    pub fn with_custom_bandwidth_provider(
+        mut self,
+        bandwidth_provider: Box<dyn BandwidthTicketProvider>,
+    ) -> Self {
+        self.custom_bandwidth_provider = Some(bandwidth_provider);
         self
     }
 
@@ -536,12 +549,12 @@ where
     async fn start_gateway_client(
         config: &Config,
         initialisation_result: InitialisationResult,
-        bandwidth_provider: Option<BandwidthController<C, S::CredentialStore>>,
+        bandwidth_provider: Box<dyn BandwidthTicketProvider>,
         packet_router: PacketRouter,
         stats_reporter: ClientStatsSender,
         #[cfg(unix)] connection_fd_callback: Option<Arc<dyn Fn(RawFd) + Send + Sync>>,
         shutdown_tracker: &ShutdownTracker,
-    ) -> Result<GatewayClient<C, S::CredentialStore>, ClientCoreError> {
+    ) -> Result<GatewayClient, ClientCoreError> {
         let managed_keys = initialisation_result.client_keys;
         let GatewayDetails::Remote(details) = initialisation_result.gateway_registration.details
         else {
@@ -611,7 +624,7 @@ where
         custom_gateway_transceiver: Option<Box<dyn GatewayTransceiver + Send>>,
         config: &Config,
         initialisation_result: InitialisationResult,
-        bandwidth_provider: Option<BandwidthController<C, S::CredentialStore>>,
+        bandwidth_provider: Box<dyn BandwidthTicketProvider>,
         packet_router: PacketRouter,
         stats_reporter: ClientStatsSender,
         #[cfg(unix)] connection_fd_callback: Option<Arc<dyn Fn(RawFd) + Send + Sync>>,
@@ -782,6 +795,34 @@ where
             input_sender.clone(),
             shutdown_tracker,
         )
+    }
+
+    fn start_bandwidth_controller(
+        custom_bandwidth_provider: Option<Box<dyn BandwidthTicketProvider>>,
+        public_data_fetcher_client: Option<C>,
+        credential_store: S::CredentialStore,
+        shutdown_tracker: &ShutdownTracker,
+    ) -> Box<dyn BandwidthTicketProvider> {
+        // if an externally managed bandwidth controller was provided, use it as-is and
+        // don't spin up our own.
+        if let Some(provider) = custom_bandwidth_provider {
+            return provider;
+        }
+
+        let mut bandwidth_controller = BandwidthController::new(credential_store);
+        // if a dkg query client is available, attach a nyxd-backed public data fetcher so the
+        // controller can fetch any missing global ecash data itself.
+        if let Some(client) = public_data_fetcher_client {
+            bandwidth_controller = bandwidth_controller
+                .with_credential_public_data_fetcher(NyxdGlobalDataFetcher::new(client));
+        }
+        let request_sender = bandwidth_controller.get_request_sender();
+        let shutdown_token = shutdown_tracker.clone_shutdown_token();
+        shutdown_tracker.try_spawn_named(
+            async move { bandwidth_controller.run(shutdown_token).await },
+            "BandwidthController",
+        );
+        Box::new(request_sender)
     }
 
     fn start_mix_traffic_controller(
@@ -998,21 +1039,8 @@ where
         let encryption_keys = init_res.client_keys.encryption_keypair();
         let identity_keys = init_res.client_keys.identity_keypair();
 
-        let credential_store_for_close = credential_store.clone();
-        let close_credential_token = shutdown_tracker.clone_shutdown_token();
-        shutdown_tracker.try_spawn_named(
-            async move {
-                close_credential_token.cancelled().await;
-                credential_store_for_close.close().await;
-            },
-            "CredentialStorage::close_on_shutdown",
-        );
-
         // the components are started in very specific order. Unless you know what you are doing,
         // do not change that.
-        let bandwidth_provider = self
-            .dkg_query_client
-            .map(|client| BandwidthController::new(credential_store, client));
 
         let nym_api_client = Self::construct_nym_api_client(
             self.nym_api_urls.as_ref(),
@@ -1034,6 +1062,13 @@ where
             generate_client_stats_id(*self_address.identity()),
             input_sender.clone(),
             &shutdown_tracker.clone(),
+        );
+
+        let bandwidth_provider = Self::start_bandwidth_controller(
+            self.custom_bandwidth_provider,
+            self.dkg_query_client,
+            credential_store,
+            &shutdown_tracker,
         );
 
         // needs to be started as the first thing to block if required waiting for the gateway

--- a/common/client-core/src/client/mix_traffic/transceiver.rs
+++ b/common/client-core/src/client/mix_traffic/transceiver.rs
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use nym_credential_storage::storage::Storage as CredentialStorage;
 use nym_crypto::asymmetric::ed25519;
 use nym_gateway_client::GatewayClient;
 use nym_gateway_client::error::GatewayClientError;
 pub use nym_gateway_client::{GatewayPacketRouter, PacketRouter};
 use nym_gateway_requests::ClientRequest;
 use nym_sphinx::forwarding::packet::MixPacket;
-use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
 use std::fmt::Debug;
 use std::os::raw::c_int as RawFd;
 use thiserror::Error;
@@ -117,22 +115,18 @@ impl<G: GatewayReceiver + ?Sized> GatewayReceiver for Box<G> {
 
 /// Gateway to which the client is connected through a socket.
 /// Most likely through a websocket.
-pub struct RemoteGateway<C, St> {
-    gateway_client: GatewayClient<C, St>,
+pub struct RemoteGateway {
+    gateway_client: GatewayClient,
 }
 
-impl<C, St> RemoteGateway<C, St> {
-    pub fn new(gateway_client: GatewayClient<C, St>) -> Self {
+impl RemoteGateway {
+    pub fn new(gateway_client: GatewayClient) -> Self {
         Self { gateway_client }
     }
 }
 
 #[async_trait]
-impl<C, St> GatewayTransceiver for RemoteGateway<C, St>
-where
-    C: DkgQueryClient,
-    St: CredentialStorage,
-{
+impl GatewayTransceiver for RemoteGateway {
     fn gateway_identity(&self) -> ed25519::PublicKey {
         self.gateway_client.gateway_identity()
     }
@@ -150,11 +144,7 @@ where
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl<C, St> GatewaySender for RemoteGateway<C, St>
-where
-    C: DkgQueryClient,
-    St: CredentialStorage,
-{
+impl GatewaySender for RemoteGateway {
     async fn send_mix_packet(&mut self, packet: MixPacket) -> Result<(), ErasedGatewayError> {
         self.gateway_client
             .send_mix_packet(packet)
@@ -173,7 +163,7 @@ where
     }
 }
 
-impl<C, St> GatewayReceiver for RemoteGateway<C, St> {}
+impl GatewayReceiver for RemoteGateway {}
 
 #[derive(Debug, Error)]
 pub enum LocalGatewayError {

--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -392,6 +392,7 @@ pub(super) async fn register_with_gateway(
     );
 
     init_gateway_client
+        .inner_mut()
         .establish_connection()
         .await
         .map_err(|err| {
@@ -402,6 +403,7 @@ pub(super) async fn register_with_gateway(
             }
         })?;
     let auth_response = init_gateway_client
+        .inner_mut()
         .perform_initial_authentication()
         .await
         .map_err(|err| {

--- a/common/client-core/src/init/helpers.rs
+++ b/common/client-core/src/init/helpers.rs
@@ -5,8 +5,7 @@ use crate::error::ClientCoreError;
 use crate::init::types::RegistrationResult;
 use futures::{SinkExt, StreamExt};
 use nym_crypto::asymmetric::ed25519;
-use nym_gateway_client::GatewayClient;
-use nym_gateway_client::client::GatewayListeners;
+use nym_gateway_client::client::{GatewayListeners, InitGatewayClient};
 use nym_topology::node::RoutingNode;
 use nym_validator_client::UserAgent;
 use nym_validator_client::client::{IdentityKeyRef, NymApiClientExt};
@@ -384,7 +383,7 @@ pub(super) async fn register_with_gateway(
     our_identity: Arc<ed25519::KeyPair>,
     #[cfg(unix)] connection_fd_callback: Option<Arc<dyn Fn(RawFd) + Send + Sync>>,
 ) -> Result<RegistrationResult, ClientCoreError> {
-    let mut gateway_client = GatewayClient::new_init(
+    let mut init_gateway_client = InitGatewayClient::new(
         gateway_listeners,
         gateway_id,
         our_identity.clone(),
@@ -392,14 +391,17 @@ pub(super) async fn register_with_gateway(
         connection_fd_callback,
     );
 
-    gateway_client.establish_connection().await.map_err(|err| {
-        tracing::warn!("Failed to establish connection with gateway!");
-        ClientCoreError::GatewayClientError {
-            gateway_id: gateway_id.to_base58_string(),
-            source: Box::new(err),
-        }
-    })?;
-    let auth_response = gateway_client
+    init_gateway_client
+        .establish_connection()
+        .await
+        .map_err(|err| {
+            tracing::warn!("Failed to establish connection with gateway!");
+            ClientCoreError::GatewayClientError {
+                gateway_id: gateway_id.to_base58_string(),
+                source: Box::new(err),
+            }
+        })?;
+    let auth_response = init_gateway_client
         .perform_initial_authentication()
         .await
         .map_err(|err| {
@@ -412,7 +414,7 @@ pub(super) async fn register_with_gateway(
 
     Ok(RegistrationResult {
         shared_keys: auth_response.initial_shared_key,
-        authenticated_ephemeral_client: gateway_client,
+        authenticated_ephemeral_client: init_gateway_client,
     })
 }
 

--- a/common/client-libs/gateway-client/src/client/mod.rs
+++ b/common/client-libs/gateway-client/src/client/mod.rs
@@ -12,9 +12,8 @@ use crate::socket_state::{ws_fd, PartiallyDelegatedHandle, SocketState};
 use crate::traits::GatewayPacketRouter;
 use crate::{cleanup_socket_message, try_decrypt_binary_message};
 use futures::{SinkExt, StreamExt};
-use nym_bandwidth_controller::BandwidthController;
-use nym_credential_storage::ephemeral_storage::EphemeralStorage as EphemeralCredentialStorage;
-use nym_credential_storage::storage::Storage as CredentialStorage;
+use nym_bandwidth_controller::requests::BandwidthControllerRequestSender;
+use nym_bandwidth_controller::BandwidthTicketProvider;
 use nym_credentials::CredentialSpendingData;
 use nym_credentials_interface::TicketType;
 use nym_crypto::asymmetric::ed25519;
@@ -28,9 +27,9 @@ use nym_sphinx::forwarding::packet::MixPacket;
 use nym_statistics_common::clients::connection::ConnectionStatsEvent;
 use nym_statistics_common::clients::ClientStatsSender;
 use nym_task::ShutdownToken;
-use nym_validator_client::nyxd::contract_traits::DkgQueryClient;
 use rand::rngs::OsRng;
 use std::sync::Arc;
+use time::OffsetDateTime;
 use tracing::instrument;
 use tracing::*;
 use tungstenite::protocol::Message;
@@ -83,7 +82,7 @@ pub struct AuthenticationResponse {
 }
 
 // TODO: this should be refactored into a state machine that keeps track of its authentication state
-pub struct GatewayClient<C, St = EphemeralCredentialStorage> {
+pub struct GatewayClient {
     pub cfg: GatewayClientConfig,
 
     authenticated: bool,
@@ -94,7 +93,7 @@ pub struct GatewayClient<C, St = EphemeralCredentialStorage> {
     shared_key: Option<Arc<SharedSymmetricKey>>,
     connection: SocketState,
     packet_router: PacketRouter,
-    bandwidth_provider: Option<BandwidthController<C, St>>,
+    bandwidth_provider: Box<dyn BandwidthTicketProvider>,
     stats_reporter: ClientStatsSender,
 
     negotiated_protocol: Option<GatewayProtocolVersion>,
@@ -107,7 +106,7 @@ pub struct GatewayClient<C, St = EphemeralCredentialStorage> {
     shutdown_token: ShutdownToken,
 }
 
-impl<C, St> GatewayClient<C, St> {
+impl GatewayClient {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         cfg: GatewayClientConfig,
@@ -116,7 +115,7 @@ impl<C, St> GatewayClient<C, St> {
         // TODO: make it mandatory. if you don't want to pass it, use `new_init`
         shared_key: Option<Arc<SharedSymmetricKey>>,
         packet_router: PacketRouter,
-        bandwidth_provider: Option<BandwidthController<C, St>>,
+        bandwidth_provider: Box<dyn BandwidthTicketProvider>,
         stats_reporter: ClientStatsSender,
         #[cfg(unix)] connection_fd_callback: Option<Arc<dyn Fn(RawFd) + Send + Sync>>,
         shutdown_token: ShutdownToken,
@@ -772,17 +771,7 @@ impl<C, St> GatewayClient<C, St> {
         Ok(())
     }
 
-    fn unchecked_bandwidth_controller(&self) -> &BandwidthController<C, St> {
-        // this is an unchecked method
-        #[allow(clippy::unwrap_used)]
-        self.bandwidth_provider.as_ref().unwrap()
-    }
-
-    pub async fn claim_bandwidth(&mut self) -> Result<(), GatewayClientError>
-    where
-        C: DkgQueryClient,
-        St: CredentialStorage,
-    {
+    pub async fn claim_bandwidth(&mut self) -> Result<(), GatewayClientError> {
         // TODO: make it configurable
         const TICKETS_TO_SPEND: u32 = 1;
         const MIXNET_TICKET: TicketType = TicketType::V1MixnetEntry;
@@ -792,9 +781,6 @@ impl<C, St> GatewayClient<C, St> {
         }
         if self.shared_key.is_none() {
             return Err(GatewayClientError::NoSharedKeyAvailable);
-        }
-        if self.bandwidth_provider.is_none() && self.cfg.bandwidth.require_tickets {
-            return Err(GatewayClientError::NoBandwidthControllerAvailable);
         }
 
         let Some(_claim_guard) = self.bandwidth.begin_bandwidth_claim() else {
@@ -820,13 +806,15 @@ impl<C, St> GatewayClient<C, St> {
             });
         }
         let prepared_credential = self
-            .unchecked_bandwidth_controller()
-            .prepare_ecash_ticket(
+            .bandwidth_provider
+            .get_ecash_ticket(
                 MIXNET_TICKET,
-                self.gateway_identity.to_bytes(),
+                self.gateway_identity,
                 TICKETS_TO_SPEND,
+                OffsetDateTime::now_utc(),
             )
-            .await?;
+            .await?
+            .ok_or(GatewayClientError::NoMoreBandwidthCredentials)?;
 
         match self.claim_ecash_bandwidth(prepared_credential.data).await {
             Ok(_) => {
@@ -846,8 +834,8 @@ impl<C, St> GatewayClient<C, St> {
                 } else {
                     // TODO: tracing span
                     info!("attempting to revert ticket withdrawal...");
-                    self.unchecked_bandwidth_controller()
-                        .attempt_revert_ticket_usage(prepared_credential.metadata)
+                    self.bandwidth_provider
+                        .attempt_revert_spending(prepared_credential.metadata)
                         .await?;
                 }
 
@@ -876,11 +864,7 @@ impl<C, St> GatewayClient<C, St> {
     pub async fn batch_send_mix_packets(
         &mut self,
         packets: Vec<MixPacket>,
-    ) -> Result<(), GatewayClientError>
-    where
-        C: DkgQueryClient,
-        St: CredentialStorage,
-    {
+    ) -> Result<(), GatewayClientError> {
         debug!("Sending {} mix packets", packets.len());
 
         if !self.authenticated {
@@ -946,11 +930,10 @@ impl<C, St> GatewayClient<C, St> {
     }
 
     // TODO: possibly make responses optional
-    pub async fn send_mix_packet(&mut self, mix_packet: MixPacket) -> Result<(), GatewayClientError>
-    where
-        C: DkgQueryClient,
-        St: CredentialStorage,
-    {
+    pub async fn send_mix_packet(
+        &mut self,
+        mix_packet: MixPacket,
+    ) -> Result<(), GatewayClientError> {
         if !self.authenticated {
             return Err(GatewayClientError::NotAuthenticated);
         }
@@ -1055,11 +1038,7 @@ impl<C, St> GatewayClient<C, St> {
         Ok(())
     }
 
-    pub async fn claim_initial_bandwidth(&mut self) -> Result<(), GatewayClientError>
-    where
-        C: DkgQueryClient,
-        St: CredentialStorage,
-    {
+    pub async fn claim_initial_bandwidth(&mut self) -> Result<(), GatewayClientError> {
         if !self.authenticated {
             return Err(GatewayClientError::NotAuthenticated);
         }
@@ -1076,14 +1055,11 @@ impl<C, St> GatewayClient<C, St> {
     }
 }
 
-// type alias for an ease of use
-pub type InitGatewayClient = GatewayClient<InitOnly>;
+// type alias to make it clear it's incomplete
+pub type InitGatewayClient = GatewayClient;
 
-#[derive(Debug)]
-pub struct InitOnly;
-
-impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
-    // for initialisation we do not need credential storage. Though it's still a bit weird we have to set the generic...
+impl GatewayClient {
+    // for initialisation we do not need all the pieces. Some of them can be dummies
     pub fn new_init(
         gateway_listeners: GatewayListeners,
         gateway_identity: ed25519::PublicKey,
@@ -1100,6 +1076,10 @@ impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
         let shutdown_token = ShutdownToken::default();
         let packet_router = PacketRouter::new(ack_tx, mix_tx, shutdown_token.clone());
 
+        // same comment as above
+        let (bc_tx, _) = tokio::sync::mpsc::unbounded_channel();
+        let bandwidth_provider = Box::new(BandwidthControllerRequestSender::new(bc_tx));
+
         GatewayClient {
             cfg: GatewayClientConfig::default().with_disabled_credentials_mode(true),
             authenticated: false,
@@ -1110,7 +1090,7 @@ impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
             shared_key: None,
             connection: SocketState::NotConnected,
             packet_router,
-            bandwidth_provider: None,
+            bandwidth_provider,
             stats_reporter: ClientStatsSender::new(None, shutdown_token.clone()),
             negotiated_protocol: None,
             #[cfg(unix)]
@@ -1119,13 +1099,13 @@ impl GatewayClient<InitOnly, EphemeralCredentialStorage> {
         }
     }
 
-    pub fn upgrade<C, St>(
+    pub fn upgrade(
         self,
         packet_router: PacketRouter,
-        bandwidth_provider: Option<BandwidthController<C, St>>,
+        bandwidth_provider: Box<dyn BandwidthTicketProvider>,
         stats_reporter: ClientStatsSender,
         shutdown_token: ShutdownToken,
-    ) -> GatewayClient<C, St> {
+    ) -> GatewayClient {
         // invariants that can't be broken
         // (unless somebody decided to expose some field that wasn't meant to be exposed)
         assert!(self.authenticated);

--- a/common/client-libs/gateway-client/src/client/mod.rs
+++ b/common/client-libs/gateway-client/src/client/mod.rs
@@ -28,7 +28,6 @@ use nym_statistics_common::clients::connection::ConnectionStatsEvent;
 use nym_statistics_common::clients::ClientStatsSender;
 use nym_task::ShutdownToken;
 use rand::rngs::OsRng;
-use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tracing::instrument;
@@ -1132,18 +1131,8 @@ impl InitGatewayClient {
             shutdown_token,
         }
     }
-}
 
-impl Deref for InitGatewayClient {
-    type Target = GatewayClient;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for InitGatewayClient {
-    fn deref_mut(&mut self) -> &mut Self::Target {
+    pub fn inner_mut(&mut self) -> &mut GatewayClient {
         &mut self.0
     }
 }

--- a/common/client-libs/gateway-client/src/client/mod.rs
+++ b/common/client-libs/gateway-client/src/client/mod.rs
@@ -28,6 +28,7 @@ use nym_statistics_common::clients::connection::ConnectionStatsEvent;
 use nym_statistics_common::clients::ClientStatsSender;
 use nym_task::ShutdownToken;
 use rand::rngs::OsRng;
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tracing::instrument;
@@ -1055,12 +1056,12 @@ impl GatewayClient {
     }
 }
 
-// type alias to make it clear it's incomplete
-pub type InitGatewayClient = GatewayClient;
+// wrapper to make it clear it's incomplete
+pub struct InitGatewayClient(GatewayClient);
 
-impl GatewayClient {
+impl InitGatewayClient {
     // for initialisation we do not need all the pieces. Some of them can be dummies
-    pub fn new_init(
+    pub fn new(
         gateway_listeners: GatewayListeners,
         gateway_identity: ed25519::PublicKey,
         local_identity: Arc<ed25519::KeyPair>,
@@ -1080,7 +1081,7 @@ impl GatewayClient {
         let (bc_tx, _) = tokio::sync::mpsc::unbounded_channel();
         let bandwidth_provider = Box::new(BandwidthControllerRequestSender::new(bc_tx));
 
-        GatewayClient {
+        Self(GatewayClient {
             cfg: GatewayClientConfig::default().with_disabled_credentials_mode(true),
             authenticated: false,
             bandwidth: ClientBandwidth::new_empty(),
@@ -1096,7 +1097,7 @@ impl GatewayClient {
             #[cfg(unix)]
             connection_fd_callback,
             shutdown_token,
-        }
+        })
     }
 
     pub fn upgrade(
@@ -1106,28 +1107,43 @@ impl GatewayClient {
         stats_reporter: ClientStatsSender,
         shutdown_token: ShutdownToken,
     ) -> GatewayClient {
+        let inner = self.0;
         // invariants that can't be broken
         // (unless somebody decided to expose some field that wasn't meant to be exposed)
-        assert!(self.authenticated);
-        assert!(self.connection.is_available());
-        assert!(self.shared_key.is_some());
+        assert!(inner.authenticated);
+        assert!(inner.connection.is_available());
+        assert!(inner.shared_key.is_some());
 
         GatewayClient {
-            cfg: self.cfg,
-            authenticated: self.authenticated,
-            bandwidth: self.bandwidth,
-            gateway_addresses: self.gateway_addresses,
-            gateway_identity: self.gateway_identity,
-            local_identity: self.local_identity,
-            shared_key: self.shared_key,
-            connection: self.connection,
+            cfg: inner.cfg,
+            authenticated: inner.authenticated,
+            bandwidth: inner.bandwidth,
+            gateway_addresses: inner.gateway_addresses,
+            gateway_identity: inner.gateway_identity,
+            local_identity: inner.local_identity,
+            shared_key: inner.shared_key,
+            connection: inner.connection,
             packet_router,
             bandwidth_provider,
             stats_reporter,
-            negotiated_protocol: self.negotiated_protocol,
+            negotiated_protocol: inner.negotiated_protocol,
             #[cfg(unix)]
-            connection_fd_callback: self.connection_fd_callback,
+            connection_fd_callback: inner.connection_fd_callback,
             shutdown_token,
         }
+    }
+}
+
+impl Deref for InitGatewayClient {
+    type Target = GatewayClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for InitGatewayClient {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }

--- a/common/client-libs/gateway-client/src/error.rs
+++ b/common/client-libs/gateway-client/src/error.rs
@@ -59,9 +59,6 @@ pub enum GatewayClientError {
     #[error("No shared key was provided or obtained")]
     NoSharedKeyAvailable,
 
-    #[error("No bandwidth controller provided")]
-    NoBandwidthControllerAvailable,
-
     #[error("Bandwidth controller error: {0}")]
     BandwidthControllerError(#[from] nym_bandwidth_controller::error::BandwidthControllerError),
 

--- a/common/commands/Cargo.toml
+++ b/common/commands/Cargo.toml
@@ -44,8 +44,8 @@ zeroize = { workspace = true }
 cosmrs = { workspace = true }
 cosmwasm-std = { workspace = true }
 
-nym-validator-client = { workspace = true}
-nym-http-api-client = { workspace = true}
+nym-validator-client = { workspace = true }
+nym-http-api-client = { workspace = true }
 nym-bin-common = { workspace = true, features = ["output_format"] }
 nym-crypto = { workspace = true, features = ["asymmetric"] }
 nym-network-defaults = { workspace = true }

--- a/common/commands/src/ecash/generate_ticket.rs
+++ b/common/commands/src/ecash/generate_ticket.rs
@@ -11,6 +11,7 @@ use nym_credential_storage::storage::Storage;
 use nym_credentials::ecash::bandwidth::serialiser::VersionedSerialise;
 use nym_credentials_interface::TicketType;
 use std::path::PathBuf;
+use time::OffsetDateTime;
 
 #[derive(Debug, Parser)]
 pub struct Args {
@@ -105,7 +106,9 @@ pub async fn execute(args: Args) -> anyhow::Result<()> {
     let next_ticket = args
         .ticket_index
         .unwrap_or(next_ticketbook.ticketbook.spent_tickets());
-    let pay_info = next_ticketbook.ticketbook.generate_pay_info(provider_arr);
+    let pay_info = next_ticketbook
+        .ticketbook
+        .generate_pay_info(provider_arr, OffsetDateTime::now_utc());
 
     println!("{}", "TICKETBOOK DATA:".bold());
     println!("{}", bs58::encode(&ticketbook_data.data).into_string());

--- a/common/credentials-interface/src/lib.rs
+++ b/common/credentials-interface/src/lib.rs
@@ -217,11 +217,11 @@ impl NymPayInfo {
     ///
     /// A new `NymPayInfo` instance.
     ///
-    pub fn generate(provider_pk: [u8; 32]) -> Self {
+    pub fn generate(provider_pk: [u8; 32], spend_time: OffsetDateTime) -> Self {
         let mut randomness = [0u8; 32];
         rand::thread_rng().fill(&mut randomness[..32]);
 
-        let timestamp = OffsetDateTime::now_utc().unix_timestamp();
+        let timestamp = spend_time.unix_timestamp();
 
         NymPayInfo {
             randomness,

--- a/common/credentials/src/ecash/bandwidth/issued.rs
+++ b/common/credentials/src/ecash/bandwidth/issued.rs
@@ -14,7 +14,7 @@ use nym_ecash_time::EcashTime;
 use nym_validator_client::nym_api::EpochId;
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
-use time::Date;
+use time::{Date, OffsetDateTime};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub const CURRENT_SERIALIZATION_REVISION: u8 = 1;
@@ -119,8 +119,12 @@ impl IssuedTicketBook {
         &self.signatures_wallet
     }
 
-    pub fn generate_pay_info(&self, provider_pk: [u8; 32]) -> NymPayInfo {
-        NymPayInfo::generate(provider_pk)
+    pub fn generate_pay_info(
+        &self,
+        provider_pk: [u8; 32],
+        spend_time: OffsetDateTime,
+    ) -> NymPayInfo {
+        NymPayInfo::generate(provider_pk, spend_time)
     }
 
     pub fn prepare_for_spending<BI, BE>(

--- a/nym-api/src/network_monitor/mod.rs
+++ b/nym-api/src/network_monitor/mod.rs
@@ -19,7 +19,8 @@ use crate::support::caching::cache::SharedCache;
 use crate::support::config::Config;
 use crate::support::nyxd;
 use futures::channel::mpsc;
-use nym_bandwidth_controller::BandwidthController;
+use nym_bandwidth_controller::requests::BandwidthControllerRequestSender;
+use nym_bandwidth_controller::{BandwidthController, NyxdGlobalDataFetcher};
 use nym_credential_storage::persistent_storage::PersistentStorage;
 use nym_crypto::asymmetric::{ed25519, x25519};
 use nym_sphinx::acknowledgements::AckKey;
@@ -119,15 +120,19 @@ impl<'a> NetworkMonitorBuilder<'a> {
                         .credentials_database_path,
                 )
                 .await,
-                self.nyxd_client.clone(),
             )
+            .with_credential_public_data_fetcher(NyxdGlobalDataFetcher::new(
+                self.nyxd_client.clone(),
+            ))
         };
+
+        let bandwidth_request_sender = bandwidth_controller.get_request_sender();
 
         let packet_sender = new_packet_sender(
             self.config,
             gateway_status_update_sender,
             Arc::clone(&identity_keypair),
-            bandwidth_controller,
+            bandwidth_request_sender,
             shutdown_token,
         );
 
@@ -156,6 +161,7 @@ impl<'a> NetworkMonitorBuilder<'a> {
         NetworkMonitorRunnables {
             monitor,
             packet_receiver,
+            bandwidth_controller,
         }
     }
 }
@@ -163,6 +169,7 @@ impl<'a> NetworkMonitorBuilder<'a> {
 pub(crate) struct NetworkMonitorRunnables<R: MessageReceiver + Send + Sync + 'static> {
     monitor: Monitor<R>,
     packet_receiver: PacketReceiver,
+    bandwidth_controller: BandwidthController<PersistentStorage>,
 }
 
 impl<R: MessageReceiver + Send + Sync + 'static> NetworkMonitorRunnables<R> {
@@ -172,6 +179,10 @@ impl<R: MessageReceiver + Send + Sync + 'static> NetworkMonitorRunnables<R> {
     pub(crate) fn spawn_tasks(self, shutdown: &ShutdownManager) {
         let mut packet_receiver = self.packet_receiver;
         let mut monitor = self.monitor;
+        let bandwidth_controller = self.bandwidth_controller;
+
+        let shutdown_listener = shutdown.clone_shutdown_token();
+        tokio::spawn(async move { bandwidth_controller.run(shutdown_listener).await });
         let shutdown_listener = shutdown.clone_shutdown_token();
         tokio::spawn(async move { packet_receiver.run(shutdown_listener).await });
         let shutdown_listener = shutdown.clone_shutdown_token();
@@ -203,14 +214,14 @@ fn new_packet_sender(
     config: &Config,
     gateways_status_updater: GatewayClientUpdateSender,
     local_identity: Arc<ed25519::KeyPair>,
-    bandwidth_controller: BandwidthController<nyxd::Client, PersistentStorage>,
+    bandwidth_request_sender: BandwidthControllerRequestSender,
     shutdown_token: ShutdownToken,
 ) -> PacketSender {
     PacketSender::new(
         config,
         gateways_status_updater,
         local_identity,
-        bandwidth_controller,
+        bandwidth_request_sender,
         shutdown_token,
     )
 }

--- a/nym-api/src/network_monitor/monitor/gateway_client_handle.rs
+++ b/nym-api/src/network_monitor/monitor/gateway_client_handle.rs
@@ -2,20 +2,18 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::network_monitor::monitor::receiver::{GatewayClientUpdate, GatewayClientUpdateSender};
-use crate::support::nyxd;
-use nym_credential_storage::persistent_storage::PersistentStorage;
 use nym_gateway_client::GatewayClient;
 use std::ops::{Deref, DerefMut};
 use tracing::warn;
 
 pub(crate) struct GatewayClientHandle {
-    client: GatewayClient<nyxd::Client, PersistentStorage>,
+    client: GatewayClient,
     gateways_status_updater: GatewayClientUpdateSender,
 }
 
 impl GatewayClientHandle {
     pub(crate) fn new(
-        client: GatewayClient<nyxd::Client, PersistentStorage>,
+        client: GatewayClient,
         gateways_status_updater: GatewayClientUpdateSender,
     ) -> Self {
         GatewayClientHandle {
@@ -40,7 +38,7 @@ impl Drop for GatewayClientHandle {
 }
 
 impl Deref for GatewayClientHandle {
-    type Target = GatewayClient<nyxd::Client, PersistentStorage>;
+    type Target = GatewayClient;
 
     fn deref(&self) -> &Self::Target {
         &self.client

--- a/nym-api/src/network_monitor/monitor/sender.rs
+++ b/nym-api/src/network_monitor/monitor/sender.rs
@@ -4,14 +4,12 @@
 use crate::network_monitor::monitor::gateway_client_handle::GatewayClientHandle;
 use crate::network_monitor::monitor::receiver::{GatewayClientUpdate, GatewayClientUpdateSender};
 use crate::support::config::Config;
-use crate::support::nyxd;
 use dashmap::DashMap;
 use futures::channel::mpsc;
 use futures::stream::{self, FuturesUnordered, StreamExt};
 use futures::task::Context;
 use futures::{Future, Stream};
-use nym_bandwidth_controller::BandwidthController;
-use nym_credential_storage::persistent_storage::PersistentStorage;
+use nym_bandwidth_controller::requests::BandwidthControllerRequestSender;
 use nym_crypto::asymmetric::ed25519;
 use nym_gateway_client::client::config::GatewayClientConfig;
 use nym_gateway_client::client::{GatewayConfig, GatewayListeners};
@@ -98,7 +96,7 @@ struct FreshGatewayClientData {
     local_identity: Arc<ed25519::KeyPair>,
     shutdown_token: ShutdownToken,
     gateway_response_timeout: Duration,
-    bandwidth_controller: BandwidthController<nyxd::Client, PersistentStorage>,
+    bandwidth_request_sender: BandwidthControllerRequestSender,
     disabled_credentials_mode: bool,
     gateways_key_cache: DashMap<ed25519::PublicKey, Arc<SharedSymmetricKey>>,
 }
@@ -132,7 +130,7 @@ impl PacketSender {
         config: &Config,
         gateways_status_updater: GatewayClientUpdateSender,
         local_identity: Arc<ed25519::KeyPair>,
-        bandwidth_controller: BandwidthController<nyxd::Client, PersistentStorage>,
+        bandwidth_request_sender: BandwidthControllerRequestSender,
         shutdown_token: ShutdownToken,
     ) -> Self {
         PacketSender {
@@ -141,7 +139,7 @@ impl PacketSender {
                 local_identity,
                 shutdown_token,
                 gateway_response_timeout: config.network_monitor.debug.gateway_response_timeout,
-                bandwidth_controller,
+                bandwidth_request_sender,
                 disabled_credentials_mode: config.network_monitor.debug.disabled_credentials_mode,
                 gateways_key_cache: Default::default(),
             }),
@@ -187,7 +185,7 @@ impl PacketSender {
             Arc::clone(&fresh_gateway_client_data.local_identity),
             shared_keys,
             gateway_packet_router,
-            Some(fresh_gateway_client_data.bandwidth_controller.clone()),
+            Box::new(fresh_gateway_client_data.bandwidth_request_sender.clone()),
             nym_statistics_common::clients::ClientStatsSender::new(
                 None,
                 fresh_gateway_client_data.shutdown_token.clone(),
@@ -207,7 +205,7 @@ impl PacketSender {
     }
 
     async fn attempt_to_send_packets(
-        client: &mut GatewayClient<nyxd::Client, PersistentStorage>,
+        client: &mut GatewayClient,
         mut mix_packets: Vec<MixPacket>,
         max_sending_rate: usize,
     ) -> Result<(), GatewayClientError> {
@@ -346,7 +344,7 @@ impl PacketSender {
     }
 
     async fn check_remaining_bandwidth(
-        client: &mut GatewayClient<nyxd::Client, PersistentStorage>,
+        client: &mut GatewayClient,
     ) -> Result<(), GatewayClientError> {
         if client.remaining_bandwidth() < client.cfg.bandwidth.remaining_bandwidth_threshold {
             Err(GatewayClientError::NotEnoughBandwidth(

--- a/nym-authenticator-client/Cargo.toml
+++ b/nym-authenticator-client/Cargo.toml
@@ -17,6 +17,7 @@ bincode.workspace = true
 futures.workspace = true
 semver.workspace = true
 thiserror.workspace = true
+time.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/nym-authenticator-client/src/error.rs
+++ b/nym-authenticator-client/src/error.rs
@@ -40,6 +40,9 @@ pub enum AuthenticationClientError {
         source: nym_bandwidth_controller::error::BandwidthControllerError,
     },
 
+    #[error("No {ticketbook_type} tickets available")]
+    NoTicketsAvailable { ticketbook_type: TicketType },
+
     #[error("failed to retrieve upgrade mode token")]
     UpgradeModeToken {
         #[source]

--- a/nym-authenticator-client/src/lib.rs
+++ b/nym-authenticator-client/src/lib.rs
@@ -8,6 +8,7 @@ use nym_registration_common::WireguardConfiguration;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
+use time::OffsetDateTime;
 use tracing::{debug, error, trace, warn};
 
 use crate::error::Result;
@@ -208,12 +209,12 @@ impl AuthenticatorClient {
 
     async fn produce_bandwidth_claim(
         &self,
-        controller: &dyn BandwidthTicketProvider,
+        bandwidth_provider: &dyn BandwidthTicketProvider,
         upgrade_mode_enabled: bool,
         ticketbook_type: TicketType,
     ) -> Result<BandwidthClaim> {
         if upgrade_mode_enabled {
-            match controller
+            match bandwidth_provider
                 .get_upgrade_mode_token()
                 .await
                 .map_err(|source| AuthenticationClientError::UpgradeModeToken { source })?
@@ -233,17 +234,19 @@ impl AuthenticatorClient {
             }
         }
 
-        let credential = controller
+        let credential = bandwidth_provider
             .get_ecash_ticket(
                 ticketbook_type,
                 self.auth_recipient.gateway(),
                 DEFAULT_TICKETS_TO_SPEND,
+                OffsetDateTime::now_utc(),
             )
             .await
             .map_err(|source| AuthenticationClientError::GetTicket {
                 ticketbook_type,
                 source,
             })?
+            .ok_or(AuthenticationClientError::NoTicketsAvailable { ticketbook_type })?
             .data;
 
         let credential = credential
@@ -259,7 +262,7 @@ impl AuthenticatorClient {
 
     pub async fn register_wireguard(
         &mut self,
-        controller: &dyn BandwidthTicketProvider,
+        bandwidth_provider: &dyn BandwidthTicketProvider,
         ticketbook_type: TicketType,
     ) -> std::result::Result<WireguardConfiguration, RegistrationError> {
         debug!("Registering with the wg gateway...");
@@ -314,7 +317,11 @@ impl AuthenticatorClient {
                     .is_enabled();
 
                 let bandwidth_claim = self
-                    .produce_bandwidth_claim(controller, upgrade_mode_enabled, ticketbook_type)
+                    .produce_bandwidth_claim(
+                        bandwidth_provider,
+                        upgrade_mode_enabled,
+                        ticketbook_type,
+                    )
                     .await
                     .map_err(|source| RegistrationError::CredentialSent { source })?;
 

--- a/nym-gateway-probe/src/common/bandwidth_helpers.rs
+++ b/nym-gateway-probe/src/common/bandwidth_helpers.rs
@@ -1,9 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, bail};
+use anyhow::bail;
 use nym_bandwidth_controller::BandwidthTicketProvider;
-use nym_bandwidth_controller::error::BandwidthControllerError;
 use nym_bandwidth_controller::mock::MockBandwidthController;
 use nym_client_core::client::base_client::storage::OnDiskPersistent;
 use nym_credentials::{
@@ -14,7 +13,6 @@ use nym_credentials_interface::TicketType;
 use nym_sdk::NymNetworkDetails;
 use nym_sdk::bandwidth::BandwidthImporter;
 use nym_sdk::mixnet::{CredentialStorage, DisconnectedMixnetClient, EphemeralCredentialStorage};
-use nym_validator_client::nyxd::error::NyxdError;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -31,8 +29,9 @@ where
     S: CredentialStorage + 'static,
 {
     if !use_mock_ecash {
+        // the controller owns the storage; it fetches any missing global ecash data from the
+        // nym-apis via a nyxd-backed public data fetcher.
         let config = nym_validator_client::nyxd::Config::try_from_nym_network_details(network)?;
-
         let nyxd_url = network
             .endpoints
             .first()
@@ -42,7 +41,10 @@ where
             nym_validator_client::nyxd::NyxdClient::connect(config, nyxd_url.as_str())?;
 
         Ok(Box::new(
-            nym_bandwidth_controller::BandwidthController::new(storage, rpc_client),
+            nym_bandwidth_controller::BandwidthController::new(storage)
+                .with_credential_public_data_fetcher(
+                    nym_bandwidth_controller::NyxdGlobalDataFetcher::new(rpc_client),
+                ),
         ))
     } else {
         Ok(Box::new(MockBandwidthController::default()))

--- a/nym-gateway-probe/src/common/bandwidth_helpers.rs
+++ b/nym-gateway-probe/src/common/bandwidth_helpers.rs
@@ -1,8 +1,9 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::bail;
+use anyhow::{Context, bail};
 use nym_bandwidth_controller::BandwidthTicketProvider;
+use nym_bandwidth_controller::error::BandwidthControllerError;
 use nym_bandwidth_controller::mock::MockBandwidthController;
 use nym_client_core::client::base_client::storage::OnDiskPersistent;
 use nym_credentials::{
@@ -13,6 +14,7 @@ use nym_credentials_interface::TicketType;
 use nym_sdk::NymNetworkDetails;
 use nym_sdk::bandwidth::BandwidthImporter;
 use nym_sdk::mixnet::{CredentialStorage, DisconnectedMixnetClient, EphemeralCredentialStorage};
+use nym_validator_client::nyxd::error::NyxdError;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;

--- a/nym-gateway-probe/src/lib.rs
+++ b/nym-gateway-probe/src/lib.rs
@@ -27,6 +27,7 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use time::OffsetDateTime;
 use tokio_util::sync::CancellationToken;
 use tracing::*;
 
@@ -177,10 +178,21 @@ impl Probe {
 
             let credential = match bandwidth
                 .provider
-                .get_ecash_ticket(bandwidth.ticket_type, bandwidth.credential_provider, 1)
+                .get_ecash_ticket(
+                    bandwidth.ticket_type,
+                    bandwidth.credential_provider,
+                    1,
+                    OffsetDateTime::now_utc(),
+                )
                 .await
             {
-                Ok(ticket) => ticket.data,
+                Ok(Some(ticket)) => ticket.data,
+                Ok(None) => {
+                    error!("Failed to get ecash ticket: No tickets available");
+                    last_error =
+                        Some("Failed to get ecash ticket: No tickets available".to_string());
+                    break;
+                }
                 Err(e) => {
                     error!("Failed to get ecash ticket: {e}");
                     last_error = Some(format!("Failed to get ecash ticket: {e}"));
@@ -848,8 +860,14 @@ impl Probe {
                     };
 
                     let credential = bandwith_provider
-                        .get_ecash_ticket(wg_ticket_type, credential_provider, 1)
+                        .get_ecash_ticket(
+                            wg_ticket_type,
+                            credential_provider,
+                            1,
+                            OffsetDateTime::now_utc(),
+                        )
                         .await?
+                        .ok_or(anyhow::anyhow!("No tickets available"))?
                         .data;
 
                     let outcome = wg_probe(

--- a/nym-registration-client/Cargo.toml
+++ b/nym-registration-client/Cargo.toml
@@ -19,6 +19,7 @@ bytes.workspace = true
 futures.workspace = true
 rand09.workspace = true
 thiserror.workspace = true
+time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
@@ -34,7 +35,6 @@ nym-lp = { path = "../common/nym-lp" }
 nym-lp-data.workspace = true
 nym-registration-common = { workspace = true }
 nym-sdk = { workspace = true }
-nym-validator-client = { workspace = true }
 nym-wireguard-types = { path = "../common/wireguard-types" }
 
 [dev-dependencies]

--- a/nym-registration-client/src/builder/config.rs
+++ b/nym-registration-client/src/builder/config.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use nym_credential_storage::persistent_storage::PersistentStorage;
+use nym_bandwidth_controller::requests::BandwidthControllerRequestSender;
 use nym_registration_common::NymNodeInformation;
 use nym_sdk::{
     DebugConfig, NymNetworkDetails, RememberMe, TopologyProvider, UserAgent,
@@ -35,8 +35,9 @@ pub struct BuilderConfig {
     // Common options
     pub entry_node: NymNodeWithKeys,
     pub exit_node: NymNodeWithKeys,
-    pub data_path: Option<PathBuf>,
+    pub data_path: PathBuf,
     pub mode: RegistrationMode,
+    pub bandwidth_request_sender: BandwidthControllerRequestSender,
     pub cancel_token: CancellationToken,
 
     // Toggle
@@ -102,46 +103,21 @@ impl BuilderConfig {
 
     pub async fn setup_mixnet_client_storage(
         &self,
-    ) -> Result<Option<(OnDiskPersistent, PersistentStorage)>, RegistrationClientError> {
-        if let Some(path) = &self.data_path {
-            tracing::debug!("Using custom key storage path: {}", path.display());
+    ) -> Result<OnDiskPersistent, RegistrationClientError> {
+        tracing::debug!(
+            "Using custom mixnet client storage path: {}",
+            self.data_path.display()
+        );
 
-            let storage_paths = StoragePaths::new_from_dir(path)
-                .map_err(|err| RegistrationClientError::StorageInitialization(Box::new(err)))?;
+        let storage_paths = StoragePaths::new_from_dir(&self.data_path)
+            .map_err(|err| RegistrationClientError::StorageInitialization(Box::new(err)))?;
 
-            let mixnet_client_storage = storage_paths
-                .initialise_persistent_storage(&self.mixnet_client_debug_config())
-                .await
-                .map_err(|err| RegistrationClientError::StorageInitialization(Box::new(err)))?;
-            let credential_storage = storage_paths
-                .persistent_credential_storage()
-                .await
-                .map_err(|err| RegistrationClientError::StorageInitialization(Box::new(err)))?;
+        let mixnet_client_storage = storage_paths
+            .initialise_persistent_storage(&self.mixnet_client_debug_config())
+            .await
+            .map_err(|err| RegistrationClientError::StorageInitialization(Box::new(err)))?;
 
-            Ok(Some((mixnet_client_storage, credential_storage)))
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub async fn setup_credential_storage(
-        &self,
-    ) -> Result<Option<PersistentStorage>, RegistrationClientError> {
-        if let Some(path) = &self.data_path {
-            tracing::debug!("Using custom credential storage path: {}", path.display());
-
-            let storage_paths = StoragePaths::new_from_dir(path)
-                .map_err(|err| RegistrationClientError::StorageInitialization(Box::new(err)))?;
-
-            let credential_storage = storage_paths
-                .persistent_credential_storage()
-                .await
-                .map_err(|err| RegistrationClientError::StorageInitialization(Box::new(err)))?;
-
-            Ok(Some(credential_storage))
-        } else {
-            Ok(None)
-        }
+        Ok(mixnet_client_storage)
     }
 
     pub async fn build_and_connect_mixnet_client<S>(
@@ -166,7 +142,8 @@ impl BuilderConfig {
             .credentials_mode(true)
             .no_hostname(true)
             .with_remember_me(remember_me)
-            .custom_topology_provider(self.custom_topology_provider);
+            .custom_topology_provider(self.custom_topology_provider)
+            .with_custom_bandwidth_provider(Box::new(self.bandwidth_request_sender));
 
         #[cfg(unix)]
         let builder = builder.with_connection_fd_callback(self.connection_fd_callback);

--- a/nym-registration-client/src/builder/mod.rs
+++ b/nym-registration-client/src/builder/mod.rs
@@ -2,16 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use futures::channel::mpsc;
-use nym_bandwidth_controller::{BandwidthController, BandwidthTicketProvider};
-use nym_credential_storage::ephemeral_storage::EphemeralCredentialStorage;
-use nym_sdk::{
-    NymNetworkDetails,
-    mixnet::{EventSender, MixnetClient, MixnetClientBuilder},
-};
-use nym_validator_client::{
-    QueryHttpRpcNyxdClient,
-    nyxd::{Config as NyxdClientConfig, NyxdClient},
-};
+use nym_sdk::mixnet::{EventSender, MixnetClientBuilder};
 
 use crate::{
     RegistrationClient,
@@ -67,48 +58,26 @@ impl RegistrationClientBuilder {
         let cancel_token = self.config.cancel_token.clone();
         let (event_tx, event_rx) = mpsc::unbounded();
 
-        let nyxd_client = get_nyxd_client(&self.config.network_env)?;
         let mixnet_client_startup_timeout = self.config.mixnet_client_startup_timeout;
 
-        let (mixnet_client, bandwidth_provider): (MixnetClient, Box<dyn BandwidthTicketProvider>) =
-            if let Some((mixnet_client_storage, credential_storage)) = storage {
-                let builder = MixnetClientBuilder::new_with_storage(mixnet_client_storage)
-                    .event_tx(EventSender(event_tx));
-                let mixnet_client = tokio::time::timeout(
-                    mixnet_client_startup_timeout,
-                    self.config.build_and_connect_mixnet_client(builder),
-                )
-                .await
-                .inspect_err(|_| {
-                    tracing::warn!(
-                        "mixnet client connection timed out after {:?}",
-                        mixnet_client_startup_timeout
-                    )
-                })?
-                .inspect_err(|e| tracing::warn!("mixnet build/connect error: {e}"))?;
-                let bandwidth_controller =
-                    Box::new(BandwidthController::new(credential_storage, nyxd_client));
-                (mixnet_client, bandwidth_controller)
-            } else {
-                let builder = MixnetClientBuilder::new_ephemeral().event_tx(EventSender(event_tx));
-                let mixnet_client = tokio::time::timeout(
-                    mixnet_client_startup_timeout,
-                    self.config.build_and_connect_mixnet_client(builder),
-                )
-                .await
-                .inspect_err(|_| {
-                    tracing::warn!(
-                        "mixnet client connection timed out after {:?}",
-                        mixnet_client_startup_timeout
-                    )
-                })?
-                .inspect_err(|e| tracing::warn!("mixnet build/connect error: {e}"))?;
-                let bandwidth_controller = Box::new(BandwidthController::new(
-                    EphemeralCredentialStorage::default(),
-                    nyxd_client,
-                ));
-                (mixnet_client, bandwidth_controller)
-            };
+        let bc_request_sender = self.config.bandwidth_request_sender.clone();
+
+        let builder =
+            MixnetClientBuilder::new_with_storage(storage).event_tx(EventSender(event_tx));
+
+        let mixnet_client = tokio::time::timeout(
+            mixnet_client_startup_timeout,
+            self.config.build_and_connect_mixnet_client(builder),
+        )
+        .await
+        .inspect_err(|_| {
+            tracing::warn!(
+                "mixnet client connection timed out after {:?}",
+                mixnet_client_startup_timeout
+            )
+        })?
+        .inspect_err(|e| tracing::warn!("mixnet build/connect error: {e}"))?;
+
         let mixnet_client_address = *mixnet_client.nym_address();
 
         Ok(MixnetBasedRegistrationClient {
@@ -116,47 +85,19 @@ impl RegistrationClientBuilder {
             config,
             cancel_token,
             mixnet_client_address,
-            bandwidth_provider,
+            bandwidth_provider: Box::new(bc_request_sender),
             event_rx,
         })
     }
 
     async fn build_lp(self) -> Result<LpBasedRegistrationClient, RegistrationClientError> {
-        let storage = self.config.setup_credential_storage().await?;
         let config = self.config.registration_client_config();
-
-        let nyxd_client = get_nyxd_client(&self.config.network_env)?;
-
-        let bandwidth_provider: Box<dyn BandwidthTicketProvider> =
-            if let Some(credential_storage) = storage {
-                Box::new(BandwidthController::new(credential_storage, nyxd_client))
-            } else {
-                Box::new(BandwidthController::new(
-                    EphemeralCredentialStorage::default(),
-                    nyxd_client,
-                ))
-            };
+        let bc_request_sender = self.config.bandwidth_request_sender;
 
         Ok(LpBasedRegistrationClient {
             config,
-            bandwidth_provider,
+            bandwidth_provider: Box::new(bc_request_sender),
             cancel_token: self.config.cancel_token.clone(),
         })
     }
-}
-
-// temporary while we use the legacy bandwidth-controller
-fn get_nyxd_client(
-    network: &NymNetworkDetails,
-) -> Result<QueryHttpRpcNyxdClient, RegistrationClientError> {
-    let config = NyxdClientConfig::try_from_nym_network_details(network)
-        .map_err(RegistrationClientError::FailedToCreateNyxdClientConfig)?;
-    let nyxd_url = network
-        .endpoints
-        .first()
-        .map(|ep| ep.nyxd_url())
-        .ok_or(RegistrationClientError::InvalidNyxdUrl)?;
-
-    NyxdClient::connect(config, nyxd_url.as_str())
-        .map_err(RegistrationClientError::FailedToConnectUsingNyxdClient)
 }

--- a/nym-registration-client/src/clients/lp.rs
+++ b/nym-registration-client/src/clients/lp.rs
@@ -151,7 +151,6 @@ impl LpBasedRegistrationClient {
             exit_gateway_data,
             entry_lp_keypair,
             exit_lp_keypair,
-            self.bandwidth_provider,
         ))
     }
 

--- a/nym-registration-client/src/clients/mixnet.rs
+++ b/nym-registration-client/src/clients/mixnet.rs
@@ -204,7 +204,6 @@ impl MixnetBasedRegistrationClient {
             entry,
             exit,
             mixnet_listener,
-            self.bandwidth_provider,
         ))
     }
 

--- a/nym-registration-client/src/error.rs
+++ b/nym-registration-client/src/error.rs
@@ -26,15 +26,6 @@ pub enum RegistrationClientError {
     )]
     AuthenticationNotPossible { node_id: String },
 
-    #[error("Failed to create nyxd client config")]
-    FailedToCreateNyxdClientConfig(nym_validator_client::nyxd::error::NyxdError),
-
-    #[error("failed to parse nyxd_url")]
-    InvalidNyxdUrl,
-
-    #[error("Failed to connect using nyxd client")]
-    FailedToConnectUsingNyxdClient(nym_validator_client::nyxd::error::NyxdError),
-
     #[error("connection cancelled")]
     Cancelled,
 

--- a/nym-registration-client/src/lp_client/client.rs
+++ b/nym-registration-client/src/lp_client/client.rs
@@ -30,6 +30,7 @@ use rand09::{CryptoRng, RngCore};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
+use time::OffsetDateTime;
 use tokio::net::TcpStream;
 use tracing::{debug, warn};
 
@@ -439,12 +440,20 @@ where
 
         // 1. Get bandwidth credential from controller
         let credential_spending = bandwidth_provider
-            .get_ecash_ticket(ticket_type, gateway_identity, DEFAULT_TICKETS_TO_SPEND)
+            .get_ecash_ticket(
+                ticket_type,
+                gateway_identity,
+                DEFAULT_TICKETS_TO_SPEND,
+                OffsetDateTime::now_utc(),
+            )
             .await
             .map_err(|e| {
                 LpClientError::SendRegistrationRequest(format!(
                     "Failed to acquire bandwidth credential: {e}",
                 ))
+            })?
+            .ok_or(LpClientError::NoTicketsAvailable {
+                ticketbook_type: ticket_type,
             })?
             .data;
 

--- a/nym-registration-client/src/lp_client/error.rs
+++ b/nym-registration-client/src/lp_client/error.rs
@@ -3,6 +3,7 @@
 
 //! Error types for LP (Lewes Protocol) client operations.
 
+use nym_credentials_interface::TicketType;
 use nym_lp::LpError;
 use nym_lp::session::LpAction;
 use nym_lp::transport::LpTransportError;
@@ -50,6 +51,9 @@ pub enum LpClientError {
 
     #[error("timed out while attempting to send to/receive from the connection")]
     ConnectionTimeout,
+
+    #[error("No {ticketbook_type} tickets available")]
+    NoTicketsAvailable { ticketbook_type: TicketType },
 
     /// Failed to send registration request
     #[error("Failed to send registration request: {0}")]

--- a/nym-registration-client/src/lp_client/nested_session/mod.rs
+++ b/nym-registration-client/src/lp_client/nested_session/mod.rs
@@ -43,6 +43,7 @@ use nym_wireguard_types::PeerPublicKey;
 use rand09::{CryptoRng, RngCore};
 use std::net::SocketAddr;
 use std::sync::Arc;
+use time::OffsetDateTime;
 use tracing::{debug, warn};
 
 pub(crate) mod connection;
@@ -236,12 +237,20 @@ impl NestedLpSession {
 
         // Step 1: Get bandwidth credential from controller
         let credential_spending = bandwidth_provider
-            .get_ecash_ticket(ticket_type, gateway_identity, DEFAULT_TICKETS_TO_SPEND)
+            .get_ecash_ticket(
+                ticket_type,
+                gateway_identity,
+                DEFAULT_TICKETS_TO_SPEND,
+                OffsetDateTime::now_utc(),
+            )
             .await
             .map_err(|e| {
                 LpClientError::SendRegistrationRequest(format!(
                     "Failed to acquire bandwidth credential: {e}",
                 ))
+            })?
+            .ok_or(LpClientError::NoTicketsAvailable {
+                ticketbook_type: ticket_type,
             })?
             .data;
 

--- a/nym-registration-client/src/types.rs
+++ b/nym-registration-client/src/types.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use nym_authenticator_client::{AuthClientMixnetListenerHandle, AuthenticatorClient};
-use nym_bandwidth_controller::BandwidthTicketProvider;
 use nym_lp::peer::DHKeyPair;
 use nym_registration_common::{AssignedAddresses, WireguardConfiguration};
 use nym_sdk::mixnet::{EventReceiver, MixnetClient};
@@ -32,7 +31,6 @@ impl RegistrationResult {
         entry_gateway_data: WireguardConfiguration,
         exit_gateway_data: WireguardConfiguration,
         authenticator_listener_handle: AuthClientMixnetListenerHandle,
-        bw_controller: Box<dyn BandwidthTicketProvider>,
     ) -> Self {
         RegistrationResult::Wireguard(Box::new(WireguardRegistrationResult::Legacy(Box::new(
             AuthenticatorRegistrationResult {
@@ -41,7 +39,6 @@ impl RegistrationResult {
                 entry_gateway_data,
                 exit_gateway_data,
                 authenticator_listener_handle,
-                bw_controller,
             },
         ))))
     }
@@ -51,7 +48,6 @@ impl RegistrationResult {
         exit_gateway_data: WireguardConfiguration,
         entry_lp_keypair: Arc<DHKeyPair>,
         exit_lp_keypair: Arc<DHKeyPair>,
-        bw_controller: Box<dyn BandwidthTicketProvider>,
     ) -> Self {
         RegistrationResult::Wireguard(Box::new(WireguardRegistrationResult::LewesProtocol(
             Box::new(LpRegistrationResult {
@@ -59,7 +55,6 @@ impl RegistrationResult {
                 exit_gateway_data,
                 entry_lp_keypair,
                 exit_lp_keypair,
-                bw_controller,
             }),
         )))
     }
@@ -98,7 +93,6 @@ pub struct AuthenticatorRegistrationResult {
     pub entry_gateway_data: WireguardConfiguration,
     pub exit_gateway_data: WireguardConfiguration,
     pub authenticator_listener_handle: AuthClientMixnetListenerHandle,
-    pub bw_controller: Box<dyn BandwidthTicketProvider>,
 }
 
 /// Result of LP (Lewes Protocol) registration with entry and exit gateways.
@@ -127,7 +121,4 @@ pub struct LpRegistrationResult {
     /// x25519 keypair used on the exit channel
     /// the purpose of persisting those keys is to be able to resume the pre-established session
     pub exit_lp_keypair: Arc<DHKeyPair>,
-
-    /// Bandwidth controller for credential management
-    pub bw_controller: Box<dyn BandwidthTicketProvider>,
 }

--- a/sdk/rust/nym-sdk/src/mixnet/client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/client.rs
@@ -9,6 +9,7 @@ use crate::GatewayTransceiver;
 use crate::NymNetworkDetails;
 use crate::{Error, Result};
 use log::{debug, warn};
+use nym_bandwidth_controller::BandwidthTicketProvider;
 use nym_client_core::client::base_client::storage::gateways_storage::GatewayRegistration;
 use nym_client_core::client::base_client::storage::helpers::{
     get_active_gateway_identity, get_all_registered_identities, has_gateway_details,
@@ -73,6 +74,7 @@ pub struct MixnetClientBuilder<S: MixnetClientStorage = Ephemeral> {
     wait_for_initial_topology: bool,
     custom_topology_provider: Option<Box<dyn TopologyProvider + Send + Sync>>,
     custom_gateway_transceiver: Option<Box<dyn GatewayTransceiver + Send + Sync>>,
+    custom_bandwidth_provider: Option<Box<dyn BandwidthTicketProvider>>,
     custom_shutdown: Option<ShutdownTracker>,
     event_tx: Option<EventSender>,
     force_tls: bool,
@@ -116,6 +118,7 @@ impl MixnetClientBuilder<OnDiskPersistent> {
             wait_for_gateway: false,
             wait_for_initial_topology: false,
             custom_topology_provider: None,
+            custom_bandwidth_provider: None,
             storage: storage_paths
                 .initialise_default_persistent_storage()
                 .await?,
@@ -151,6 +154,7 @@ where
             wait_for_initial_topology: false,
             custom_topology_provider: None,
             custom_gateway_transceiver: None,
+            custom_bandwidth_provider: None,
             custom_shutdown: None,
             event_tx: None,
             force_tls: false,
@@ -178,6 +182,7 @@ where
             wait_for_initial_topology: self.wait_for_initial_topology,
             custom_topology_provider: self.custom_topology_provider,
             custom_gateway_transceiver: self.custom_gateway_transceiver,
+            custom_bandwidth_provider: self.custom_bandwidth_provider,
             custom_shutdown: self.custom_shutdown,
             event_tx: self.event_tx,
             force_tls: self.force_tls,
@@ -370,6 +375,17 @@ where
         self
     }
 
+    /// Use an externally managed bandwidth controller instead of having the client spin up its own.
+    /// only for advanced use
+    #[must_use]
+    pub fn with_custom_bandwidth_provider(
+        mut self,
+        bandwidth_provider: Box<dyn BandwidthTicketProvider>,
+    ) -> Self {
+        self.custom_bandwidth_provider = Some(bandwidth_provider);
+        self
+    }
+
     /// Use specified file for storing gateway configuration.
     pub fn gateway_endpoint_config_path<P: AsRef<Path>>(mut self, path: P) -> Self {
         self.gateway_endpoint_config_path = Some(path.as_ref().to_owned());
@@ -387,6 +403,7 @@ where
         )?;
 
         client.custom_gateway_transceiver = self.custom_gateway_transceiver;
+        client.custom_bandwidth_provider = self.custom_bandwidth_provider;
         client.custom_topology_provider = self.custom_topology_provider;
         client.custom_shutdown = self.custom_shutdown;
         client.wait_for_gateway = self.wait_for_gateway;
@@ -439,6 +456,9 @@ where
 
     /// advanced usage of custom gateways
     custom_gateway_transceiver: Option<Box<dyn GatewayTransceiver + Send + Sync>>,
+
+    /// advanced usage of an externally managed bandwidth controller
+    custom_bandwidth_provider: Option<Box<dyn BandwidthTicketProvider>>,
 
     /// Attempt to wait for the selected gateway (if applicable) to come online if it's currently not bonded.
     wait_for_gateway: bool,
@@ -516,6 +536,7 @@ where
             storage,
             custom_topology_provider: None,
             custom_gateway_transceiver: None,
+            custom_bandwidth_provider: None,
             wait_for_gateway: false,
             wait_for_initial_topology: false,
             force_tls: false,
@@ -837,6 +858,10 @@ where
 
         if let Some(gateway_transceiver) = self.custom_gateway_transceiver {
             base_builder = base_builder.with_gateway_transceiver(gateway_transceiver);
+        }
+
+        if let Some(bandwidth_provider) = self.custom_bandwidth_provider {
+            base_builder = base_builder.with_custom_bandwidth_provider(bandwidth_provider);
         }
 
         #[cfg(unix)]


### PR DESCRIPTION
# Standalone, actor-based bandwidth controller

## Summary

Step 1 of the bandwidth-controller rework. This makes the `BandwidthController` a self-contained, actor-style component that runs on its own task and is addressed through a cloneable handle, instead of being a generic struct embedded (and cloned) into every gateway client.

The behavior is intended to be **equivalent** to the previous implementation — this is a structural refactor that removes generics from the consumer side and decouples the controller from the DKG query client.

## Key changes

**Controller becomes an actor** (`common/bandwidth-controller/src/controller.rs`)
- `BandwidthController<St>` — generic only over storage now.
- A `run(shutdown_token)` event loop processes `BandwidthControllerRequest`s off an mpsc channel until cancelled, then closes storage on shutdown.
- `get_request_sender()` hands out a cloneable `BandwidthControllerRequestSender` (`requests/sender.rs`) that implements `BandwidthTicketProvider` and talks to the controller over the channel (oneshot reply via `ReturnSender`).

**Public data fetching abstracted behind a trait** (`traits.rs`, `fetcher/`)
- New `CredentialPublicDataFetcher` trait for fetching the global ecash signing materials (master VK, coin-index sigs, expiration-date sigs).
- `NyxdGlobalDataFetcher` is the in-repo, nyxd-backed implementation, attached via `with_credential_public_data_fetcher(...)`. The previous `ApiClientsWrapper` logic moved here, now with a lock-free `ArcSwapOption` cache so the trait methods can stay `&self`.
- The controller's `ensure_*` helpers fetch-and-persist any missing global data on demand, removing the `DkgQueryClient` generic from the controller itself.

**Consumers de-generified**
- `GatewayClient<C, St>` → `GatewayClient`; it now holds a `Box<dyn BandwidthTicketProvider>` (`common/client-libs/gateway-client/src/client/mod.rs`).
- Base client wires up the controller in `start_bandwidth_controller(...)`, spawns it as a named `"BandwidthController"` task, and passes the request sender down (`common/client-core/src/client/base_client/mod.rs`). The standalone `CredentialStorage::close_on_shutdown` task is gone — the controller owns storage close now.
- `with_custom_bandwidth_provider(...)` added to both the base client builder and the SDK `MixnetClientBuilder` (`sdk/rust/nym-sdk/src/mixnet/client.rs`) for advanced use cases that manage their own controller.

## Notable API / behavior details
- `get_ecash_ticket` now returns `Option<PreparedCredential>` — `None` instead of the old `NoCredentialsAvailable` error when storage has nothing usable. Gateway client maps `None` to `NoMoreBandwidthCredentials`.
- `get_ecash_ticket` / `prepare_for_spending` take an explicit `spend_time: OffsetDateTime`.
- `attempt_revert_spending` and `get_upgrade_mode_token` are now part of the `BandwidthTicketProvider` trait.
- `BandwidthControllerError` slimmed down: removed now-unused variants, added `FetcherError`, `Missing{VerificationKey,CoinIndexSignatures,ExpirationDateSignatures}`, and `Internal` (for channel/comms failures).

## Diffstat
39 files changed, ~1130 insertions, ~600 deletions. Core changes in `common/bandwidth-controller`; the rest is propagating the de-generified types through gateway-client, client-core, the SDK, registration-client, nym-api, and probe/authenticator clients.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated bandwidth controller with support for fetching ticketbooks, upgrade-mode tokens, global signing materials, and reverting failed spending.
  * Introduced a unified bandwidth-provider interface that enables custom bandwidth sourcing for gateway and mixnet clients.

* **Improvements**
  * Ticket/payment generation now uses explicit timestamps for spending.
  * “No tickets available” errors are clearer and include the relevant ticket type.

* **Updates**
  * Refactored network monitoring and registration flows to use a request-sender pattern for bandwidth operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->