### PR TITLE
feat: introduce /aggregated-coin-indices-signatures and /aggregated-expiration-date-signatures credential proxy queries

### DIFF
--- a/common/credential-proxy/src/shared_state/ecash_state.rs
+++ b/common/credential-proxy/src/shared_state/ecash_state.rs
@@ -303,7 +303,6 @@ impl EcashState {
                 );
 
                 // 3. go around APIs and attempt to aggregate the data
-                let epoch_id = self.current_epoch_id(client).await?;
                 let master_vk = self.master_verification_key(client, storage, Some(epoch_id)).await?;
                 let all_apis = self.ecash_clients(client, epoch_id).await?;
                 let threshold = self.ecash_threshold(client, epoch_id).await?;

--- a/common/credential-proxy/src/ticketbook_manager/ticketbook_handlers.rs
+++ b/common/credential-proxy/src/ticketbook_manager/ticketbook_handlers.rs
@@ -6,12 +6,15 @@ use crate::nym_api_helpers::ensure_sane_expiration_date;
 use crate::ticketbook_manager::TicketbookManager;
 use nym_compact_ecash::Base58;
 use nym_credential_proxy_requests::api::v1::ticketbook::models::{
+    AggregatedCoinIndicesSignaturesResponse, AggregatedExpirationDateSignaturesResponse,
     CurrentEpochResponse, DepositResponse, GlobalDataParams, MasterVerificationKeyResponse,
     ObtainTicketBookSharesAsyncResponse, PartialVerificationKey, PartialVerificationKeysResponse,
     TicketbookAsyncRequest, TicketbookObtainParams, TicketbookRequest,
     TicketbookWalletSharesAsyncResponse, TicketbookWalletSharesResponse,
 };
-use time::OffsetDateTime;
+use nym_credentials::ecash::utils::ecash_default_expiration_date;
+use nym_validator_client::nym_api::EpochId;
+use time::{Date, OffsetDateTime};
 use tracing::{Instrument, Level, error, info, span, warn};
 use uuid::Uuid;
 
@@ -145,14 +148,53 @@ impl TicketbookManager {
 
     pub async fn master_verification_key(
         &self,
+        epoch_id: Option<EpochId>,
     ) -> Result<MasterVerificationKeyResponse, CredentialProxyError> {
         self.state.ensure_credentials_issuable().await?;
 
-        let epoch_id = self.state.current_epoch_id().await?;
+        let epoch_id = match epoch_id {
+            Some(epoch_id) => epoch_id,
+            None => self.state.current_epoch_id().await?,
+        };
         let key = self.state.master_verification_key(Some(epoch_id)).await?;
         Ok(MasterVerificationKeyResponse {
             epoch_id,
             bs58_encoded_key: key.to_bs58(),
+        })
+    }
+    pub async fn master_coin_index_signatures(
+        &self,
+        epoch_id: Option<EpochId>,
+    ) -> Result<AggregatedCoinIndicesSignaturesResponse, CredentialProxyError> {
+        let signatures = self.state.master_coin_index_signatures(epoch_id).await?;
+
+        Ok(AggregatedCoinIndicesSignaturesResponse {
+            signatures: signatures.clone(),
+        })
+    }
+
+    pub async fn master_expiration_date_signatures(
+        &self,
+        epoch_id: Option<EpochId>,
+        expiration_date: Option<Date>,
+    ) -> Result<AggregatedExpirationDateSignaturesResponse, CredentialProxyError> {
+        let epoch_id = match epoch_id {
+            Some(id) => id,
+            None => self.state.current_epoch_id().await?,
+        };
+
+        let expiration_date = match expiration_date {
+            Some(date) => date,
+            None => ecash_default_expiration_date(),
+        };
+
+        let signatures = self
+            .state
+            .master_expiration_date_signatures(epoch_id, expiration_date)
+            .await?;
+
+        Ok(AggregatedExpirationDateSignaturesResponse {
+            signatures: signatures.clone(),
         })
     }
 

--- a/common/credential-proxy/src/ticketbook_manager/ticketbook_handlers.rs
+++ b/common/credential-proxy/src/ticketbook_manager/ticketbook_handlers.rs
@@ -166,6 +166,8 @@ impl TicketbookManager {
         &self,
         epoch_id: Option<EpochId>,
     ) -> Result<AggregatedCoinIndicesSignaturesResponse, CredentialProxyError> {
+        self.state.ensure_credentials_issuable().await?;
+
         let signatures = self.state.master_coin_index_signatures(epoch_id).await?;
 
         Ok(AggregatedCoinIndicesSignaturesResponse {
@@ -178,6 +180,8 @@ impl TicketbookManager {
         epoch_id: Option<EpochId>,
         expiration_date: Option<Date>,
     ) -> Result<AggregatedExpirationDateSignaturesResponse, CredentialProxyError> {
+        self.state.ensure_credentials_issuable().await?;
+
         let epoch_id = match epoch_id {
             Some(id) => id,
             None => self.state.current_epoch_id().await?,

--- a/nym-credential-proxy/nym-credential-proxy-requests/src/api/v1/ticketbook/models.rs
+++ b/nym-credential-proxy/nym-credential-proxy-requests/src/api/v1/ticketbook/models.rs
@@ -17,13 +17,12 @@ use uuid::Uuid;
 #[cfg(feature = "query-types")]
 use nym_http_api_common::Output;
 
+use nym_http_api_common::OutputV2;
+pub use nym_upgrade_mode_check::UpgradeModeAttestation;
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
-
 #[cfg(feature = "tsify")]
 use wasm_bindgen::prelude::wasm_bindgen;
-
-pub use nym_upgrade_mode_check::UpgradeModeAttestation;
 
 #[derive(JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -286,6 +285,23 @@ pub struct WebhookTicketbookWalletShares {
 pub struct WebhookTicketbookWalletSharesRequest {
     pub ticketbook_wallet_shares: WebhookTicketbookWalletShares,
     pub secret: String,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema, utoipa::IntoParams))]
+#[serde(default, rename_all = "kebab-case")]
+pub struct EpochIdParams {
+    pub epoch_id: Option<u64>,
+    pub output: Option<OutputV2>,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema, utoipa::IntoParams))]
+#[serde(default, rename_all = "kebab-case")]
+pub struct ExpirationDateParams {
+    pub expiration_date: Option<String>,
+    pub epoch_id: Option<u64>,
+    pub output: Option<OutputV2>,
 }
 
 #[serde_as]

--- a/nym-credential-proxy/nym-credential-proxy-requests/src/lib.rs
+++ b/nym-credential-proxy/nym-credential-proxy-requests/src/lib.rs
@@ -39,6 +39,10 @@ pub mod routes {
                 pub const OBTAIN_ASYNC: &str = "/obtain-async";
                 pub const DEPOSIT_AMOUNT: &str = "/deposit-amount";
                 pub const MASTER_KEY: &str = "/master-verification-key";
+                pub const AGGREGATED_EXPIRATION_DATE_SIGNATURES: &str =
+                    "/aggregated-expiration-date-signatures";
+                pub const AGGREGATED_COIN_INDICES_SIGNATURES: &str =
+                    "/aggregated-coin-indices-signatures";
                 pub const PARTIAL_KEYS: &str = "/partial-verification-keys";
                 pub const CURRENT_EPOCH: &str = "/current-epoch";
                 pub const SHARES: &str = "/shares";
@@ -55,6 +59,16 @@ pub mod routes {
                     DEPOSIT_AMOUNT
                 );
                 absolute_route!(master_key_absolute, ticketbook_absolute(), MASTER_KEY);
+                absolute_route!(
+                    aggregated_expiration_date_signatures_absolute,
+                    ticketbook_absolute(),
+                    AGGREGATED_EXPIRATION_DATE_SIGNATURES
+                );
+                absolute_route!(
+                    aggregated_coin_indices_signatures_absolute,
+                    ticketbook_absolute(),
+                    AGGREGATED_COIN_INDICES_SIGNATURES
+                );
                 absolute_route!(partial_keys_absolute, ticketbook_absolute(), PARTIAL_KEYS);
                 absolute_route!(current_epoch_absolute, ticketbook_absolute(), CURRENT_EPOCH);
                 absolute_route!(shares_absolute, ticketbook_absolute(), SHARES);

--- a/nym-credential-proxy/nym-credential-proxy/src/http/router/api/v1/ticketbook/mod.rs
+++ b/nym-credential-proxy/nym-credential-proxy/src/http/router/api/v1/ticketbook/mod.rs
@@ -8,18 +8,27 @@ use axum::{Json, Router};
 use nym_credential_proxy_lib::helpers::random_uuid;
 use nym_credential_proxy_lib::http_helpers::RequestError;
 use nym_credential_proxy_requests::api::v1::ticketbook::models::{
-    CurrentEpochResponse, DepositResponse, MasterVerificationKeyResponse,
-    ObtainTicketBookSharesAsyncResponse, PartialVerificationKeysResponse, TicketbookAsyncRequest,
-    TicketbookObtainQueryParams, TicketbookRequest, TicketbookWalletSharesResponse,
+    AggregatedCoinIndicesSignaturesResponse, AggregatedExpirationDateSignaturesResponse,
+    CurrentEpochResponse, DepositResponse, EpochIdParams, ExpirationDateParams,
+    MasterVerificationKeyResponse, ObtainTicketBookSharesAsyncResponse,
+    PartialVerificationKeysResponse, TicketbookAsyncRequest, TicketbookObtainQueryParams,
+    TicketbookRequest, TicketbookWalletSharesResponse,
 };
 use nym_credential_proxy_requests::routes::api::v1::ticketbook;
 use nym_http_api_common::{FormattedResponse, OutputParams};
+use nym_validator_client::nym_api::rfc_3339_date;
+use reqwest::StatusCode;
+use time::Date;
 
 pub(crate) mod shares;
 
 pub type FormattedDepositResponse = FormattedResponse<DepositResponse>;
 pub type FormattedCurrentEpochResponse = FormattedResponse<CurrentEpochResponse>;
 pub type FormattedMasterVerificationKeyResponse = FormattedResponse<MasterVerificationKeyResponse>;
+pub type FormattedExpirationDateSignaturesResponse =
+    FormattedResponse<AggregatedExpirationDateSignaturesResponse>;
+pub type FormattedCoinIndexSignaturesResponse =
+    FormattedResponse<AggregatedCoinIndicesSignaturesResponse>;
 pub type FormattedPartialVerificationKeysResponse =
     FormattedResponse<PartialVerificationKeysResponse>;
 pub type FormattedTicketbookWalletSharesResponse =
@@ -190,7 +199,7 @@ pub(crate) async fn partial_verification_keys(
     Ok(output.to_response(response))
 }
 
-/// Obtain the master verification key for the current epoch.
+/// Obtain the master verification key for the given or current epoch.
 #[utoipa::path(
     get,
     path = "/master-verification-key",
@@ -205,20 +214,101 @@ pub(crate) async fn partial_verification_keys(
         (status = 500, body = String, description = "failed to obtain current epoch information"),
         (status = 503, body = String, description = "credentials can't be issued at this moment: the epoch transition is probably taking place"),
     ),
-    params(OutputParams),
+    params(EpochIdParams),
     security(
         ("auth_token" = [])
     )
 )]
 pub(crate) async fn master_verification_key(
-    Query(output): Query<OutputParams>,
+    Query(EpochIdParams { epoch_id, output }): Query<EpochIdParams>,
     State(state): State<ApiState>,
 ) -> Result<FormattedMasterVerificationKeyResponse, RequestError> {
-    let output = output.output.unwrap_or_default();
+    let output = output.unwrap_or_default();
 
     let response = state
         .ticketbooks()
-        .master_verification_key()
+        .master_verification_key(epoch_id)
+        .await
+        .map_err(RequestError::new_plain_error)?;
+
+    Ok(output.to_response(response))
+}
+
+/// Obtain the expiration date signatures for the given or current epoch and expiration date.
+#[utoipa::path(
+    get,
+    path = "/aggregated-expiration-date-signatures",
+    context_path = "/api/v1/ticketbook",
+    tag = "Ticketbook",
+    responses(
+        (status = 200, content(
+            (AggregatedExpirationDateSignaturesResponse = "application/json"),
+            (AggregatedExpirationDateSignaturesResponse = "application/yaml"),
+        )),
+        (status = 401, description = "authentication token is missing or is invalid"),
+        (status = 500, body = String, description = "failed to obtain current epoch information"),
+        (status = 503, body = String, description = "credentials can't be issued at this moment: the epoch transition is probably taking place"),
+    ),
+    params(ExpirationDateParams),
+    security(
+        ("auth_token" = [])
+    )
+)]
+pub(crate) async fn expiration_date_signatures(
+    Query(ExpirationDateParams {
+        expiration_date,
+        epoch_id,
+        output,
+    }): Query<ExpirationDateParams>,
+    State(state): State<ApiState>,
+) -> Result<FormattedExpirationDateSignaturesResponse, RequestError> {
+    let output = output.unwrap_or_default();
+
+    let expiration_date = expiration_date
+        .map(|raw| {
+            Date::parse(&raw, &rfc_3339_date())
+                .map_err(|err| RequestError::from_err(err, StatusCode::BAD_REQUEST))
+        })
+        .transpose()?;
+
+    let response = state
+        .ticketbooks()
+        .master_expiration_date_signatures(epoch_id, expiration_date)
+        .await
+        .map_err(RequestError::new_plain_error)?;
+
+    Ok(output.to_response(response))
+}
+
+/// Obtain the coin index signatures for the given or current epoch.
+#[utoipa::path(
+    get,
+    path = "/aggregated-coin-indices-signatures",
+    context_path = "/api/v1/ticketbook",
+    tag = "Ticketbook",
+    responses(
+        (status = 200, content(
+            (AggregatedCoinIndicesSignaturesResponse = "application/json"),
+            (AggregatedCoinIndicesSignaturesResponse = "application/yaml"),
+        )),
+        (status = 401, description = "authentication token is missing or is invalid"),
+        (status = 500, body = String, description = "failed to obtain current epoch information"),
+        (status = 503, body = String, description = "credentials can't be issued at this moment: the epoch transition is probably taking place"),
+    ),
+    params(EpochIdParams),
+    security(
+        ("auth_token" = [])
+    )
+)]
+pub(crate) async fn coin_index_signatures(
+    Query(EpochIdParams { epoch_id, output }): Query<EpochIdParams>,
+    State(state): State<ApiState>,
+) -> Result<FormattedCoinIndexSignaturesResponse, RequestError> {
+    let output = output.unwrap_or_default();
+
+    let response = state
+        .ticketbooks()
+        .master_coin_index_signatures(epoch_id)
         .await
         .map_err(RequestError::new_plain_error)?;
 
@@ -265,6 +355,14 @@ pub(crate) fn routes() -> Router<ApiState> {
     Router::new()
         .route(ticketbook::DEPOSIT_AMOUNT, get(current_deposit))
         .route(ticketbook::MASTER_KEY, get(master_verification_key))
+        .route(
+            ticketbook::AGGREGATED_EXPIRATION_DATE_SIGNATURES,
+            get(expiration_date_signatures),
+        )
+        .route(
+            ticketbook::AGGREGATED_COIN_INDICES_SIGNATURES,
+            get(coin_index_signatures),
+        )
         .route(ticketbook::PARTIAL_KEYS, get(partial_verification_keys))
         .route(ticketbook::CURRENT_EPOCH, get(current_epoch))
         .route(ticketbook::OBTAIN, post(obtain_ticketbook_shares))

--- a/nym-credential-proxy/nym-credential-proxy/src/http/router/api/v1/ticketbook/mod.rs
+++ b/nym-credential-proxy/nym-credential-proxy/src/http/router/api/v1/ticketbook/mod.rs
@@ -245,6 +245,7 @@ pub(crate) async fn master_verification_key(
             (AggregatedExpirationDateSignaturesResponse = "application/json"),
             (AggregatedExpirationDateSignaturesResponse = "application/yaml"),
         )),
+        (status = 400, body = String, description = "expiration_date is not a valid RFC3339 date"),
         (status = 401, description = "authentication token is missing or is invalid"),
         (status = 500, body = String, description = "failed to obtain current epoch information"),
         (status = 503, body = String, description = "credentials can't be issued at this moment: the epoch transition is probably taking place"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added two new ticketbook API endpoints to fetch aggregated signatures:
  - Aggregated expiration-date signatures (supports optional `expiration_date` in RFC3339 and optional `epoch_id`; invalid date returns **400 BAD_REQUEST**)
  - Aggregated master coin index signatures (supports optional `epoch_id`)

**Updates**
- The master verification key endpoint now accepts an optional `epoch_id` to return the key for the requested epoch instead of always using the current one.

**Bug Fixes**
- Aggregated expiration-date signatures now consistently use the provided `epoch_id` without overriding it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->