### PR TITLE
bugfix: feature-lock OutputV2 in nym-credential-proxy-requests

### DIFF
--- a/nym-credential-proxy/nym-credential-proxy-requests/src/api/v1/ticketbook/models.rs
+++ b/nym-credential-proxy/nym-credential-proxy-requests/src/api/v1/ticketbook/models.rs
@@ -9,20 +9,22 @@ use schemars::JsonSchema;
 use schemars::r#gen::SchemaGenerator;
 use schemars::schema::Schema;
 use serde::{Deserialize, Serialize};
-use serde_with::{DisplayFromStr, serde_as};
 use std::ops::{Deref, DerefMut};
 use time::{Date, OffsetDateTime};
 use uuid::Uuid;
 
 #[cfg(feature = "query-types")]
-use nym_http_api_common::Output;
+use serde_with::{DisplayFromStr, serde_as};
 
-use nym_http_api_common::OutputV2;
-pub use nym_upgrade_mode_check::UpgradeModeAttestation;
+#[cfg(feature = "query-types")]
+use nym_http_api_common::{Output, OutputV2};
+
 #[cfg(feature = "tsify")]
 use tsify::Tsify;
 #[cfg(feature = "tsify")]
 use wasm_bindgen::prelude::wasm_bindgen;
+
+pub use nym_upgrade_mode_check::UpgradeModeAttestation;
 
 #[derive(JsonSchema)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -290,6 +292,7 @@ pub struct WebhookTicketbookWalletSharesRequest {
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema, utoipa::IntoParams))]
 #[serde(default, rename_all = "kebab-case")]
+#[cfg(feature = "query-types")]
 pub struct EpochIdParams {
     pub epoch_id: Option<u64>,
     pub output: Option<OutputV2>,
@@ -298,6 +301,7 @@ pub struct EpochIdParams {
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema, utoipa::IntoParams))]
 #[serde(default, rename_all = "kebab-case")]
+#[cfg(feature = "query-types")]
 pub struct ExpirationDateParams {
     pub expiration_date: Option<String>,
     pub epoch_id: Option<u64>,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened optional query-related support so certain request parameters are only included when the matching feature is enabled.
  * Improved build-time consistency by aligning related imports and types with the same feature gate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->