### PR TITLE
Make socks5 more visible in docs

### DIFF
--- a/documentation/docs/components/outputs/api-scraping-outputs/nodes-count.json
+++ b/documentation/docs/components/outputs/api-scraping-outputs/nodes-count.json
@@ -1,6 +1,6 @@
 {
-  "nodes": 694,
-  "locations": 73,
-  "mixnodes": 234,
-  "exit_gateways": 452
+  "nodes": 702,
+  "locations": 72,
+  "mixnodes": 239,
+  "exit_gateways": 454
 }

--- a/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
+++ b/documentation/docs/components/outputs/api-scraping-outputs/time-now.md
@@ -1,1 +1,1 @@
-Tuesday, June 16th 2026, 14:01:39 UTC
+Thursday, June 25th 2026, 12:32:07 UTC

--- a/documentation/docs/components/outputs/command-outputs/nym-api-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-api-help.md
@@ -8,13 +8,8 @@ Commands:
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-  -c, --config-env-file <CONFIG_ENV_FILE>
-          Path pointing to an env file that configures the Nym API [env: NYMAPI_CONFIG_ENV_FILE_ARG=]
-      --no-banner
-          A no-op flag included for consistency with other binaries (and compatibility with nymvisor,
-          oops) [env: NYMAPI_NO_BANNER_ARG=]
-  -h, --help
-          Print help
-  -V, --version
-          Print version
+  -c, --config-env-file <CONFIG_ENV_FILE>  Path pointing to an env file that configures the Nym API [env: NYMAPI_CONFIG_ENV_FILE_ARG=]
+      --no-banner                          A no-op flag included for consistency with other binaries (and compatibility with nymvisor, oops) [env: NYMAPI_NO_BANNER_ARG=]
+  -h, --help                               Print help
+  -V, --version                            Print version
 ```

--- a/documentation/docs/components/outputs/command-outputs/nym-node-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-node-help.md
@@ -8,18 +8,12 @@ Commands:
   migrate                   Attempt to migrate an existing mixnode or gateway into a nym-node
   run                       Start this nym-node
   sign                      Use identity key of this node to sign provided message
-  unsafe-reset-sphinx-keys  UNSAFE: reset existing sphinx keys and attempt to generate fresh one for the
-                            current network state
+  unsafe-reset-sphinx-keys  UNSAFE: reset existing sphinx keys and attempt to generate fresh one for the current network state
   help                      Print this message or the help of the given subcommand(s)
 
 Options:
-  -c, --config-env-file <CONFIG_ENV_FILE>
-          Path pointing to an env file that configures the nym-node and overrides any preconfigured values
-          [env: NYMNODE_CONFIG_ENV_FILE_ARG=]
-      --no-banner
-          Flag used for disabling the printed banner in tty [env: NYMNODE_NO_BANNER=]
-  -h, --help
-          Print help
-  -V, --version
-          Print version
+  -c, --config-env-file <CONFIG_ENV_FILE>  Path pointing to an env file that configures the nym-node and overrides any preconfigured values [env: NYMNODE_CONFIG_ENV_FILE_ARG=]
+      --no-banner                          Flag used for disabling the printed banner in tty [env: NYMNODE_NO_BANNER=]
+  -h, --help                               Print help
+  -V, --version                            Print version
 ```

--- a/documentation/docs/components/outputs/command-outputs/nym-node-run-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nym-node-run-help.md
@@ -4,159 +4,75 @@ Start this nym-node
 Usage: nym-node run [OPTIONS]
 
 Options:
-      --id <ID>
-          Id of the nym-node to use [env: NYMNODE_ID=] [default: default-nym-node]
-      --config-file <CONFIG_FILE>
-          Path to a configuration file of this node [env: NYMNODE_CONFIG=]
-      --accept-operator-terms-and-conditions
-          Explicitly specify whether you agree with the terms and conditions of a nym node operator as
-          defined at <https://nymtech.net/terms-and-conditions/operators/v1.0.0> [env:
-          NYMNODE_ACCEPT_OPERATOR_TERMS=]
-      --deny-init
-          Forbid a new node from being initialised if configuration file for the provided specification
-          doesn't already exist [env: NYMNODE_DENY_INIT=]
-      --init-only
-          If this is a brand new nym-node, specify whether it should only be initialised without actually
-          running the subprocesses [env: NYMNODE_INIT_ONLY=]
-      --local
-          Flag specifying this node will be running in a local setting [env: NYMNODE_LOCAL=]
-      --mode [<MODE>...]
-          Specifies the current mode(s) of this nym-node [env: NYMNODE_MODE=] [possible values: mixnode,
-          entry-gateway, exit-gateway, exit-providers-only]
-      --modes <MODES>
-          Specifies the current mode(s) of this nym-node as a single flag [env: NYMNODE_MODES=] [possible
-          values: mixnode, entry-gateway, exit-gateway, exit-providers-only]
-  -w, --write-changes
-          If this node has been initialised before, specify whether to write any new changes to the config
-          file [env: NYMNODE_WRITE_CONFIG_CHANGES=]
-      --bonding-information-output <BONDING_INFORMATION_OUTPUT>
-          Specify output file for bonding information of this nym-node, i.e. its encoded keys. NOTE: the
-          required bonding information is still a subject to change and this argument should be treated
-          only as a preview of future features [env: NYMNODE_BONDING_INFORMATION_OUTPUT=]
-  -o, --output <OUTPUT>
-          Specify the output format of the bonding information (`text` or `json`) [env: NYMNODE_OUTPUT=]
-          [default: text] [possible values: text, json]
-      --public-ips <PUBLIC_IPS>
-          Comma separated list of public ip addresses that will be announced to the nym-api and
-          subsequently to the clients. In nearly all circumstances, it's going to be identical to the
-          address you're going to use for bonding [env: NYMNODE_PUBLIC_IPS=]
-      --hostname <HOSTNAME>
-          Optional hostname associated with this gateway that will be announced to the nym-api and
-          subsequently to the clients [env: NYMNODE_HOSTNAME=]
-      --location <LOCATION>
-          Optional **physical** location of this node's server. Either full country name (e.g. 'Poland'),
-          two-letter alpha2 (e.g. 'PL'), three-letter alpha3 (e.g. 'POL') or three-digit numeric-3 (e.g.
-          '616') can be provided [env: NYMNODE_LOCATION=]
-      --http-bind-address <HTTP_BIND_ADDRESS>
-          Socket address this node will use for binding its http API. default: `[::]:8080` [env:
-          NYMNODE_HTTP_BIND_ADDRESS=]
-      --landing-page-assets-path <LANDING_PAGE_ASSETS_PATH>
-          Path to assets directory of custom landing page of this node [env: NYMNODE_HTTP_LANDING_ASSETS=]
-      --http-access-token <HTTP_ACCESS_TOKEN>
-          An optional bearer token for accessing certain http endpoints. Currently only used for
-          prometheus metrics [env: NYMNODE_HTTP_ACCESS_TOKEN=]
-      --expose-system-info <EXPOSE_SYSTEM_INFO>
-          Specify whether basic system information should be exposed. default: true [env:
-          NYMNODE_HTTP_EXPOSE_SYSTEM_INFO=] [possible values: true, false]
-      --expose-system-hardware <EXPOSE_SYSTEM_HARDWARE>
-          Specify whether basic system hardware information should be exposed. default: true [env:
-          NYMNODE_HTTP_EXPOSE_SYSTEM_HARDWARE=] [possible values: true, false]
-      --expose-crypto-hardware <EXPOSE_CRYPTO_HARDWARE>
-          Specify whether detailed system crypto hardware information should be exposed. default: true
-          [env: NYMNODE_HTTP_EXPOSE_CRYPTO_HARDWARE=] [possible values: true, false]
-      --nyxd-urls <NYXD_URLS>
-          Addresses to nyxd chain endpoint which the node will use for chain interactions [env:
-          NYMNODE_NYXD=]
-      --nyxd-websocket-url <NYXD_WEBSOCKET_URL>
-          Url to the websocket endpoint of a nyx validator, for example `wss://rpc.nymtech.net/websocket`.
-          It is used for subscribing to new block events [env: NYMNODE_NYXD_WEBSOCKET=]
-      --mixnet-bind-address <MIXNET_BIND_ADDRESS>
-          Address this node will bind to for listening for mixnet packets default: `[::]:1789` [env:
-          NYMNODE_MIXNET_BIND_ADDRESS=]
-      --mixnet-announce-port <MIXNET_ANNOUNCE_PORT>
-          If applicable, custom port announced in the self-described API that other clients and nodes will
-          use. Useful when the node is behind a proxy [env: NYMNODE_MIXNET_ANNOUNCE_PORT=]
-      --nym-api-urls <NYM_API_URLS>
-          Addresses to nym APIs from which the node gets the view of the network [env: NYMNODE_NYM_APIS=]
-      --enable-console-logging <ENABLE_CONSOLE_LOGGING>
-          Specify whether running statistics of this node should be logged to the console [env:
-          NYMNODE_ENABLE_CONSOLE_LOGGING=] [possible values: true, false]
-      --wireguard-enabled <WIREGUARD_ENABLED>
-          Specifies whether the wireguard service is enabled on this node [env: NYMNODE_WG_ENABLED=]
-          [possible values: true, false]
-      --wireguard-bind-address <WIREGUARD_BIND_ADDRESS>
-          Socket address this node will use for binding its wireguard interface. default: `[::]:51822`
-          [env: NYMNODE_WG_BIND_ADDRESS=]
-      --wireguard-tunnel-announced-port <WIREGUARD_TUNNEL_ANNOUNCED_PORT>
-          Tunnel port announced to external clients wishing to connect to the wireguard interface. Useful
-          in the instances where the node is behind a proxy [env: NYMNODE_WG_ANNOUNCED_PORT=]
-      --wireguard-private-network-prefix <WIREGUARD_PRIVATE_NETWORK_PREFIX>
-          The prefix denoting the maximum number of the clients that can be connected via Wireguard. The
-          maximum value for IPv4 is 32 and for IPv6 is 128 [env: NYMNODE_WG_PRIVATE_NETWORK_PREFIX=]
-      --wireguard-userspace <WIREGUARD_USERSPACE>
-          Use userspace implementation of WireGuard (wireguard-go) instead of kernel module. Useful in
-          containerized environments without kernel WireGuard support [env: NYMNODE_WG_USERSPACE=]
-          [possible values: true, false]
-      --verloc-bind-address <VERLOC_BIND_ADDRESS>
-          Socket address this node will use for binding its verloc API. default: `[::]:1790` [env:
-          NYMNODE_VERLOC_BIND_ADDRESS=]
-      --verloc-announce-port <VERLOC_ANNOUNCE_PORT>
-          If applicable, custom port announced in the self-described API that other clients and nodes will
-          use. Useful when the node is behind a proxy [env: NYMNODE_VERLOC_ANNOUNCE_PORT=]
-      --entry-bind-address <ENTRY_BIND_ADDRESS>
-          Socket address this node will use for binding its client websocket API. default: `[::]:9000`
-          [env: NYMNODE_ENTRY_BIND_ADDRESS=]
-      --announce-ws-port <ANNOUNCE_WS_PORT>
-          Custom announced port for listening for websocket client traffic. If unspecified, the value from
-          the `bind_address` will be used instead [env: NYMNODE_ENTRY_ANNOUNCE_WS_PORT=]
-      --announce-wss-port <ANNOUNCE_WSS_PORT>
-          If applicable, announced port for listening for secure websocket client traffic [env:
-          NYMNODE_ENTRY_ANNOUNCE_WSS_PORT=]
-      --enforce-zk-nyms <ENFORCE_ZK_NYMS>
-          Indicates whether this gateway is accepting only coconut credentials for accessing the mixnet or
-          if it also accepts non-paying clients [env: NYMNODE_ENFORCE_ZK_NYMS=] [possible values: true,
-          false]
-      --mnemonic <MNEMONIC>
-          Custom cosmos wallet mnemonic used for zk-nym redemption. If no value is provided, a fresh
-          mnemonic is going to be generated [env: NYMNODE_MNEMONIC=]
-      --upgrade-mode-attestation-url <UPGRADE_MODE_ATTESTATION_URL>
-          Endpoint to query to retrieve current upgrade mode attestation. This argument should never be
-          set outside testnets and local networks [env: NYMNODE_UPGRADE_MODE_ATTESTATION_URL=]
-      --upgrade-mode-attester-public-key <UPGRADE_MODE_ATTESTER_PUBLIC_KEY>
-          Expected public key of the entity signing the published attestation. This argument should never
-          be set outside testnets and local networks [env: NYMNODE_UPGRADE_MODE_ATTESTER_PUBKEY=]
-      --upstream-exit-policy-url <UPSTREAM_EXIT_POLICY_URL>
-          Specifies the url for an upstream source of the exit policy used by this node [env:
-          NYMNODE_UPSTREAM_EXIT_POLICY=]
-      --open-proxy <OPEN_PROXY>
-          Specifies whether this exit node should run in 'open-proxy' mode and thus would attempt to
-          resolve **ANY** request it receives [env: NYMNODE_OPEN_PROXY=] [possible values: true, false]
-      --nr-allow-local-ips <NR_ALLOW_LOCAL_IPS>
-          Allow the network requester to forward traffic to non-globally-routable addresses. Intended for
-          local development, private-network deployments, and testnet scenarios. Not recommended on
-          production exit gateway unless you know what you're doing [env: NYMNODE_NR_ALLOW_LOCAL_IPS=]
-          [possible values: true, false]
-      --ipr-allow-local-ips <IPR_ALLOW_LOCAL_IPS>
-          Allow the IP packet router to forward traffic to non-globally-routable addresses. Intended for
-          local development, private-network deployments, and testnet scenarios. Not recommended on
-          production exit gateway unless you know what you're doing [env: NYMNODE_IPR_ALLOW_LOCAL_IPS=]
-          [possible values: true, false]
-      --lp-control-bind-address <LP_CONTROL_BIND_ADDRESS>
-          Bind address for the TCP LP control traffic. default: `[::]:41264` [env:
-          NYMNODE_LP_CONTROL_BIND_ADDRESS=]
-      --lp-control-announce-port <LP_CONTROL_ANNOUNCE_PORT>
-          Custom announced port for listening for the TCP LP control traffic. If unspecified, the value
-          from the `lp_control_bind_address` will be used instead [env: NYMNODE_LP_CONTROL_ANNOUNCE_PORT=]
-      --lp-data-bind-address <LP_DATA_BIND_ADDRESS>
-          Bind address for the UDP LP data traffic. default: `[::]:51264` [env:
-          NYMNODE_LP_DATA_BIND_ADDRESS=]
-      --lp-data-announce-port <LP_DATA_ANNOUNCE_PORT>
-          Custom announced port for listening for the UDP LP data traffic. If unspecified, the value from
-          the `lp_data_bind_address` will be used instead [env: NYMNODE_LP_DATA_ANNOUNCE_PORT=]
-      --lp-use-mock-ecash <LP_USE_MOCK_ECASH>
-          Use mock ecash manager for LP testing. WARNING: Only use this for local testing! Never enable in
-          production. When enabled, the LP listener will accept any credential without blockchain
-          verification [env: NYMNODE_LP_USE_MOCK_ECASH=] [possible values: true, false]
-  -h, --help
-          Print help
+      --id <ID>                                                              Id of the nym-node to use [env: NYMNODE_ID=] [default: default-nym-node]
+      --config-file <CONFIG_FILE>                                            Path to a configuration file of this node [env: NYMNODE_CONFIG=]
+      --accept-operator-terms-and-conditions                                 Explicitly specify whether you agree with the terms and conditions of a nym node operator as defined at
+                                                                             <https://nymtech.net/terms-and-conditions/operators/v1.0.0> [env: NYMNODE_ACCEPT_OPERATOR_TERMS=]
+      --deny-init                                                            Forbid a new node from being initialised if configuration file for the provided specification doesn't already exist [env: NYMNODE_DENY_INIT=]
+      --init-only                                                            If this is a brand new nym-node, specify whether it should only be initialised without actually running the subprocesses [env: NYMNODE_INIT_ONLY=]
+      --local                                                                Flag specifying this node will be running in a local setting [env: NYMNODE_LOCAL=]
+      --mode [<MODE>...]                                                     Specifies the current mode(s) of this nym-node [env: NYMNODE_MODE=] [possible values: mixnode, entry-gateway, exit-gateway, exit-providers-only]
+      --modes <MODES>                                                        Specifies the current mode(s) of this nym-node as a single flag [env: NYMNODE_MODES=] [possible values: mixnode, entry-gateway, exit-gateway, exit-providers-only]
+  -w, --write-changes                                                        If this node has been initialised before, specify whether to write any new changes to the config file [env: NYMNODE_WRITE_CONFIG_CHANGES=]
+      --bonding-information-output <BONDING_INFORMATION_OUTPUT>              Specify output file for bonding information of this nym-node, i.e. its encoded keys. NOTE: the required bonding information is still a subject to change and this
+                                                                             argument should be treated only as a preview of future features [env: NYMNODE_BONDING_INFORMATION_OUTPUT=]
+  -o, --output <OUTPUT>                                                      Specify the output format of the bonding information (`text` or `json`) [env: NYMNODE_OUTPUT=] [default: text] [possible values: text, json]
+      --public-ips <PUBLIC_IPS>                                              Comma separated list of public ip addresses that will be announced to the nym-api and subsequently to the clients. In nearly all circumstances, it's going to be
+                                                                             identical to the address you're going to use for bonding [env: NYMNODE_PUBLIC_IPS=]
+      --hostname <HOSTNAME>                                                  Optional hostname associated with this gateway that will be announced to the nym-api and subsequently to the clients [env: NYMNODE_HOSTNAME=]
+      --location <LOCATION>                                                  Optional **physical** location of this node's server. Either full country name (e.g. 'Poland'), two-letter alpha2 (e.g. 'PL'), three-letter alpha3 (e.g. 'POL') or
+                                                                             three-digit numeric-3 (e.g. '616') can be provided [env: NYMNODE_LOCATION=]
+      --http-bind-address <HTTP_BIND_ADDRESS>                                Socket address this node will use for binding its http API. default: `[::]:8080` [env: NYMNODE_HTTP_BIND_ADDRESS=]
+      --landing-page-assets-path <LANDING_PAGE_ASSETS_PATH>                  Path to assets directory of custom landing page of this node [env: NYMNODE_HTTP_LANDING_ASSETS=]
+      --http-access-token <HTTP_ACCESS_TOKEN>                                An optional bearer token for accessing certain http endpoints. Currently only used for prometheus metrics [env: NYMNODE_HTTP_ACCESS_TOKEN=]
+      --expose-system-info <EXPOSE_SYSTEM_INFO>                              Specify whether basic system information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_SYSTEM_INFO=] [possible values: true, false]
+      --expose-system-hardware <EXPOSE_SYSTEM_HARDWARE>                      Specify whether basic system hardware information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_SYSTEM_HARDWARE=] [possible values: true, false]
+      --expose-crypto-hardware <EXPOSE_CRYPTO_HARDWARE>                      Specify whether detailed system crypto hardware information should be exposed. default: true [env: NYMNODE_HTTP_EXPOSE_CRYPTO_HARDWARE=] [possible values: true,
+                                                                             false]
+      --nyxd-urls <NYXD_URLS>                                                Addresses to nyxd chain endpoint which the node will use for chain interactions [env: NYMNODE_NYXD=]
+      --nyxd-websocket-url <NYXD_WEBSOCKET_URL>                              Url to the websocket endpoint of a nyx validator, for example `wss://rpc.nymtech.net/websocket`. It is used for subscribing to new block events [env:
+                                                                             NYMNODE_NYXD_WEBSOCKET=]
+      --mixnet-bind-address <MIXNET_BIND_ADDRESS>                            Address this node will bind to for listening for mixnet packets default: `[::]:1789` [env: NYMNODE_MIXNET_BIND_ADDRESS=]
+      --mixnet-announce-port <MIXNET_ANNOUNCE_PORT>                          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node is behind a proxy [env:
+                                                                             NYMNODE_MIXNET_ANNOUNCE_PORT=]
+      --nym-api-urls <NYM_API_URLS>                                          Addresses to nym APIs from which the node gets the view of the network [env: NYMNODE_NYM_APIS=]
+      --enable-console-logging <ENABLE_CONSOLE_LOGGING>                      Specify whether running statistics of this node should be logged to the console [env: NYMNODE_ENABLE_CONSOLE_LOGGING=] [possible values: true, false]
+      --wireguard-enabled <WIREGUARD_ENABLED>                                Specifies whether the wireguard service is enabled on this node [env: NYMNODE_WG_ENABLED=] [possible values: true, false]
+      --wireguard-bind-address <WIREGUARD_BIND_ADDRESS>                      Socket address this node will use for binding its wireguard interface. default: `[::]:51822` [env: NYMNODE_WG_BIND_ADDRESS=]
+      --wireguard-tunnel-announced-port <WIREGUARD_TUNNEL_ANNOUNCED_PORT>    Tunnel port announced to external clients wishing to connect to the wireguard interface. Useful in the instances where the node is behind a proxy [env:
+                                                                             NYMNODE_WG_ANNOUNCED_PORT=]
+      --wireguard-private-network-prefix <WIREGUARD_PRIVATE_NETWORK_PREFIX>  The prefix denoting the maximum number of the clients that can be connected via Wireguard. The maximum value for IPv4 is 32 and for IPv6 is 128 [env:
+                                                                             NYMNODE_WG_PRIVATE_NETWORK_PREFIX=]
+      --wireguard-userspace <WIREGUARD_USERSPACE>                            Use userspace implementation of WireGuard (wireguard-go) instead of kernel module. Useful in containerized environments without kernel WireGuard support [env:
+                                                                             NYMNODE_WG_USERSPACE=] [possible values: true, false]
+      --verloc-bind-address <VERLOC_BIND_ADDRESS>                            Socket address this node will use for binding its verloc API. default: `[::]:1790` [env: NYMNODE_VERLOC_BIND_ADDRESS=]
+      --verloc-announce-port <VERLOC_ANNOUNCE_PORT>                          If applicable, custom port announced in the self-described API that other clients and nodes will use. Useful when the node is behind a proxy [env:
+                                                                             NYMNODE_VERLOC_ANNOUNCE_PORT=]
+      --entry-bind-address <ENTRY_BIND_ADDRESS>                              Socket address this node will use for binding its client websocket API. default: `[::]:9000` [env: NYMNODE_ENTRY_BIND_ADDRESS=]
+      --announce-ws-port <ANNOUNCE_WS_PORT>                                  Custom announced port for listening for websocket client traffic. If unspecified, the value from the `bind_address` will be used instead [env:
+                                                                             NYMNODE_ENTRY_ANNOUNCE_WS_PORT=]
+      --announce-wss-port <ANNOUNCE_WSS_PORT>                                If applicable, announced port for listening for secure websocket client traffic [env: NYMNODE_ENTRY_ANNOUNCE_WSS_PORT=]
+      --enforce-zk-nyms <ENFORCE_ZK_NYMS>                                    Indicates whether this gateway is accepting only coconut credentials for accessing the mixnet or if it also accepts non-paying clients [env:
+                                                                             NYMNODE_ENFORCE_ZK_NYMS=] [possible values: true, false]
+      --mnemonic <MNEMONIC>                                                  Custom cosmos wallet mnemonic used for zk-nym redemption. If no value is provided, a fresh mnemonic is going to be generated [env: NYMNODE_MNEMONIC=]
+      --upgrade-mode-attestation-url <UPGRADE_MODE_ATTESTATION_URL>          Endpoint to query to retrieve current upgrade mode attestation. This argument should never be set outside testnets and local networks [env:
+                                                                             NYMNODE_UPGRADE_MODE_ATTESTATION_URL=]
+      --upgrade-mode-attester-public-key <UPGRADE_MODE_ATTESTER_PUBLIC_KEY>  Expected public key of the entity signing the published attestation. This argument should never be set outside testnets and local networks [env:
+                                                                             NYMNODE_UPGRADE_MODE_ATTESTER_PUBKEY=]
+      --upstream-exit-policy-url <UPSTREAM_EXIT_POLICY_URL>                  Specifies the url for an upstream source of the exit policy used by this node [env: NYMNODE_UPSTREAM_EXIT_POLICY=]
+      --open-proxy <OPEN_PROXY>                                              Specifies whether this exit node should run in 'open-proxy' mode and thus would attempt to resolve **ANY** request it receives [env: NYMNODE_OPEN_PROXY=]
+                                                                             [possible values: true, false]
+      --nr-allow-local-ips <NR_ALLOW_LOCAL_IPS>                              Allow the network requester to forward traffic to non-globally-routable addresses. Intended for local development, private-network deployments, and testnet
+                                                                             scenarios. Not recommended on production exit gateway unless you know what you're doing [env: NYMNODE_NR_ALLOW_LOCAL_IPS=] [possible values: true, false]
+      --ipr-allow-local-ips <IPR_ALLOW_LOCAL_IPS>                            Allow the IP packet router to forward traffic to non-globally-routable addresses. Intended for local development, private-network deployments, and testnet
+                                                                             scenarios. Not recommended on production exit gateway unless you know what you're doing [env: NYMNODE_IPR_ALLOW_LOCAL_IPS=] [possible values: true, false]
+      --lp-control-bind-address <LP_CONTROL_BIND_ADDRESS>                    Bind address for the TCP LP control traffic. default: `[::]:41264` [env: NYMNODE_LP_CONTROL_BIND_ADDRESS=]
+      --lp-control-announce-port <LP_CONTROL_ANNOUNCE_PORT>                  Custom announced port for listening for the TCP LP control traffic. If unspecified, the value from the `lp_control_bind_address` will be used instead [env:
+                                                                             NYMNODE_LP_CONTROL_ANNOUNCE_PORT=]
+      --lp-data-bind-address <LP_DATA_BIND_ADDRESS>                          Bind address for the UDP LP data traffic. default: `[::]:51264` [env: NYMNODE_LP_DATA_BIND_ADDRESS=]
+      --lp-data-announce-port <LP_DATA_ANNOUNCE_PORT>                        Custom announced port for listening for the UDP LP data traffic. If unspecified, the value from the `lp_data_bind_address` will be used instead [env:
+                                                                             NYMNODE_LP_DATA_ANNOUNCE_PORT=]
+      --lp-use-mock-ecash <LP_USE_MOCK_ECASH>                                Use mock ecash manager for LP testing. WARNING: Only use this for local testing! Never enable in production. When enabled, the LP listener will accept any
+                                                                             credential without blockchain verification [env: NYMNODE_LP_USE_MOCK_ECASH=] [possible values: true, false]
+  -h, --help                                                                 Print help
 ```

--- a/documentation/docs/components/outputs/command-outputs/nymvisor-help.md
+++ b/documentation/docs/components/outputs/command-outputs/nymvisor-help.md
@@ -11,10 +11,7 @@ Commands:
   help               Print this message or the help of the given subcommand(s)
 
 Options:
-  -c, --config-env-file <CONFIG_ENV_FILE>
-          Path pointing to an env file that configures the nymvisor and overrides any preconfigured values
-  -h, --help
-          Print help
-  -V, --version
-          Print version
+  -c, --config-env-file <CONFIG_ENV_FILE>  Path pointing to an env file that configures the nymvisor and overrides any preconfigured values
+  -h, --help                               Print help
+  -V, --version                            Print version
 ```

--- a/documentation/docs/pages/developers/_meta.json
+++ b/documentation/docs/pages/developers/_meta.json
@@ -10,7 +10,12 @@
     "title": "Rust"
   },
   "smolmix": "smolmix (TCP/UDP tunnel)",
-  "rust": "nym-sdk",
+  "rust": {
+    "title": "nym-sdk",
+    "theme": {
+      "collapsed": false
+    }
+  },
 
   "-": {
     "type": "separator",

--- a/documentation/docs/pages/developers/clients/socks5.mdx
+++ b/documentation/docs/pages/developers/clients/socks5.mdx
@@ -1,6 +1,6 @@
 # Socks5 Client (Standalone)
 
-> This client can also be utilised via the [Rust SDK](/developers/rust).
+> This proxy is also available embedded in a Rust application via the [nym-sdk SOCKS5 module](/developers/rust/socks5).
 
 Many existing applications are able to use either the SOCKS4, SOCKS4A, or SOCKS5 proxy protocols. If you want to send such an application's traffic through the mixnet, you can use the `nym-socks5-client` to bounce network traffic through the Nym network, like this:
 

--- a/documentation/docs/pages/developers/index.mdx
+++ b/documentation/docs/pages/developers/index.mdx
@@ -21,7 +21,7 @@ The table below maps those two answers to a package.
 
 | Runtime | End-to-end (both sides run Nym) | Proxy (exit to clearnet) |
 |---|---|---|
-| **Native Rust** (desktop / CLI / server) | [`nym-sdk`](/developers/rust): Mixnet, Stream, Client Pool | [`smolmix`](/developers/smolmix): `TcpStream` / `UdpSocket` · [`nym-sdk` SOCKS](/developers/rust) |
+| **Native Rust** (desktop / CLI / server) | [`nym-sdk`](/developers/rust): Mixnet, Stream, Client Pool | [`smolmix`](/developers/smolmix): `TcpStream` / `UdpSocket` · [`nym-sdk` SOCKS5](/developers/rust/socks5) |
 | **Browser / WebView** (JS + WASM) | [TypeScript SDK](/developers/typescript): `@nymproject/sdk` raw messaging | [`mix-fetch`](/developers/mix-fetch) HTTP/S · [`mix-dns`](/developers/mix-dns) DNS · [`mix-websocket`](/developers/mix-websocket) WS/WSS |
 
 <Callout type="info">

--- a/documentation/docs/pages/developers/rust.mdx
+++ b/documentation/docs/pages/developers/rust.mdx
@@ -37,6 +37,7 @@ For an overview of what the SDK can do, see the **[Tour](./rust/tour)**. For set
 |---|---|---|
 | [**Stream**](./rust/stream) | Multiplexed `AsyncRead + AsyncWrite` byte streams over the Mixnet, the closest analogue to TCP sockets. | Recommended |
 | [**Mixnet**](./rust/mixnet) | Raw message payloads, independently routed, no connections or ordering. Full control over the communication model. | Stable |
+| [**SOCKS5**](./rust/socks5) | Local SOCKS5 proxy that routes any SOCKS-capable application through the Mixnet to a network requester (proxy mode, exits to clearnet). | Stable |
 | [**Client Pool**](./rust/client-pool) | Keeps ready-to-use `MixnetClient` instances warm for bursty workloads. | Stable |
 | [**TcpProxy**](./rust/tcpproxy) | TCP socket proxying with session management and message ordering. | Deprecated |
 | [**FFI**](./rust/ffi) | Go and C/C++ bindings. | Stable |
@@ -50,4 +51,4 @@ For an overview of what the SDK can do, see the **[Tour](./rust/tour)**. For set
 For proxy-mode integrations (reaching third-party services through an Exit Gateway), see also:
 
 - [**`smolmix`**](/developers/smolmix): `TcpStream` and `UdpSocket` over the Mixnet via a userspace IP stack. Compatible with `tokio-rustls`, `hyper`, `tokio-tungstenite`, and the rest of the async Rust ecosystem.
-- [**SOCKS Client**](./rust/mixnet): SOCKS4/4a/5 proxy via the Exit Gateway's Network Requester. Works with any SOCKS-capable application without code changes.
+- [**SOCKS5 module**](./rust/socks5): SOCKS4/4a/5 proxy via the Exit Gateway's network requester. Works with any SOCKS-capable application without code changes.

--- a/documentation/docs/pages/developers/rust/_meta.json
+++ b/documentation/docs/pages/developers/rust/_meta.json
@@ -3,6 +3,7 @@
   "importing": "Installation",
   "mixnet": "Mixnet Module",
   "stream": "Stream Module",
+  "socks5": "SOCKS5 Module",
   "tcpproxy": "TcpProxy Module (Deprecated)",
   "client-pool": "Client Pool Module",
   "ffi": "FFI"

--- a/documentation/docs/pages/developers/rust/socks5.mdx
+++ b/documentation/docs/pages/developers/rust/socks5.mdx
@@ -1,0 +1,96 @@
+---
+title: "Nym Rust SDK: SOCKS5 Proxy Module"
+description: "Use the Nym Rust SDK SOCKS5 module to route any SOCKS4/4a/5-capable application through the mixnet. Covers Socks5MixnetClient, the socks5h proxy URL, network requesters, and a reqwest example."
+schemaType: "TechArticle"
+section: "Developers"
+lastUpdated: "2026-06-25"
+---
+
+# SOCKS5 Module
+
+import { Callout } from 'nextra/components'
+
+The `socks5` module provides [`Socks5MixnetClient`](https://docs.rs/nym-sdk/latest/nym_sdk/mixnet/struct.Socks5MixnetClient.html): a local SOCKS5 proxy that routes any SOCKS4, SOCKS4a, or SOCKS5-capable application's traffic through the mixnet. Your application connects to a normal-looking SOCKS5 proxy on `localhost`; the client forwards that traffic over the mixnet to a **network requester** running on an Exit Gateway, which makes the real request on your behalf.
+
+<Callout type="warning">
+This is a **proxy-mode** integration, not end-to-end. Unlike the [Mixnet](./mixnet) and [Stream](./stream) modules (where both sides run a Nym client), traffic here leaves the mixnet at an Exit Gateway and continues to the destination over the public internet. The mixnet anonymises the sender; protecting the payload (TLS) is your application's job. See [Exit security](/developers/concepts/exit-security) for what the exit can and cannot observe.
+</Callout>
+
+## How it works
+
+```text
+Your machine
+   Application (reqwest, curl, a browser, ...)
+       │  SOCKS5  (socks5h://127.0.0.1:1080)
+       ▼
+   Socks5MixnetClient  (local listener + MixnetClient)
+       │  Sphinx packets
+       ▼
+   Entry Gateway → 3 mix layers → Exit Gateway
+                                      │  network requester
+                                      ▼  makes the real request
+                                  Destination (clearnet)
+```
+
+Any application that speaks SOCKS sees a standard proxy on `localhost`. It never has to know the mixnet exists. The client chops the TCP stream into Sphinx packets, sends them through the mixnet, and the network requester at the exit reassembles the stream and performs the request, returning the response the same way.
+
+## Quick example
+
+You need the Nym address of a **network requester** (an Exit Gateway running in network-requester mode) to act as the service provider. Point an HTTP client at the SOCKS5 URL the client exposes, and every request travels through the mixnet:
+
+```rust
+use nym_sdk::mixnet::Socks5MixnetClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    nym_bin_common::logging::setup_tracing_logger();
+
+    // Connect to a network requester service provider over the mixnet.
+    // This opens a local SOCKS5 listener (default 127.0.0.1:1080).
+    let client = Socks5MixnetClient::connect_new("provider_nym_address...").await?;
+
+    // Point any SOCKS5-capable HTTP client at the proxy URL.
+    let proxy = reqwest::Proxy::all(client.socks5_url())?;
+    let http = reqwest::Client::builder().proxy(proxy).build()?;
+
+    // This request now travels through the mixnet and exits at the requester.
+    let body = http.get("https://nymtech.net").send().await?.text().await?;
+    println!("{body}");
+
+    client.disconnect().await;
+    Ok(())
+}
+```
+
+<Callout type="info">
+`socks5_url()` returns a **`socks5h://`** URL, not `socks5://`. The trailing `h` tells the HTTP client to hand the hostname to the proxy and let the network requester resolve DNS at the exit, rather than resolving locally and leaking the destination through a local DNS query.
+</Callout>
+
+For finer control (binding a different address, reusing persistent keys), build the client through `MixnetClientBuilder` instead of `connect_new`:
+
+```rust
+use nym_sdk::mixnet;
+
+let socks5_config = mixnet::Socks5::new("provider_nym_address...".to_string());
+let client = mixnet::MixnetClientBuilder::new_ephemeral()
+    .socks5_config(socks5_config)
+    .build()?
+    .connect_to_mixnet_via_socks5()
+    .await?;
+```
+
+## SDK module or standalone binary
+
+The same proxy logic ships two ways. They are interchangeable on the wire; choose by how you want to run it:
+
+| | Use it when |
+|---|---|
+| **`socks5` module** (this page) | You want the proxy embedded in a Rust application and managed in-process, alongside other SDK clients. |
+| [**Standalone `nym-socks5-client`**](/developers/clients/socks5) | You want a language-agnostic local proxy binary that any application (in any language) can point at, with no code changes. |
+
+## Further reading
+
+- [API reference on docs.rs](https://docs.rs/nym-sdk/latest/nym_sdk/mixnet/struct.Socks5MixnetClient.html): all methods, configuration, and types
+- [Example source on GitHub](https://github.com/nymtech/nym/blob/develop/sdk/rust/nym-sdk/examples/socks5.rs): complete working example
+- [Standalone SOCKS5 client](/developers/clients/socks5): the language-agnostic binary form
+- [Exit security](/developers/concepts/exit-security): what an Exit Gateway can observe in proxy mode


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Rust SDK guide for SOCKS5 proxy support, including setup examples, DNS handling, configuration options, and related references.
  * Updated developer docs to highlight SOCKS5 as the recommended proxy-mode option.
  * Refreshed CLI help documentation formatting for several commands to improve readability.
  * Updated developer navigation and proxy support references.
  * Brought recorded API-scraping counts and a timestamp page up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->