### PR TITLE
Max/bump docs sdk version

### DIFF
--- a/.github/workflows/ci-crates-version-bump.yml
+++ b/.github/workflows/ci-crates-version-bump.yml
@@ -70,9 +70,10 @@ jobs:
             --yes
 
       - name: Bump docs version constants and Cargo.toml snippets
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          VERSION="${{ inputs.version }}"
           DOCS=documentation/docs
 
           # Rust crate constants in the centralised versions file. The TypeScript

--- a/.github/workflows/ci-crates-version-bump.yml
+++ b/.github/workflows/ci-crates-version-bump.yml
@@ -69,6 +69,30 @@ jobs:
             --no-git-commit \
             --yes
 
+      - name: Bump docs version constants and Cargo.toml snippets
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          DOCS=documentation/docs
+
+          # Rust crate constants in the centralised versions file. The TypeScript
+          # package constants (MIX_FETCH_VERSION etc.) track separate npm releases,
+          # so they are intentionally left untouched.
+          sed -i -E "s/(export const NYM_SDK_VERSION = )\"[^\"]*\"/\1\"${VERSION}\"/" "$DOCS/components/versions.ts"
+          sed -i -E "s/(export const SMOLMIX_VERSION = )\"[^\"]*\"/\1\"${VERSION}\"/" "$DOCS/components/versions.ts"
+
+          # Hardcoded Cargo.toml snippets. Match the crate key at the start of a
+          # fenced-block line and rewrite whatever semver it carries, so a drifted
+          # snippet self-heals the same way the workspace path-dep sed above does.
+          # cargo-workspaces unifies every workspace crate to VERSION, so all of
+          # these crates share it after the bump.
+          sed -i -E "s/^(nym-sdk|nym-bin-common|nym-network-defaults|smolmix)(.*)\"[0-9]+\.[0-9]+\.[0-9]+\"/\1\2\"${VERSION}\"/" \
+            "$DOCS/pages/developers/rust/importing.mdx" \
+            "$DOCS/pages/developers/rust/mixnet/tutorial.mdx" \
+            "$DOCS/pages/developers/rust/stream/tutorial.mdx" \
+            "$DOCS/pages/developers/rust/client-pool/tutorial.mdx" \
+            "$DOCS/pages/developers/smolmix.mdx"
+
       - name: Commit and push version bump
         run: |
           set -euo pipefail

--- a/documentation/docs/components/versions.ts
+++ b/documentation/docs/components/versions.ts
@@ -22,10 +22,10 @@
  */
 
 // nym-sdk / nym-bin-common / nym-network-defaults (Rust SDK crates)
-export const NYM_SDK_VERSION = "1.21.1";
+export const NYM_SDK_VERSION = "1.21.2";
 
 // smolmix standalone crate
-export const SMOLMIX_VERSION = "1.21.1";
+export const SMOLMIX_VERSION = "1.21.2";
 
 // TypeScript SDK packages (published to npm). mix-fetch is on its own 2.x track
 // after the v1 to v2 break; the tunnel + mix-dns + mix-websocket facades share

--- a/documentation/docs/components/versions.ts
+++ b/documentation/docs/components/versions.ts
@@ -8,11 +8,14 @@
  * When bumping versions here, also update the Cargo.toml snippets in:
  *
  *   pages/developers/rust/importing.mdx
- *   pages/developers/rust/tcpproxy.mdx
  *   pages/developers/rust/mixnet/tutorial.mdx
  *   pages/developers/rust/stream/tutorial.mdx
  *   pages/developers/rust/client-pool/tutorial.mdx
- *   public/llms.txt
+ *   pages/developers/smolmix.mdx          (SMOLMIX_VERSION)
+ *
+ * public/llms-full.txt is generated from these pages by generate-llms-txt.mjs
+ * at build time, so it picks up the bumps automatically. (public/llms.txt is a
+ * static index with no version snippets.)
  *
  * RUST_MSRV is imported directly by all pages that display the Rust version,
  * so no manual file edits are needed for MSRV bumps:

--- a/documentation/docs/pages/developers/rust/client-pool/tutorial.mdx
+++ b/documentation/docs/pages/developers/rust/client-pool/tutorial.mdx
@@ -40,9 +40,9 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-nym-sdk = "1.21.1"
-nym-network-defaults = "1.21.1"
-nym-bin-common = { version = "1.21.1", features = ["basic_tracing"] }
+nym-sdk = "1.21.2"
+nym-network-defaults = "1.21.2"
+nym-bin-common = { version = "1.21.2", features = ["basic_tracing"] }
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/documentation/docs/pages/developers/rust/importing.mdx
+++ b/documentation/docs/pages/developers/rust/importing.mdx
@@ -13,7 +13,7 @@ import { RUST_MSRV } from '../../../components/versions'
 
 ```toml
 [dependencies]
-nym-sdk = "1.21.1"
+nym-sdk = "1.21.2"
 ```
 
 **Minimum Rust version:** {RUST_MSRV}+

--- a/documentation/docs/pages/developers/rust/mixnet/tutorial.mdx
+++ b/documentation/docs/pages/developers/rust/mixnet/tutorial.mdx
@@ -29,8 +29,8 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-nym-sdk = "1.21.1"
-nym-bin-common = { version = "1.21.1", features = ["basic_tracing"] }
+nym-sdk = "1.21.2"
+nym-bin-common = { version = "1.21.2", features = ["basic_tracing"] }
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/documentation/docs/pages/developers/rust/stream/tutorial.mdx
+++ b/documentation/docs/pages/developers/rust/stream/tutorial.mdx
@@ -41,8 +41,8 @@ Add dependencies to `Cargo.toml`:
 
 ```toml
 [dependencies]
-nym-sdk = "1.21.1"
-nym-bin-common = { version = "1.21.1", features = ["basic_tracing"] }
+nym-sdk = "1.21.2"
+nym-bin-common = { version = "1.21.2", features = ["basic_tracing"] }
 tokio = { version = "1", features = ["full"] }
 rand = "0.8"
 ```

--- a/documentation/docs/pages/developers/smolmix.mdx
+++ b/documentation/docs/pages/developers/smolmix.mdx
@@ -43,8 +43,8 @@ Add `smolmix` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-smolmix = "1.21.1"
-nym-bin-common = { version = "1.21.1", features = ["basic_tracing"] }
+smolmix = "1.21.2"
+nym-bin-common = { version = "1.21.2", features = ["basic_tracing"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 


### PR DESCRIPTION
Bumping the versions in the docs for the recently released crates + adding a step to the CI which bumps the versions to mod the docs as well. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Rust SDK and Smolmix version references to **1.21.2** across installation guides and developer tutorials.
  * Refreshed all shown `Cargo.toml` dependency snippets (including related crates) to match the latest documented versions.
  * Kept version listings consistent with the current release, including pages that feed the generated public version index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6922)
<!-- Reviewable:end -->
