### PR TITLE
Mechanism to Notify HTTP Client of Network Reconfiguration

### DIFF
--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -142,8 +142,8 @@
 use http::header::USER_AGENT;
 pub use inventory;
 pub use reqwest::{self, ClientBuilder as ReqwestClientBuilder, StatusCode};
-use rustls::lock::Mutex;
 use std::error::Error;
+use std::sync::Mutex;
 use std::time::Instant;
 
 pub mod registry;

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -233,6 +233,14 @@ static SHARED_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     }
 });
 
+pub(crate) static SHARED_NETWORK_RECONFIGURATION: LazyLock<Arc<Mutex<Instant>>> =
+    LazyLock::new(|| Arc::new(Mutex::new(Instant::now())));
+
+/// Indicate to the shared marker that a network reconfiguration happened.
+pub fn network_reconfigured() {
+    *SHARED_NETWORK_RECONFIGURATION.lock().unwrap() = Instant::now();
+}
+
 /// Collection of URL Path Segments
 pub type PathSegments<'a> = &'a [&'a str];
 /// Collection of HTTP Request Parameters
@@ -618,7 +626,6 @@ pub struct ClientBuilder {
 
     retry_limit: usize,
     serialization: SerializationFormat,
-    last_net_reconfiguration: Option<Arc<Mutex<Instant>>>,
 
     error: Option<HttpClientError>,
 }
@@ -719,7 +726,6 @@ impl ClientBuilder {
 
             retry_limit: 0,
             serialization: SerializationFormat::Json,
-            last_net_reconfiguration: None,
             error: None,
         })
     }
@@ -808,15 +814,6 @@ impl ClientBuilder {
         self.with_serialization(SerializationFormat::Bincode)
     }
 
-    /// Configure a shared marker for the most recent network reconfiguration time.
-    pub fn with_last_net_reconfiguration(
-        mut self,
-        last_net_reconfiguration: Arc<Mutex<Instant>>,
-    ) -> Self {
-        self.last_net_reconfiguration = Some(last_net_reconfiguration);
-        self
-    }
-
     /// Returns a Client that uses this ClientBuilder configuration.
     pub fn build(self) -> Result<Client, HttpClientError> {
         if let Some(err) = self.error {
@@ -854,7 +851,6 @@ impl ClientBuilder {
             request_timeout: self.timeout.unwrap_or(DEFAULT_TIMEOUT),
             retry_limit: self.retry_limit,
             serialization: self.serialization,
-            last_net_reconfiguration: self.last_net_reconfiguration,
         };
 
         Ok(client)
@@ -875,7 +871,6 @@ pub struct Client {
     #[cfg(target_arch = "wasm32")]
     request_timeout: Duration,
 
-    last_net_reconfiguration: Option<Arc<Mutex<Instant>>>,
     retry_limit: usize,
     serialization: SerializationFormat,
 }
@@ -935,8 +930,6 @@ impl Client {
             #[cfg(target_arch = "wasm32")]
             request_timeout: self.request_timeout,
             serialization: self.serialization,
-
-            last_net_reconfiguration: self.last_net_reconfiguration.clone(),
         }
     }
 
@@ -958,19 +951,6 @@ impl Client {
     /// Change the currently configured limit on the number of retries for a request.
     pub fn change_retry_limit(&mut self, limit: usize) {
         self.retry_limit = limit;
-    }
-
-    /// Set a shared marker for the most recent network reconfiguration time.
-    pub fn set_last_net_reconfiguration(
-        &mut self,
-        last_net_reconfiguration: Option<Arc<Mutex<Instant>>>,
-    ) {
-        self.last_net_reconfiguration = last_net_reconfiguration;
-    }
-
-    /// Get a clone of the shared marker for the most recent network reconfiguration time.
-    pub fn last_net_reconfiguration(&self) -> Option<Arc<Mutex<Instant>>> {
-        self.last_net_reconfiguration.clone()
     }
 
     #[cfg(feature = "tunneling")]
@@ -1216,10 +1196,10 @@ impl ApiClientCore for Client {
                     return Ok(resp);
                 }
                 Err(err) => {
-                    let network_reconfigured = self
-                        .last_net_reconfiguration
-                        .as_ref()
-                        .is_some_and(|t_reconf| t_reconf.lock().unwrap().gt(&request_start));
+                    let network_reconfigured = SHARED_NETWORK_RECONFIGURATION
+                        .lock()
+                        .unwrap()
+                        .gt(&request_start);
 
                     #[cfg(target_arch = "wasm32")]
                     let is_network_err = err.is_timeout();

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -233,12 +233,12 @@ static SHARED_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     }
 });
 
-pub(crate) static SHARED_NETWORK_RECONFIGURATION: LazyLock<Arc<Mutex<Instant>>> =
-    LazyLock::new(|| Arc::new(Mutex::new(Instant::now())));
+pub(crate) static SHARED_NETWORK_RECONFIGURATION: LazyLock<Arc<Mutex<Option<Instant>>>> =
+    LazyLock::new(|| Arc::new(Mutex::new(None)));
 
 /// Indicate to the shared marker that a network reconfiguration happened.
 pub fn network_reconfigured() {
-    *SHARED_NETWORK_RECONFIGURATION.lock().unwrap() = Instant::now();
+    *SHARED_NETWORK_RECONFIGURATION.lock().unwrap() = Some(Instant::now());
 }
 
 /// Collection of URL Path Segments
@@ -1196,10 +1196,10 @@ impl ApiClientCore for Client {
                     return Ok(resp);
                 }
                 Err(err) => {
-                    let network_reconfigured = SHARED_NETWORK_RECONFIGURATION
-                        .lock()
-                        .unwrap()
-                        .gt(&request_start);
+                    let last_network_reconfiguration =
+                        *SHARED_NETWORK_RECONFIGURATION.lock().unwrap();
+                    let network_reconfigured =
+                        last_network_reconfiguration.is_some_and(|last| last > request_start);
 
                     #[cfg(target_arch = "wasm32")]
                     let is_network_err = err.is_timeout();

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -142,7 +142,9 @@
 use http::header::USER_AGENT;
 pub use inventory;
 pub use reqwest::{self, ClientBuilder as ReqwestClientBuilder, StatusCode};
+use rustls::lock::Mutex;
 use std::error::Error;
+use std::time::Instant;
 
 pub mod registry;
 
@@ -616,6 +618,7 @@ pub struct ClientBuilder {
 
     retry_limit: usize,
     serialization: SerializationFormat,
+    last_net_reconfiguration: Option<Arc<Mutex<Instant>>>,
 
     error: Option<HttpClientError>,
 }
@@ -716,6 +719,7 @@ impl ClientBuilder {
 
             retry_limit: 0,
             serialization: SerializationFormat::Json,
+            last_net_reconfiguration: None,
             error: None,
         })
     }
@@ -804,6 +808,15 @@ impl ClientBuilder {
         self.with_serialization(SerializationFormat::Bincode)
     }
 
+    /// Configure a shared marker for the most recent network reconfiguration time.
+    pub fn with_last_net_reconfiguration(
+        mut self,
+        last_net_reconfiguration: Arc<Mutex<Instant>>,
+    ) -> Self {
+        self.last_net_reconfiguration = Some(last_net_reconfiguration);
+        self
+    }
+
     /// Returns a Client that uses this ClientBuilder configuration.
     pub fn build(self) -> Result<Client, HttpClientError> {
         if let Some(err) = self.error {
@@ -841,6 +854,7 @@ impl ClientBuilder {
             request_timeout: self.timeout.unwrap_or(DEFAULT_TIMEOUT),
             retry_limit: self.retry_limit,
             serialization: self.serialization,
+            last_net_reconfiguration: self.last_net_reconfiguration,
         };
 
         Ok(client)
@@ -861,6 +875,7 @@ pub struct Client {
     #[cfg(target_arch = "wasm32")]
     request_timeout: Duration,
 
+    last_net_reconfiguration: Option<Arc<Mutex<Instant>>>,
     retry_limit: usize,
     serialization: SerializationFormat,
 }
@@ -920,6 +935,8 @@ impl Client {
             #[cfg(target_arch = "wasm32")]
             request_timeout: self.request_timeout,
             serialization: self.serialization,
+
+            last_net_reconfiguration: self.last_net_reconfiguration.clone(),
         }
     }
 
@@ -941,6 +958,19 @@ impl Client {
     /// Change the currently configured limit on the number of retries for a request.
     pub fn change_retry_limit(&mut self, limit: usize) {
         self.retry_limit = limit;
+    }
+
+    /// Set a shared marker for the most recent network reconfiguration time.
+    pub fn set_last_net_reconfiguration(
+        &mut self,
+        last_net_reconfiguration: Option<Arc<Mutex<Instant>>>,
+    ) {
+        self.last_net_reconfiguration = last_net_reconfiguration;
+    }
+
+    /// Get a clone of the shared marker for the most recent network reconfiguration time.
+    pub fn last_net_reconfiguration(&self) -> Option<Arc<Mutex<Instant>>> {
+        self.last_net_reconfiguration.clone()
     }
 
     #[cfg(feature = "tunneling")]
@@ -1150,6 +1180,8 @@ impl ApiClientCore for Client {
             self.apply_hosts_to_req(&mut req);
             let url: Url = req.url().clone().into();
 
+            let request_start = Instant::now();
+
             #[cfg(target_arch = "wasm32")]
             let response: Result<Response, HttpClientError> = {
                 let client = self
@@ -1184,12 +1216,17 @@ impl ApiClientCore for Client {
                     return Ok(resp);
                 }
                 Err(err) => {
+                    let network_reconfigured = self
+                        .last_net_reconfiguration
+                        .as_ref()
+                        .is_some_and(|t_reconf| t_reconf.lock().unwrap().gt(&request_start));
+
                     #[cfg(target_arch = "wasm32")]
                     let is_network_err = err.is_timeout();
                     #[cfg(not(target_arch = "wasm32"))]
                     let is_network_err = might_be_network_interference(&err);
 
-                    if is_network_err {
+                    if is_network_err & !network_reconfigured {
                         // if we have multiple urls, update to the next
                         self.maybe_rotate_hosts(Some(url.clone()));
 

--- a/common/http-api-client/src/tests.rs
+++ b/common/http-api-client/src/tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+use rustls::lock::Mutex;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 #[test]
 fn sanitizing_urls() {
@@ -305,4 +308,59 @@ fn from_network_configures_multiple_urls_and_retries() {
         "https://nym-frontdoor.global.ssl.fastly.net/api/"
     );
     assert!(client.base_urls()[2].front_str().is_some());
+}
+
+/// Tests that network reconfiguration timestamp tempers host rotation / fronting activation.
+///
+/// If a network reconfiguration happened after request start we avoid rotating and avoid enabling
+/// fronting. Otherwise, a network error should rotate host and enable fronting (for `OnRetry`).
+#[tokio::test]
+#[cfg(feature = "tunneling")]
+async fn host_rotation_tempered_by_net_reconfigure() {
+    let url1 = Url::new("http://nym-api.test", Some(vec!["http://cdn1.test"])).unwrap();
+    let url2 = Url::new("http://nym-api2.test", Some(vec!["http://cdn2.test"])).unwrap();
+    let urls = vec![url1.clone(), url2.clone()];
+
+    let last_net_reconfigured = Arc::new(Mutex::new(Instant::now()));
+
+    let client = ClientBuilder::new_with_urls(urls)
+        .unwrap()
+        .with_fronting(Some(crate::fronted::FrontPolicy::OnRetry))
+        .with_last_net_reconfiguration(last_net_reconfigured.clone())
+        .build()
+        .unwrap();
+
+    let request_host = |client: &Client| {
+        client
+            .create_get_request(&["health"], NO_PARAMS)
+            .unwrap()
+            .build()
+            .unwrap()
+            .url()
+            .host_str()
+            .unwrap()
+            .to_string()
+    };
+
+    // fronting starts disabled for OnRetry policy.
+    assert_eq!(request_host(&client), "nym-api.test");
+    assert_eq!(client.current_url().as_str(), "http://nym-api.test/");
+
+    // Simulate a network reconfiguration happening during the request. This should suppress both
+    // host rotation and fronting activation.
+    *last_net_reconfigured.lock().unwrap() = Instant::now() + Duration::from_secs(60);
+    let req = client.create_get_request(&["health"], NO_PARAMS).unwrap();
+    let _ = client.send(req).await;
+
+    assert_eq!(client.current_url().as_str(), "http://nym-api.test/");
+    assert_eq!(request_host(&client), "nym-api.test");
+
+    // Simulate no recent network reconfiguration. Now the same network error should rotate to the
+    // next host and enable fronting for OnRetry.
+    *last_net_reconfigured.lock().unwrap() = Instant::now() - Duration::from_secs(60);
+    let req = client.create_get_request(&["health"], NO_PARAMS).unwrap();
+    let _ = client.send(req).await;
+
+    assert_eq!(client.current_url().as_str(), "http://nym-api2.test/");
+    assert_eq!(request_host(&client), "cdn2.test");
 }

--- a/common/http-api-client/src/tests.rs
+++ b/common/http-api-client/src/tests.rs
@@ -319,7 +319,6 @@ async fn host_rotation_tempered_by_net_reconfigure() {
     let url2 = Url::new("http://nym-api2.test", Some(vec!["http://cdn2.test"])).unwrap();
     let urls = vec![url1.clone(), url2.clone()];
 
-
     let client = ClientBuilder::new_with_urls(urls)
         .unwrap()
         .with_fronting(Some(crate::fronted::FrontPolicy::OnRetry))
@@ -344,7 +343,8 @@ async fn host_rotation_tempered_by_net_reconfigure() {
 
     // Simulate a network reconfiguration happening during the request. This should suppress both
     // host rotation and fronting activation.
-    *crate::SHARED_NETWORK_RECONFIGURATION.lock().unwrap() = Instant::now() + Duration::from_secs(60);
+    *crate::SHARED_NETWORK_RECONFIGURATION.lock().unwrap() =
+        Instant::now() + Duration::from_secs(60);
     let req = client.create_get_request(&["health"], NO_PARAMS).unwrap();
     let _ = client.send(req).await;
 
@@ -353,7 +353,8 @@ async fn host_rotation_tempered_by_net_reconfigure() {
 
     // Simulate no recent network reconfiguration. Now the same network error should rotate to the
     // next host and enable fronting for OnRetry.
-    *crate::SHARED_NETWORK_RECONFIGURATION.lock().unwrap() = Instant::now() - Duration::from_secs(60);
+    *crate::SHARED_NETWORK_RECONFIGURATION.lock().unwrap() =
+        Instant::now() - Duration::from_secs(60);
     let req = client.create_get_request(&["health"], NO_PARAMS).unwrap();
     let _ = client.send(req).await;
 

--- a/common/http-api-client/src/tests.rs
+++ b/common/http-api-client/src/tests.rs
@@ -1,6 +1,4 @@
 use super::*;
-use rustls::lock::Mutex;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[test]
@@ -321,12 +319,10 @@ async fn host_rotation_tempered_by_net_reconfigure() {
     let url2 = Url::new("http://nym-api2.test", Some(vec!["http://cdn2.test"])).unwrap();
     let urls = vec![url1.clone(), url2.clone()];
 
-    let last_net_reconfigured = Arc::new(Mutex::new(Instant::now()));
 
     let client = ClientBuilder::new_with_urls(urls)
         .unwrap()
         .with_fronting(Some(crate::fronted::FrontPolicy::OnRetry))
-        .with_last_net_reconfiguration(last_net_reconfigured.clone())
         .build()
         .unwrap();
 
@@ -348,7 +344,7 @@ async fn host_rotation_tempered_by_net_reconfigure() {
 
     // Simulate a network reconfiguration happening during the request. This should suppress both
     // host rotation and fronting activation.
-    *last_net_reconfigured.lock().unwrap() = Instant::now() + Duration::from_secs(60);
+    *crate::SHARED_NETWORK_RECONFIGURATION.lock().unwrap() = Instant::now() + Duration::from_secs(60);
     let req = client.create_get_request(&["health"], NO_PARAMS).unwrap();
     let _ = client.send(req).await;
 
@@ -357,7 +353,7 @@ async fn host_rotation_tempered_by_net_reconfigure() {
 
     // Simulate no recent network reconfiguration. Now the same network error should rotate to the
     // next host and enable fronting for OnRetry.
-    *last_net_reconfigured.lock().unwrap() = Instant::now() - Duration::from_secs(60);
+    *crate::SHARED_NETWORK_RECONFIGURATION.lock().unwrap() = Instant::now() - Duration::from_secs(60);
     let req = client.create_get_request(&["health"], NO_PARAMS).unwrap();
     let _ = client.send(req).await;
 

--- a/common/http-api-client/src/tests.rs
+++ b/common/http-api-client/src/tests.rs
@@ -344,7 +344,7 @@ async fn host_rotation_tempered_by_net_reconfigure() {
     // Simulate a network reconfiguration happening during the request. This should suppress both
     // host rotation and fronting activation.
     *crate::SHARED_NETWORK_RECONFIGURATION.lock().unwrap() =
-        Instant::now() + Duration::from_secs(60);
+        Some(Instant::now() + Duration::from_secs(60));
     let req = client.create_get_request(&["health"], NO_PARAMS).unwrap();
     let _ = client.send(req).await;
 
@@ -354,7 +354,7 @@ async fn host_rotation_tempered_by_net_reconfigure() {
     // Simulate no recent network reconfiguration. Now the same network error should rotate to the
     // next host and enable fronting for OnRetry.
     *crate::SHARED_NETWORK_RECONFIGURATION.lock().unwrap() =
-        Instant::now() - Duration::from_secs(60);
+        Some(Instant::now() - Duration::from_secs(60));
     let req = client.create_get_request(&["health"], NO_PARAMS).unwrap();
     let _ = client.send(req).await;
 


### PR DESCRIPTION
Add a mechanism to alert the HTTP client that either network reconfiguration happened so that the HTTP client can avoid interpretting device / app firewalls as interference caused by a malicious  network adversary.

When an HTTP connection fails with an error check if time of connection start is before the time of the last network reconfiguration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary host rotation and (when enabled) fronting activation for retry attempts occurring immediately after recent network reconfiguration.
  * Retries now treat “post-reconfiguration” requests differently from other transient network errors, improving stability during network changes.
* **Tests**
  * Added a new async, feature-gated test confirming retry behavior is suppressed right after a recent reconfiguration, then resumes host rotation and fronting after the reconfiguration becomes older.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6923)
<!-- Reviewable:end -->
