### PR TITLE
[BandwidthController] Fetching Logic

### DIFF
--- a/common/bandwidth-controller/Cargo.toml
+++ b/common/bandwidth-controller/Cargo.toml
@@ -15,14 +15,13 @@ publish = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arc-swap = { workspace = true }
 async-trait = { workspace = true }
 log = { workspace = true }
-rand = { workspace = true }
+si-scale = { workspace = true, features = ["lossy-conversions"] }
 strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "sync"] }
 
 nym-credential-storage = { workspace = true }
 nym-credentials = { workspace = true }
@@ -41,6 +40,16 @@ nym-validator-client = { workspace = true }
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies.nym-validator-client]
 workspace = true
 features = ["http-client"]
+
+# credential fetching (background tasks + restock timer) is native-only
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies.tokio]
+workspace = true
+features = ["rt", "time"]
+
+# wasm has no tokio timer; wasmtimer drives the periodic global-data top-up
+[target."cfg(target_arch = \"wasm32\")".dependencies.wasmtimer]
+workspace = true
+features = ["tokio"]
 
 [lints]
 workspace = true

--- a/common/bandwidth-controller/src/controller.rs
+++ b/common/bandwidth-controller/src/controller.rs
@@ -2,16 +2,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::BandwidthControllerError;
+use crate::readiness::{FetchFailure, ReadinessRequest, ReadinessSnapshot, ReadinessStatus};
 use crate::requests::{BandwidthControllerRequest, BandwidthControllerRequestSender};
-use crate::traits::CredentialPublicDataFetcher;
+use crate::ticketbooks::AvailableTicketbooks;
+use crate::traits::{CredentialFetcher, CredentialPublicDataFetcher};
 use crate::{
     BandwidthTicketProvider, PreparedCredential, PreparedCredentialMetadata, UPGRADE_MODE_JWT_TYPE,
 };
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::traits::CredentialFetcherError;
+use crate::NymCredential;
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use log::error;
+use nym_credential_storage::models::EmergencyCredentialContent;
 use nym_credential_storage::models::RetrievedTicketbook;
 use nym_credential_storage::storage::Storage;
 use nym_credentials::ecash::bandwidth::CredentialSpendingData;
+use nym_credentials::IssuedTicketBook;
 use nym_credentials_interface::{
     AnnotatedCoinIndexSignature, AnnotatedExpirationDateSignature, TicketType, VerificationKeyAuth,
 };
@@ -21,6 +34,36 @@ use nym_task::ShutdownToken;
 use nym_validator_client::nym_api::EpochId;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
+/// How often the controller proactively checks whether any ticket type needs restocking.
+const TOPUP_INTERVAL: Duration = Duration::from_secs(3 * 3600); // 3 hours
+
+/// Result of a background ticketbook fetch, drained from `fetch_tasks` in the `run` loop.
+#[cfg(not(target_arch = "wasm32"))]
+struct FetchOutcome {
+    ticket_type: TicketType,
+    result: Result<Vec<NymCredential>, CredentialFetcherError>,
+}
+
+/// Owns all ecash credential state and is the **single writer** to the credential [`Storage`].
+///
+/// It serves ticket spending, credential acquisition, and global signing-data retrieval while
+/// keeping storage consistent by being the only component that writes to it. The acquisition and
+/// retrieval work is delegated to two pluggable, **storage-free** fetchers: they only do the
+/// network/cryptographic work and hand the results back for the controller to persist.
+///
+/// - [`CredentialPublicDataFetcher`] (`public_data_fetcher`): lazily retrieves the global ecash
+///   signing materials - master verification key, coin-index and expiration-date signatures - when
+///   they're missing locally.
+/// - [`CredentialFetcher`] (`credential_fetcher`): provisions usable ticketbooks (making deposits
+///   and aggregating wallet signatures). It is a superset of the public-data fetcher, so installing
+///   one via [`Self::with_credential_fetcher`] also registers it as the public-data fetcher.
+///
+/// It can be driven two ways:
+/// - [`Self::run`] — the event loop: handles requests from [`BandwidthControllerRequestSender`] and,
+///   on native targets, proactively restocks low ticket types in the background, keeps the global
+///   data topped up, and resolves `wait_for_ticketbooks` readiness waiters as fetches complete.
+/// - directly on a non-running instance — e.g. [`Self::fetch_ticketbook`] or
+///   [`Self::prepare_ecash_ticket`] — for one-shot use without spawning the loop.
 pub struct BandwidthController<St> {
     storage: St,
 
@@ -31,17 +74,51 @@ pub struct BandwidthController<St> {
     ),
 
     // fetches the global ecash signing materials when they are missing locally
-    public_data_fetcher: Option<Box<dyn CredentialPublicDataFetcher>>,
+    public_data_fetcher: Option<Arc<dyn CredentialPublicDataFetcher>>,
+
+    // provisions usable ticketbooks. Available on all targets for manual (inline) fetching;
+    // `Arc` so the native auto path can clone it into spawned fetch tasks.
+    credential_fetcher: Option<Arc<dyn CredentialFetcher>>,
+
+    // ticket types with an automatic fetch currently in flight, so we don't request the same
+    // type twice (native auto path only)
+    #[cfg(not(target_arch = "wasm32"))]
+    in_flight: HashSet<TicketType>,
+
+    // background ticketbook fetches; completions are drained in the `run` loop
+    #[cfg(not(target_arch = "wasm32"))]
+    fetch_tasks: tokio::task::JoinSet<FetchOutcome>,
+
+    // callers parked on `wait_for_ticketbooks`, re-evaluated whenever a fetch completes
+    pending_readiness: Vec<ReadinessRequest>,
 }
 
 impl<St: Storage> BandwidthController<St> {
+    // ---------------------------------------------------------------------
+    // Construction & configuration
+    // ---------------------------------------------------------------------
+
     pub fn new(storage: St) -> Self {
         let request_channel = mpsc::unbounded_channel();
         BandwidthController {
             storage,
             request_channel,
             public_data_fetcher: None,
+            credential_fetcher: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            in_flight: HashSet::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            fetch_tasks: tokio::task::JoinSet::new(),
+            pending_readiness: Vec::new(),
         }
+    }
+
+    #[must_use]
+    pub fn with_credential_fetcher(mut self, fetcher: impl CredentialFetcher + 'static) -> Self {
+        let fetcher = Arc::new(fetcher);
+        self.credential_fetcher = Some(fetcher.clone());
+        self.public_data_fetcher = Some(fetcher);
+        self
     }
 
     #[must_use]
@@ -49,7 +126,7 @@ impl<St: Storage> BandwidthController<St> {
         mut self,
         fetcher: impl CredentialPublicDataFetcher + 'static,
     ) -> Self {
-        self.public_data_fetcher = Some(Box::new(fetcher));
+        self.public_data_fetcher = Some(Arc::new(fetcher));
         self
     }
 
@@ -59,179 +136,212 @@ impl<St: Storage> BandwidthController<St> {
         BandwidthControllerRequestSender::new(self.request_channel.0.clone())
     }
 
-    /// Tries to retrieve one of the stored, unused credentials for the given type that hasn't yet expired.
-    pub async fn get_next_usable_ticketbook(
-        &self,
-        ticketbook_type: TicketType,
-        tickets: u32,
-    ) -> Result<Option<RetrievedTicketbook>, BandwidthControllerError> {
-        self.storage
-            .get_next_unspent_usable_ticketbook(ticketbook_type.to_string(), tickets)
-            .await
-            .map_err(BandwidthControllerError::credential_storage_error)
-    }
+    // ---------------------------------------------------------------------
+    // Event loop
+    // ---------------------------------------------------------------------
 
-    pub async fn attempt_revert_ticket_usage(
-        &self,
-        info: PreparedCredentialMetadata,
-    ) -> Result<bool, BandwidthControllerError> {
-        self.storage
-            .attempt_revert_ticketbook_withdrawal(
-                info.ticketbook_id,
-                info.tickets_withdrawn,
-                info.used_tickets,
-            )
-            .await
-            .map_err(BandwidthControllerError::credential_storage_error)
-    }
-
-    pub async fn get_aggregate_verification_key(
-        &self,
-        epoch_id: EpochId,
-    ) -> Result<Option<VerificationKeyAuth>, BandwidthControllerError> {
-        self.storage
-            .get_master_verification_key(epoch_id)
-            .await
-            .map_err(BandwidthControllerError::credential_storage_error)
-    }
-
-    pub async fn get_coin_index_signatures(
-        &self,
-        epoch_id: EpochId,
-    ) -> Result<Option<Vec<AnnotatedCoinIndexSignature>>, BandwidthControllerError> {
-        self.storage
-            .get_coin_index_signatures(epoch_id)
-            .await
-            .map_err(BandwidthControllerError::credential_storage_error)
-    }
-
-    pub async fn get_expiration_date_signatures(
-        &self,
-        epoch_id: EpochId,
-        expiration_date: Date,
-    ) -> Result<Option<Vec<AnnotatedExpirationDateSignature>>, BandwidthControllerError> {
-        self.storage
-            .get_expiration_date_signatures(expiration_date, epoch_id)
-            .await
-            .map_err(BandwidthControllerError::credential_storage_error)
-    }
-
-    /// Returns the master verification key for the epoch, fetching it via the configured public
-    /// data fetcher and persisting it if it isn't already in local storage.
-    async fn ensure_master_verification_key(
-        &self,
-        epoch_id: EpochId,
-    ) -> Result<VerificationKeyAuth, BandwidthControllerError> {
-        if let Some(key) = self.get_aggregate_verification_key(epoch_id).await? {
-            return Ok(key);
-        }
-        let Some(fetcher) = &self.public_data_fetcher else {
-            return Err(BandwidthControllerError::MissingVerificationKey { epoch_id });
+    /// Runs the controller event loop, handling incoming requests until the
+    /// request channel is closed or cancellation is requested. Additionally drives
+    /// the proactive restock timer and drains completed background fetches.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn run(mut self, shutdown_token: ShutdownToken) {
+        tracing::info!("BandwidthController started successfully");
+        let mut topup_interval = {
+            let mut interval = tokio::time::interval(TOPUP_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            interval
         };
-        let key = fetcher
-            .fetch_master_verification_key(epoch_id)
-            .await
-            .map_err(BandwidthControllerError::fetcher_error)?;
-        self.storage
-            .insert_master_verification_key(&key)
-            .await
-            .map_err(BandwidthControllerError::credential_storage_error)?;
-        Ok(key.key)
-    }
 
-    /// Returns the coin index signatures for the epoch, fetching them via the configured public
-    /// data fetcher and persisting them if they aren't already in local storage.
-    async fn ensure_coin_index_signatures(
-        &self,
-        epoch_id: EpochId,
-    ) -> Result<Vec<AnnotatedCoinIndexSignature>, BandwidthControllerError> {
-        if let Some(signatures) = self.get_coin_index_signatures(epoch_id).await? {
-            return Ok(signatures);
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_token.cancelled() => {
+                    log::debug!("bandwidth controller received cancellation request; shutting down");
+                    break;
+                }
+                _ = topup_interval.tick() => {
+                    let _ = self.print_info().await;
+                    self.ensure_global_data().await;
+                    self.check_and_restock(AvailableTicketbooks::ticketbook_types()).await;
+                }
+                Some(done) = self.fetch_tasks.join_next() => {
+                    self.on_fetch_complete(done).await;
+                }
+                request = self.request_channel.1.recv() => match request {
+                    Some(request) => self.handle_request(request).await,
+                    None => {
+                        log::warn!("bandwidth controller request channel closed; this should never happen as we own a sender; shutting down");
+                        break;
+                    }
+                }
+            }
         }
-        let Some(fetcher) = &self.public_data_fetcher else {
-            return Err(BandwidthControllerError::MissingCoinIndexSignatures { epoch_id });
-        };
-        let signatures = fetcher
-            .fetch_coin_index_signatures(epoch_id)
-            .await
-            .map_err(BandwidthControllerError::fetcher_error)?;
-        self.storage
-            .insert_coin_index_signatures(&signatures)
-            .await
-            .map_err(BandwidthControllerError::credential_storage_error)?;
-        Ok(signatures.signatures)
+
+        if let Some(fetcher) = self.credential_fetcher {
+            fetcher.cleanup().await;
+        }
+        self.storage.close().await;
     }
 
-    /// Returns the expiration date signatures for the epoch and expiration date, fetching them via
-    /// the configured public data fetcher and persisting them if they aren't already in local storage.
-    async fn ensure_expiration_date_signatures(
-        &self,
-        epoch_id: EpochId,
-        expiration_date: Date,
-    ) -> Result<Vec<AnnotatedExpirationDateSignature>, BandwidthControllerError> {
-        if let Some(signatures) = self
-            .get_expiration_date_signatures(epoch_id, expiration_date)
-            .await?
+    /// Runs the controller event loop, handling incoming requests until the
+    /// request channel is closed or cancellation is requested
+    #[cfg(target_arch = "wasm32")]
+    pub async fn run(mut self, shutdown_token: ShutdownToken) {
+        let mut topup_interval = {
+            let mut interval = wasmtimer::tokio::interval(TOPUP_INTERVAL);
+            interval.set_missed_tick_behavior(wasmtimer::tokio::MissedTickBehavior::Delay);
+            interval
+        };
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_token.cancelled() => {
+                    log::debug!("bandwidth controller received cancellation request; shutting down");
+                    break;
+                }
+                _ = topup_interval.tick() => {
+                    let _ = self.print_info().await;
+                    self.ensure_global_data().await;
+                }
+                request = self.request_channel.1.recv() => match request {
+                    Some(request) => self.handle_request(request).await,
+                    None => {
+                        log::warn!("bandwidth controller request channel closed; this should never happen as we own a sender; shutting down");
+                        break;
+                    }
+                }
+            }
+        }
+        self.storage.close().await;
+    }
+
+    // ---------------------------------------------------------------------
+    // Request dispatch & handlers
+    // ---------------------------------------------------------------------
+
+    async fn handle_request(&mut self, request: BandwidthControllerRequest) {
+        match request {
+            BandwidthControllerRequest::EcashTicket(return_sender, request) => {
+                let ticket_type = request.ticket_type;
+                let credential_result = self
+                    .prepare_ecash_ticket(
+                        ticket_type,
+                        request.gateway_id.to_bytes(),
+                        request.tickets_to_spend,
+                        request.spend_time,
+                    )
+                    .await;
+                return_sender.send(credential_result);
+                // a ticket was just requested for this type - top it up if it's now running low
+                #[cfg(not(target_arch = "wasm32"))]
+                self.check_and_restock(vec![ticket_type]).await;
+            }
+            BandwidthControllerRequest::UpgradeModeToken(return_sender) => {
+                return_sender.send(self.get_upgrade_mode_token().await)
+            }
+            BandwidthControllerRequest::AttemptRevertSpending(return_sender, metadata) => {
+                return_sender.send(self.attempt_revert_ticket_usage(metadata).await)
+            }
+            BandwidthControllerRequest::SetCredentialFetcher(return_sender, fetcher) => {
+                self.handle_set_credential_fetcher(fetcher).await;
+                return_sender.send(Ok(()))
+            }
+
+            BandwidthControllerRequest::SetPublicDataFetcher(return_sender, fetcher) => {
+                self.public_data_fetcher = fetcher;
+                return_sender.send(Ok(()))
+            }
+            BandwidthControllerRequest::Reset(return_sender) => {
+                return_sender.send(self.handle_reset().await)
+            }
+            BandwidthControllerRequest::ClearEmergencyCredentials(return_sender) => return_sender
+                .send(
+                    self.storage
+                        .clear_emergency_credentials()
+                        .await
+                        .map_err(BandwidthControllerError::credential_storage_error),
+                ),
+            BandwidthControllerRequest::GetAvailableTicketbooks(return_sender) => {
+                return_sender.send(self.handle_get_available_ticketbooks().await)
+            }
+            BandwidthControllerRequest::WaitForTicketbooks(return_sender, ticket_types) => {
+                self.handle_wait_for_ticketbooks(ReadinessRequest {
+                    return_sender,
+                    ticket_types,
+                })
+                .await
+            }
+        }
+    }
+
+    async fn handle_set_credential_fetcher(&mut self, fetcher: Option<Arc<dyn CredentialFetcher>>) {
+        if let Some(old_fetcher) = self.credential_fetcher.take() {
+            old_fetcher.cleanup().await;
+        }
+        // Explicit upcast required because of the option
+        self.public_data_fetcher = fetcher
+            .clone()
+            .map(|f| f as Arc<dyn CredentialPublicDataFetcher>);
+        self.credential_fetcher = fetcher;
+        #[cfg(not(target_arch = "wasm32"))]
+        self.check_and_restock(AvailableTicketbooks::ticketbook_types())
+            .await;
+    }
+
+    // Removes fetcher, stops in flight requests, clear credentials, answer all readiness request with unavailable
+    async fn handle_reset(&mut self) -> Result<(), BandwidthControllerError> {
+        // Cancel fetching
+        #[cfg(not(target_arch = "wasm32"))]
         {
-            return Ok(signatures);
+            self.fetch_tasks.shutdown().await;
+            self.in_flight = HashSet::new();
         }
-        let Some(fetcher) = &self.public_data_fetcher else {
-            return Err(BandwidthControllerError::MissingExpirationDateSignatures { epoch_id });
-        };
-        let signatures = fetcher
-            .fetch_expiration_date_signatures(expiration_date, epoch_id)
-            .await
-            .map_err(BandwidthControllerError::fetcher_error)?;
+
+        if let Some(fetcher) = &self.credential_fetcher {
+            fetcher.cleanup().await;
+        }
+        self.credential_fetcher = None;
+
+        let requests = std::mem::take(&mut self.pending_readiness);
+        requests.into_iter().for_each(|r| r.cancel());
+
+        // Clear credentials
         self.storage
-            .insert_expiration_date_signatures(&signatures)
+            .clear_ticketbooks()
             .await
             .map_err(BandwidthControllerError::credential_storage_error)?;
-        Ok(signatures.signatures)
+        self.storage
+            .clear_emergency_credentials()
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)
     }
 
-    /// Ensures all global ecash signing materials for the given epoch and expiration date are
-    /// present in local storage, fetching and persisting any that are missing.
-    pub async fn ensure_global_data(
+    async fn handle_get_available_ticketbooks(
         &self,
-        epoch_id: EpochId,
-        expiration_date: Date,
-    ) -> Result<(), BandwidthControllerError> {
-        self.ensure_master_verification_key(epoch_id).await?;
-        self.ensure_coin_index_signatures(epoch_id).await?;
-        self.ensure_expiration_date_signatures(epoch_id, expiration_date)
-            .await?;
-        Ok(())
+    ) -> Result<AvailableTicketbooks, BandwidthControllerError> {
+        self.print_info().await?;
+        self.get_available_ticketbooks().await
     }
 
-    async fn prepare_ecash_ticket_inner(
-        &self,
-        provider_pk: [u8; 32],
-        spend_time: OffsetDateTime,
-        tickets_to_spend: u32,
-        mut retrieved_ticketbook: RetrievedTicketbook,
-    ) -> Result<CredentialSpendingData, BandwidthControllerError> {
-        let epoch_id = retrieved_ticketbook.ticketbook.epoch_id();
-        let expiration_date = retrieved_ticketbook.ticketbook.expiration_date();
-
-        let verification_key = self.ensure_master_verification_key(epoch_id).await?;
-        let expiration_signatures = self
-            .ensure_expiration_date_signatures(epoch_id, expiration_date)
-            .await?;
-        let coin_indices_signatures = self.ensure_coin_index_signatures(epoch_id).await?;
-
-        let pay_info = retrieved_ticketbook
-            .ticketbook
-            .generate_pay_info(provider_pk, spend_time);
-
-        let spend_request = retrieved_ticketbook.ticketbook.prepare_for_spending(
-            &verification_key,
-            pay_info.into(),
-            &coin_indices_signatures,
-            &expiration_signatures,
-            tickets_to_spend as u64,
-        )?;
-        Ok(spend_request)
+    async fn handle_wait_for_ticketbooks(&mut self, request: ReadinessRequest) {
+        let snapshot = match self.build_readiness_snapshot(None).await {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                // transient storage failure - leave waiters parked for the next state change
+                tracing::warn!("could not assess ticketbook readiness: {err}");
+                self.pending_readiness.push(request);
+                return;
+            }
+        };
+        tracing::debug!("Readiness snapshot : {:#?}", snapshot);
+        if let Some(request) = request.try_resolve(&snapshot) {
+            self.pending_readiness.push(request);
+        }
     }
+
+    // ---------------------------------------------------------------------
+    // Ticket spending
+    // ---------------------------------------------------------------------
 
     pub async fn prepare_ecash_ticket(
         &self,
@@ -280,6 +390,441 @@ impl<St: Storage> BandwidthController<St> {
         }
     }
 
+    async fn prepare_ecash_ticket_inner(
+        &self,
+        provider_pk: [u8; 32],
+        spend_time: OffsetDateTime,
+        tickets_to_spend: u32,
+        mut retrieved_ticketbook: RetrievedTicketbook,
+    ) -> Result<CredentialSpendingData, BandwidthControllerError> {
+        let epoch_id = retrieved_ticketbook.ticketbook.epoch_id();
+        let expiration_date = retrieved_ticketbook.ticketbook.expiration_date();
+
+        let verification_key = self.ensure_master_verification_key(epoch_id).await?;
+        let expiration_signatures = self
+            .ensure_expiration_date_signatures(epoch_id, expiration_date)
+            .await?;
+        let coin_indices_signatures = self.ensure_coin_index_signatures(epoch_id).await?;
+
+        let pay_info = retrieved_ticketbook
+            .ticketbook
+            .generate_pay_info(provider_pk, spend_time);
+
+        let spend_request = retrieved_ticketbook.ticketbook.prepare_for_spending(
+            &verification_key,
+            pay_info.into(),
+            &coin_indices_signatures,
+            &expiration_signatures,
+            tickets_to_spend as u64,
+        )?;
+        Ok(spend_request)
+    }
+
+    /// Tries to retrieve one of the stored, unused credentials for the given type that hasn't yet expired.
+    pub async fn get_next_usable_ticketbook(
+        &self,
+        ticketbook_type: TicketType,
+        tickets: u32,
+    ) -> Result<Option<RetrievedTicketbook>, BandwidthControllerError> {
+        self.storage
+            .get_next_unspent_usable_ticketbook(ticketbook_type.to_string(), tickets)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)
+    }
+
+    async fn attempt_revert_ticket_usage(
+        &self,
+        info: PreparedCredentialMetadata,
+    ) -> Result<bool, BandwidthControllerError> {
+        self.storage
+            .attempt_revert_ticketbook_withdrawal(
+                info.ticketbook_id,
+                info.tickets_withdrawn,
+                info.used_tickets,
+            )
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)
+    }
+
+    // ---------------------------------------------------------------------
+    // Automatic restocking & background fetches (native only)
+    // ---------------------------------------------------------------------
+
+    /// Fetches a ticketbook of `ticketbook_type` via the configured credential fetcher and persists
+    /// it (together with the global signing materials it needs). The fetch runs inline, so this
+    /// works on a controller that isn't running its event loop - suitable for one-shot issuance.
+    pub async fn fetch_ticketbook(
+        &self,
+        ticketbook_type: TicketType,
+    ) -> Result<(), BandwidthControllerError> {
+        let Some(fetcher) = &self.credential_fetcher else {
+            return Err(BandwidthControllerError::MissingCredentialFetcher);
+        };
+        let credentials = fetcher
+            .fetch_ticketbooks(ticketbook_type)
+            .await
+            .map_err(BandwidthControllerError::fetcher_error)?;
+        self.store_fetched(credentials).await;
+        Ok(())
+    }
+
+    /// Restocks the given ticket types that are running low or about to expire.
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn check_and_restock(&mut self, ticketbook_types: Vec<TicketType>) {
+        let available = match self.get_available_ticketbooks().await {
+            Ok(available) => available,
+            Err(err) => {
+                tracing::warn!("could not assess ticket stock for restocking: {err}");
+                return;
+            }
+        };
+
+        for typ in ticketbook_types {
+            tracing::debug!("Checking credential stock for {typ} ticket");
+            if available.needs_restock(typ) {
+                tracing::debug!("{typ} tickets need a restock");
+                self.ensure_stocked(typ);
+            }
+        }
+    }
+
+    /// Spawns a background fetch for `ticketbook_type` unless one is already in flight for it.
+    /// Non-blocking: the result is drained later in the `run` loop via `on_fetch_complete`.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn ensure_stocked(&mut self, ticketbook_type: TicketType) {
+        if self.in_flight.contains(&ticketbook_type) {
+            // already fetching this type; don't ask again while we're still waiting
+            tracing::debug!("{ticketbook_type} ticket restock already in flight");
+            return;
+        }
+        let Some(fetcher) = &self.credential_fetcher else {
+            tracing::debug!("No credential fetcher set. No restock possible");
+            return;
+        };
+        let fetcher = Arc::clone(fetcher);
+        self.in_flight.insert(ticketbook_type);
+        tracing::debug!("requesting more {ticketbook_type} ticketbooks");
+        self.fetch_tasks.spawn(async move {
+            let result = fetcher.fetch_ticketbooks(ticketbook_type).await;
+            FetchOutcome {
+                ticket_type: ticketbook_type,
+                result,
+            }
+        });
+    }
+
+    /// Persists the credentials returned by a completed fetch and clears its in-flight marker.
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn on_fetch_complete(&mut self, done: Result<FetchOutcome, tokio::task::JoinError>) {
+        // a failed fetch is surfaced to any readiness waiter that required the failed type
+        let failure = match done {
+            Ok(FetchOutcome {
+                ticket_type,
+                result: Ok(credentials),
+            }) => {
+                self.in_flight.remove(&ticket_type);
+                self.store_fetched(credentials).await;
+                tracing::info!("fetched and stored a {ticket_type} ticketbook");
+                None
+            }
+            Ok(FetchOutcome {
+                ticket_type,
+                result: Err(err),
+            }) => {
+                self.in_flight.remove(&ticket_type);
+                tracing::warn!("failed to fetch {ticket_type} ticketbooks: {err}");
+                Some(FetchFailure {
+                    ticket_type,
+                    error: err,
+                })
+            }
+            Err(join_err) => {
+                // a panicking fetch loses its ticket type, so it stays marked in-flight until the
+                // controller is restarted - acceptable as our fetcher isn't expected to panic.
+                tracing::error!("a credential fetch task terminated abnormally: {join_err}");
+                None
+            }
+        };
+        self.resolve_pending_waiters(failure).await;
+    }
+
+    /// Persists fetched credential
+    async fn store_fetched(&self, credentials: Vec<NymCredential>) {
+        for credential in credentials {
+            match credential {
+                NymCredential::Ticketbook(ticketbook) => self.store_ticketbook(*ticketbook).await,
+                NymCredential::UpgradeModeToken { jwt, expiration } => {
+                    self.store_upgrade_token(jwt, expiration).await
+                }
+            }
+        }
+    }
+
+    /// Persists fetched ticketbooks together with the global materials they need to be spent.
+    ///
+    /// Best-effort: each step (storing a material that came with the credential, or ensuring a
+    /// missing one is fetched, or storing the ticketbook itself) is logged on failure and the rest
+    /// still proceed - a single failure never aborts the batch.
+    async fn store_ticketbook(&self, ticketbook: IssuedTicketBook) {
+        // This path is used when a CredentialFetcher is there, so there will be a way to get the public data as well
+        let epoch_id = ticketbook.epoch_id();
+
+        if let Err(err) = self.ensure_master_verification_key(epoch_id).await {
+            tracing::warn!("failed to ensure master verification key for epoch {epoch_id}: {err}");
+        }
+        if let Err(err) = self.ensure_coin_index_signatures(epoch_id).await {
+            tracing::warn!("failed to ensure coin index signatures for epoch {epoch_id}: {err}");
+        }
+
+        if let Err(err) = self
+            .ensure_expiration_date_signatures(epoch_id, ticketbook.expiration_date())
+            .await
+        {
+            tracing::warn!(
+                "failed to ensure expiration date signatures for epoch {epoch_id}: {err}"
+            );
+        }
+
+        if let Err(err) = self.storage.insert_issued_ticketbook(&ticketbook).await {
+            tracing::warn!("failed to store ticketbook: {err}");
+        }
+    }
+
+    async fn store_upgrade_token(&self, jwt: String, expiration: OffsetDateTime) {
+        let credential_content = EmergencyCredentialContent {
+            typ: UPGRADE_MODE_JWT_TYPE.into(),
+            content: jwt.into_bytes(),
+            expiration: Some(expiration),
+        };
+        if let Err(e) = self
+            .storage
+            .insert_emergency_credential(&credential_content)
+            .await
+        {
+            tracing::warn!("failed to store emergency credential: {e}");
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Ticketbook readiness
+    // ---------------------------------------------------------------------
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn is_in_flight(&self, typ: TicketType) -> bool {
+        self.in_flight.contains(&typ)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn is_in_flight(&self, _typ: TicketType) -> bool {
+        false
+    }
+
+    async fn build_readiness_snapshot(
+        &self,
+        failure: Option<FetchFailure>,
+    ) -> Result<ReadinessSnapshot, BandwidthControllerError> {
+        let upgrade_mode = self.get_upgrade_mode_token().await?.is_some();
+        let available = self.get_available_ticketbooks().await?;
+
+        let mut tickets_readiness = HashMap::new();
+        for typ in AvailableTicketbooks::ticketbook_types() {
+            let status = if available.contains_minimal_tickets(typ) {
+                ReadinessStatus::Ready
+            } else if self.is_in_flight(typ) {
+                ReadinessStatus::InFlight
+            } else {
+                match failure.as_ref() {
+                    Some(failure) if failure.ticket_type == typ => {
+                        ReadinessStatus::FetchFailed(failure.error.to_string())
+                    }
+                    _ => ReadinessStatus::Unavailable,
+                }
+            };
+            tickets_readiness.insert(typ, status);
+        }
+
+        Ok(ReadinessSnapshot {
+            upgrade_mode,
+            tickets_readiness,
+        })
+    }
+
+    /// Re-evaluates parked `wait_for_ticketbooks` callers after stock/in-flight state changed,
+    /// answering and dropping the ones that resolved.
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn resolve_pending_waiters(&mut self, failure: Option<FetchFailure>) {
+        if self.pending_readiness.is_empty() {
+            return;
+        }
+        let snapshot = match self.build_readiness_snapshot(failure).await {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                // transient storage failure - leave waiters parked for the next state change
+                tracing::warn!("could not assess ticketbook readiness: {err}");
+                return;
+            }
+        };
+
+        tracing::debug!("Readiness snapshot : {:#?}", snapshot);
+
+        let requests = std::mem::take(&mut self.pending_readiness);
+
+        let still_waiting = requests
+            .into_iter()
+            .filter_map(|request| request.try_resolve(&snapshot))
+            .collect();
+
+        self.pending_readiness = still_waiting;
+    }
+
+    // ---------------------------------------------------------------------
+    // Global signing data (fetched & cached on demand)
+    // ---------------------------------------------------------------------
+
+    /// Returns the master verification key for the epoch, fetching it via the configured public
+    /// data fetcher and persisting it if it isn't already in local storage.
+    async fn ensure_master_verification_key(
+        &self,
+        epoch_id: EpochId,
+    ) -> Result<VerificationKeyAuth, BandwidthControllerError> {
+        if let Some(key) = self
+            .storage
+            .get_master_verification_key(epoch_id)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)?
+        {
+            return Ok(key);
+        }
+        let Some(fetcher) = &self.public_data_fetcher else {
+            return Err(BandwidthControllerError::MissingVerificationKey { epoch_id });
+        };
+        let key = fetcher
+            .fetch_master_verification_key(epoch_id)
+            .await
+            .map_err(BandwidthControllerError::fetcher_error)?;
+        self.storage
+            .insert_master_verification_key(&key)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)?;
+        Ok(key.key)
+    }
+
+    /// Returns the coin index signatures for the epoch, fetching them via the configured public
+    /// data fetcher and persisting them if they aren't already in local storage.
+    async fn ensure_coin_index_signatures(
+        &self,
+        epoch_id: EpochId,
+    ) -> Result<Vec<AnnotatedCoinIndexSignature>, BandwidthControllerError> {
+        if let Some(signatures) = self
+            .storage
+            .get_coin_index_signatures(epoch_id)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)?
+        {
+            return Ok(signatures);
+        }
+        let Some(fetcher) = &self.public_data_fetcher else {
+            return Err(BandwidthControllerError::MissingCoinIndexSignatures { epoch_id });
+        };
+        let signatures = fetcher
+            .fetch_coin_index_signatures(epoch_id)
+            .await
+            .map_err(BandwidthControllerError::fetcher_error)?;
+        self.storage
+            .insert_coin_index_signatures(&signatures)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)?;
+        Ok(signatures.signatures)
+    }
+
+    /// Returns the expiration date signatures for the epoch and expiration date, fetching them via
+    /// the configured public data fetcher and persisting them if they aren't already in local storage.
+    async fn ensure_expiration_date_signatures(
+        &self,
+        epoch_id: EpochId,
+        expiration_date: Date,
+    ) -> Result<Vec<AnnotatedExpirationDateSignature>, BandwidthControllerError> {
+        if let Some(signatures) = self
+            .storage
+            .get_expiration_date_signatures(expiration_date, epoch_id)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)?
+        {
+            return Ok(signatures);
+        }
+        let Some(fetcher) = &self.public_data_fetcher else {
+            return Err(BandwidthControllerError::MissingExpirationDateSignatures { epoch_id });
+        };
+        let signatures = fetcher
+            .fetch_expiration_date_signatures(expiration_date, epoch_id)
+            .await
+            .map_err(BandwidthControllerError::fetcher_error)?;
+        self.storage
+            .insert_expiration_date_signatures(&signatures)
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)?;
+        Ok(signatures.signatures)
+    }
+
+    /// Ensures the global signing data (master key, coin-index and expiration-date signatures) is
+    /// present locally for every epoch/expiration referenced by a stored ticketbook, fetching
+    /// whatever is missing.
+    ///
+    /// Best-effort: each missing piece is fetched independently and failures are logged, so one
+    /// failure never blocks the rest.
+    async fn ensure_global_data(&self) {
+        let ticketbooks = match self.storage.get_ticketbooks_info().await {
+            Ok(ticketbooks) => ticketbooks,
+            Err(err) => {
+                tracing::warn!("could not read ticketbooks to ensure global data: {err}");
+                return;
+            }
+        };
+
+        // master key and coin-index signatures are per-epoch
+        let epochs = ticketbooks
+            .iter()
+            .map(|ticketbook| EpochId::from(ticketbook.epoch_id))
+            .collect::<HashSet<_>>();
+        for epoch_id in epochs {
+            if let Err(err) = self.ensure_master_verification_key(epoch_id).await {
+                tracing::warn!(
+                    "failed to ensure master verification key for epoch {epoch_id}: {err}"
+                );
+            }
+            if let Err(err) = self.ensure_coin_index_signatures(epoch_id).await {
+                tracing::warn!(
+                    "failed to ensure coin index signatures for epoch {epoch_id}: {err}"
+                );
+            }
+        }
+
+        // expiration-date signatures are keyed by (epoch, expiration date)
+        let expirations = ticketbooks
+            .iter()
+            .map(|ticketbook| {
+                (
+                    EpochId::from(ticketbook.epoch_id),
+                    ticketbook.expiration_date,
+                )
+            })
+            .collect::<HashSet<_>>();
+        for (epoch_id, expiration_date) in expirations {
+            if let Err(err) = self
+                .ensure_expiration_date_signatures(epoch_id, expiration_date)
+                .await
+            {
+                tracing::warn!(
+                    "failed to ensure expiration date signatures for epoch {epoch_id}: {err}"
+                );
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Storage queries & diagnostics
+    // ---------------------------------------------------------------------
+
     async fn get_upgrade_mode_token(&self) -> Result<Option<String>, BandwidthControllerError> {
         let Some(emergency_credential) = self
             .storage
@@ -295,49 +840,34 @@ impl<St: Storage> BandwidthController<St> {
         Ok(Some(token))
     }
 
-    /// Runs the controller event loop, handling incoming requests until the
-    /// request channel is closed or cancellation is requested.
-    pub async fn run(mut self, shutdown_token: ShutdownToken) {
-        loop {
-            tokio::select! {
-                biased;
-                _ = shutdown_token.cancelled() => {
-                    log::debug!("bandwidth controller received cancellation request; shutting down");
-                    break;
-                }
-                request = self.request_channel.1.recv() => match request {
-                    Some(request) => self.handle_request(request).await,
-                    None => {
-                        log::warn!("bandwidth controller request channel closed; this should never happened as we are owning a sender; shutting down");
-                        break;
-                    }
-                }
-            }
-        }
-
-        self.storage.close().await;
+    async fn get_available_ticketbooks(
+        &self,
+    ) -> Result<AvailableTicketbooks, BandwidthControllerError> {
+        let ticketbooks_info = self
+            .storage
+            .get_ticketbooks_info()
+            .await
+            .map_err(BandwidthControllerError::credential_storage_error)?;
+        AvailableTicketbooks::try_from(ticketbooks_info)
     }
 
-    async fn handle_request(&mut self, request: BandwidthControllerRequest) {
-        match request {
-            BandwidthControllerRequest::EcashTicket(return_sender, request) => {
-                let credential_result = self
-                    .prepare_ecash_ticket(
-                        request.ticket_type,
-                        request.gateway_id.to_bytes(),
-                        request.tickets_to_spend,
-                        request.spend_time,
-                    )
-                    .await;
-                return_sender.send(credential_result)
-            }
-            BandwidthControllerRequest::UpgradeModeToken(return_sender) => {
-                return_sender.send(self.get_upgrade_mode_token().await)
-            }
-            BandwidthControllerRequest::AttemptRevertSpending(return_sender, metadata) => {
-                return_sender.send(self.attempt_revert_ticket_usage(metadata).await)
+    async fn print_info(&self) -> Result<(), BandwidthControllerError> {
+        let ticketbooks_info = self.get_available_ticketbooks().await?;
+        let num_ticketbooks = ticketbooks_info.len_not_expired();
+        let num_total_ticketbooks = ticketbooks_info.len();
+        tracing::info!("Ticketbooks stored: {num_ticketbooks}");
+        tracing::debug!("Total ticketbooks stored: {num_total_ticketbooks}");
+        for ticketbook in ticketbooks_info {
+            if ticketbook.has_expired() {
+                tracing::debug!("Expired ticketbook: {ticketbook}");
+            } else if ticketbook.expired_soon() {
+                tracing::info!("Soon expired ticketbook: {ticketbook}");
+            } else {
+                tracing::info!("Ticketbook: {ticketbook}");
             }
         }
+
+        Ok(())
     }
 }
 

--- a/common/bandwidth-controller/src/error.rs
+++ b/common/bandwidth-controller/src/error.rs
@@ -5,6 +5,8 @@ use nym_credentials::error::Error as CredentialsError;
 use nym_validator_client::{coconut::EcashApiError, nym_api::EpochId};
 use thiserror::Error;
 
+use crate::traits::CredentialFetcherError;
+
 #[derive(Debug, Error)]
 pub enum BandwidthControllerError {
     #[error("Nyxd error: {0}")]
@@ -17,7 +19,7 @@ pub enum BandwidthControllerError {
     CredentialStorageError(Box<dyn std::error::Error + Send + Sync>),
 
     #[error("a credential/global-data fetcher failed - {0}")]
-    FetcherError(Box<dyn std::error::Error + Send + Sync>),
+    CredentialFetcherError(CredentialFetcherError),
 
     #[error("No expiration date signatures for epoch : {epoch_id}")]
     MissingExpirationDateSignatures { epoch_id: EpochId },
@@ -27,6 +29,9 @@ pub enum BandwidthControllerError {
 
     #[error("No verification key for epoch : {epoch_id}")]
     MissingVerificationKey { epoch_id: EpochId },
+
+    #[error("No credential fetcher available")]
+    MissingCredentialFetcher,
 
     #[error("retrieved upgrade mode token is not a valid String")]
     MalformedUpgradeModeToken,
@@ -46,6 +51,18 @@ pub enum BandwidthControllerError {
 
     #[error("did not receive a valid response for aggregated data ({typ}) from ANY nym-api")]
     ExhaustedApiQueries { typ: String },
+
+    #[error("failed to parse ticket type: {0}")]
+    ParseTicketType(String),
+
+    /// A required type has no usable stock and nothing is being fetched for it - as opposed to a
+    /// fetch that actively failed (see [`Self::TicketbookFetchFailed`]).
+    #[error("some required ticketbooks are unavailable and none are being fetched")]
+    TicketbooksUnavailable,
+
+    /// A required type's fetch actively failed; `reason` is the underlying fetcher error as text.
+    #[error("a required ticketbook fetch failed : {reason}")]
+    TicketbookFetchFailed { reason: String },
 }
 
 impl BandwidthControllerError {
@@ -55,11 +72,27 @@ impl BandwidthControllerError {
         BandwidthControllerError::CredentialStorageError(Box::new(source))
     }
 
-    pub fn fetcher_error(source: Box<dyn std::error::Error + Send + Sync>) -> Self {
-        BandwidthControllerError::FetcherError(source)
+    pub fn fetcher_error(source: CredentialFetcherError) -> Self {
+        BandwidthControllerError::CredentialFetcherError(source)
     }
 
     pub fn internal(message: impl ToString) -> Self {
         BandwidthControllerError::Internal(message.to_string())
     }
+}
+
+/// Coarse category of a fetcher error, so the controller can react to specific cases; anything it
+/// doesn't special-case is `Other`.
+#[derive(Debug, Clone, Copy)]
+pub enum FetcherErrorKind {
+    /// the account lacks the funds to make further deposits
+    BandwidthDepleted,
+    /// a nym-api / ecash query failed
+    Api,
+    /// an unexpected failure that shouldn't normally happen
+    Unexpected,
+    /// a local storage failure
+    Storage,
+    /// anything not worth branching on
+    Other,
 }

--- a/common/bandwidth-controller/src/lib.rs
+++ b/common/bandwidth-controller/src/lib.rs
@@ -1,24 +1,26 @@
 // Copyright 2021-2024 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use nym_credentials::ecash::bandwidth::CredentialSpendingData;
-use nym_credentials_interface::TicketType;
+use nym_credentials::{ecash::bandwidth::CredentialSpendingData, IssuedTicketBook};
 use nym_crypto::asymmetric::ed25519;
 use nym_ecash_time::OffsetDateTime;
 use nym_validator_client::nym_api::EpochId;
 
 pub use controller::BandwidthController;
-pub use fetcher::NyxdGlobalDataFetcher;
-pub use traits::{BandwidthTicketProvider, FetcherError};
+pub use nym_credentials_interface::TicketType;
+pub use ticketbooks::AvailableTicketbooks;
+pub use traits::{
+    BandwidthTicketProvider, CredentialFetcher, CredentialFetcherError,
+    CredentialPublicDataFetcher, FetcherError,
+};
 
-pub mod acquire;
 mod controller;
 pub mod error;
-mod fetcher;
 pub mod mock;
+mod readiness;
 pub mod requests;
+mod ticketbooks;
 mod traits;
-mod utils;
 
 pub const DEFAULT_TICKETS_TO_SPEND: u32 = 1;
 
@@ -55,4 +57,12 @@ pub struct EcashTicketRequest {
     pub gateway_id: ed25519::PublicKey,
     pub tickets_to_spend: u32,
     pub spend_time: OffsetDateTime,
+}
+
+pub enum NymCredential {
+    Ticketbook(Box<IssuedTicketBook>),
+    UpgradeModeToken {
+        jwt: String,
+        expiration: OffsetDateTime,
+    },
 }

--- a/common/bandwidth-controller/src/readiness.rs
+++ b/common/bandwidth-controller/src/readiness.rs
@@ -1,0 +1,103 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use nym_credentials_interface::TicketType;
+
+use crate::{
+    error::BandwidthControllerError, requests::ReturnSender, traits::CredentialFetcherError,
+};
+
+/// Per-type readiness used to build a snapshot; variants are ordered by severity (see `severity`).
+#[derive(Clone, Debug)]
+pub(crate) enum ReadinessStatus {
+    Ready,
+    InFlight,
+    Unavailable,
+    /// unavailable because the last fetch failed; carries the reason for the waiter
+    FetchFailed(String),
+}
+
+impl ReadinessStatus {
+    // higher = worse; `evaluate_readiness` reports the most severe status across required types
+    fn severity(&self) -> u8 {
+        match self {
+            ReadinessStatus::Ready => 0,
+            ReadinessStatus::InFlight => 1,
+            ReadinessStatus::Unavailable => 2,
+            ReadinessStatus::FetchFailed(_) => 3,
+        }
+    }
+}
+
+/// A ticketbook fetch that just failed; folded into a snapshot so a waiting caller learns why.
+#[derive(Debug)]
+pub(crate) struct FetchFailure {
+    pub(crate) ticket_type: TicketType,
+    pub(crate) error: CredentialFetcherError,
+}
+
+/// The state readiness is judged against - built once and reused across a batch of waiters.
+#[derive(Debug)]
+pub(crate) struct ReadinessSnapshot {
+    pub(crate) upgrade_mode: bool,
+    pub(crate) tickets_readiness: HashMap<TicketType, ReadinessStatus>,
+}
+
+impl ReadinessSnapshot {
+    // Return the most severe ReadinessStatus across `required` (upgrade mode short-circuits to Ready)
+    fn evaluate_readiness(&self, required: &[TicketType]) -> ReadinessStatus {
+        if self.upgrade_mode {
+            return ReadinessStatus::Ready;
+        }
+        required
+            .iter()
+            .map(|typ| {
+                self.tickets_readiness
+                    .get(typ)
+                    .cloned()
+                    .unwrap_or(ReadinessStatus::Unavailable)
+            })
+            .max_by_key(|status| status.severity())
+            .unwrap_or(ReadinessStatus::Ready)
+    }
+}
+
+/// A parked `wait_for_ticketbooks` caller: its reply channel plus the types it needs usable.
+#[derive(Debug)]
+pub(crate) struct ReadinessRequest {
+    pub(crate) return_sender: ReturnSender<()>,
+    pub(crate) ticket_types: Vec<TicketType>,
+}
+
+impl ReadinessRequest {
+    /// Resolves against the snapshot: `Ok` once ready, an error once a required type is unavailable
+    /// (carrying the fetch failure reason when the snapshot recorded one), `Some(self)` while still
+    /// waiting on an in-flight fetch.
+    pub(crate) fn try_resolve(self, readiness_snapshot: &ReadinessSnapshot) -> Option<Self> {
+        match readiness_snapshot.evaluate_readiness(&self.ticket_types) {
+            ReadinessStatus::Ready => {
+                self.return_sender.send(Ok(()));
+                None
+            }
+            ReadinessStatus::InFlight => Some(self),
+            ReadinessStatus::Unavailable => {
+                self.return_sender
+                    .send(Err(BandwidthControllerError::TicketbooksUnavailable));
+                None
+            }
+            ReadinessStatus::FetchFailed(reason) => {
+                self.return_sender
+                    .send(Err(BandwidthControllerError::TicketbookFetchFailed { reason }));
+                None
+            }
+        }
+    }
+
+    /// Fails the waiter with `TicketbooksUnavailable`; used when the controller is reset.
+    pub(crate) fn cancel(self) {
+        self.return_sender
+            .send(Err(BandwidthControllerError::TicketbooksUnavailable));
+    }
+}

--- a/common/bandwidth-controller/src/requests/mod.rs
+++ b/common/bandwidth-controller/src/requests/mod.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    error::BandwidthControllerError, EcashTicketRequest, PreparedCredential,
+    error::BandwidthControllerError, ticketbooks::AvailableTicketbooks, traits::CredentialFetcher,
+    CredentialPublicDataFetcher, EcashTicketRequest, PreparedCredential,
     PreparedCredentialMetadata,
 };
+use nym_credentials_interface::TicketType;
+use std::sync::Arc;
 
 pub use sender::BandwidthControllerRequestSender;
 use tokio::sync::oneshot;
@@ -18,6 +21,25 @@ pub enum BandwidthControllerRequest {
     UpgradeModeToken(ReturnSender<Option<String>>),
 
     AttemptRevertSpending(ReturnSender<bool>, PreparedCredentialMetadata),
+
+    /// Sets (or clears, with `None`) the credential fetcher; a new one triggers an immediate restock.
+    SetCredentialFetcher(ReturnSender<()>, Option<Arc<dyn CredentialFetcher>>),
+    /// Sets (or clears, with `None`) the global-data fetcher.
+    SetPublicDataFetcher(
+        ReturnSender<()>,
+        Option<Arc<dyn CredentialPublicDataFetcher>>,
+    ),
+    /// Cancels in-flight fetches, drops the fetcher, clears all stored credentials, and fails every
+    /// parked readiness waiter.
+    Reset(ReturnSender<()>),
+    /// Removes the stored emergency (upgrade-mode) credentials only, leaving ticketbooks intact.
+    ClearEmergencyCredentials(ReturnSender<()>),
+    /// Returns the currently stored ticketbooks (also logs a stock summary).
+    GetAvailableTicketbooks(ReturnSender<AvailableTicketbooks>),
+
+    /// Resolves once every required ticket type is usable (stocked or covered by upgrade mode),
+    /// or fails if a required type is neither stocked nor being fetched.
+    WaitForTicketbooks(ReturnSender<()>, Vec<TicketType>),
 }
 
 #[derive(Debug)]

--- a/common/bandwidth-controller/src/requests/sender.rs
+++ b/common/bandwidth-controller/src/requests/sender.rs
@@ -11,8 +11,12 @@ use tracing::instrument;
 use crate::{
     error::BandwidthControllerError,
     requests::{BandwidthControllerRequest, ReturnSender},
-    BandwidthTicketProvider, EcashTicketRequest, PreparedCredential, PreparedCredentialMetadata,
+    ticketbooks::AvailableTicketbooks,
+    traits::CredentialFetcher,
+    BandwidthTicketProvider, CredentialPublicDataFetcher, EcashTicketRequest, PreparedCredential,
+    PreparedCredentialMetadata,
 };
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct BandwidthControllerRequestSender {
@@ -73,6 +77,106 @@ impl BandwidthControllerRequestSender {
             .map_err(|_| BandwidthControllerError::ChannelClosed)?;
         rx.await
             .map_err(|_| BandwidthControllerError::ChannelClosed)?
+    }
+
+    /// Installs the credential fetcher; the controller immediately restocks any low types.
+    #[instrument(skip(self, credential_fetcher))]
+    pub async fn set_credential_fetcher(
+        &self,
+        credential_fetcher: Arc<impl CredentialFetcher + 'static>,
+    ) -> Result<(), BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::SetCredentialFetcher(
+                tx,
+                Some(credential_fetcher),
+            ))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
+    }
+
+    /// Removes the credential fetcher; no further automatic restocking happens until one is set.
+    #[instrument(skip(self))]
+    pub async fn unset_credential_fetcher(&self) -> Result<(), BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::SetCredentialFetcher(tx, None))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
+    }
+
+    /// Installs the global-data fetcher used to retrieve missing ecash signing materials.
+    #[instrument(skip(self, public_data_fetcher))]
+    pub async fn set_public_data_fetcher(
+        &self,
+        public_data_fetcher: Arc<impl CredentialPublicDataFetcher + 'static>,
+    ) -> Result<(), BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::SetPublicDataFetcher(
+                tx,
+                Some(public_data_fetcher),
+            ))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
+    }
+
+    /// Removes the global-data fetcher.
+    #[instrument(skip(self))]
+    pub async fn unset_public_data_fetcher(&self) -> Result<(), BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::SetPublicDataFetcher(tx, None))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
+    }
+
+    /// Cancels in-flight fetches, drops the fetcher, clears stored credentials, and fails any parked
+    /// readiness waiters. Used to fully de-provision the controller.
+    #[instrument(skip(self))]
+    pub async fn reset(&self) -> Result<(), BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::Reset(tx))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
+    }
+
+    /// Removes stored emergency (upgrade-mode) credentials, leaving ticketbooks intact.
+    #[instrument(skip(self))]
+    pub async fn clear_emergency_credentials(&self) -> Result<(), BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::ClearEmergencyCredentials(tx))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
+    }
+
+    /// Returns the currently stored ticketbooks.
+    #[instrument(skip(self))]
+    pub async fn get_available_ticketbooks(
+        &self,
+    ) -> Result<AvailableTicketbooks, BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::GetAvailableTicketbooks(tx))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
+    }
+
+    /// Resolves once every listed type is usable (stocked or covered by upgrade mode). Errors if a
+    /// required type is neither stocked nor being fetched; otherwise waits while the unsatisfied
+    /// ones are still in flight.
+    #[instrument(skip(self))]
+    pub async fn wait_for_ticketbooks(
+        &self,
+        types: Vec<TicketType>,
+    ) -> Result<(), BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::WaitForTicketbooks(tx, types))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
     }
 }
 

--- a/common/bandwidth-controller/src/ticketbooks.rs
+++ b/common/bandwidth-controller/src/ticketbooks.rs
@@ -1,0 +1,210 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{fmt, time::Duration};
+
+use nym_credential_storage::models::BasicTicketbookInformation;
+use nym_credentials_interface::TicketType;
+use nym_ecash_time::{Date, EcashTime, OffsetDateTime};
+use strum::IntoEnumIterator;
+
+use crate::error::BandwidthControllerError;
+
+// If we go below this threshold, we should request more tickets
+const TICKET_NUMBER_THRESHOLD: u64 = 20;
+
+// If we go below this threshold, we can't proceed with a connection
+const TICKET_NUMBER_LOW_THRESHOLD: u64 = 5;
+
+// Threshold to determine if a ticket is soon expired
+const SOON_EXPIRY_THRESHOLD: Duration = Duration::from_secs(12 * 3600); // 12 hours
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AvailableTicketbook {
+    pub id: i64,
+    pub typ: TicketType,
+    pub expiration: Date,
+    pub issued_tickets: u32,
+    pub claimed_tickets: u32,
+    pub ticket_size: u64,
+}
+
+impl AvailableTicketbook {
+    pub fn issued_tickets_si(&self) -> String {
+        si_scale::helpers::bibytes2(self.issued_tickets as u64 * self.ticket_size)
+    }
+
+    pub fn remaining_tickets(&self) -> u32 {
+        self.issued_tickets.saturating_sub(self.claimed_tickets)
+    }
+
+    pub fn remaining_tickets_si(&self) -> String {
+        si_scale::helpers::bibytes2(self.remaining_tickets() as u64 * self.ticket_size)
+    }
+
+    pub fn ticket_size_si(&self) -> String {
+        si_scale::helpers::bibytes2(self.ticket_size)
+    }
+
+    pub fn has_expired(&self) -> bool {
+        self.expiration <= nym_ecash_time::ecash_today().date()
+    }
+
+    // If that ticketbook will be expired in SOON_EXPIRY_THRESHOLD
+    pub fn expired_soon(&self) -> bool {
+        self.expiration.ecash_datetime() < OffsetDateTime::now_utc() + SOON_EXPIRY_THRESHOLD
+    }
+}
+
+impl fmt::Display for AvailableTicketbook {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ecash_today = nym_ecash_time::ecash_today().date();
+
+        let expiration = if self.expiration <= ecash_today {
+            format!("EXPIRED ON: {}", self.expiration)
+        } else {
+            format!("expires: {}", self.expiration)
+        };
+
+        write!(
+            f,
+            "{{ id: {}, type: {}, tickets: {}/{}, size: {}, remaining: {}/{}, {} }}",
+            self.id,
+            self.typ,
+            self.remaining_tickets(),
+            self.issued_tickets,
+            self.ticket_size_si(),
+            self.remaining_tickets_si(),
+            self.issued_tickets_si(),
+            expiration
+        )
+    }
+}
+
+impl TryFrom<BasicTicketbookInformation> for AvailableTicketbook {
+    type Error = BandwidthControllerError;
+
+    fn try_from(value: BasicTicketbookInformation) -> Result<Self, Self::Error> {
+        let typ = value
+            .ticketbook_type
+            .parse()
+            .map_err(|_| BandwidthControllerError::ParseTicketType(value.ticketbook_type))?;
+        Ok(AvailableTicketbook {
+            id: value.id,
+            typ,
+            expiration: value.expiration_date,
+            issued_tickets: value.total_tickets,
+            claimed_tickets: value.used_tickets,
+            ticket_size: typ.to_repr().bandwidth_value(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AvailableTicketbooks {
+    pub ticketbooks: Vec<AvailableTicketbook>,
+}
+
+impl AvailableTicketbooks {
+    pub fn remaining_tickets(&self, typ: TicketType) -> u64 {
+        self.tickets_by_type(typ)
+            .filter(|ticketbook| !ticketbook.has_expired())
+            .map(|ticketbook| ticketbook.remaining_tickets())
+            .fold(0, |acc, remaining| acc.saturating_add(remaining.into()))
+    }
+
+    pub fn remaining_data(&self, typ: TicketType) -> u64 {
+        self.remaining_tickets(typ) * typ.to_repr().bandwidth_value()
+    }
+
+    pub fn remaining_data_si(&self, typ: TicketType) -> String {
+        si_scale::helpers::bibytes2(
+            self.remaining_tickets(typ) as f64 * typ.to_repr().bandwidth_value() as f64,
+        )
+    }
+
+    fn tickets_by_type(&self, typ: TicketType) -> impl Iterator<Item = &AvailableTicketbook> {
+        self.ticketbooks
+            .iter()
+            .filter(move |ticketbook| ticketbook.typ == typ)
+    }
+
+    pub fn remaining_tickets_long_lasting(&self, typ: TicketType) -> u64 {
+        self.tickets_by_type(typ)
+            .filter(|ticketbook| !ticketbook.expired_soon())
+            .map(|ticketbook| ticketbook.remaining_tickets())
+            .fold(0, |acc, remaining| acc.saturating_add(remaining.into()))
+    }
+
+    pub fn remaining_unexpired_tickets(&self, typ: TicketType) -> u64 {
+        self.tickets_by_type(typ)
+            .filter(|ticketbook| !ticketbook.has_expired())
+            .map(|ticketbook| ticketbook.remaining_tickets())
+            .fold(0, |acc, remaining| acc.saturating_add(remaining.into()))
+    }
+
+    /// Whether `typ` should be proactively restocked
+    pub fn needs_restock(&self, typ: TicketType) -> bool {
+        let remaining = self.remaining_tickets_long_lasting(typ);
+        remaining <= TICKET_NUMBER_THRESHOLD
+    }
+
+    pub fn contains_minimal_tickets(&self, typ: TicketType) -> bool {
+        let remaining = self.remaining_unexpired_tickets(typ);
+        remaining > TICKET_NUMBER_LOW_THRESHOLD
+    }
+
+    pub fn len(&self) -> usize {
+        self.ticketbooks.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ticketbooks.is_empty()
+    }
+
+    pub fn len_not_expired(&self) -> usize {
+        self.ticketbooks
+            .iter()
+            .filter(|ticketbook| !ticketbook.has_expired())
+            .count()
+    }
+
+    pub fn ticketbook_types() -> Vec<TicketType> {
+        // We don't include the mixnet exit ticket type as it's not used by the client
+        TicketType::iter()
+            .filter(|&t| t != TicketType::V1MixnetExit)
+            .collect()
+    }
+}
+
+impl Iterator for AvailableTicketbooks {
+    type Item = AvailableTicketbook;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.ticketbooks.pop()
+    }
+}
+
+impl From<Vec<AvailableTicketbook>> for AvailableTicketbooks {
+    fn from(ticketbooks: Vec<AvailableTicketbook>) -> Self {
+        Self { ticketbooks }
+    }
+}
+
+impl TryFrom<Vec<BasicTicketbookInformation>> for AvailableTicketbooks {
+    type Error = BandwidthControllerError;
+
+    fn try_from(value: Vec<BasicTicketbookInformation>) -> Result<Self, Self::Error> {
+        let ticketbooks: Vec<_> = value
+            .into_iter()
+            .filter_map(|ticketbook| {
+                AvailableTicketbook::try_from(ticketbook)
+                    .inspect_err(|err| {
+                        tracing::error!("Failed to parse ticketbook {err}");
+                    })
+                    .ok()
+            })
+            .collect();
+        Ok(AvailableTicketbooks::from(ticketbooks))
+    }
+}

--- a/common/bandwidth-controller/src/traits.rs
+++ b/common/bandwidth-controller/src/traits.rs
@@ -12,6 +12,8 @@ use nym_crypto::asymmetric::ed25519;
 use nym_ecash_time::{Date, OffsetDateTime};
 use nym_validator_client::nym_api::EpochId;
 
+use crate::error::FetcherErrorKind;
+use crate::NymCredential;
 use crate::{error::BandwidthControllerError, PreparedCredential, PreparedCredentialMetadata};
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -67,12 +69,42 @@ impl<T: BandwidthTicketProvider + ?Sized + Send> BandwidthTicketProvider for Box
     }
 }
 
-// This isn't an associated type because
-// a) it would make it dyn-incompatible and we want it
-// b) BandwidthController will pack everything its own variant anyway
+/// Boxed, dyn-compatible fetcher error. Deliberately a boxed trait object rather than an associated
+/// type on [`CredentialFetcher`]: an associated type would make the trait dyn-incompatible, and the
+/// controller wraps it in its own [`crate::error::BandwidthControllerError`] anyway.
+pub type CredentialFetcherError = Box<dyn FetcherError>;
 
 /// Error any fetcher implementation may return; the controller wraps it with context.
-pub type FetcherError = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub trait FetcherError: std::error::Error + Send + Sync + 'static {
+    /// Coarse category the controller can branch on without knowing the concrete error type.
+    fn kind(&self) -> FetcherErrorKind;
+}
+
+// so `?` converts any concrete fetcher error into the boxed form
+impl<E: FetcherError> From<E> for CredentialFetcherError {
+    fn from(e: E) -> Self {
+        Box::new(e)
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait CredentialFetcher: CredentialPublicDataFetcher + Send + Sync {
+    /// Fetches (or recovers) ticketbooks of the given type. The controller does **not** retry on
+    /// failure - retrying transient errors is the fetcher's responsibility. Recovery can yield
+    /// several ticketbooks of the same type, hence the `Vec`.
+    async fn fetch_ticketbooks(
+        &self,
+        ticketbook_type: TicketType,
+    ) -> Result<Vec<NymCredential>, CredentialFetcherError>;
+
+    /// Persists any in-progress state (e.g. closing storage) before the fetcher is dropped, such
+    /// that it can be resumed later.
+    async fn cleanup(&self);
+
+    /// Wipes the fetcher's long-term data (e.g. removes its storage).
+    async fn reset(self) -> Result<(), CredentialFetcherError>;
+}
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -80,16 +112,16 @@ pub trait CredentialPublicDataFetcher: Send + Sync {
     async fn fetch_master_verification_key(
         &self,
         epoch_id: EpochId,
-    ) -> Result<EpochVerificationKey, FetcherError>;
+    ) -> Result<EpochVerificationKey, CredentialFetcherError>;
 
     async fn fetch_coin_index_signatures(
         &self,
         epoch_id: EpochId,
-    ) -> Result<AggregatedCoinIndicesSignatures, FetcherError>;
+    ) -> Result<AggregatedCoinIndicesSignatures, CredentialFetcherError>;
 
     async fn fetch_expiration_date_signatures(
         &self,
         expiration_date: Date,
         epoch_id: EpochId,
-    ) -> Result<AggregatedExpirationDateSignatures, FetcherError>;
+    ) -> Result<AggregatedExpirationDateSignatures, CredentialFetcherError>;
 }


### PR DESCRIPTION
## Bandwidth controller: pluggable fetchers + auto-restock loop

First PR of the bandwidth-controller-step-2 stack. This reworks the
`BandwidthController` internals so credential acquisition and global-data
retrieval are delegated to **pluggable, storage-free fetchers**, and adds the
background loop that keeps ticket stocks topped up. No fetcher implementation
lives here yet (that's PR 2) — this is the controller-side contract and logic.

### What changes

**Fetcher traits (`traits.rs`)**
- `FetcherError` becomes a real trait (`std::error::Error + kind()`) instead of
  a bare boxed error. `CredentialFetcherError` is the boxed, dyn-compatible form,
  with a blanket `From` so `?` works on any concrete fetcher error.
- `FetcherErrorKind` (in `error.rs`) gives the controller a coarse category to
  branch on (`BandwidthDepleted`, `Api`, `Storage`, `Unexpected`, `Other`)
  without knowing the concrete error type.
- New `CredentialFetcher` trait: `fetch_ticketbooks`, `cleanup`, `reset`. It's a
  superset of `CredentialPublicDataFetcher`, so installing a credential fetcher
  also registers it for global-data retrieval.
- Fetchers are storage-free: they do only network/crypto work and hand results
  back for the controller to persist. The controller does **not** retry —
  transient-error handling is the fetcher's job.

**Controller (`controller.rs`)**
- The `BandwidthController` is now the **single writer** to credential storage;
  all acquisition/retrieval delegates to the two fetchers.
- Two ways to drive it:
  - `run()` — event loop. On native targets it proactively restocks low ticket
    types in the background (`JoinSet` of fetch tasks, `in_flight` dedup), keeps
    global data topped up, and resolves readiness waiters as fetches land.
  - direct one-shot calls (`fetch_ticketbook`, `prepare_ecash_ticket`) for use
    without spawning the loop.
- Builder-style config: `with_credential_fetcher`, `with_credential_public_data_fetcher`.

**Readiness (`readiness.rs`, new)**
- `wait_for_ticketbooks` support: callers park until every required ticket type
  is usable (stocked or covered by upgrade mode), or fail if a required type is
  neither stocked nor being fetched. Severity-ordered `ReadinessStatus` so a
  waiter learns *why* a type is unavailable (incl. the last fetch failure reason).

**Ticketbooks (`ticketbooks.rs`, new)**
- `AvailableTicketbook` / `AvailableTicketbooks` stock model with restock
  thresholds and SI-scaled reporting helpers.

**New request variants (`requests/mod.rs`)**
- `SetCredentialFetcher` / `SetPublicDataFetcher` (hot-swap; a new fetcher
  triggers an immediate restock), `Reset`, `ClearEmergencyCredentials`,
  `GetAvailableTicketbooks`, `WaitForTicketbooks`.

**`NymCredential`** — new enum: `Ticketbook` or `UpgradeModeToken { jwt, expiration }`.

### Notes
- The old inline `acquire`/`fetcher`/`utils` modules are still present here; they
  get removed in PR 3 once consumers are migrated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6938)
<!-- Reviewable:end -->
