### PR TITLE
feat: expose nym-api public keys + proof of possession

### DIFF
--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -90,13 +90,10 @@ pub const DIRECTORY_ATTESTATION_SOURCES: &[DirectoryAttestationSourceConst] = &[
         api_url: "https://nym-api-signer-2.nymtech.net/api",
         identity_ed25519_bs58: "2dJHDhUr5bRWxELMzZBZGVAW8cUHEJC1mGQYniKscQMo",
     },
-    // TODO: we need unconditional key exposure for this to work
-    // (currently https://validator.nymtech.net/api even though has an ed25519 key it does NOT expose
-    // it anywhere)
-    // DirectoryAttestationSourceConst {
-    //     api_url: "https://validator.nymtech.net/api",
-    //     identity_ed25519_bs58: "<UNKNOWN>",
-    // },
+    DirectoryAttestationSourceConst {
+        api_url: "https://validator.nymtech.net/api",
+        identity_ed25519_bs58: "Dp7x8TaSNyUX9k2n9A2v5yr6D5UHevhEegRu6aCiCC45",
+    },
 ];
 
 #[cfg(feature = "network")]

--- a/nym-api/nym-api-requests/src/models/api_status.rs
+++ b/nym-api/nym-api-requests/src/models/api_status.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::signable::{SignableMessageBody, SignedMessage};
+use nym_crypto::asymmetric::ed25519;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use utoipa::ToSchema;
@@ -66,3 +68,46 @@ pub struct SignerInformationResponse {
 
     pub verification_key: Option<String>,
 }
+
+// we only allow json and yaml responses so we can easily add additional fields later
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiInformationResponse {
+    #[schema(value_type = String)]
+    #[serde(with = "ed25519::bs58_ed25519_pubkey")]
+    pub identity: ed25519::PublicKey,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyPossessionChallenge {
+    pub nonce: [u8; 32],
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyPossessionChallengePlaintext {
+    version: u8,
+
+    #[serde(flatten)]
+    challenge: KeyPossessionChallenge,
+
+    purpose: &'static str,
+}
+
+impl KeyPossessionChallenge {
+    pub fn sign(&self, key: &ed25519::PrivateKey) -> KeyPossessionChallengeResponse {
+        self.plaintext_message().sign(key)
+    }
+
+    #[allow(clippy::expect_used)]
+    pub fn plaintext_message(&self) -> KeyPossessionChallengePlaintext {
+        KeyPossessionChallengePlaintext {
+            version: 1,
+            challenge: *self,
+            purpose: "key-possession-challenge",
+        }
+    }
+}
+
+pub type KeyPossessionChallengeResponse = SignedMessage<KeyPossessionChallengePlaintext>;

--- a/nym-api/nym-api-requests/src/signable.rs
+++ b/nym-api/nym-api-requests/src/signable.rs
@@ -56,7 +56,8 @@ pub(crate) mod sealed {
     use crate::ecash::models::*;
     use crate::models::network_monitor::v3::StressTestBatchSubmissionContent;
     use crate::models::{
-        ChainBlocksStatusResponseBody, DetailedSignersStatusResponseBody, SignersStatusResponseBody,
+        ChainBlocksStatusResponseBody, DetailedSignersStatusResponseBody,
+        KeyPossessionChallengePlaintext, SignersStatusResponseBody,
     };
 
     pub trait Sealed {}
@@ -76,4 +77,7 @@ pub(crate) mod sealed {
 
     // v3 stress testing
     impl Sealed for StressTestBatchSubmissionContent {}
+
+    // api key possession challenge
+    impl Sealed for KeyPossessionChallengePlaintext {}
 }

--- a/nym-api/src/ecash/state/local.rs
+++ b/nym-api/src/ecash/state/local.rs
@@ -135,7 +135,7 @@ impl DailyMerkleTree {
 
 pub(crate) struct LocalEcashState {
     pub(crate) ecash_keypair: KeyPair,
-    pub(crate) identity_keypair: ed25519::KeyPair,
+    pub(crate) identity_keypair: Arc<ed25519::KeyPair>,
 
     pub(crate) explicitly_disabled: bool,
 
@@ -153,7 +153,7 @@ pub(crate) struct LocalEcashState {
 impl LocalEcashState {
     pub(crate) fn new(
         ecash_keypair: KeyPair,
-        identity_keypair: ed25519::KeyPair,
+        identity_keypair: Arc<ed25519::KeyPair>,
         explicitly_disabled: bool,
     ) -> Self {
         LocalEcashState {

--- a/nym-api/src/ecash/state/mod.rs
+++ b/nym-api/src/ecash/state/mod.rs
@@ -51,6 +51,7 @@ use nym_validator_client::nyxd::AccountId;
 use nym_validator_client::EcashApiClient;
 use rand::{thread_rng, RngCore};
 use std::collections::HashMap;
+use std::sync::Arc;
 use time::{Date, OffsetDateTime};
 use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 use tokio::task::JoinHandle;
@@ -123,7 +124,7 @@ impl EcashState {
         global_config: &Config,
         contract_address: AccountId,
         client: C,
-        identity_keypair: ed25519::KeyPair,
+        identity_keypair: Arc<ed25519::KeyPair>,
         key_pair: KeyPair,
         comm_channel: D,
         storage: NymApiStorage,

--- a/nym-api/src/ecash/tests/mod.rs
+++ b/nym-api/src/ecash/tests/mod.rs
@@ -1284,7 +1284,7 @@ pub(crate) async fn build_dummy_ecash_state(
 ) -> DummyEcashBundle {
     let mut rng = crate::ecash::tests::fixtures::test_rng(rng_seed);
     let coconut_keypair = ttp_keygen(1, 1).unwrap().remove(0);
-    let identity = ed25519::KeyPair::new(&mut rng);
+    let identity = Arc::new(ed25519::KeyPair::new(&mut rng));
     let epoch = Arc::new(AtomicU64::new(1));
     let address = AccountId::from_str(TEST_REWARDING_VALIDATOR_ADDRESS).unwrap();
     let comm_channel = DummyCommunicationChannel::new_single_dummy(
@@ -1544,7 +1544,7 @@ mod credential_tests {
     #[tokio::test]
     async fn state_functions() {
         let mut rng = OsRng;
-        let identity = ed25519::KeyPair::new(&mut rng);
+        let identity = Arc::new(ed25519::KeyPair::new(&mut rng));
         let address = AccountId::from_str(TEST_REWARDING_VALIDATOR_ADDRESS).unwrap();
 
         let nyxd_client = DummyClient::new(address.clone(), Default::default());

--- a/nym-api/src/status/handlers.rs
+++ b/nym-api/src/status/handlers.rs
@@ -6,13 +6,14 @@ use crate::status::ApiStatusState;
 use crate::support::config::CHAIN_STALL_THRESHOLD;
 use crate::support::http::state::AppState;
 use axum::extract::{Query, State};
-use axum::Router;
+use axum::{Json, Router};
 use nym_api_requests::models::{
-    ApiHealthResponse, ApiStatus, ChainStatus, SignerInformationResponse,
+    ApiHealthResponse, ApiInformationResponse, ApiStatus, ChainStatus, KeyPossessionChallenge,
+    KeyPossessionChallengeResponse, SignerInformationResponse,
 };
 use nym_bin_common::build_information::BinaryBuildInformationOwned;
 use nym_compact_ecash::Base58;
-use nym_http_api_common::{FormattedResponse, OutputParams};
+use nym_http_api_common::{FormattedResponse, OutputParams, OutputParamsV2};
 use time::OffsetDateTime;
 
 pub(crate) fn api_status_routes() -> Router<AppState> {
@@ -22,6 +23,11 @@ pub(crate) fn api_status_routes() -> Router<AppState> {
         .route(
             "/signer-information",
             axum::routing::get(signer_information),
+        )
+        .route("/api-information", axum::routing::get(api_information))
+        .route(
+            "/prove_key_possession",
+            axum::routing::post(prove_key_possession),
         )
 }
 
@@ -119,4 +125,52 @@ async fn signer_information(
             .await
             .map(|maybe_vk| maybe_vk.to_bs58()),
     }))
+}
+
+#[utoipa::path(
+    tag = "API Status",
+    get,
+    path = "/api-information",
+    context_path = "/v1/api-status",
+    responses(
+        (status = 200, content(
+            (ApiInformationResponse = "application/json"),
+            (ApiInformationResponse = "application/yaml"),
+        ))
+    ),
+    params(
+        OutputParamsV2,
+    )
+)]
+async fn api_information(
+    Query(output): Query<OutputParamsV2>,
+    State(state): State<AppState>,
+) -> FormattedResponse<ApiInformationResponse> {
+    // we only allow json and yaml responses so we can easily add additional fields later
+    output.to_response(ApiInformationResponse {
+        identity: *state.identity_keypair.public_key(),
+    })
+}
+
+#[utoipa::path(
+    tag = "API Status",
+    post,
+    path = "/prove-key-possession",
+    context_path = "/v1/api-status",
+    responses(
+        (status = 200, content(
+            (KeyPossessionChallengeResponse = "application/json"),
+            (KeyPossessionChallengeResponse = "application/yaml"),
+        ))
+    ),
+    params(
+        OutputParamsV2,
+    )
+)]
+async fn prove_key_possession(
+    Query(output): Query<OutputParamsV2>,
+    State(state): State<AppState>,
+    Json(challenge): Json<KeyPossessionChallenge>,
+) -> FormattedResponse<KeyPossessionChallengeResponse> {
+    output.to_response(challenge.sign(state.identity_keypair.private_key()))
 }

--- a/nym-api/src/support/cli/run.rs
+++ b/nym-api/src/support/cli/run.rs
@@ -159,7 +159,7 @@ async fn start_nym_api_tasks(mut config: Config) -> anyhow::Result<ShutdownManag
 
     let storage = initialise_storage(&config).await?;
 
-    let identity_keypair = config.base.storage_paths.load_identity()?;
+    let identity_keypair = Arc::new(config.base.storage_paths.load_identity()?);
     let identity_public_key = *identity_keypair.public_key();
 
     let mix_denom = network_details.network.chain_details.mix_denom.base.clone();
@@ -244,7 +244,7 @@ async fn start_nym_api_tasks(mut config: Config) -> anyhow::Result<ShutdownManag
         &config,
         ecash_contract,
         nyxd_client.clone(),
-        identity_keypair,
+        identity_keypair.clone(),
         ecash_keypair_wrapper.clone(),
         comm_channel,
         storage.clone(),
@@ -406,6 +406,7 @@ async fn start_nym_api_tasks(mut config: Config) -> anyhow::Result<ShutdownManag
         config.base.utility_routes_bearer.take(),
     )
     .with_state(AppState {
+        identity_keypair,
         nyxd_client,
         chain_status_cache: ChainStatusCache::new(DEFAULT_CHAIN_STATUS_CACHE_TTL),
         ecash_signers_cache,

--- a/nym-api/src/support/http/state/mod.rs
+++ b/nym-api/src/support/http/state/mod.rs
@@ -41,6 +41,9 @@ pub(crate) mod test_helpers;
 
 #[derive(Clone)]
 pub(crate) struct AppState {
+    /// Identity of this nym-api instance.
+    pub(crate) identity_keypair: Arc<ed25519::KeyPair>,
+
     // ideally this would have been made generic to make tests easier,
     // however, it'd be a way bigger change (I tried)
     /// Instance of a client used for interacting with the nyx chain.

--- a/nym-api/src/support/http/state/test_helpers.rs
+++ b/nym-api/src/support/http/state/test_helpers.rs
@@ -46,6 +46,7 @@ pub(crate) fn build_app_state(
         NodeAnnotationsCache::new(node_status_cache, RefreshRequester::default());
 
     AppState {
+        identity_keypair: ecash_state.local.identity_keypair.clone(),
         nyxd_client,
         chain_status_cache: ChainStatusCache::new(Duration::from_secs(42)),
         ecash_signers_cache: Default::default(),


### PR DESCRIPTION
small PR to unconditionally expose an endpoint with nym-api public (ed25519) key without requiring it to be a signer. it also introduces an endpoint for providing proof of possession of the key

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6949)
<!-- Reviewable:end -->
