### PR TITLE
bugfix: allow single topology retrieval retry upon data being fetched across epochs

### DIFF
--- a/common/client-core/src/client/topology_control/nym_api_provider.rs
+++ b/common/client-core/src/client/topology_control/nym_api_provider.rs
@@ -118,6 +118,18 @@ impl NymApiTopologyProvider {
         let metadata = all_nodes_res.metadata;
         let all_nodes = all_nodes_res.nodes;
 
+        if rewarded_set.epoch_id != metadata.absolute_epoch_id {
+            // while technically the requests did succeed, they still returned data across epochs
+            // so the responses were internally inconsistent
+            return Err(NymAPIError::InternalResponseInconsistency {
+                url: self.validator_client.current_url().clone().into(),
+                details: format!(
+                    "retrieved rewarded set information for different epoch than the nodes details {} and {}",
+                    rewarded_set.epoch_id, metadata.absolute_epoch_id
+                ),
+            });
+        }
+
         debug!(
             "there are {} nodes on the network (before filtering)",
             all_nodes.len()
@@ -170,6 +182,18 @@ impl NymApiTopologyProvider {
             return Err(NymAPIError::InternalResponseInconsistency {
                 url: self.validator_client.current_url().clone().into(),
                 details: msg,
+            });
+        }
+
+        // finally, compare epoch for the rewarded set and the nodes
+        // (we might have got rewarded set for epoch 123, but mixnodes AND gateways for 124
+        if rewarded_set.epoch_id != metadata.absolute_epoch_id {
+            return Err(NymAPIError::InternalResponseInconsistency {
+                url: self.validator_client.current_url().clone().into(),
+                details: format!(
+                    "retrieved rewarded set information for different epoch than the nodes details {} and {}",
+                    rewarded_set.epoch_id, metadata.absolute_epoch_id
+                ),
             });
         }
 

--- a/common/client-core/src/client/topology_control/nym_api_provider.rs
+++ b/common/client-core/src/client/topology_control/nym_api_provider.rs
@@ -6,6 +6,7 @@ use nym_mixnet_contract_common::EpochRewardedSet;
 use nym_topology::NymTopology;
 use nym_topology::provider_trait::{ToTopologyMetadata, TopologyProvider};
 use nym_validator_client::nym_api::NymApiClientExt;
+use nym_validator_client::nym_api::error::NymAPIError;
 use rand::prelude::SliceRandom;
 use rand::thread_rng;
 use std::cmp::min;
@@ -104,93 +105,132 @@ impl NymApiTopologyProvider {
         self.validator_client.change_base_urls(rotated_urls)
     }
 
-    async fn get_current_compatible_topology(&mut self) -> Option<NymTopology> {
+    async fn try_get_extended_topology(&mut self) -> Result<NymTopology, NymAPIError> {
+        let rewarded_set_fut = self.validator_client.get_current_rewarded_set();
+        let all_nodes_fut = self.validator_client.get_all_basic_nodes_with_metadata();
+
+        // Join rewarded_set_fut and all_nodes_fut concurrently
+        let (rewarded_set, all_nodes_res) = futures::try_join!(rewarded_set_fut, all_nodes_fut)
+            .inspect_err(|err| {
+                error!("failed to get network nodes: {err}");
+            })?;
+
+        let metadata = all_nodes_res.metadata;
+        let all_nodes = all_nodes_res.nodes;
+
+        debug!(
+            "there are {} nodes on the network (before filtering)",
+            all_nodes.len()
+        );
+        let nodes_filtered = all_nodes
+            .into_iter()
+            .filter(|n| n.performance.round_to_integer() >= self.config.min_node_performance())
+            .collect::<Vec<_>>();
+
+        let epoch_rewarded_set: EpochRewardedSet = rewarded_set.into();
+        Ok(NymTopology::new(
+            metadata.to_topology_metadata(),
+            epoch_rewarded_set,
+            Vec::new(),
+        )
+        .with_skimmed_nodes(&nodes_filtered))
+    }
+
+    async fn try_get_active_topology(&mut self) -> Result<NymTopology, NymAPIError> {
         let rewarded_set_fut = self.validator_client.get_current_rewarded_set();
 
-        let topology = if self.config.use_extended_topology {
-            let all_nodes_fut = self.validator_client.get_all_basic_nodes_with_metadata();
+        let mixnodes_fut = self
+            .validator_client
+            .get_all_basic_active_mixing_assigned_nodes_with_metadata();
 
-            // Join rewarded_set_fut and all_nodes_fut concurrently
-            let (rewarded_set, all_nodes_res) = futures::try_join!(rewarded_set_fut, all_nodes_fut)
-                .inspect_err(|err| error!("failed to get network nodes: {err}"))
-                .ok()?;
+        // TODO: we really should be getting ACTIVE gateways only
+        let gateways_fut = self
+            .validator_client
+            .get_all_basic_entry_assigned_nodes_with_metadata();
 
-            let metadata = all_nodes_res.metadata;
-            let all_nodes = all_nodes_res.nodes;
+        let (rewarded_set, mixnodes_res, gateways_res) =
+            futures::try_join!(rewarded_set_fut, mixnodes_fut, gateways_fut).inspect_err(
+                |err| {
+                    error!("failed to get network nodes: {err}");
+                },
+            )?;
 
-            debug!(
-                "there are {} nodes on the network (before filtering)",
-                all_nodes.len()
+        let metadata = mixnodes_res.metadata;
+        let mixnodes = mixnodes_res.nodes;
+
+        if !gateways_res.metadata.consistency_check(&metadata) {
+            let msg = format!(
+                "inconsistent nodes metadata between mixnodes and gateways calls! {metadata:?} and {:?}",
+                gateways_res.metadata
             );
-            let nodes_filtered = all_nodes
-                .into_iter()
-                .filter(|n| n.performance.round_to_integer() >= self.config.min_node_performance())
-                .collect::<Vec<_>>();
+            warn!("{msg}");
 
-            let epoch_rewarded_set: EpochRewardedSet = rewarded_set.into();
-            NymTopology::new(
-                metadata.to_topology_metadata(),
-                epoch_rewarded_set,
-                Vec::new(),
-            )
-            .with_skimmed_nodes(&nodes_filtered)
+            // while technically the requests did succeed, they still returned data across epochs
+            // so the responses were internally inconsistent
+            return Err(NymAPIError::InternalResponseInconsistency {
+                url: self.validator_client.current_url().clone().into(),
+                details: msg,
+            });
+        }
+
+        let gateways = gateways_res.nodes;
+
+        debug!(
+            "there are {} mixnodes and {} gateways in total (before performance filtering)",
+            mixnodes.len(),
+            gateways.len()
+        );
+
+        let mut nodes = Vec::new();
+        for mix in mixnodes {
+            if mix.performance.round_to_integer() >= self.config.min_mixnode_performance {
+                nodes.push(mix)
+            }
+        }
+        for gateway in gateways {
+            if gateway.performance.round_to_integer() >= self.config.min_gateway_performance {
+                nodes.push(gateway)
+            }
+        }
+
+        let epoch_rewarded_set: EpochRewardedSet = rewarded_set.into();
+        Ok(NymTopology::new(
+            metadata.to_topology_metadata(),
+            epoch_rewarded_set,
+            Vec::new(),
+        )
+        .with_skimmed_nodes(&nodes))
+    }
+
+    async fn get_current_compatible_topology_inner(&mut self) -> Result<NymTopology, NymAPIError> {
+        if self.config.use_extended_topology {
+            self.try_get_extended_topology().await
         } else {
             // if we're not using extended topology, we're only getting active set mixnodes and gateways
+            self.try_get_active_topology().await
+        }
+    }
 
-            let mixnodes_fut = self
-                .validator_client
-                .get_all_basic_active_mixing_assigned_nodes_with_metadata();
-
-            // TODO: we really should be getting ACTIVE gateways only
-            let gateways_fut = self
-                .validator_client
-                .get_all_basic_entry_assigned_nodes_with_metadata();
-
-            let (rewarded_set, mixnodes_res, gateways_res) =
-                futures::try_join!(rewarded_set_fut, mixnodes_fut, gateways_fut)
-                    .inspect_err(|err| {
-                        error!("failed to get network nodes: {err}");
-                    })
-                    .ok()?;
-
-            let metadata = mixnodes_res.metadata;
-            let mixnodes = mixnodes_res.nodes;
-
-            if !gateways_res.metadata.consistency_check(&metadata) {
-                warn!(
-                    "inconsistent nodes metadata between mixnodes and gateways calls! {metadata:?} and {:?}",
-                    gateways_res.metadata
-                );
-                return None;
-            }
-
-            let gateways = gateways_res.nodes;
-
-            debug!(
-                "there are {} mixnodes and {} gateways in total (before performance filtering)",
-                mixnodes.len(),
-                gateways.len()
-            );
-
-            let mut nodes = Vec::new();
-            for mix in mixnodes {
-                if mix.performance.round_to_integer() >= self.config.min_mixnode_performance {
-                    nodes.push(mix)
+    async fn get_current_compatible_topology(&mut self) -> Option<NymTopology> {
+        let topology = match self.get_current_compatible_topology_inner().await {
+            Ok(topology) => topology,
+            Err(err) => {
+                // if the error is due to the data inconsistency, it means we made the requests across epoch boundaries
+                // and thus we can afford a single retry.
+                // note that we have to throw away all the data we might have retrieved,
+                // such as the rewarding set assignment (since it'd now correspond to the old epoch)
+                if err.is_data_inconsistency() {
+                    self.get_current_compatible_topology_inner()
+                        .await
+                        .inspect_err(|err| {
+                            error!("failed to retrieve network topology after retry: {err}")
+                        })
+                        .ok()?
+                } else {
+                    error!("failed to retrieve network topology: {err}");
+                    return None;
                 }
             }
-            for gateway in gateways {
-                if gateway.performance.round_to_integer() >= self.config.min_gateway_performance {
-                    nodes.push(gateway)
-                }
-            }
-
-            let epoch_rewarded_set: EpochRewardedSet = rewarded_set.into();
-            NymTopology::new(
-                metadata.to_topology_metadata(),
-                epoch_rewarded_set,
-                Vec::new(),
-            )
-            .with_skimmed_nodes(&nodes)
         };
 
         if !topology.is_minimally_routable() {

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -498,6 +498,10 @@ impl HttpClientError {
             source: ReqwestErrorWrapper(source),
         }
     }
+
+    pub fn is_data_inconsistency(&self) -> bool {
+        matches!(self, HttpClientError::InternalResponseInconsistency { .. })
+    }
 }
 
 /// Core functionality required for types acting as API clients.


### PR DESCRIPTION
…

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6951)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topology loading to better handle inconsistent server responses.
  * Added a safer retry path only when returned data is inconsistent.
  * Added stricter validation to detect mismatches between mixnode and gateway data earlier.
  * Reduced failures by cleanly returning no topology when data can’t be verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->