### PR TITLE
[BandwidthController ] Manual restock command

### DIFF
--- a/common/bandwidth-controller/src/controller.rs
+++ b/common/bandwidth-controller/src/controller.rs
@@ -226,6 +226,10 @@ impl<St: Storage> BandwidthController<St> {
             BandwidthControllerRequest::GetAvailableTicketbooks(return_sender) => {
                 return_sender.send(self.handle_get_available_ticketbooks().await)
             }
+            BandwidthControllerRequest::RestockTicketbooks(return_sender, ticket_types) => {
+                self.check_and_restock(ticket_types).await;
+                return_sender.send(Ok(()))
+            }
             BandwidthControllerRequest::WaitForTicketbooks(return_sender, ticket_types) => {
                 self.handle_wait_for_ticketbooks(ReadinessRequest {
                     return_sender,

--- a/common/bandwidth-controller/src/requests/mod.rs
+++ b/common/bandwidth-controller/src/requests/mod.rs
@@ -37,6 +37,13 @@ pub enum BandwidthControllerRequest {
     /// Returns the currently stored ticketbooks (also logs a stock summary).
     GetAvailableTicketbooks(ReturnSender<AvailableTicketbooks>),
 
+    /// Checks the given ticket types and kicks off a background restock for any running low or
+    /// about to expire. Resolves once the check has been scheduled, not once the fetches finish.
+    ///
+    /// Not to be used lightly: the automatic triggers (ticket handout, timer, fetcher install)
+    /// already keep every type stocked. This is a manual safety valve, not a routine call.
+    RestockTicketbooks(ReturnSender<()>, Vec<TicketType>),
+
     /// Resolves once every required ticket type is usable (stocked or covered by upgrade mode),
     /// or fails if a required type is neither stocked nor being fetched.
     WaitForTicketbooks(ReturnSender<()>, Vec<TicketType>),
@@ -62,8 +69,8 @@ where
     {
         self.sender
             .send(response)
-            .inspect_err(|err| {
-                tracing::error!("Failed to send response: {:#?}", err);
+            .inspect_err(|_| {
+                tracing::warn!("Failed to send response, receiver is gone already");
             })
             .ok();
     }

--- a/common/bandwidth-controller/src/requests/sender.rs
+++ b/common/bandwidth-controller/src/requests/sender.rs
@@ -171,6 +171,32 @@ impl BandwidthControllerRequestSender {
             .map_err(|_| BandwidthControllerError::ChannelClosed)?
     }
 
+    /// Kicks off a background restock for the given ticket types
+    /// Returns once the restock is scheduled - it does not wait for the fetches to finish
+    /// (use [`Self::wait_for_ticketbooks`] for that).
+    ///
+    /// Not to be used lightly: the automatic triggers (ticket handout, timer, fetcher install)
+    /// already keep every type stocked. This is a manual safety valve, not a routine call.
+    #[instrument(skip(self))]
+    pub async fn restock_ticketbooks(
+        &self,
+        types: Vec<TicketType>,
+    ) -> Result<(), BandwidthControllerError> {
+        let (tx, rx) = ReturnSender::new();
+        self.command_tx
+            .send(BandwidthControllerRequest::RestockTicketbooks(tx, types))
+            .map_err(BandwidthControllerError::internal)?;
+        rx.await.map_err(BandwidthControllerError::internal)?
+    }
+
+    /// Kicks off a background restock for every ticket type running low or about to expire.
+    /// Returns once the restock is scheduled, not once the fetches finish.
+    #[instrument(skip(self))]
+    pub async fn restock_all_ticketbooks(&self) -> Result<(), BandwidthControllerError> {
+        self.restock_ticketbooks(AvailableTicketbooks::ticketbook_types())
+            .await
+    }
+
     /// Resolves once every listed type is usable (stocked or covered by upgrade mode). Errors if a
     /// required type is neither stocked nor being fetched; otherwise waits while the unsatisfied
     /// ones are still in flight.


### PR DESCRIPTION
## Add a manual restock command to the BandwidthController

Adds a `RestockTicketbooks` request so callers can explicitly ask the
`BandwidthController` to top up ticketbooks, alongside the existing automatic
triggers (ticket handout, timer, fetcher install).

### API
- `BandwidthControllerRequestSender::restock_ticketbooks(types)` — restock a given set of ticket types
- `BandwidthControllerRequestSender::restock_all_ticketbooks()` — restock every type

### Behaviour
- Routes through the existing `check_and_restock`, so it's **threshold-aware**: a fetch is only spawned for types actually running low or about to expire, and duplicate fetches are deduped against in-flight ones.
- Returns as soon as the restock is *scheduled*, not once fetches land — pair with `wait_for_ticketbooks` to block until ready.

### Notes
This is a manual safety valve, not a routine call: the automatic triggers already keep every type stocked, and each fetch is a potentially expensive provisioning operation depending on the fetcher. Documented as such on both the request and the sender methods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6952)
<!-- Reviewable:end -->
