### PR TITLE
bandwidth controller: allow scoping ticketbook acquisition to specific types

### DIFF
--- a/common/bandwidth-controller/src/config.rs
+++ b/common/bandwidth-controller/src/config.rs
@@ -3,7 +3,11 @@
 
 use std::time::Duration;
 
-#[derive(Debug, Clone, Copy)]
+use nym_credentials_interface::TicketType;
+
+use crate::ticketbooks::AvailableTicketbooks;
+
+#[derive(Debug, Clone)]
 pub struct BandwidthControllerConfig {
     // How often the controller proactively checks whether any ticket type needs restocking.
     pub topup_interval: Duration,
@@ -15,6 +19,13 @@ pub struct BandwidthControllerConfig {
 
     // If we go below this threshold, we should request more tickets
     pub min_nb_ticket_needed: u64,
+
+    // Ticket types the controller proactively restocks: the periodic sweep, the post-spend top-up,
+    // and the restock triggered when a credential fetcher is installed. Defaults to every
+    // non-mixnet-exit type. Set to an empty vec to disable proactive restocking entirely — a
+    // credential fetcher can still be installed to serve on-demand / explicit fetches without the
+    // controller ever depositing on its own.
+    pub managed_ticket_types: Vec<TicketType>,
 }
 
 impl Default for BandwidthControllerConfig {
@@ -24,6 +35,7 @@ impl Default for BandwidthControllerConfig {
             soon_expiry_threshold: Duration::from_secs(12 * 3600), // 12 hours,
             nb_ticket_restock: 20,
             min_nb_ticket_needed: 5,
+            managed_ticket_types: AvailableTicketbooks::ticketbook_types(),
         }
     }
 }

--- a/common/bandwidth-controller/src/controller.rs
+++ b/common/bandwidth-controller/src/controller.rs
@@ -155,7 +155,7 @@ impl<St: Storage> BandwidthController<St> {
                 _ = topup_interval.tick() => {
                     let _ = self.print_info().await;
                     self.ensure_global_data().await;
-                    self.check_and_restock(AvailableTicketbooks::ticketbook_types()).await;
+                    self.check_and_restock(self.config.managed_ticket_types.clone()).await;
                 }
                 (typ, res) = self.in_flight.next_result(), if !self.in_flight.is_empty() => {
                     self.on_fetch_complete(typ, res).await;
@@ -195,8 +195,12 @@ impl<St: Storage> BandwidthController<St> {
                     )
                     .await;
                 return_sender.send(credential_result);
-                // a ticket was just requested for this type - top it up if it's now running low
-                self.check_and_restock(vec![ticket_type]).await;
+                // a ticket was just requested for this type - top it up if it's now running low, but
+                // only if it's a managed type (don't start depositing for a type this controller
+                // isn't configured to proactively restock, e.g. a leftover ticketbook of another kind)
+                if self.config.managed_ticket_types.contains(&ticket_type) {
+                    self.check_and_restock(vec![ticket_type]).await;
+                }
             }
             BandwidthControllerRequest::UpgradeModeToken(return_sender) => {
                 return_sender.send(self.get_upgrade_mode_token().await)
@@ -246,7 +250,7 @@ impl<St: Storage> BandwidthController<St> {
             .clone()
             .map(|f| f as Arc<dyn CredentialPublicDataFetcher>);
         self.credential_fetcher = fetcher;
-        self.check_and_restock(AvailableTicketbooks::ticketbook_types())
+        self.check_and_restock(self.config.managed_ticket_types.clone())
             .await;
     }
 
@@ -441,7 +445,7 @@ impl<St: Storage> BandwidthController<St> {
 
         for typ in ticketbook_types {
             tracing::debug!("Checking credential stock for {typ} ticket");
-            if available.needs_restock(typ, self.config) {
+            if available.needs_restock(typ, &self.config) {
                 tracing::debug!("{typ} tickets need a restock");
                 self.ensure_stocked(typ);
             }
@@ -570,7 +574,7 @@ impl<St: Storage> BandwidthController<St> {
 
         let mut tickets_readiness = HashMap::new();
         for typ in AvailableTicketbooks::ticketbook_types() {
-            let status = if available.contains_minimal_tickets(typ, self.config) {
+            let status = if available.contains_minimal_tickets(typ, &self.config) {
                 ReadinessStatus::Ready
             } else if self.is_in_flight(typ) {
                 ReadinessStatus::InFlight
@@ -801,7 +805,7 @@ impl<St: Storage> BandwidthController<St> {
         for ticketbook in ticketbooks_info {
             if ticketbook.has_expired() {
                 tracing::debug!("Expired ticketbook: {ticketbook}");
-            } else if ticketbook.expired_soon(OffsetDateTime::now_utc(), self.config) {
+            } else if ticketbook.expired_soon(OffsetDateTime::now_utc(), &self.config) {
                 tracing::info!("Soon expired ticketbook: {ticketbook}");
             } else {
                 tracing::info!("Ticketbook: {ticketbook}");

--- a/common/bandwidth-controller/src/ticketbooks.rs
+++ b/common/bandwidth-controller/src/ticketbooks.rs
@@ -45,7 +45,7 @@ impl AvailableTicketbook {
     pub fn expired_soon(
         &self,
         datetime: OffsetDateTime,
-        bc_config: BandwidthControllerConfig,
+        bc_config: &BandwidthControllerConfig,
     ) -> bool {
         self.expiration.ecash_datetime() < datetime + bc_config.soon_expiry_threshold
     }
@@ -125,7 +125,7 @@ impl AvailableTicketbooks {
     pub fn remaining_tickets_long_lasting(
         &self,
         typ: TicketType,
-        bc_config: BandwidthControllerConfig,
+        bc_config: &BandwidthControllerConfig,
     ) -> u64 {
         self.tickets_by_type(typ)
             .filter(|ticketbook| !ticketbook.expired_soon(OffsetDateTime::now_utc(), bc_config))
@@ -141,7 +141,7 @@ impl AvailableTicketbooks {
     }
 
     /// Whether `typ` should be proactively restocked
-    pub fn needs_restock(&self, typ: TicketType, bc_config: BandwidthControllerConfig) -> bool {
+    pub fn needs_restock(&self, typ: TicketType, bc_config: &BandwidthControllerConfig) -> bool {
         let remaining = self.remaining_tickets_long_lasting(typ, bc_config);
         remaining <= bc_config.nb_ticket_restock
     }
@@ -149,7 +149,7 @@ impl AvailableTicketbooks {
     pub fn contains_minimal_tickets(
         &self,
         typ: TicketType,
-        bc_config: BandwidthControllerConfig,
+        bc_config: &BandwidthControllerConfig,
     ) -> bool {
         let remaining = self.remaining_unexpired_tickets(typ);
         remaining > bc_config.min_nb_ticket_needed

--- a/common/bandwidth-controller/tests/managed_ticket_types.rs
+++ b/common/bandwidth-controller/tests/managed_ticket_types.rs
@@ -1,0 +1,198 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Proves the controller only proactively restocks (and therefore only deposits for) the ticket
+//! types in `BandwidthControllerConfig::managed_ticket_types`. A wireguard-scoped controller must
+//! never deposit for mixnet types, and an empty managed set must never deposit at all.
+
+// Test code legitimately asserts/`expect`s on setup; the workspace denies `expect_used`
+// (see `mock.rs` for the same allowance). The mutex locks below are poisoned-lock-safe (no unwrap).
+#![allow(clippy::expect_used)]
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use nym_bandwidth_controller::config::BandwidthControllerConfig;
+use nym_bandwidth_controller::error::FetcherErrorKind;
+use nym_bandwidth_controller::{
+    BandwidthController, CredentialFetcher, CredentialFetcherError, CredentialPublicDataFetcher,
+    FetcherError, NymCredential, TicketType,
+};
+use nym_credential_storage::initialise_ephemeral_storage;
+use nym_task::ShutdownToken;
+
+/// Records every ticket type it is asked to fetch, and returns no credentials (so the controller's
+/// stock never actually rises and the recording reflects exactly what the restock logic requested).
+#[derive(Default)]
+struct RecordingFetcher {
+    requested: Arc<Mutex<Vec<TicketType>>>,
+}
+
+impl RecordingFetcher {
+    fn record(&self, ticketbook_type: TicketType) {
+        // Recover a poisoned lock rather than `unwrap()` (CI denies `clippy::unwrap-used`).
+        self.requested
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(ticketbook_type);
+    }
+}
+
+/// Snapshot the recorded requests without `unwrap()` on a possibly-poisoned lock.
+fn recorded(requested: &Arc<Mutex<Vec<TicketType>>>) -> Vec<TicketType> {
+    requested
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("unused test fetcher error")]
+struct TestFetcherError;
+
+impl FetcherError for TestFetcherError {
+    fn kind(&self) -> FetcherErrorKind {
+        FetcherErrorKind::Other
+    }
+}
+
+#[async_trait]
+impl CredentialFetcher for RecordingFetcher {
+    async fn fetch_ticketbooks(
+        &self,
+        ticketbook_type: TicketType,
+    ) -> Result<Vec<NymCredential>, CredentialFetcherError> {
+        self.record(ticketbook_type);
+        Ok(Vec::new())
+    }
+
+    async fn cleanup(&self) {}
+
+    async fn reset(self) -> Result<(), CredentialFetcherError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl CredentialPublicDataFetcher for RecordingFetcher {
+    async fn fetch_master_verification_key(
+        &self,
+        _epoch_id: u64,
+    ) -> Result<nym_credentials::EpochVerificationKey, CredentialFetcherError> {
+        Err(Box::new(TestFetcherError))
+    }
+
+    async fn fetch_coin_index_signatures(
+        &self,
+        _epoch_id: u64,
+    ) -> Result<nym_credentials::AggregatedCoinIndicesSignatures, CredentialFetcherError> {
+        Err(Box::new(TestFetcherError))
+    }
+
+    async fn fetch_expiration_date_signatures(
+        &self,
+        _expiration_date: nym_ecash_time::Date,
+        _epoch_id: u64,
+    ) -> Result<nym_credentials::AggregatedExpirationDateSignatures, CredentialFetcherError> {
+        Err(Box::new(TestFetcherError))
+    }
+}
+
+fn config_with_managed(managed: Vec<TicketType>) -> BandwidthControllerConfig {
+    BandwidthControllerConfig {
+        managed_ticket_types: managed,
+        ..Default::default()
+    }
+}
+
+/// Installing a fetcher into a controller scoped (via config) to the wireguard ticket types must
+/// trigger restock requests only for those types — never for mixnet types.
+#[tokio::test]
+async fn scoped_controller_restocks_only_managed_types() {
+    let storage = initialise_ephemeral_storage();
+    let requested = Arc::new(Mutex::new(Vec::new()));
+    let fetcher = RecordingFetcher {
+        requested: requested.clone(),
+    };
+
+    let managed = vec![TicketType::V1WireguardEntry, TicketType::V1WireguardExit];
+    let controller =
+        BandwidthController::new(storage).with_config(config_with_managed(managed.clone()));
+    let sender = controller.get_request_sender();
+
+    let shutdown = ShutdownToken::new();
+    let run_handle = tokio::spawn({
+        let shutdown = shutdown.clone();
+        async move { controller.run(shutdown).await }
+    });
+
+    // installing the fetcher immediately restocks any low managed type (all are low on empty storage)
+    sender
+        .set_credential_fetcher(Arc::new(fetcher))
+        .await
+        .expect("set fetcher");
+
+    // wait for the spawned restock fetches to run and be recorded
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let seen: HashSet<_> = recorded(&requested).into_iter().collect();
+        if seen.len() >= managed.len() {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for restock fetches"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let seen: HashSet<_> = recorded(&requested).into_iter().collect();
+    assert_eq!(
+        seen,
+        managed.into_iter().collect::<HashSet<_>>(),
+        "restock requested exactly the managed types"
+    );
+    // the hard guarantee: no mixnet ticket type was ever requested
+    assert!(!seen.contains(&TicketType::V1MixnetEntry));
+    assert!(!seen.contains(&TicketType::V1MixnetExit));
+
+    shutdown.cancel();
+    let _ = run_handle.await;
+}
+
+/// With an empty managed set, installing a fetcher must NOT trigger any background deposit — the
+/// controller only spends existing stock. This backs the session's opt-out (no auto-restock) mode.
+#[tokio::test]
+async fn empty_managed_set_makes_no_deposits() {
+    let storage = initialise_ephemeral_storage();
+    let requested = Arc::new(Mutex::new(Vec::new()));
+    let fetcher = RecordingFetcher {
+        requested: requested.clone(),
+    };
+
+    let controller = BandwidthController::new(storage).with_config(config_with_managed(vec![]));
+    let sender = controller.get_request_sender();
+
+    let shutdown = ShutdownToken::new();
+    let run_handle = tokio::spawn({
+        let shutdown = shutdown.clone();
+        async move { controller.run(shutdown).await }
+    });
+
+    sender
+        .set_credential_fetcher(Arc::new(fetcher))
+        .await
+        .expect("set fetcher");
+
+    // give any (erroneous) restock a chance to fire, then assert nothing was requested
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        recorded(&requested).is_empty(),
+        "no deposits must be made when the managed set is empty"
+    );
+
+    shutdown.cancel();
+    let _ = run_handle.await;
+}


### PR DESCRIPTION
Additive, opt-in controls so a consumer can bound which ticket types are ever deposited for, and whether the controller restocks in the background:

- `nym-bandwidth-fetcher`: NyxdCredentialFetcher::with_allowed_ticketbook_types vetoes a *fresh* deposit for a type outside the set (recovery of already-paid deposits is unaffected); a disallowed type returns a new TicketbookTypeNotAllowed error mapped to FetcherErrorKind::Other (no new FetcherErrorKind variant, so exhaustive matches downstream keep compiling).
- `nym-bandwidth-controller`: BandwidthController::with_managed_ticket_types scopes the proactive restock sweep; with_auto_restock toggles background restocking (periodic sweep, post-spend top-up, fetcher-install restock) while still honouring explicit restock_ticketbooks requests.

All default to current behaviour. This lets a dVPN session provision only WireGuard ticketbooks and never deposit for mixnet bandwidth.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6976)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration to select which ticket types receive proactive restocking.
  * Restocking can now be disabled entirely by providing an empty selection.
  * Post-spending and post-configuration restocking follows the configured ticket types.

* **Bug Fixes**
  * Prevented unselected ticket types from receiving unnecessary deposits.
  * Added coverage confirming restocking is limited precisely to the configured types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->