### PR TITLE
Max/smol family crate cleanup

### DIFF
--- a/.github/workflows/ci-crates-version-bump.yml
+++ b/.github/workflows/ci-crates-version-bump.yml
@@ -96,7 +96,7 @@ jobs:
           # snippet self-heals the same way the workspace path-dep sed above does.
           # cargo-workspaces unifies every workspace crate to VERSION, so all of
           # these crates share it after the bump.
-          sed -i -E "s/^(nym-sdk|nym-bin-common|nym-network-defaults|smolmix)(.*)\"[0-9]+\.[0-9]+\.[0-9]+\"/\1\2\"${VERSION}\"/" \
+          sed -i -E "s/^(nym-sdk|nym-bin-common|nym-network-defaults|nym-smolmix)(.*)\"[0-9]+\.[0-9]+\.[0-9]+\"/\1\2\"${VERSION}\"/" \
             "$DOCS/pages/developers/rust/importing.mdx" \
             "$DOCS/pages/developers/rust/mixnet/tutorial.mdx" \
             "$DOCS/pages/developers/rust/stream/tutorial.mdx" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8375,6 +8375,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-smol-core"
+version = "1.21.5-rc.2"
+dependencies = [
+ "futures",
+ "hickory-proto",
+ "rand 0.8.6",
+ "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-smoltcp",
+ "tracing",
+]
+
+[[package]]
+name = "nym-smoldvpn"
+version = "1.21.5-rc.2"
+dependencies = [
+ "base64 0.22.1",
+ "bip39",
+ "boringtun",
+ "bs58",
+ "bytes",
+ "futures",
+ "http 1.4.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "nym-bandwidth-controller",
+ "nym-bridges",
+ "nym-credentials-interface",
+ "nym-crypto",
+ "nym-http-api-client",
+ "nym-network-defaults",
+ "nym-sdk-session",
+ "nym-smol-core",
+ "nym-wireguard-private-metadata-client",
+ "nym-wireguard-private-metadata-shared",
+ "pin-project",
+ "prost 0.14.3",
+ "quinn",
+ "quinn-proto",
+ "rcgen 0.13.2",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "serde_json",
+ "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "tonic 0.14.6",
+ "tonic-health",
+ "tonic-prost",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "nym-smolmix"
+version = "1.21.5-rc.2"
+dependencies = [
+ "futures",
+ "hickory-proto",
+ "hickory-resolver",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "nym-bin-common",
+ "nym-ip-packet-requests",
+ "nym-sdk",
+ "nym-smol-core",
+ "reqwest 0.13.4",
+ "rustls 0.23.40",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-tungstenite",
+ "tracing",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "nym-socks5-client"
 version = "1.1.81"
 dependencies = [
@@ -11761,20 +11846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
-name = "smol-core"
-version = "1.21.5-rc.2"
-dependencies = [
- "futures",
- "hickory-proto",
- "rand 0.8.6",
- "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.18",
- "tokio",
- "tokio-smoltcp",
- "tracing",
-]
-
-[[package]]
 name = "smol_str"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11782,77 +11853,6 @@ checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
  "borsh",
  "serde_core",
-]
-
-[[package]]
-name = "smoldvpn"
-version = "1.21.5-rc.2"
-dependencies = [
- "base64 0.22.1",
- "bip39",
- "boringtun",
- "bs58",
- "bytes",
- "futures",
- "http 1.4.1",
- "http-body-util",
- "hyper 1.10.1",
- "hyper-util",
- "nym-bandwidth-controller",
- "nym-bridges",
- "nym-credentials-interface",
- "nym-crypto",
- "nym-http-api-client",
- "nym-network-defaults",
- "nym-sdk-session",
- "nym-wireguard-private-metadata-client",
- "nym-wireguard-private-metadata-shared",
- "pin-project",
- "prost 0.14.3",
- "quinn",
- "quinn-proto",
- "rcgen 0.13.2",
- "rustls 0.23.40",
- "rustls-pki-types",
- "serde_json",
- "smol-core",
- "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tokio-rustls 0.26.4",
- "tokio-util",
- "tonic 0.14.6",
- "tonic-health",
- "tonic-prost",
- "tower",
- "tracing",
- "tracing-subscriber",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "smolmix"
-version = "1.21.5-rc.2"
-dependencies = [
- "futures",
- "hickory-proto",
- "hickory-resolver",
- "http-body-util",
- "hyper 1.10.1",
- "hyper-util",
- "nym-bin-common",
- "nym-ip-packet-requests",
- "nym-sdk",
- "reqwest 0.13.4",
- "rustls 0.23.40",
- "smol-core",
- "thiserror 2.0.18",
- "tokio",
- "tokio-rustls 0.26.4",
- "tokio-tungstenite",
- "tracing",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8460,6 +8460,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "nym-smolmix-wasm"
+version = "0.1.0"
+dependencies = [
+ "async-tungstenite",
+ "bytes",
+ "futures",
+ "futures-rustls",
+ "getrandom 0.2.17",
+ "getrandom 0.4.2",
+ "hickory-proto",
+ "http 1.4.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "js-sys",
+ "nym-bin-common",
+ "nym-ip-packet-requests",
+ "nym-lp-data",
+ "nym-validator-client",
+ "nym-wasm-client-core",
+ "nym-wasm-utils",
+ "rand 0.8.6",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "rustls-rustcrypto",
+ "semver 1.0.28",
+ "serde",
+ "serde-wasm-bindgen 0.6.5",
+ "smoltcp 0.12.0 (git+https://github.com/nymtech/smoltcp?rev=62ac5b8b3287d4773694f19a3b55e4c004354a0b)",
+ "thiserror 2.0.18",
+ "tokio",
+ "tsify",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasmtimer",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "nym-socks5-client"
 version = "1.1.81"
 dependencies = [
@@ -11853,45 +11892,6 @@ checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
  "borsh",
  "serde_core",
-]
-
-[[package]]
-name = "smolmix-wasm"
-version = "0.1.0"
-dependencies = [
- "async-tungstenite",
- "bytes",
- "futures",
- "futures-rustls",
- "getrandom 0.2.17",
- "getrandom 0.4.2",
- "hickory-proto",
- "http 1.4.1",
- "http-body-util",
- "hyper 1.10.1",
- "js-sys",
- "nym-bin-common",
- "nym-ip-packet-requests",
- "nym-lp-data",
- "nym-validator-client",
- "nym-wasm-client-core",
- "nym-wasm-utils",
- "rand 0.8.6",
- "rustls 0.23.40",
- "rustls-pki-types",
- "rustls-rustcrypto",
- "semver 1.0.28",
- "serde",
- "serde-wasm-bindgen 0.6.5",
- "smoltcp 0.12.0 (git+https://github.com/nymtech/smoltcp?rev=62ac5b8b3287d4773694f19a3b55e4c004354a0b)",
- "thiserror 2.0.18",
- "tokio",
- "tsify",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasmtimer",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -610,7 +610,7 @@ opt-level = 3
 # lto = true
 opt-level = 'z'
 
-[profile.release.package.smolmix-wasm]
+[profile.release.package.nym-smolmix-wasm]
 # lto = true
 opt-level = 'z'
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -431,118 +431,119 @@ libcrux-sha3 = "0.0.8"
 libcrux-traits = "0.0.6"
 
 # Workspace dep definitions required by crates.io publication - we need a workspace version since `cargo workspaces` doesn't work with path imports from crate manifests
-nym-api-requests = { version = "1.21.5-rc.1", path = "nym-api/nym-api-requests" }
-nym-authenticator-requests = { version = "1.21.5-rc.1", path = "common/authenticator-requests" }
-nym-async-file-watcher = { version = "1.21.5-rc.1", path = "common/async-file-watcher" }
-nym-authenticator-client = { version = "1.21.5-rc.1", path = "nym-authenticator-client" }
-nym-bandwidth-controller = { version = "1.21.5-rc.1", path = "common/bandwidth-controller" }
-nym-bandwidth-fetcher = { version = "1.21.5-rc.1", path = "common/bandwidth-fetcher" }
-nym-bin-common = { version = "1.21.5-rc.1", path = "common/bin-common" }
-nym-cache = { version = "1.21.5-rc.1", path = "common/nym-cache" }
-nym-client-core = { version = "1.21.5-rc.1", path = "common/client-core", default-features = false }
-nym-client-core-config-types = { version = "1.21.5-rc.1", path = "common/client-core/config-types" }
-nym-client-core-gateways-storage = { version = "1.21.5-rc.1", path = "common/client-core/gateways-storage" }
-nym-client-core-surb-storage = { version = "1.21.5-rc.1", path = "common/client-core/surb-storage" }
-nym-client-websocket-requests = { version = "1.21.5-rc.1", path = "clients/native/websocket-requests" }
-nym-common = { version = "1.21.5-rc.1", path = "common/nym-common" }
-nym-compact-ecash = { version = "1.21.5-rc.1", path = "common/nym_offline_compact_ecash" }
-nym-config = { version = "1.21.5-rc.1", path = "common/config" }
-nym-contracts-common = { version = "1.21.5-rc.1", path = "common/cosmwasm-smart-contracts/contracts-common" }
-nym-coconut-dkg-common = { version = "1.21.5-rc.1", path = "common/cosmwasm-smart-contracts/coconut-dkg" }
-nym-credential-storage = { version = "1.21.5-rc.1", path = "common/credential-storage" }
-nym-credential-proxy-lib = { version = "1.21.5-rc.1", path = "common/credential-proxy" }
-nym-credentials = { version = "1.21.5-rc.1", path = "common/credentials", default-features = false }
-nym-credentials-interface = { version = "1.21.5-rc.1", path = "common/credentials-interface" }
-nym-credential-proxy-requests = { version = "1.21.5-rc.1", path = "nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
-nym-credential-verification = { version = "1.21.5-rc.1", path = "common/credential-verification" }
-nym-crypto = { version = "1.21.5-rc.1", path = "common/crypto", default-features = false }
-nym-dkg = { version = "1.21.5-rc.1", path = "common/dkg" }
-nym-ecash-contract-common = { version = "1.21.5-rc.1", path = "common/cosmwasm-smart-contracts/ecash-contract" }
-nym-ecash-signer-check = { version = "1.21.5-rc.1", path = "common/ecash-signer-check" }
-nym-ecash-signer-check-types = { version = "1.21.5-rc.1", path = "common/ecash-signer-check-types" }
-nym-ecash-time = { version = "1.21.5-rc.1", path = "common/ecash-time" }
-nym-exit-policy = { version = "1.21.5-rc.1", path = "common/exit-policy" }
-nym-ffi-shared = { version = "1.21.5-rc.1", path = "sdk/ffi/shared" }
-nym-gateway-client = { version = "1.21.5-rc.1", path = "common/client-libs/gateway-client", default-features = false }
-nym-gateway-probe = { version = "1.21.5-rc.1", path = "nym-gateway-probe" }
-nym-gateway-requests = { version = "1.21.5-rc.1", path = "common/gateway-requests" }
-nym-gateway-storage = { version = "1.21.5-rc.1", path = "common/gateway-storage" }
-nym-gateway-stats-storage = { version = "1.21.5-rc.1", path = "common/gateway-stats-storage" }
-nym-group-contract-common = { version = "1.21.5-rc.1", path = "common/cosmwasm-smart-contracts/group-contract" }
-nym-http-api-client = { version = "1.21.5-rc.1", path = "common/http-api-client" }
-nym-http-api-client-macro = { version = "1.21.5-rc.1", path = "common/http-api-client-macro" }
-nym-http-api-common = { version = "1.21.5-rc.1", path = "common/http-api-common", default-features = false }
-nym-id = { version = "1.21.5-rc.1", path = "common/nym-id" }
-nym-ip-packet-client = { version = "1.21.5-rc.1", path = "nym-ip-packet-client" }
-nym-ip-packet-requests = { version = "1.21.5-rc.1", path = "common/ip-packet-requests" }
-nym-lp = { version = "1.21.5-rc.1", path = "common/nym-lp" }
-nym-lp-data = { version = "1.21.5-rc.1", path = "common/nym-lp-data" }
-nym-kkt = { version = "1.21.5-rc.1", path = "common/nym-kkt" }
-nym-kkt-ciphersuite = { version = "1.21.5-rc.1", path = "common/nym-kkt-ciphersuite" }
-nym-kkt-context = { version = "1.21.5-rc.1", path = "common/nym-kkt-context" }
-nym-metrics = { version = "1.21.5-rc.1", path = "common/nym-metrics" }
-nym-mixnet-client = { version = "1.21.5-rc.1", path = "common/client-libs/mixnet-client" }
-nym-mixnet-contract-common = { version = "1.21.5-rc.1", path = "common/cosmwasm-smart-contracts/mixnet-contract" }
-nym-multisig-contract-common = { version = "1.21.5-rc.1", path = "common/cosmwasm-smart-contracts/multisig-contract" }
-nym-network-defaults = { version = "1.21.5-rc.1", path = "common/network-defaults" }
-nym-node-tester-utils = { version = "1.21.5-rc.1", path = "common/node-tester-utils" }
-nym-noise = { version = "1.21.5-rc.1", path = "common/nymnoise" }
-nym-noise-keys = { version = "1.21.5-rc.1", path = "common/nymnoise/keys" }
-nym-nonexhaustive-delayqueue = { version = "1.21.5-rc.1", path = "common/nonexhaustive-delayqueue" }
-nym-node-requests = { version = "1.21.5-rc.1", path = "nym-node/nym-node-requests", default-features = false }
-nym-node-metrics = { version = "1.21.5-rc.1", path = "nym-node/nym-node-metrics" }
-nym-node-families-contract-common = { version = "1.21.5-rc.1", path = "common/cosmwasm-smart-contracts/node-families-contract" }
-nym-ordered-buffer = { version = "1.21.5-rc.1", path = "common/socks5/ordered-buffer" }
-nym-outfox = { version = "1.21.5-rc.1", path = "nym-outfox" }
-nym-registration-client = { version = "1.21.5-rc.1", path = "nym-registration-client" }
-nym-registration-common = { version = "1.21.5-rc.1", path = "common/registration" }
-nym-sdk-session = { version = "1.21.5-rc.1", path = "sdk/rust/nym-sdk-session" }
-nym-pemstore = { version = "1.21.5-rc.1", path = "common/pemstore" }
-nym-performance-contract-common = { version = "1.21.5-rc.1", path = "common/cosmwasm-smart-contracts/nym-performance-contract" }
-nym-sdk = { version = "1.21.5-rc.1", path = "sdk/rust/nym-sdk" }
-nym-serde-helpers = { version = "1.21.5-rc.1", path = "common/serde-helpers" }
-nym-service-providers-common = { version = "1.21.5-rc.1", path = "service-providers/common" }
-nym-service-provider-requests-common = { version = "1.21.5-rc.1", path = "common/service-provider-requests-common" }
-nym-socks5-client-core = { version = "1.21.5-rc.1", path = "common/socks5-client-core" }
-nym-socks5-proxy-helpers = { version = "1.21.5-rc.1", path = "common/socks5/proxy-helpers" }
-nym-socks5-requests = { version = "1.21.5-rc.1", path = "common/socks5/requests" }
-nym-sphinx = { version = "1.21.5-rc.1", path = "common/nymsphinx" }
-nym-sphinx-acknowledgements = { version = "1.21.5-rc.1", path = "common/nymsphinx/acknowledgements" }
-nym-sphinx-addressing = { version = "1.21.5-rc.1", path = "common/nymsphinx/addressing" }
-nym-sphinx-anonymous-replies = { version = "1.21.5-rc.1", path = "common/nymsphinx/anonymous-replies" }
-nym-sphinx-chunking = { version = "1.21.5-rc.1", path = "common/nymsphinx/chunking" }
-nym-sphinx-cover = { version = "1.21.5-rc.1", path = "common/nymsphinx/cover" }
-nym-sphinx-forwarding = { version = "1.21.5-rc.1", path = "common/nymsphinx/forwarding" }
-nym-sphinx-framing = { version = "1.21.5-rc.1", path = "common/nymsphinx/framing" }
-nym-sphinx-params = { version = "1.21.5-rc.1", path = "common/nymsphinx/params" }
-nym-sphinx-routing = { version = "1.21.5-rc.1", path = "common/nymsphinx/routing" }
-nym-sphinx-types = { version = "1.21.5-rc.1", path = "common/nymsphinx/types" }
-nym-statistics-common = { version = "1.21.5-rc.1", path = "common/statistics" }
-nym-store-cipher = { version = "1.21.5-rc.1", path = "common/store-cipher" }
-nym-task = { version = "1.21.5-rc.1", path = "common/task" }
-nym-tun = { version = "1.21.5-rc.1", path = "common/tun" }
-nym-test-utils = { version = "1.21.5-rc.1", path = "common/test-utils" }
-nym-ticketbooks-merkle = { version = "1.21.5-rc.1", path = "common/ticketbooks-merkle" }
-nym-topology = { version = "1.21.5-rc.1", path = "common/topology" }
-nym-types = { version = "1.21.5-rc.1", path = "common/types" }
-nym-upgrade-mode-check = { version = "1.21.5-rc.1", path = "common/upgrade-mode-check" }
-nym-validator-client = { version = "1.21.5-rc.1", path = "common/client-libs/validator-client", default-features = false }
-nym-vesting-contract-common = { version = "1.21.5-rc.1", path = "common/cosmwasm-smart-contracts/vesting-contract" }
-nym-network-monitors-contract-common = { version = "1.21.5-rc.1", path = "common/cosmwasm-smart-contracts/network-monitors-contract" }
-nym-verloc = { version = "1.21.5-rc.1", path = "common/verloc" }
-nym-wireguard = { version = "1.21.5-rc.1", path = "common/wireguard" }
-nym-wireguard-types = { version = "1.21.5-rc.1", path = "common/wireguard-types" }
-nym-wireguard-private-metadata-shared = { version = "1.21.5-rc.1", path = "common/wireguard-private-metadata/shared" }
-nym-wireguard-private-metadata-client = { version = "1.21.5-rc.1", path = "common/wireguard-private-metadata/client" }
-nym-wireguard-private-metadata-server = { version = "1.21.5-rc.1", path = "common/wireguard-private-metadata/server" }
-nym-sqlx-pool-guard = { version = "1.21.5-rc.1", path = "nym-sqlx-pool-guard" }
-nym-wasm-client-core = { version = "1.21.5-rc.1", path = "common/wasm/client-core" }
-nym-wasm-storage = { version = "1.21.5-rc.1", path = "common/wasm/storage" }
-nym-wasm-utils = { version = "1.21.5-rc.1", path = "common/wasm/utils", default-features = false }
-nyxd-scraper-shared = { version = "1.21.5-rc.1", path = "common/nyxd-scraper-shared" }
+nym-api-requests = { version = "1.21.5-rc.2", path = "nym-api/nym-api-requests" }
+nym-authenticator-requests = { version = "1.21.5-rc.2", path = "common/authenticator-requests" }
+nym-async-file-watcher = { version = "1.21.5-rc.2", path = "common/async-file-watcher" }
+nym-authenticator-client = { version = "1.21.5-rc.2", path = "nym-authenticator-client" }
+nym-bandwidth-controller = { version = "1.21.5-rc.2", path = "common/bandwidth-controller" }
+nym-bandwidth-fetcher = { version = "1.21.5-rc.2", path = "common/bandwidth-fetcher" }
+nym-bin-common = { version = "1.21.5-rc.2", path = "common/bin-common" }
+nym-cache = { version = "1.21.5-rc.2", path = "common/nym-cache" }
+nym-client-core = { version = "1.21.5-rc.2", path = "common/client-core", default-features = false }
+nym-client-core-config-types = { version = "1.21.5-rc.2", path = "common/client-core/config-types" }
+nym-client-core-gateways-storage = { version = "1.21.5-rc.2", path = "common/client-core/gateways-storage" }
+nym-client-core-surb-storage = { version = "1.21.5-rc.2", path = "common/client-core/surb-storage" }
+nym-client-websocket-requests = { version = "1.21.5-rc.2", path = "clients/native/websocket-requests" }
+nym-common = { version = "1.21.5-rc.2", path = "common/nym-common" }
+nym-compact-ecash = { version = "1.21.5-rc.2", path = "common/nym_offline_compact_ecash" }
+nym-config = { version = "1.21.5-rc.2", path = "common/config" }
+nym-contracts-common = { version = "1.21.5-rc.2", path = "common/cosmwasm-smart-contracts/contracts-common" }
+nym-coconut-dkg-common = { version = "1.21.5-rc.2", path = "common/cosmwasm-smart-contracts/coconut-dkg" }
+nym-credential-storage = { version = "1.21.5-rc.2", path = "common/credential-storage" }
+nym-credential-proxy-lib = { version = "1.21.5-rc.2", path = "common/credential-proxy" }
+nym-credentials = { version = "1.21.5-rc.2", path = "common/credentials", default-features = false }
+nym-credentials-interface = { version = "1.21.5-rc.2", path = "common/credentials-interface" }
+nym-credential-proxy-requests = { version = "1.21.5-rc.2", path = "nym-credential-proxy/nym-credential-proxy-requests", default-features = false }
+nym-credential-verification = { version = "1.21.5-rc.2", path = "common/credential-verification" }
+nym-crypto = { version = "1.21.5-rc.2", path = "common/crypto", default-features = false }
+nym-dkg = { version = "1.21.5-rc.2", path = "common/dkg" }
+nym-ecash-contract-common = { version = "1.21.5-rc.2", path = "common/cosmwasm-smart-contracts/ecash-contract" }
+nym-ecash-signer-check = { version = "1.21.5-rc.2", path = "common/ecash-signer-check" }
+nym-ecash-signer-check-types = { version = "1.21.5-rc.2", path = "common/ecash-signer-check-types" }
+nym-ecash-time = { version = "1.21.5-rc.2", path = "common/ecash-time" }
+nym-exit-policy = { version = "1.21.5-rc.2", path = "common/exit-policy" }
+nym-ffi-shared = { version = "1.21.5-rc.2", path = "sdk/ffi/shared" }
+nym-gateway-client = { version = "1.21.5-rc.2", path = "common/client-libs/gateway-client", default-features = false }
+nym-gateway-probe = { version = "1.21.5-rc.2", path = "nym-gateway-probe" }
+nym-gateway-requests = { version = "1.21.5-rc.2", path = "common/gateway-requests" }
+nym-gateway-storage = { version = "1.21.5-rc.2", path = "common/gateway-storage" }
+nym-gateway-stats-storage = { version = "1.21.5-rc.2", path = "common/gateway-stats-storage" }
+nym-group-contract-common = { version = "1.21.5-rc.2", path = "common/cosmwasm-smart-contracts/group-contract" }
+nym-http-api-client = { version = "1.21.5-rc.2", path = "common/http-api-client" }
+nym-http-api-client-macro = { version = "1.21.5-rc.2", path = "common/http-api-client-macro" }
+nym-http-api-common = { version = "1.21.5-rc.2", path = "common/http-api-common", default-features = false }
+nym-id = { version = "1.21.5-rc.2", path = "common/nym-id" }
+nym-ip-packet-client = { version = "1.21.5-rc.2", path = "nym-ip-packet-client" }
+nym-ip-packet-requests = { version = "1.21.5-rc.2", path = "common/ip-packet-requests" }
+nym-lp = { version = "1.21.5-rc.2", path = "common/nym-lp" }
+nym-lp-data = { version = "1.21.5-rc.2", path = "common/nym-lp-data" }
+nym-kkt = { version = "1.21.5-rc.2", path = "common/nym-kkt" }
+nym-kkt-ciphersuite = { version = "1.21.5-rc.2", path = "common/nym-kkt-ciphersuite" }
+nym-kkt-context = { version = "1.21.5-rc.2", path = "common/nym-kkt-context" }
+nym-metrics = { version = "1.21.5-rc.2", path = "common/nym-metrics" }
+nym-mixnet-client = { version = "1.21.5-rc.2", path = "common/client-libs/mixnet-client" }
+nym-mixnet-contract-common = { version = "1.21.5-rc.2", path = "common/cosmwasm-smart-contracts/mixnet-contract" }
+nym-multisig-contract-common = { version = "1.21.5-rc.2", path = "common/cosmwasm-smart-contracts/multisig-contract" }
+nym-network-defaults = { version = "1.21.5-rc.2", path = "common/network-defaults" }
+nym-node-tester-utils = { version = "1.21.5-rc.2", path = "common/node-tester-utils" }
+nym-noise = { version = "1.21.5-rc.2", path = "common/nymnoise" }
+nym-noise-keys = { version = "1.21.5-rc.2", path = "common/nymnoise/keys" }
+nym-nonexhaustive-delayqueue = { version = "1.21.5-rc.2", path = "common/nonexhaustive-delayqueue" }
+nym-node-requests = { version = "1.21.5-rc.2", path = "nym-node/nym-node-requests", default-features = false }
+nym-node-metrics = { version = "1.21.5-rc.2", path = "nym-node/nym-node-metrics" }
+nym-node-families-contract-common = { version = "1.21.5-rc.2", path = "common/cosmwasm-smart-contracts/node-families-contract" }
+nym-ordered-buffer = { version = "1.21.5-rc.2", path = "common/socks5/ordered-buffer" }
+nym-outfox = { version = "1.21.5-rc.2", path = "nym-outfox" }
+nym-registration-client = { version = "1.21.5-rc.2", path = "nym-registration-client" }
+nym-registration-common = { version = "1.21.5-rc.2", path = "common/registration" }
+nym-sdk-session = { version = "1.21.5-rc.2", path = "sdk/rust/nym-sdk-session" }
+nym-pemstore = { version = "1.21.5-rc.2", path = "common/pemstore" }
+nym-performance-contract-common = { version = "1.21.5-rc.2", path = "common/cosmwasm-smart-contracts/nym-performance-contract" }
+nym-sdk = { version = "1.21.5-rc.2", path = "sdk/rust/nym-sdk" }
+nym-serde-helpers = { version = "1.21.5-rc.2", path = "common/serde-helpers" }
+nym-service-providers-common = { version = "1.21.5-rc.2", path = "service-providers/common" }
+nym-service-provider-requests-common = { version = "1.21.5-rc.2", path = "common/service-provider-requests-common" }
+nym-socks5-client-core = { version = "1.21.5-rc.2", path = "common/socks5-client-core" }
+nym-socks5-proxy-helpers = { version = "1.21.5-rc.2", path = "common/socks5/proxy-helpers" }
+nym-socks5-requests = { version = "1.21.5-rc.2", path = "common/socks5/requests" }
+nym-sphinx = { version = "1.21.5-rc.2", path = "common/nymsphinx" }
+nym-sphinx-acknowledgements = { version = "1.21.5-rc.2", path = "common/nymsphinx/acknowledgements" }
+nym-sphinx-addressing = { version = "1.21.5-rc.2", path = "common/nymsphinx/addressing" }
+nym-sphinx-anonymous-replies = { version = "1.21.5-rc.2", path = "common/nymsphinx/anonymous-replies" }
+nym-sphinx-chunking = { version = "1.21.5-rc.2", path = "common/nymsphinx/chunking" }
+nym-sphinx-cover = { version = "1.21.5-rc.2", path = "common/nymsphinx/cover" }
+nym-sphinx-forwarding = { version = "1.21.5-rc.2", path = "common/nymsphinx/forwarding" }
+nym-sphinx-framing = { version = "1.21.5-rc.2", path = "common/nymsphinx/framing" }
+nym-sphinx-params = { version = "1.21.5-rc.2", path = "common/nymsphinx/params" }
+nym-sphinx-routing = { version = "1.21.5-rc.2", path = "common/nymsphinx/routing" }
+nym-sphinx-types = { version = "1.21.5-rc.2", path = "common/nymsphinx/types" }
+nym-statistics-common = { version = "1.21.5-rc.2", path = "common/statistics" }
+nym-store-cipher = { version = "1.21.5-rc.2", path = "common/store-cipher" }
+nym-task = { version = "1.21.5-rc.2", path = "common/task" }
+nym-tun = { version = "1.21.5-rc.2", path = "common/tun" }
+nym-test-utils = { version = "1.21.5-rc.2", path = "common/test-utils" }
+nym-ticketbooks-merkle = { version = "1.21.5-rc.2", path = "common/ticketbooks-merkle" }
+nym-topology = { version = "1.21.5-rc.2", path = "common/topology" }
+nym-types = { version = "1.21.5-rc.2", path = "common/types" }
+nym-upgrade-mode-check = { version = "1.21.5-rc.2", path = "common/upgrade-mode-check" }
+nym-validator-client = { version = "1.21.5-rc.2", path = "common/client-libs/validator-client", default-features = false }
+nym-vesting-contract-common = { version = "1.21.5-rc.2", path = "common/cosmwasm-smart-contracts/vesting-contract" }
+nym-network-monitors-contract-common = { version = "1.21.5-rc.2", path = "common/cosmwasm-smart-contracts/network-monitors-contract" }
+nym-verloc = { version = "1.21.5-rc.2", path = "common/verloc" }
+nym-wireguard = { version = "1.21.5-rc.2", path = "common/wireguard" }
+nym-wireguard-types = { version = "1.21.5-rc.2", path = "common/wireguard-types" }
+nym-wireguard-private-metadata-shared = { version = "1.21.5-rc.2", path = "common/wireguard-private-metadata/shared" }
+nym-wireguard-private-metadata-client = { version = "1.21.5-rc.2", path = "common/wireguard-private-metadata/client" }
+nym-wireguard-private-metadata-server = { version = "1.21.5-rc.2", path = "common/wireguard-private-metadata/server" }
+nym-sqlx-pool-guard = { version = "1.21.5-rc.2", path = "nym-sqlx-pool-guard" }
+nym-wasm-client-core = { version = "1.21.5-rc.2", path = "common/wasm/client-core" }
+nym-wasm-storage = { version = "1.21.5-rc.2", path = "common/wasm/storage" }
+nym-wasm-utils = { version = "1.21.5-rc.2", path = "common/wasm/utils", default-features = false }
+nyxd-scraper-shared = { version = "1.21.5-rc.2", path = "common/nyxd-scraper-shared" }
 
-smol-core = { version = "1.21.5-rc.1", path = "common/smol-core" }
-smolmix = { version = "1.21.5-rc.1", path = "smolmix/core" }
+smol-core = { version = "1.21.5-rc.2", path = "common/smol-core" }
+smolmix = { version = "1.21.5-rc.2", path = "smolmix/core" }
+# TODO add smoldvpn here whatever you end up with name-wise 
 
 # coconut/DKG related
 # unfortunately until https://github.com/zkcrypto/nym-bls12_381-fork/issues/10 is resolved, we have to rely on the fork

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -542,7 +542,7 @@ nym-wasm-utils = { version = "1.21.5-rc.2", path = "common/wasm/utils", default-
 nyxd-scraper-shared = { version = "1.21.5-rc.2", path = "common/nyxd-scraper-shared" }
 
 nym-smol-core = { version = "1.21.5-rc.2", path = "common/smol-core" }
-smolmix = { version = "1.21.5-rc.2", path = "smolmix/core" }
+nym-smolmix = { version = "1.21.5-rc.2", path = "smolmix/core" }
 # TODO add smoldvpn here whatever you end up with name-wise 
 
 # coconut/DKG related

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -543,7 +543,7 @@ nyxd-scraper-shared = { version = "1.21.5-rc.2", path = "common/nyxd-scraper-sha
 
 nym-smol-core = { version = "1.21.5-rc.2", path = "common/smol-core" }
 nym-smolmix = { version = "1.21.5-rc.2", path = "smolmix/core" }
-# TODO add smoldvpn here whatever you end up with name-wise 
+nym-smoldvpn = { version = "1.21.5-rc.2", path = "smoldvpn" }
 
 # coconut/DKG related
 # unfortunately until https://github.com/zkcrypto/nym-bls12_381-fork/issues/10 is resolved, we have to rely on the fork

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -541,7 +541,7 @@ nym-wasm-storage = { version = "1.21.5-rc.2", path = "common/wasm/storage" }
 nym-wasm-utils = { version = "1.21.5-rc.2", path = "common/wasm/utils", default-features = false }
 nyxd-scraper-shared = { version = "1.21.5-rc.2", path = "common/nyxd-scraper-shared" }
 
-smol-core = { version = "1.21.5-rc.2", path = "common/smol-core" }
+nym-smol-core = { version = "1.21.5-rc.2", path = "common/smol-core" }
 smolmix = { version = "1.21.5-rc.2", path = "smolmix/core" }
 # TODO add smoldvpn here whatever you end up with name-wise 
 

--- a/common/smol-core/Cargo.toml
+++ b/common/smol-core/Cargo.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "smol-core"
+name = "nym-smol-core"
 description = "Transport-agnostic pure-Rust userspace smoltcp TCP/IP stack: turns a bidirectional stream of raw IP packets into tokio TcpStream/UdpSocket sockets plus a tunnel-scoped DNS resolver"
 version.workspace = true
 authors.workspace = true

--- a/common/smol-core/README.md
+++ b/common/smol-core/README.md
@@ -1,4 +1,4 @@
-# smol-core
+# nym-smol-core
 
 A transport-agnostic, pure-Rust userspace TCP/IP stack. It turns a
 bidirectional stream of raw IP packets (`Vec<u8>`) into tokio-native
@@ -18,7 +18,7 @@ datapath, a test harness), build a `Stack`, and open sockets.
 
 ```rust
 use futures::channel::mpsc;
-use smol_core::{ChannelDevice, Stack, StackConfig, DEFAULT_MTU};
+use nym_smol_core::{ChannelDevice, Stack, StackConfig, DEFAULT_MTU};
 
 let (outbound_tx, outbound_rx) = mpsc::unbounded::<Vec<u8>>(); // stack -> transport
 let (inbound_tx, inbound_rx) = mpsc::unbounded::<Vec<u8>>();   // transport -> stack
@@ -41,7 +41,7 @@ let addrs = stack.resolve("example.com").await?;            // DNS over the tunn
 
 ## Tests
 
-`cargo test -p smol-core` runs the stack integration tests (two crossed stacks):
+`cargo test -p nym-smol-core` runs the stack integration tests (two crossed stacks):
 UDP round-trip, TCP round-trip, connect-failure, and DNS resolution over a stack
 socket.
 

--- a/common/smol-core/README.md
+++ b/common/smol-core/README.md
@@ -6,7 +6,7 @@ bidirectional stream of raw IP packets (`Vec<u8>`) into tokio-native
 OS `tun` device and no elevated privileges**, and no Go / gVisor / FFI netstack.
 
 It is the shared stack beneath [`smolmix`](../../smolmix) (the 5-hop mixnet
-tunnel) and [`smoldvpn`](../../sdk/rust/smoldvpn) (the WireGuard dVPN
+tunnel) and [`nym-smoldvpn`](../../smoldvpn) (the WireGuard dVPN
 datapath).
 
 ## Concept
@@ -48,5 +48,5 @@ socket.
 ## Design
 
 See the architecture docs in
-[`docs/design/sdk/smoldvpn/`](../../docs/design/sdk/smoldvpn/) and the
+[`docs/design/smoldvpn/`](../../docs/design/smoldvpn/) and the
 [`smol-core-stack`](../../openspec/specs/smol-core-stack/spec.md) OpenSpec capability.

--- a/common/smol-core/src/lib.rs
+++ b/common/smol-core/src/lib.rs
@@ -17,7 +17,7 @@
 //! ```no_run
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! use futures::channel::mpsc;
-//! use smol_core::{ChannelDevice, Stack, StackConfig, DEFAULT_MTU};
+//! use nym_smol_core::{ChannelDevice, Stack, StackConfig, DEFAULT_MTU};
 //!
 //! // `inbound_*` carry IP packets from the transport into the stack;
 //! // `outbound_*` carry stack-produced IP packets back to the transport.

--- a/common/smol-core/tests/stack.rs
+++ b/common/smol-core/tests/stack.rs
@@ -12,7 +12,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
 use futures::channel::mpsc;
-use smol_core::{ChannelDevice, DnsConfig, Stack, StackConfig};
+use nym_smol_core::{ChannelDevice, DnsConfig, Stack, StackConfig};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const A_IP: &str = "10.0.0.1";
@@ -228,7 +228,7 @@ async fn dns_ignores_mismatched_id() {
         .expect("resolve should have returned")
         .expect_err("a mismatched-id response must not resolve");
     assert!(
-        matches!(err, smol_core::SmolCoreError::DnsTimeout { .. }),
+        matches!(err, nym_smol_core::SmolCoreError::DnsTimeout { .. }),
         "expected DnsTimeout, got {err:?}"
     );
 }
@@ -262,7 +262,7 @@ async fn dns_servfail_is_distinct() {
         .expect("resolve should have returned")
         .expect_err("SERVFAIL must surface as an error");
     assert!(
-        matches!(err, smol_core::SmolCoreError::DnsServerFailure { .. }),
+        matches!(err, nym_smol_core::SmolCoreError::DnsServerFailure { .. }),
         "expected DnsServerFailure, got {err:?}"
     );
 }
@@ -355,7 +355,7 @@ async fn dns_rejects_truncated_response() {
         .expect("resolve should have returned")
         .expect_err("a truncated response must not resolve");
     assert!(
-        matches!(err, smol_core::SmolCoreError::DnsTruncated { .. }),
+        matches!(err, nym_smol_core::SmolCoreError::DnsTruncated { .. }),
         "expected DnsTruncated, got {err:?}"
     );
 }

--- a/docs/design/smoldvpn/README.md
+++ b/docs/design/smoldvpn/README.md
@@ -1,24 +1,24 @@
-# `smoldvpn` — architecture & design
+# `nym-smoldvpn` — architecture & design
 
 This directory documents the architecture of the pure-Rust, userspace two-hop
 WireGuard dVPN datapath. It is background for contributors and integrators who
 want to understand *how* the pieces fit together.
 
-> **Building on top of `smoldvpn`?** Start with the crate README at
+> **Building on top of `nym-smoldvpn`?** Start with the crate README at
 > [`smoldvpn/README.md`](../../../smoldvpn/README.md) — it
 > covers the public API, examples, and how to run against a live network. This
 > document is the design rationale behind that API.
 
 ## Names at a glance
 
-- **`smoldvpn`** — the dVPN datapath crate. Directory: `smoldvpn/`.
+- **`nym-smoldvpn`** — the dVPN datapath crate. Directory: `smoldvpn/`.
 - **`nym-sdk-session`** — the shared provisioning facade crate (ticketbooks +
   gateway registration), used by both mixnet and dvpn modes. In `sdk/rust`.
-- **`smol-core`** — the transport-agnostic smoltcp stack. In `common/`.
+- **`nym-smol-core`** — the transport-agnostic smoltcp stack. In `common/`.
 
 ## One-paragraph summary
 
-`smoldvpn` brings up a **userspace, two-hop (or single-hop) WireGuard
+`nym-smoldvpn` brings up a **userspace, two-hop (or single-hop) WireGuard
 tunnel** from an entry gateway to an exit gateway using
 [`boringtun`](https://github.com/cloudflare/boringtun), with **no OS `tun` device
 and no root**. Traffic goes in via ordinary `tokio` primitives — a `TcpStream`, a
@@ -42,11 +42,11 @@ Most of the machinery already existed in the monorepo; the new work is narrow.
 | Gateway directory fetch | reuse | `nym-validator-client` + `nym-client-core` |
 | Gateway selection by identity / random | reuse | `nym-client-core` `init/helpers.rs` |
 | Gateway selection by two-letter country code | thin new | filter on described-node `location: Option<celes::Country>` |
-| smoltcp userspace TCP/IP stack → `TcpStream` / `UdpSocket` / DNS | reuse | `smol-core` (extracted from `smolmix`) |
-| **boringtun single-/two-hop WG datapath** | **new** | `smoldvpn` |
-| **QUIC-bridge transport** for blocked clients | **new** | `smoldvpn` (over the `nym-bridges` client) |
-| Connector adapters (tonic / hyper / reqwest) | **new** | `smoldvpn` |
-| Lifecycle facade + cancellation | **new** | `smoldvpn` |
+| smoltcp userspace TCP/IP stack → `TcpStream` / `UdpSocket` / DNS | reuse | `nym-smol-core` (extracted from `smolmix`) |
+| **boringtun single-/two-hop WG datapath** | **new** | `nym-smoldvpn` |
+| **QUIC-bridge transport** for blocked clients | **new** | `nym-smoldvpn` (over the `nym-bridges` client) |
+| Connector adapters (tonic / hyper / reqwest) | **new** | `nym-smoldvpn` |
+| Lifecycle facade + cancellation | **new** | `nym-smoldvpn` |
 
 ## The crate family
 
@@ -54,16 +54,16 @@ Most of the machinery already existed in the monorepo; the new work is narrow.
 common/smol-core                 smoltcp stack: channels<IP packet> → TcpStream / UdpSocket / DNS.
                                  Pure tokio + Rust, WASM-capable, transport-agnostic.
     ├── smolmix                  + IPR / mixnet bridge         (5-hop)
-    └── smoldvpn/      crate smoldvpn
-        (smoldvpn)          + boringtun WG datapath       (1- or 2-hop)
+    └── smoldvpn/      crate nym-smoldvpn
+        (nym-smoldvpn)          + boringtun WG datapath       (1- or 2-hop)
                                  + GatewayTransport::{ Direct | QuicBridge }  (quinn; crate-local)
 
 sdk/rust/nym-sdk-session         ticketbooks (nym-bandwidth-controller) + gateway registration
                                  (nym-registration-client). Shared by BOTH mixnet and dvpn modes.
 ```
 
-`smoldvpn` depends on `nym-sdk-session` for "get me paid access to these
-gateways" and on `smol-core` for "give me sockets over this IP-packet pipe". Its
+`nym-smoldvpn` depends on `nym-sdk-session` for "get me paid access to these
+gateways" and on `nym-smol-core` for "give me sockets over this IP-packet pipe". Its
 only unique job is the boringtun WireGuard datapath and the transport strategy.
 
 ## Contents
@@ -76,7 +76,7 @@ only unique job is the boringtun WireGuard datapath and the transport strategy.
 
 The normative behaviour lives in the OpenSpec capability specs, one per concern:
 
-- [`dvpn-tunnel`](../../../openspec/specs/dvpn-tunnel/spec.md) — the `smoldvpn`
+- [`dvpn-tunnel`](../../../openspec/specs/dvpn-tunnel/spec.md) — the `nym-smoldvpn`
   userspace WireGuard datapath, tunnel modes, lifecycle, DNS, MTU, and top-up.
 - [`dvpn-quic-bridge`](../../../openspec/specs/dvpn-quic-bridge/spec.md) — the
   `WgPacketTransport` abstraction and the QUIC bridge transport.
@@ -84,5 +84,5 @@ The normative behaviour lives in the OpenSpec capability specs, one per concern:
   (config export, bandwidth top-up, gRPC/IP/Zcash demos).
 - [`dvpn-session`](../../../openspec/specs/dvpn-session/spec.md) — `nym-sdk-session`
   provisioning: ticketbook issuance, credential storage, gateway selection/registration.
-- [`smol-core-stack`](../../../openspec/specs/smol-core-stack/spec.md) — `smol-core`,
+- [`smol-core-stack`](../../../openspec/specs/smol-core-stack/spec.md) — `nym-smol-core`,
   the transport-agnostic userspace TCP/IP stack.

--- a/docs/design/smoldvpn/README.md
+++ b/docs/design/smoldvpn/README.md
@@ -5,13 +5,13 @@ WireGuard dVPN datapath. It is background for contributors and integrators who
 want to understand *how* the pieces fit together.
 
 > **Building on top of `smoldvpn`?** Start with the crate README at
-> [`sdk/rust/smoldvpn/README.md`](../../../../sdk/rust/smoldvpn/README.md) — it
+> [`smoldvpn/README.md`](../../../smoldvpn/README.md) — it
 > covers the public API, examples, and how to run against a live network. This
 > document is the design rationale behind that API.
 
 ## Names at a glance
 
-- **`smoldvpn`** — the dVPN datapath crate. Directory: `sdk/rust/smoldvpn/`.
+- **`smoldvpn`** — the dVPN datapath crate. Directory: `smoldvpn/`.
 - **`nym-sdk-session`** — the shared provisioning facade crate (ticketbooks +
   gateway registration), used by both mixnet and dvpn modes. In `sdk/rust`.
 - **`smol-core`** — the transport-agnostic smoltcp stack. In `common/`.
@@ -54,7 +54,7 @@ Most of the machinery already existed in the monorepo; the new work is narrow.
 common/smol-core                 smoltcp stack: channels<IP packet> → TcpStream / UdpSocket / DNS.
                                  Pure tokio + Rust, WASM-capable, transport-agnostic.
     ├── smolmix                  + IPR / mixnet bridge         (5-hop)
-    └── sdk/rust/smoldvpn/      crate smoldvpn
+    └── smoldvpn/      crate smoldvpn
         (smoldvpn)          + boringtun WG datapath       (1- or 2-hop)
                                  + GatewayTransport::{ Direct | QuicBridge }  (quinn; crate-local)
 
@@ -76,13 +76,13 @@ only unique job is the boringtun WireGuard datapath and the transport strategy.
 
 The normative behaviour lives in the OpenSpec capability specs, one per concern:
 
-- [`dvpn-tunnel`](../../../../openspec/specs/dvpn-tunnel/spec.md) — the `smoldvpn`
+- [`dvpn-tunnel`](../../../openspec/specs/dvpn-tunnel/spec.md) — the `smoldvpn`
   userspace WireGuard datapath, tunnel modes, lifecycle, DNS, MTU, and top-up.
-- [`dvpn-quic-bridge`](../../../../openspec/specs/dvpn-quic-bridge/spec.md) — the
+- [`dvpn-quic-bridge`](../../../openspec/specs/dvpn-quic-bridge/spec.md) — the
   `WgPacketTransport` abstraction and the QUIC bridge transport.
-- [`dvpn-tools`](../../../../openspec/specs/dvpn-tools/spec.md) — the example CLIs
+- [`dvpn-tools`](../../../openspec/specs/dvpn-tools/spec.md) — the example CLIs
   (config export, bandwidth top-up, gRPC/IP/Zcash demos).
-- [`dvpn-session`](../../../../openspec/specs/dvpn-session/spec.md) — `nym-sdk-session`
+- [`dvpn-session`](../../../openspec/specs/dvpn-session/spec.md) — `nym-sdk-session`
   provisioning: ticketbook issuance, credential storage, gateway selection/registration.
-- [`smol-core-stack`](../../../../openspec/specs/smol-core-stack/spec.md) — `smol-core`,
+- [`smol-core-stack`](../../../openspec/specs/smol-core-stack/spec.md) — `smol-core`,
   the transport-agnostic userspace TCP/IP stack.

--- a/docs/design/smoldvpn/design.md
+++ b/docs/design/smoldvpn/design.md
@@ -48,7 +48,7 @@ already uses), referred to here as "the smoltcp stack".
   common/smol-core            smoltcp stack: channels<IP packet Vec<u8>> → TcpStream / UdpSocket / DNS.
                               Pure tokio + Rust. WASM-capable. No opinion on transport.
       ├── smolmix             + IPR / mixnet bridge          (5-hop)   [exists → refactor onto smol-core]
-      └── sdk/rust/smoldvpn/  crate smoldvpn
+      └── smoldvpn/  crate smoldvpn
           (smoldvpn)     + boringtun WG datapath        (1-/2-hop) [NEW]
 
   sdk/rust/nym-sdk-session    ticketbooks (bandwidth-controller) + gateway registration
@@ -68,7 +68,7 @@ already uses), referred to here as "the smoltcp stack".
 - **Dependency isolation (required):** every *new* dependency `smoldvpn` needs
   — `boringtun`, `quinn`, `quinn-proto`, `nym_bridges` (git, pinned), and anything
   else not already used elsewhere — is declared **directly in
-  `sdk/rust/smoldvpn/Cargo.toml`**, *not* promoted to the workspace-root
+  `smoldvpn/Cargo.toml`**, *not* promoted to the workspace-root
   `[workspace.dependencies]` table. Deps already in the workspace table (e.g.
   `smoltcp`, `tokio`, `tokio-smoltcp`, the `nym-*` crates) continue to use
   `workspace = true`. This keeps the WG/QUIC dependency surface contained to this
@@ -455,7 +455,7 @@ Traffic surfaces to expose (all reuse `smol-core`):
 - Thin `tonic_channel(..)` / `reqwest_client(..)` conveniences over that connector.
 - `allocated_ips()`, `available_bandwidth()`, `shutdown()`.
 
-## 12. Example CLIs (in `sdk/rust/smoldvpn/examples`)
+## 12. Example CLIs (in `smoldvpn/examples`)
 
 - **`smoldvpn-config --gateway <spec>`** — performs an LP registration against a
   **single gateway** and prints a **plain WireGuard config** (`[Interface]

--- a/docs/design/smoldvpn/design.md
+++ b/docs/design/smoldvpn/design.md
@@ -1,4 +1,4 @@
-# `smoldvpn` — design
+# `nym-smoldvpn` — design
 
 ## 1. Goals & non-goals
 
@@ -47,25 +47,25 @@ already uses), referred to here as "the smoltcp stack".
 ```
   common/smol-core            smoltcp stack: channels<IP packet Vec<u8>> → TcpStream / UdpSocket / DNS.
                               Pure tokio + Rust. WASM-capable. No opinion on transport.
-      ├── smolmix             + IPR / mixnet bridge          (5-hop)   [exists → refactor onto smol-core]
-      └── smoldvpn/  crate smoldvpn
-          (smoldvpn)     + boringtun WG datapath        (1-/2-hop) [NEW]
+      ├── smolmix             + IPR / mixnet bridge          (5-hop)   [exists → refactor onto nym-smol-core]
+      └── smoldvpn/  crate nym-smoldvpn
+          (nym-smoldvpn)     + boringtun WG datapath        (1-/2-hop) [NEW]
 
   sdk/rust/nym-sdk-session    ticketbooks (bandwidth-controller) + gateway registration
                               (registration-client). Shared by mixnet AND dvpn. [NEW]
 ```
 
-- **`smol-core`** is `smolmix` with the mixnet-specific bridge removed: the
+- **`nym-smol-core`** is `smolmix` with the mixnet-specific bridge removed: the
   transport-agnostic core that turns a bidirectional stream of IP-packet
   `Vec<u8>` into `tcp_connect() -> TcpStream`, `udp_socket() -> UdpSocket`, and a
-  DNS resolver. `smolmix` (5-hop) and `smoldvpn` (2-hop) both sit on it.
+  DNS resolver. `smolmix` (5-hop) and `nym-smoldvpn` (2-hop) both sit on it.
 - **`nym-sdk-session`** wraps `nym-registration-client` +
   `nym-bandwidth-controller` + the credential store. It answers "acquire paid
   access to these gateways" for **both** mixnet and dvpn modes, so it lives beside
-  the mixnet client rather than inside `smoldvpn`.
-- **`smoldvpn`** owns only the WireGuard datapath (boringtun) and the
+  the mixnet client rather than inside `nym-smoldvpn`.
+- **`nym-smoldvpn`** owns only the WireGuard datapath (boringtun) and the
   transport strategy.
-- **Dependency isolation (required):** every *new* dependency `smoldvpn` needs
+- **Dependency isolation (required):** every *new* dependency `nym-smoldvpn` needs
   — `boringtun`, `quinn`, `quinn-proto`, `nym_bridges` (git, pinned), and anything
   else not already used elsewhere — is declared **directly in
   `smoldvpn/Cargo.toml`**, *not* promoted to the workspace-root
@@ -96,7 +96,7 @@ ever fronts the **entry-gateway leg**. There is no "QUIC one-hop" mode.
         │   (connector returns AsyncRead+AsyncWrite / datagram)
         ▼
  ┌───────────────────────────────────────────────────────────┐
- │  smoltcp stack (smol-core)                                  │  pure Rust ✓  WASM ✓
+ │  smoltcp stack (nym-smol-core)                                  │  pure Rust ✓  WASM ✓
  │    tcp_connect() → TcpStream   udp_socket() → UdpSocket     │
  │    DNS resolver bound to the tunnel (default on)            │
  └───────────────────────────────────────────────────────────┘
@@ -128,7 +128,7 @@ ever fronts the **entry-gateway leg**. There is no "QUIC one-hop" mode.
 > **Engine choice — pure Rust, no Go.** The reference client
 > (`nym-vpn-client`) runs its datapath on **wireguard-go via FFI** with a
 > **gVisor netstack** — the exact Go/netstack dependency we are avoiding.
-> `smoldvpn` **must be pure Rust: `boringtun` for the WG engine + `smoltcp`
+> `nym-smoldvpn` **must be pure Rust: `boringtun` for the WG engine + `smoltcp`
 > for the stack.** We reuse the reference's *architecture and wire protocols*
 > (registration, two-hop nesting, QUIC bridge framing) but **not its engine**.
 > (`nym-vpn-client` uses `boringtun` only in a throwaway diagnostic probe, never
@@ -172,7 +172,7 @@ Key points established from the reference:
   - mobile:  `ENTRY_MTU = 1280 + 80 = 1360`, `EXIT_MTU = 1280`
 
   So the MTU the application's sockets see (the exit stack) is **~1340 on desktop /
-  1280 on mobile**. `smoldvpn` sizes the smoltcp interface accordingly. **MTU
+  1280 on mobile**. `nym-smoldvpn` sizes the smoltcp interface accordingly. **MTU
   must be configurable** via the SDK config and **changeable dynamically while the
   tunnel is up** (a config channel that re-sizes the smoltcp interface + re-derives
   the per-hop MTUs at runtime), defaulting to the values above.
@@ -251,7 +251,7 @@ The bridge protocol (see §14 for sources):
 
 - **`quinn` 0.11 + `quinn-proto` 0.11, `rustls` 0.23 (ring provider).** The ring
   default crypto provider is installed at startup. `quinn` is a **crate-local
-  dependency of `smoldvpn`**, like `boringtun`.
+  dependency of `nym-smoldvpn`**, like `boringtun`.
 - **ALPN = `hq-29`** (legacy HTTP/QUIC id — *not* `h3`; there is no real HTTP/3).
 - **WireGuard packets ride a single reliable QUIC bi-stream, length-framed with a
   2-byte big-endian prefix** (`tokio_util::LengthDelimitedCodec`,
@@ -270,7 +270,7 @@ The bridge protocol (see §14 for sources):
   the "decoy" property is about how ordinary it *looks*, not about presenting an
   arbitrary unrelated hostname.
 - **Delegate the QUIC connection to the `nym-bridges` client; add only the datapath
-  framing on top.** `smoldvpn` depends on the `nym-bridges` crate (published to
+  framing on top.** `nym-smoldvpn` depends on the `nym-bridges` crate (published to
   crates.io) and uses its `transport::quic::{transport_conn, ClientOptions}` to
   establish the cert-pinned, ALPN-`hq-29` connection, so the client can never drift
   from the bridge server. On top of that connection this crate adds the WireGuard
@@ -355,7 +355,7 @@ plain-WG config in §11) sets the **gateway `public_key`** and the
 - **Default: DNS resolves inside the tunnel** (through the exit), so name
   resolution is not leaked to the host resolver. Configurable (opt-out, or
   point at a specific resolver).
-- Implemented by binding a resolver (e.g. `hickory-resolver`) to a `smol-core`
+- Implemented by binding a resolver (e.g. `hickory-resolver`) to a `nym-smol-core`
   `UdpSocket` — the same pattern `smolmix` uses (`mixdns`).
 - `tonic` / `hyper` / `reqwest` are given a custom connector/resolver that routes
   both the DNS query and the resulting connection through the tunnel.
@@ -377,7 +377,7 @@ plain-WG config in §11) sets the **gateway `public_key`** and the
   up in the Connected phase. LP-over-QUIC is not available yet (§5).
 - The tunnel is **long-lived** and is **explicitly** closed / torn down via the
   cancellation token (or an explicit `shutdown()`).
-- While connected, `smoldvpn` runs background tasks: the boringtun timer pump,
+- While connected, `nym-smoldvpn` runs background tasks: the boringtun timer pump,
   the transport receive loop, the DNS resolver, and a **bandwidth top-up task**.
 - **Two distinct top-up layers.** These are separate and independently controlled:
   1. *Gateway-side top-up* (extending a live tunnel): fresh tickets are *pushed to
@@ -396,7 +396,7 @@ plain-WG config in §11) sets the **gateway `public_key`** and the
      credential fetcher is unchanged and mixnet types are simply never in the managed
      set, so a dVPN session never deposits for mixnet bandwidth.)
 - **The metadata client dials through the tunnel.** The metadata endpoint IP is in
-  the entry peer's `allowed_ips` and is served in-tunnel; `smoldvpn` reaches it with
+  the entry peer's `allowed_ips` and is served in-tunnel; `nym-smoldvpn` reaches it with
   a hyper HTTP/1 client over the tunnel's own `TunnelConnector`, never the host
   network — so top-up traffic cannot leak the client's real IP.
 - **Top-up must fire with headroom.** Because the metadata request itself travels
@@ -422,7 +422,7 @@ let session = SessionBuilder::new(mnemonic, network)
     .credential_store(store_path)          // persistent → up/down at will
     .build()?;
 
-// ── smoldvpn ─────────────────────────────────────────────────────────────
+// ── nym-smoldvpn ─────────────────────────────────────────────────────────────
 let tunnel = DvpnTunnelBuilder::new(session)
     // two-hop: specify entry AND exit
     .mode(TunnelMode::TwoHop {
@@ -446,7 +446,7 @@ let client  = tunnel.reqwest_client()?;                            // reqwest w/
 token.cancel();  // tears the tunnel down; issued tickets remain in the store
 ```
 
-Traffic surfaces to expose (all reuse `smol-core`):
+Traffic surfaces to expose (all reuse `nym-smol-core`):
 
 - `tcp_connect(addr) -> TcpStream` — raw TCP, and the base for everything below.
 - `udp_socket() / udp_socket_on(port) -> UdpSocket` — raw UDP.
@@ -484,7 +484,7 @@ Traffic surfaces to expose (all reuse `smol-core`):
 | LP transport (control-plane seam) | `nym-lp` — `common/nym-lp/src/transport/traits.rs` (`LpTransportChannel`) |
 | Gateway directory + selection | `nym-validator-client`, `nym-client-core` — `init/helpers.rs`, `init/types.rs` |
 | Country field on nodes | `nym-api-requests` — described-node `auxiliary_details.location: Option<celes::Country>` |
-| smoltcp stack pattern | `smolmix` — `smolmix/core/src/{tunnel,device}.rs` → generalise into `smol-core` |
+| smoltcp stack pattern | `smolmix` — `smolmix/core/src/{tunnel,device}.rs` → generalise into `nym-smol-core` |
 | Metadata top-up | `nym-wireguard-private-metadata` (client) — `topup_bandwidth`, `available_bandwidth` |
 | WG datapath (new) | `boringtun` (`Tunn`) + `smoltcp::wire` for the middle IP/UDP frame |
 | QUIC bridge (new) | `quinn` 0.11 via the `nym-bridges` client (git-pinned, `transport::quic`): ALPN `hq-29`, ed25519-SPKI pinning; this crate adds the 2-byte len-framed WG packets over one bi-stream |
@@ -492,7 +492,7 @@ Traffic surfaces to expose (all reuse `smol-core`):
 ## 14. Reference implementations studied
 
 Two external Nym repos were read to validate the two-hop and bridge protocols.
-`smoldvpn` reuses their **architecture and wire protocols** but **not their
+`nym-smoldvpn` reuses their **architecture and wire protocols** but **not their
 engine** (they are Go; we are pure Rust).
 
 **`nym-vpn-client`** (`nym-vpn-core` workspace) — the production VPN client:
@@ -519,7 +519,7 @@ engine** (they are Go; we are pure Rust).
   gateway.
 
 **`nym-bridges`** (`github.com/nymtech/nym-bridges`) — the bridge server, and the
-QUIC client `smoldvpn` builds on. `smoldvpn` depends on the crate
+QUIC client `nym-smoldvpn` builds on. `nym-smoldvpn` depends on the crate
 (git-pinned to a commit, since the protocol is versioned `"0"` and unstable) and
 uses its client transport rather than reimplementing the connection.
 - Modules used: `transport::quic::{ClientOptions, transport_conn}` (configured

--- a/documentation/docs/pages/developers/smolmix.mdx
+++ b/documentation/docs/pages/developers/smolmix.mdx
@@ -18,7 +18,7 @@ The `TcpStream` type implements tokio's `AsyncRead`/`AsyncWrite` traits and `Udp
 ```text
 ┌──────────────────────────────────────────────────────────────┐
 │  Your application (TLS, HTTP, WebSocket, DNS, etc.)          │
-│       └─ smolmix::TcpStream / UdpSocket                      │
+│       └─ nym_smolmix::TcpStream / UdpSocket                      │
 │            └─ smoltcp (userspace TCP/IP)                     │
 │                 └─ Nym mixnet → IPR exit gateway → internet  │
 └──────────────────────────────────────────────────────────────┘
@@ -43,7 +43,7 @@ Add `smolmix` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-smolmix = "1.21.5-rc.1"
+nym-smolmix = "1.21.5-rc.1"
 nym-bin-common = { version = "1.21.5-rc.1", features = ["basic_tracing"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
@@ -61,7 +61,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 For unreleased changes, import directly from the repository:
 
 ```toml
-smolmix = { git = "https://github.com/nymtech/nym", branch = "develop" }
+nym-smolmix = { git = "https://github.com/nymtech/nym", branch = "develop" }
 ```
 
 ## When to use smolmix
@@ -89,7 +89,7 @@ The full model (what each hop sees, trust boundaries, and a comparison with Tor 
 Runnable examples in [`smolmix/core/examples/`](https://github.com/nymtech/nym/tree/develop/smolmix/core/examples). Each is self-contained; read the `//!` doc comments at the top of each file for a walkthrough.
 
 ```sh
-cargo run -p smolmix --example <name>
+cargo run -p nym-smolmix --example <name>
 ```
 
 All examples accept `--ipr <ADDRESS>` to target a specific exit node (pass a `Recipient` address to `Tunnel::builder().ipr_address()`).
@@ -107,4 +107,4 @@ The internal stack (smoltcp reactor, device adapter, bridge task, packet flow) i
 
 ## API reference
 
-Full API documentation is available on [docs.rs/smolmix](https://docs.rs/smolmix).
+Full API documentation is available on [docs.rs/nym-smolmix](https://docs.rs/nym-smolmix).

--- a/documentation/docs/pages/developers/smolmix.mdx
+++ b/documentation/docs/pages/developers/smolmix.mdx
@@ -43,8 +43,8 @@ Add `smolmix` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-nym-smolmix = "1.21.5-rc.1"
-nym-bin-common = { version = "1.21.5-rc.1", features = ["basic_tracing"] }
+nym-smolmix = "1.21.5-rc.3"
+nym-bin-common = { version = "1.21.5-rc.3", features = ["basic_tracing"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/openspec/changes/nym-prefix-smol-crates/design.md
+++ b/openspec/changes/nym-prefix-smol-crates/design.md
@@ -1,0 +1,58 @@
+# Design: nym-prefix-smol-crates
+
+## D1. Product name vs crate name
+
+Not every crate gets the `nym-` prefix in prose. The rule is whether the crate
+has a **separate product identity**:
+
+| Crate | Product identity | Prose name | Crate name |
+|---|---|---|---|
+| `smol-core` | none (library) | `nym-smol-core` | `nym-smol-core` |
+| `smolmix` | yes (`/developers/smolmix` docs page + `@nymproject/mix-*` TS SDKs) | smolmix | `nym-smolmix` |
+| `smoldvpn` | none (library) | `nym-smoldvpn` | `nym-smoldvpn` |
+
+So `smolmix` stays "smolmix" in docs prose, the docs page URL, and the nav; only
+the installable crate becomes `nym-smolmix` (the install snippet, `docs.rs`
+link, and `cargo run -p`). This mirrors the TS side, where the product is
+"smolmix" but the npm packages are `@nymproject/mix-*`.
+
+## D2. Directory names unchanged
+
+The repo is already mixed: `common/crypto` → `nym-crypto`, but `common/nym-kcp`
+→ `nym-kcp`. So a directory move is not required; renaming only the `[package]
+name` avoids a `git mv` and keeps the diff to manifests + references.
+
+## D3. `nym-smolmix-wasm` pins its artifact (Option B)
+
+The wasm crate is never published to crates.io; its bytes are base64-inlined into
+`@nymproject/mix-tunnel`. Two options existed:
+
+- **A (full derivation):** let the artifact follow the crate →
+  `nym_smolmix_wasm_bg.wasm` + `@nymproject/nym-smolmix-wasm`, updating the
+  mix-tunnel imports, webpack, and a silent-failure string-replace in
+  `rollup/worker.mjs`, then re-verifying in a browser.
+- **B (pin, chosen):** rename only the crate; keep the artifact basename
+  (`--out-name smolmix_wasm`) and the private npm name (`mark-pkg-private` stamps
+  `name: "@nymproject/smolmix-wasm"`). The TS/build wiring is untouched.
+
+B is consistent with D1 (crate prefixed, artifact keeps its established name) and
+avoids the `worker.mjs` trap. Its one dependency is that `mark-pkg-private` runs;
+made robust by ordering it after `build-rust` in the recipe (so `make -j` cannot
+race the wasm-pack write) and failing loudly (pnpm can't resolve
+`@nymproject/smolmix-wasm` if the pin is missing).
+
+## D4. Live specs: Purpose direct, requirement bodies via delta
+
+Per the OpenSpec convention (and the prior `smoldvpn-rename` change), the live
+spec **Purpose** line is outside the delta grammar and is edited directly, while
+**requirement bodies** are updated only through a change delta and applied at
+archive time. So the live specs carry `nym-*` on their Purpose lines now, and
+this change's deltas carry the renamed requirement bodies; `openspec apply`
+propagates them.
+
+## D5. What does NOT change
+
+Type names (`SmolCoreError`, `SmolmixError`), the `smol-core-stack` capability
+name, the `smoldvpn-*` example binary identifiers, the published `@nymproject/mix-*`
+package names/APIs, and all gateway/protocol behaviour. This is a naming change
+only.

--- a/openspec/changes/nym-prefix-smol-crates/proposal.md
+++ b/openspec/changes/nym-prefix-smol-crates/proposal.md
@@ -1,0 +1,79 @@
+# Proposal: nym-prefix-smol-crates
+
+## Why
+
+The `smol*` family (`smol-core`, `smolmix`, `smoldvpn`, and the internal
+`smolmix-wasm`) shipped without the `nym-` package-name prefix that the rest of
+the workspace follows (`nym-crypto`, `nym-client-core`, ...). This is naming
+drift: the crates.io namespace convention is `nym-<name>`, and these four were
+the exceptions. Aligning them now is cheap — nothing in-tree depends on
+`smolmix`/`smoldvpn` as a library, and `smol-core` has only two in-tree
+consumers (`smolmix/core`, `smoldvpn`).
+
+## What Changes
+
+- **Rename the packages** (directories unchanged; the repo already mixes
+  prefixed and un-prefixed directory names, e.g. `common/crypto` → `nym-crypto`
+  but `common/nym-kcp` → `nym-kcp`):
+  - `smol-core` → `nym-smol-core` (lib `nym_smol_core`)
+  - `smolmix` → `nym-smolmix` (lib `nym_smolmix`)
+  - `smoldvpn` → `nym-smoldvpn` (lib `nym_smoldvpn`)
+  - `smolmix-wasm` → `nym-smolmix-wasm`
+- **Cascade** into workspace dep-table keys, the `[profile.release.package.*]`
+  key, every `use nym_smol_core::…`, and the `cargo …-p` invocations in docs.
+  Type names (`SmolCoreError`, `SmolmixError`) are unchanged — only crate/lib
+  identities move.
+- **`nym-smoldvpn` logging target**: the examples' `EnvFilter` default and the
+  `RUST_LOG` hints move from `smoldvpn=…` to `nym_smoldvpn=…` (tracing targets
+  derive from the crate's module path).
+- **Product vs crate naming**: `smolmix` keeps its **product** name in prose,
+  its docs page (`/developers/smolmix`), and the TypeScript SDK family; only the
+  **crate** becomes `nym-smolmix` (install snippet, `docs.rs/nym-smolmix`,
+  `cargo run -p nym-smolmix`). `smol-core`/`smoldvpn` have no separate product
+  identity, so they take the full crate name everywhere.
+- **`nym-smolmix-wasm` pins its artifact**: the crate is renamed, but the
+  generated wasm artifact (`smolmix_wasm_bg.wasm`) and the private, never-published
+  npm package (`@nymproject/smolmix-wasm`) keep their names via `--out-name` and a
+  `package.json` `name` pin, so `@nymproject/mix-tunnel` and its inlining wiring
+  are untouched.
+- **Example binaries kept**: `smoldvpn-config`/`-topup`/`-grpc` stay (they are
+  `[[example]]` identifiers, not the crate, and were renamed once already).
+- **BREAKING** (out-of-tree consumers only): the crates.io package and lib names
+  change. `smol-core`/`smoldvpn`/`smolmix` remain published under the old names
+  (yank handled at publish time); `smolmix-wasm` was never published.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `dvpn-tunnel`: requirement text naming the crate updated `smoldvpn` →
+  `nym-smoldvpn` (deliverable name only; no behavioural change).
+- `dvpn-quic-bridge`: requirement text naming the crate updated `smoldvpn` →
+  `nym-smoldvpn` (deliverable name only; no behavioural change).
+- `dvpn-tools`: requirement text naming the crate updated `smoldvpn` →
+  `nym-smoldvpn`; the `smoldvpn-*` example CLI names are unchanged (deliverable
+  name only; no behavioural change).
+- `smol-core-stack`: requirement text naming the crate updated `smol-core` →
+  `nym-smol-core` (deliverable name only; no behavioural change). `smolmix`
+  keeps its product name in the refactor requirement.
+
+## Impact
+
+- **Code**: package/lib rename; `use` paths in `nym-smol-core`'s two consumers
+  and each crate's own examples/tests; no behavioural source change.
+- **Workspace**: root `Cargo.toml` dep-table keys + the wasm profile key; the
+  `nym-smoldvpn` dep-table entry added (previously a TODO); `Cargo.lock`
+  regenerates.
+- **CI**: `ci-crates-version-bump.yml` mdx-snippet alternation `smolmix` →
+  `nym-smolmix`; `wasm/smolmix/Makefile` `--out-name` + `mark-pkg-private`
+  ordering/name-pin.
+- **Docs**: the three crate READMEs, `documentation/docs/pages/developers/smolmix.mdx`
+  (install/`-p`/docs.rs lines), and the `docs/design/smoldvpn/**` architecture
+  docs.
+- **Not affected**: `@nymproject/mix-*` published package names/APIs; the
+  `smolmix` docs page URL and nav; `SmolCoreError`/`SmolmixError` type names;
+  gateway/protocol behaviour.

--- a/openspec/changes/nym-prefix-smol-crates/specs/dvpn-quic-bridge/spec.md
+++ b/openspec/changes/nym-prefix-smol-crates/specs/dvpn-quic-bridge/spec.md
@@ -1,0 +1,27 @@
+# Delta: dvpn-quic-bridge — crate renamed to `nym-smoldvpn`
+
+## MODIFIED Requirements
+
+### Requirement: QUIC bridge client reimplemented inline
+
+The QUIC bridge client SHALL be implemented inline in `nym-smoldvpn` using `quinn`
+declared in the crate's own `Cargo.toml`, and SHALL NOT depend on the `nym_bridges`
+crate. It SHALL byte-match the bridge protocol: ALPN `hq-29`; ed25519-based server
+certificate pinning (SNI/CN ∈ alt-names and certificate SPKI equal to the pinned
+identity public key, ED25519-only verify schemes); and one reliable QUIC
+bidirectional stream carrying WireGuard packets each prefixed by a 2-byte big-endian
+length.
+
+#### Scenario: Length-framed WireGuard packets over one bi-stream
+- **WHEN** the client sends a WireGuard packet over the bridge
+- **THEN** it writes a 2-byte big-endian length followed by the packet on a single
+  QUIC bidirectional stream, and reads inbound packets by the same framing
+
+#### Scenario: Server identity pinning enforced
+- **WHEN** the bridge presents a certificate whose SPKI does not equal the pinned
+  ed25519 `id_pubkey`, or whose SNI/CN is not an accepted alt-name
+- **THEN** the connection is rejected
+
+#### Scenario: No dependency on nym_bridges crate
+- **WHEN** the crate is built
+- **THEN** `nym-smoldvpn` does not depend on the `nym_bridges` crate

--- a/openspec/changes/nym-prefix-smol-crates/specs/dvpn-tools/spec.md
+++ b/openspec/changes/nym-prefix-smol-crates/specs/dvpn-tools/spec.md
@@ -1,13 +1,10 @@
-# dvpn-tools Specification
+# Delta: dvpn-tools — crate renamed to `nym-smoldvpn`
 
-## Purpose
-Defines the nym-smoldvpn example CLIs and tools: config export, bandwidth top-up, gRPC-through-tunnel, public-IP relocation, and Zcash sync benchmarks.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: WireGuard config export CLI (single-hop)
 
-`smoldvpn` SHALL provide a `smoldvpn-config` example CLI that performs an LP
+`nym-smoldvpn` SHALL provide a `smoldvpn-config` example CLI that performs an LP
 registration against a single gateway (`--gateway <spec>`) and prints a plain
 WireGuard configuration usable with stock `wg`/`wg-quick`, including the client
 private key and assigned address, and the peer's gateway public key, LP-negotiated
@@ -25,7 +22,7 @@ preshared key, endpoint, and allowed IPs.
 
 ### Requirement: Bandwidth top-up CLI
 
-`smoldvpn` SHALL provide a `smoldvpn-topup` example CLI that spends a stored ticket
+`nym-smoldvpn` SHALL provide a `smoldvpn-topup` example CLI that spends a stored ticket
 against the gateway `metadata` endpoint to extend the available bandwidth of an
 existing registration.
 
@@ -36,7 +33,7 @@ existing registration.
 
 ### Requirement: gRPC-through-tunnel example
 
-`smoldvpn` SHALL provide a `smoldvpn-grpc` example that brings up a tunnel and
+`nym-smoldvpn` SHALL provide a `smoldvpn-grpc` example that brings up a tunnel and
 issues a real `tonic` gRPC request through it via the tunnel connector.
 
 #### Scenario: gRPC request over the tunnel
@@ -46,7 +43,7 @@ issues a real `tonic` gRPC request through it via the tunnel connector.
 
 ### Requirement: Public-IP relocation examples
 
-`smoldvpn` SHALL provide `two-hop-ip` and `two-hop-quic` examples that query a public
+`nym-smoldvpn` SHALL provide `two-hop-ip` and `two-hop-quic` examples that query a public
 IP-echo service directly and then through the tunnel, demonstrating that the observed
 public IP/location becomes the exit gateway's. `two-hop-quic` SHALL front the entry
 leg with a QUIC bridge (selecting a QUIC-capable entry gateway).
@@ -63,7 +60,7 @@ leg with a QUIC bridge (selecting a QUIC-capable entry gateway).
 
 ### Requirement: Zcash compact-block sync benchmark example
 
-`smoldvpn` SHALL provide a `zcash-sync` example that syncs a configurable number of
+`nym-smoldvpn` SHALL provide a `zcash-sync` example that syncs a configurable number of
 Zcash compact blocks (default 10,000, selectable with `--blocks <N>`) from a public
 `lightwalletd` over gRPC-over-TLS both directly and through the tunnel, and reports the
 throughput of each.
@@ -72,20 +69,3 @@ throughput of each.
 - **WHEN** the user runs `zcash-sync` with a funded mnemonic
 - **THEN** the example reports blocks synced and elapsed time for both the direct and
   the through-tunnel path
-
-### Requirement: Shared example selection CLI
-
-The configurable examples (`two-hop-ip`, `two-hop-quic`, `zcash-sync`) SHALL share a
-command-line interface for choosing hop mode (`--one-hop`/`--two-hop`), gateways
-(`--entry`/`--exit`/`--gateway <spec>`, where `<spec>` is `random`, a two-letter
-country code, or a base58 identity), QUIC entry (`--quic`), and — for `zcash-sync` —
-the block count (`--blocks <N>`), rejecting invalid combinations (QUIC requires
-two-hop).
-
-#### Scenario: Select gateways and mode from the CLI
-- **WHEN** the user passes `--entry`/`--exit`/`--gateway`/`--one-hop`/`--two-hop`
-- **THEN** the example provisions the corresponding hop mode and gateway selection
-
-#### Scenario: Reject QUIC with single-hop
-- **WHEN** the user passes `--quic --one-hop`
-- **THEN** the example exits with an error explaining QUIC is two-hop-entry only

--- a/openspec/changes/nym-prefix-smol-crates/specs/dvpn-tunnel/spec.md
+++ b/openspec/changes/nym-prefix-smol-crates/specs/dvpn-tunnel/spec.md
@@ -1,0 +1,20 @@
+# Delta: dvpn-tunnel — crate renamed to `nym-smoldvpn`
+
+## MODIFIED Requirements
+
+### Requirement: Userspace WireGuard datapath with boringtun
+
+`nym-smoldvpn` SHALL implement the WireGuard datapath using `boringtun` in userspace,
+with no OS `tun` device and no root. It MUST NOT use `defguard_wireguard_rs`,
+`wireguard-go`, or any Go/FFI engine. Each WireGuard peer's public key and preshared
+key SHALL be taken from the session's registration output.
+
+#### Scenario: Bring up a tunnel with no OS interface
+- **WHEN** a tunnel is connected with valid per-hop WireGuard configuration
+- **THEN** encryption/decryption occurs in-process via `boringtun` and no OS network
+  interface is created and no elevated privileges are required
+
+#### Scenario: Peer configured from registration
+- **WHEN** a WireGuard peer is configured
+- **THEN** its public key and preshared key are those returned by gateway
+  registration

--- a/openspec/changes/nym-prefix-smol-crates/specs/smol-core-stack/spec.md
+++ b/openspec/changes/nym-prefix-smol-crates/specs/smol-core-stack/spec.md
@@ -1,0 +1,31 @@
+# Delta: smol-core-stack — crate renamed to `nym-smol-core`
+
+## MODIFIED Requirements
+
+### Requirement: Transport-agnostic userspace TCP/IP stack
+
+`nym-smol-core` SHALL provide a pure-Rust, `tokio`-async userspace TCP/IP stack driven by
+a caller-supplied bidirectional transport of raw IP packets (`Vec<u8>`), with no OS
+`tun` device and no elevated privileges. It MUST NOT depend on Go, a gVisor netstack,
+or any FFI network stack.
+
+#### Scenario: Stack driven by an abstract IP-packet transport
+- **WHEN** a caller constructs the stack with a transport that yields inbound IP
+  packets and accepts outbound IP packets
+- **THEN** the stack routes application socket traffic to/from that transport without
+  requiring any OS network interface or root privileges
+
+#### Scenario: Assigned tunnel address configures the interface
+- **WHEN** the stack is built with the tunnel's assigned IPv4/IPv6 address
+- **THEN** the smoltcp interface is configured with those addresses and outbound
+  packets carry them as source
+
+### Requirement: smolmix refactored onto smol-core
+
+The existing `smolmix` crate SHALL be refactored to consume `nym-smol-core` for its
+stack, while preserving its existing public API.
+
+#### Scenario: smolmix public API unchanged
+- **WHEN** `smolmix` is rebuilt on top of `nym-smol-core`
+- **THEN** existing `smolmix` public items (e.g. `Tunnel`, `tcp_connect`,
+  `udp_socket`) continue to compile and behave as before

--- a/openspec/changes/nym-prefix-smol-crates/tasks.md
+++ b/openspec/changes/nym-prefix-smol-crates/tasks.md
@@ -1,0 +1,55 @@
+# Tasks: nym-prefix-smol-crates
+
+## 1. Package renames (committed)
+
+- [x] 1.1 `smol-core` → `nym-smol-core`: `[package] name`, workspace dep-table
+      key, both consumer dep keys (`smolmix/core`, `smoldvpn`), all
+      `use nym_smol_core::…`, crate READMEs
+- [x] 1.2 `smolmix` → `nym-smolmix`: `[package] name`, workspace dep-table key,
+      lib paths + `-p` flag, `ci-crates-version-bump.yml` alternation,
+      `smolmix.mdx` functional lines (install / `-p` / docs.rs). Product name
+      "smolmix" kept in prose/page/nav
+- [x] 1.3 `smoldvpn` → `nym-smoldvpn`: `[package] name`, added the workspace
+      dep-table entry (was a TODO), lib paths + `-p` flag + `nym_smoldvpn`
+      `EnvFilter`/`RUST_LOG` target, README (migration note updated to the
+      three-name lineage). Example binaries `smoldvpn-*` kept
+- [x] 1.4 `smolmix-wasm` → `nym-smolmix-wasm`: `[package] name`, profile key,
+      Makefile `--out-name smolmix_wasm` + `mark-pkg-private` name pin
+      (`@nymproject/smolmix-wasm`). Verified: `pkg/package.json` name pinned +
+      `private: true`; artifact basename `smolmix_wasm_bg.wasm`
+
+## 2. Docs
+
+- [x] 2.1 `docs/design/smoldvpn/{README,design}.md`: crate names →
+      `nym-smoldvpn` / `nym-smol-core`; directory paths, `smoldvpn-*` example
+      names, `smol-core-stack` capability name, and the `smolmix` product name
+      left as-is. Pre-existing stale links (`sdk/rust/smoldvpn`, depth) fixed
+- [x] 2.2 Live specs' Purpose lines (outside the delta grammar) updated directly
+      to `nym-smoldvpn` / `nym-smol-core`; requirement bodies covered by this
+      change's deltas (applied at archive time)
+
+## 3. Spec deltas (this change)
+
+- [x] 3.1 `dvpn-tunnel`: MODIFIED "Userspace WireGuard datapath with boringtun"
+- [x] 3.2 `dvpn-quic-bridge`: MODIFIED "QUIC bridge client reimplemented inline"
+- [x] 3.3 `dvpn-tools`: MODIFIED the five requirements naming the crate
+      (config export, top-up, gRPC, public-IP, Zcash); `smoldvpn-*` example
+      names unchanged
+- [x] 3.4 `smol-core-stack`: MODIFIED "Transport-agnostic userspace TCP/IP
+      stack" and "smolmix refactored onto nym-smol-core" (`smolmix` kept)
+
+## 4. Verification
+
+- [x] 4.1 `cargo clippy --all-targets` + `cargo test --doc` green for the three
+      native renamed crates
+- [x] 4.2 `make -C wasm/smolmix build` → `pkg/package.json` name
+      `@nymproject/smolmix-wasm`, `private: true`
+- [x] 4.3 Link check: zero broken links in `docs/` and `openspec/specs`
+- [ ] 4.4 `openspec validate nym-prefix-smol-crates` passes (run before apply)
+
+## 5. Apply / publish (post-merge)
+
+- [ ] 5.1 `openspec apply nym-prefix-smol-crates` (propagates the deltas into the
+      live specs' requirement bodies), then archive
+- [ ] 5.2 Release train publishes the new crate names; then `cargo yank` the
+      old-named versions (yank breadth for `smolmix` stable still to decide)

--- a/openspec/specs/dvpn-quic-bridge/spec.md
+++ b/openspec/specs/dvpn-quic-bridge/spec.md
@@ -1,7 +1,7 @@
 # dvpn-quic-bridge Specification
 
 ## Purpose
-Defines the WgPacketTransport data-plane abstraction and the QUIC bridge client used to front the two-hop entry gateway leg in smoldvpn.
+Defines the WgPacketTransport data-plane abstraction and the QUIC bridge client used to front the two-hop entry gateway leg in nym-smoldvpn.
 
 ## Requirements
 
@@ -25,7 +25,7 @@ mode.
 
 ### Requirement: QUIC bridge client reimplemented inline
 
-The QUIC bridge client SHALL be implemented inline in `smoldvpn` using `quinn`
+The QUIC bridge client SHALL be implemented inline in `nym-smoldvpn` using `quinn`
 declared in the crate's own `Cargo.toml`, and SHALL NOT depend on the `nym_bridges`
 crate. It SHALL byte-match the bridge protocol: ALPN `hq-29`; ed25519-based server
 certificate pinning (SNI/CN ∈ alt-names and certificate SPKI equal to the pinned
@@ -45,7 +45,7 @@ length.
 
 #### Scenario: No dependency on nym_bridges crate
 - **WHEN** the crate is built
-- **THEN** `smoldvpn` does not depend on the `nym_bridges` crate
+- **THEN** `nym-smoldvpn` does not depend on the `nym_bridges` crate
 
 ### Requirement: Bridge parameters from the gateway directory
 

--- a/openspec/specs/dvpn-quic-bridge/spec.md
+++ b/openspec/specs/dvpn-quic-bridge/spec.md
@@ -25,7 +25,7 @@ mode.
 
 ### Requirement: QUIC bridge client reimplemented inline
 
-The QUIC bridge client SHALL be implemented inline in `nym-smoldvpn` using `quinn`
+The QUIC bridge client SHALL be implemented inline in `smoldvpn` using `quinn`
 declared in the crate's own `Cargo.toml`, and SHALL NOT depend on the `nym_bridges`
 crate. It SHALL byte-match the bridge protocol: ALPN `hq-29`; ed25519-based server
 certificate pinning (SNI/CN ∈ alt-names and certificate SPKI equal to the pinned
@@ -45,7 +45,7 @@ length.
 
 #### Scenario: No dependency on nym_bridges crate
 - **WHEN** the crate is built
-- **THEN** `nym-smoldvpn` does not depend on the `nym_bridges` crate
+- **THEN** `smoldvpn` does not depend on the `nym_bridges` crate
 
 ### Requirement: Bridge parameters from the gateway directory
 

--- a/openspec/specs/dvpn-tools/spec.md
+++ b/openspec/specs/dvpn-tools/spec.md
@@ -1,13 +1,13 @@
 # dvpn-tools Specification
 
 ## Purpose
-Defines the smoldvpn example CLIs and tools: config export, bandwidth top-up, gRPC-through-tunnel, public-IP relocation, and Zcash sync benchmarks.
+Defines the nym-smoldvpn example CLIs and tools: config export, bandwidth top-up, gRPC-through-tunnel, public-IP relocation, and Zcash sync benchmarks.
 
 ## Requirements
 
 ### Requirement: WireGuard config export CLI (single-hop)
 
-`smoldvpn` SHALL provide a `smoldvpn-config` example CLI that performs an LP
+`nym-smoldvpn` SHALL provide a `smoldvpn-config` example CLI that performs an LP
 registration against a single gateway (`--gateway <spec>`) and prints a plain
 WireGuard configuration usable with stock `wg`/`wg-quick`, including the client
 private key and assigned address, and the peer's gateway public key, LP-negotiated
@@ -25,7 +25,7 @@ preshared key, endpoint, and allowed IPs.
 
 ### Requirement: Bandwidth top-up CLI
 
-`smoldvpn` SHALL provide a `smoldvpn-topup` example CLI that spends a stored ticket
+`nym-smoldvpn` SHALL provide a `smoldvpn-topup` example CLI that spends a stored ticket
 against the gateway `metadata` endpoint to extend the available bandwidth of an
 existing registration.
 
@@ -36,7 +36,7 @@ existing registration.
 
 ### Requirement: gRPC-through-tunnel example
 
-`smoldvpn` SHALL provide a `smoldvpn-grpc` example that brings up a tunnel and
+`nym-smoldvpn` SHALL provide a `smoldvpn-grpc` example that brings up a tunnel and
 issues a real `tonic` gRPC request through it via the tunnel connector.
 
 #### Scenario: gRPC request over the tunnel
@@ -46,7 +46,7 @@ issues a real `tonic` gRPC request through it via the tunnel connector.
 
 ### Requirement: Public-IP relocation examples
 
-`smoldvpn` SHALL provide `two-hop-ip` and `two-hop-quic` examples that query a public
+`nym-smoldvpn` SHALL provide `two-hop-ip` and `two-hop-quic` examples that query a public
 IP-echo service directly and then through the tunnel, demonstrating that the observed
 public IP/location becomes the exit gateway's. `two-hop-quic` SHALL front the entry
 leg with a QUIC bridge (selecting a QUIC-capable entry gateway).
@@ -63,7 +63,7 @@ leg with a QUIC bridge (selecting a QUIC-capable entry gateway).
 
 ### Requirement: Zcash compact-block sync benchmark example
 
-`smoldvpn` SHALL provide a `zcash-sync` example that syncs a configurable number of
+`nym-smoldvpn` SHALL provide a `zcash-sync` example that syncs a configurable number of
 Zcash compact blocks (default 10,000, selectable with `--blocks <N>`) from a public
 `lightwalletd` over gRPC-over-TLS both directly and through the tunnel, and reports the
 throughput of each.

--- a/openspec/specs/dvpn-tunnel/spec.md
+++ b/openspec/specs/dvpn-tunnel/spec.md
@@ -5,7 +5,7 @@ Defines the nym-smoldvpn userspace WireGuard tunnel: boringtun datapath, single/
 ## Requirements
 ### Requirement: Userspace WireGuard datapath with boringtun
 
-`nym-smoldvpn` SHALL implement the WireGuard datapath using `boringtun` in userspace,
+`smoldvpn` SHALL implement the WireGuard datapath using `boringtun` in userspace,
 with no OS `tun` device and no root. It MUST NOT use `defguard_wireguard_rs`,
 `wireguard-go`, or any Go/FFI engine. Each WireGuard peer's public key and preshared
 key SHALL be taken from the session's registration output.

--- a/openspec/specs/dvpn-tunnel/spec.md
+++ b/openspec/specs/dvpn-tunnel/spec.md
@@ -1,11 +1,11 @@
 # dvpn-tunnel Specification
 
 ## Purpose
-Defines the smoldvpn userspace WireGuard tunnel: boringtun datapath, single/two-hop modes, tokio traffic surfaces, lifecycle, DNS, MTU, and bandwidth top-up.
+Defines the nym-smoldvpn userspace WireGuard tunnel: boringtun datapath, single/two-hop modes, tokio traffic surfaces, lifecycle, DNS, MTU, and bandwidth top-up.
 ## Requirements
 ### Requirement: Userspace WireGuard datapath with boringtun
 
-`smoldvpn` SHALL implement the WireGuard datapath using `boringtun` in userspace,
+`nym-smoldvpn` SHALL implement the WireGuard datapath using `boringtun` in userspace,
 with no OS `tun` device and no root. It MUST NOT use `defguard_wireguard_rs`,
 `wireguard-go`, or any Go/FFI engine. Each WireGuard peer's public key and preshared
 key SHALL be taken from the session's registration output.

--- a/openspec/specs/smol-core-stack/spec.md
+++ b/openspec/specs/smol-core-stack/spec.md
@@ -5,7 +5,7 @@ Defines nym-smol-core, the transport-agnostic userspace TCP/IP stack, its TCP/UD
 ## Requirements
 ### Requirement: Transport-agnostic userspace TCP/IP stack
 
-`nym-smol-core` SHALL provide a pure-Rust, `tokio`-async userspace TCP/IP stack driven by
+`smol-core` SHALL provide a pure-Rust, `tokio`-async userspace TCP/IP stack driven by
 a caller-supplied bidirectional transport of raw IP packets (`Vec<u8>`), with no OS
 `tun` device and no elevated privileges. It MUST NOT depend on Go, a gVisor netstack,
 or any FFI network stack.
@@ -77,13 +77,13 @@ IPv6 addresses (the AAAA query is skipped).
 - **WHEN** a name with both A and AAAA records is resolved on an IPv4-only stack
 - **THEN** only IPv4 addresses are returned
 
-### Requirement: smolmix refactored onto nym-smol-core
+### Requirement: smolmix refactored onto smol-core
 
-The existing `smolmix` crate SHALL be refactored to consume `nym-smol-core` for its
+The existing `smolmix` crate SHALL be refactored to consume `smol-core` for its
 stack, while preserving its existing public API.
 
 #### Scenario: smolmix public API unchanged
-- **WHEN** `smolmix` is rebuilt on top of `nym-smol-core`
+- **WHEN** `smolmix` is rebuilt on top of `smol-core`
 - **THEN** existing `smolmix` public items (e.g. `Tunnel`, `tcp_connect`,
   `udp_socket`) continue to compile and behave as before
 

--- a/openspec/specs/smol-core-stack/spec.md
+++ b/openspec/specs/smol-core-stack/spec.md
@@ -1,11 +1,11 @@
 # smol-core-stack Specification
 
 ## Purpose
-Defines smol-core, the transport-agnostic userspace TCP/IP stack, its TCP/UDP/DNS socket surfaces, and the smolmix refactor onto it.
+Defines nym-smol-core, the transport-agnostic userspace TCP/IP stack, its TCP/UDP/DNS socket surfaces, and the smolmix refactor onto it.
 ## Requirements
 ### Requirement: Transport-agnostic userspace TCP/IP stack
 
-`smol-core` SHALL provide a pure-Rust, `tokio`-async userspace TCP/IP stack driven by
+`nym-smol-core` SHALL provide a pure-Rust, `tokio`-async userspace TCP/IP stack driven by
 a caller-supplied bidirectional transport of raw IP packets (`Vec<u8>`), with no OS
 `tun` device and no elevated privileges. It MUST NOT depend on Go, a gVisor netstack,
 or any FFI network stack.
@@ -77,13 +77,13 @@ IPv6 addresses (the AAAA query is skipped).
 - **WHEN** a name with both A and AAAA records is resolved on an IPv4-only stack
 - **THEN** only IPv4 addresses are returned
 
-### Requirement: smolmix refactored onto smol-core
+### Requirement: smolmix refactored onto nym-smol-core
 
-The existing `smolmix` crate SHALL be refactored to consume `smol-core` for its
+The existing `smolmix` crate SHALL be refactored to consume `nym-smol-core` for its
 stack, while preserving its existing public API.
 
 #### Scenario: smolmix public API unchanged
-- **WHEN** `smolmix` is rebuilt on top of `smol-core`
+- **WHEN** `smolmix` is rebuilt on top of `nym-smol-core`
 - **THEN** existing `smolmix` public items (e.g. `Tunnel`, `tcp_connect`,
   `udp_socket`) continue to compile and behave as before
 

--- a/smoldvpn/Cargo.toml
+++ b/smoldvpn/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "smoldvpn"
-description = "Pure-Rust userspace 1-/2-hop WireGuard dVPN datapath (boringtun on smol-core) exposing tokio socket surfaces, with an optional QUIC bridge transport"
+description = "Pure-Rust userspace 1-/2-hop WireGuard dVPN datapath (boringtun on nym-smol-core) exposing tokio socket surfaces, with an optional QUIC bridge transport"
 version.workspace = true
 authors.workspace = true
 edition = "2021"
@@ -16,7 +16,7 @@ readme = "README.md"
 publish = true
 
 [dependencies]
-smol-core = { workspace = true }
+nym-smol-core = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time", "sync", "io-util", "net"] }
 tokio-util = { workspace = true, features = ["codec", "rt"] }
 futures = { workspace = true }

--- a/smoldvpn/Cargo.toml
+++ b/smoldvpn/Cargo.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "smoldvpn"
+name = "nym-smoldvpn"
 description = "Pure-Rust userspace 1-/2-hop WireGuard dVPN datapath (boringtun on nym-smol-core) exposing tokio socket surfaces, with an optional QUIC bridge transport"
 version.workspace = true
 authors.workspace = true
@@ -101,7 +101,7 @@ nym-network-defaults = { workspace = true }
 bip39 = { workspace = true }
 tokio-util = { workspace = true }
 # Examples install a `tracing` subscriber so the crate's datapath/handshake
-# logs are visible (honours `RUST_LOG`, defaulting to `smoldvpn=info`).
+# logs are visible (honours `RUST_LOG`, defaulting to `nym_smoldvpn=info`).
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[example]]

--- a/smoldvpn/README.md
+++ b/smoldvpn/README.md
@@ -1,66 +1,66 @@
 # smoldvpn
 
-A pure-Rust, userspace **1-/2-hop WireGuard dVPN datapath** built on
-[`boringtun`](https://docs.rs/boringtun) and [`smol-core`](../../../common/smol-core),
-with **no OS `tun` device and no root**. Application traffic flows through the
-tunnel via ordinary tokio socket surfaces (`TcpStream`, `UdpSocket`, and
+A pure-Rust, userspace 1-/2-hop WireGuard dVPN datapath built on
+[`boringtun`](https://docs.rs/boringtun) and [`smol-core`](../common/smol-core),
+with no OS `tun` device and no root. Application traffic flows through the
+tunnel over ordinary tokio socket surfaces (`TcpStream`, `UdpSocket`, and
 `tonic`/`hyper` connectors).
 
 ## What can I use `smoldvpn` for?
 
-Tunnel some or all of your app's internet traffic over the Nym network — in
-**1-hop or 2-hop dVPN mode** — straight from Rust. You don't stand up an
-OS-wide VPN; the tunnel is **scoped to the sockets your app opens through it**.
-This is *not* an OS-level kill-switch: traffic your app sends over ordinary
-(non-tunnel) sockets, and the host's own DNS, still go out normally and are **not**
-protected. For the traffic you *do* route through it, closing the tunnel cuts that
-traffic off — a per-socket kill-switch for the flows you opted in. Routing *all* of
-an app's traffic (and preventing leaks around it) is the integrator's
-responsibility.
+Tunnel some or all of your app's internet traffic over the Nym network, in
+1-hop or 2-hop dVPN mode, from Rust. You don't stand up an OS-wide VPN; the
+tunnel is scoped to the sockets your app opens through it. This is not an
+OS-level kill-switch: traffic your app sends over ordinary (non-tunnel)
+sockets, and the host's own DNS, still go out normally and are not protected.
+For the traffic you do route through it, closing the tunnel cuts that traffic
+off, so it acts as a per-socket kill-switch for the flows you opted in.
+Routing all of an app's traffic (and preventing leaks around it) is the
+integrator's responsibility.
 
 How it works, end to end:
 
 1. **Get unlinkable credentials.** Your app acquires zk-nym ticketbooks to pay
-   for access to the Nym network. Because they're zero-knowledge, there's **no
-   link between the payment and the network usage** it unlocks.
+   for access to the Nym network. Because they're zero-knowledge, there is no
+   link between the payment and the network usage it unlocks.
 2. **Register with individual gateways.** Each hop registers separately and is
-   handed its **own unique WireGuard identity** — there is no centralised, shared
-   WireGuard public key. The network is run by **independent operators**, so
-   trust isn't concentrated in one party.
+   handed its own unique WireGuard identity; there is no centralised, shared
+   WireGuard public key. The network is run by independent operators, so trust
+   isn't concentrated in one party.
 3. **Send traffic through tokio.** Drive the tunnel with ordinary async
-   primitives — `AsyncRead`/`AsyncWrite`, `TcpStream`, `UdpSocket` — and layer
-   crates like `tonic` or `hyper` on top to send **gRPC, HTTP, or anything else**
-   inside your app-specific tunnel. Under the hood it's WireGuard: **fast, with
-   very small per-packet header overhead**.
+   primitives (`AsyncRead`/`AsyncWrite`, `TcpStream`, `UdpSocket`) and layer
+   crates like `tonic` or `hyper` on top to send gRPC, HTTP, or anything else
+   inside your app-specific tunnel. Under the hood it is WireGuard, so
+   per-packet header overhead stays small.
 
-Blocked by a censor doing **Deep Packet Inspection**? Flip on the **QUIC bridge**
+To get around a censor doing deep packet inspection, turn on the QUIC bridge
 transport ([Data-plane modes](#data-plane-modes)): the WireGuard tunnel rides inside a QUIC
 connection to a Nym network bridge, so on the wire it looks like ordinary QUIC
 rather than WireGuard/UDP.
 
-### Don't want your users to touch NYM tokens?
+### Using the crate without your users holding NYM
 
-Your end-users **don't have to acquire or hold NYM** to use the Nym network. Run
-the [`nym-credential-proxy`](../../../nym-credential-proxy/nym-credential-proxy) —
-an authenticated service you operate that **gifts zk-nyms to your users** on their
+Your end-users don't have to acquire or hold NYM to use the Nym network. Run
+the [`nym-credential-proxy`](../nym-credential-proxy/nym-credential-proxy), an
+authenticated service you operate that issues zk-nyms to your users on their
 behalf. Your app authenticates to the proxy, the proxy issues the unlinkable
-credentials, and your users get Nym access with zero crypto onboarding.
+credentials, and your users get Nym access without handling any tokens.
 
 ## Data-plane modes
 
 Three modes, selected on the builder:
 
-- **one-hop** — a single `boringtun` `Tunn` to one gateway.
-- **two-hop** — nested `Tunn`s: the exit tunnel's ciphertext is framed as an
+- **one-hop**: a single `boringtun` `Tunn` to one gateway.
+- **two-hop**: nested `Tunn`s. The exit tunnel's ciphertext is framed as an
   inner IP/UDP datagram (via `smoltcp::wire`) and re-encrypted by the entry
   tunnel.
-- **QUIC-tunnelling two-hop** — the entry leg is fronted by an inline QUIC
+- **QUIC-tunnelling two-hop**: the entry leg is fronted by an inline QUIC
   bridge (ALPN `hq-29`, ed25519-SPKI pinning, 2-byte length framing) for
   clients blocked from pure UDP. QUIC only ever fronts the two-hop entry leg.
 
 ## Usage
 
-The datapath is **decoupled from provisioning**: build a `PeerConfig` per hop
+The datapath is decoupled from provisioning: build a `PeerConfig` per hop
 (e.g. by mapping a `nym-sdk-session` registration) and hand it to a
 `TunnelBuilder`.
 
@@ -93,8 +93,8 @@ let tunnel = TunnelBuilder::two_hop(entry, exit)
 ## Examples
 
 Runnable end-to-end demos live in `examples/` (shared setup is in
-`examples/common/`). **All need a funded `MNEMONIC`** and a live Nym network —
-see [Developers](#developers) for pointing at sandbox.
+`examples/common/`). All need a funded `MNEMONIC` and a live Nym network; see
+[Developers](#developers) for pointing at sandbox.
 
 | Example | What it does |
 |---|---|
@@ -106,7 +106,7 @@ see [Developers](#developers) for pointing at sandbox.
 | `zcash-sync` | Time syncing the last N Zcash compact blocks (default 10,000, `--blocks <N>`) from a public `lightwalletd` (`zec.rocks:443`, gRPC-over-TLS) directly vs. through the tunnel, and compare throughput. |
 
 Run one with (see [Developers](#developers) to set the sandbox env first).
-**Build `--release`** — `boringtun` is much slower in debug, which dominates the
+Build `--release`: `boringtun` is much slower in debug, which dominates the
 tunnel timing:
 
 ```sh
@@ -133,13 +133,13 @@ after `--`, e.g. `cargo run … --example two-hop-ip -- --entry DE --quic`):
 | `<SPEC>` | Selection |
 |---|---|
 | `random` | Any WireGuard-capable gateway (the default). |
-| `<CC>` | A two-letter ISO 3166 country code, e.g. `DE`, `CH` — a random gateway in that country. |
+| `<CC>` | A two-letter ISO 3166 country code, e.g. `DE`, `CH`: a random gateway in that country. |
 | `<identity>` | An exact gateway ed25519 identity key (base58). |
 
 Notes:
 - `two-hop-quic` is QUIC + two-hop by definition; it still honours
   `--entry`/`--exit`/`--gateway` but ignores `--one-hop`/`--quic`.
-- **QUIC only fronts the two-hop entry leg** — `--quic --one-hop` is rejected.
+- QUIC only fronts the two-hop entry leg, so `--quic --one-hop` is rejected.
 - QUIC-entry selection needs a **dVPN gateway-directory URL** so the session can
   discover QUIC-bridge-capable gateways and their bridge params. The examples
   default to the sandbox directory; override with `DVPN_DIRECTORY_URL`. If no
@@ -230,8 +230,8 @@ cargo run --release -p smoldvpn --example two-hop-ip
   their data directories are unaffected.
 - Registration reuse: successful gateway registrations are persisted by
   `nym-sdk-session` (`registrations.json` next to `creds.db`, per network +
-  gateway + role) and reused on later runs against the same gateways — **zero
-  tickets spent** until the gateway-side allowance actually depletes. The
+  gateway + role) and reused on later runs against the same gateways, spending
+  zero tickets until the gateway-side allowance actually depletes. The
   examples gate bring-up on `Tunnel::await_established` (15s bound; healthy
   establishment is ~100ms) and, when a cached registration's peer is gone,
   invalidate it and register fresh automatically (`reusing cached
@@ -242,7 +242,7 @@ cargo run --release -p smoldvpn --example two-hop-ip
   example plus `smoldvpn` and `boringtun` at `info`. Override with
   `RUST_LOG`, e.g. `RUST_LOG=smoldvpn=debug` for the full datapath/handshake
   detail, or `RUST_LOG=debug` for everything. Stdout is reserved for genuine
-  output — the `smoldvpn-config` WireGuard config and `--help` text — so e.g.
+  output (the `smoldvpn-config` WireGuard config and `--help` text), so e.g.
   `cargo run … --example smoldvpn-config > wg0.conf` stays clean.
 
 ## Features
@@ -276,26 +276,26 @@ End-to-end tunnel bring-up against a live Nym gateway is validated separately
 ## Design
 
 See the architecture docs in
-[`docs/design/sdk/smoldvpn/`](../../../docs/design/sdk/smoldvpn/) and the
+[`docs/design/smoldvpn/`](../docs/design/smoldvpn/) and the
 OpenSpec capability specs this crate implements:
 
-- [`dvpn-tunnel`](../../../openspec/specs/dvpn-tunnel/spec.md) — the userspace
+- [`dvpn-tunnel`](../openspec/specs/dvpn-tunnel/spec.md): the userspace
   WireGuard datapath, tunnel modes, lifecycle, DNS, MTU, and top-up.
-- [`dvpn-quic-bridge`](../../../openspec/specs/dvpn-quic-bridge/spec.md) — the
+- [`dvpn-quic-bridge`](../openspec/specs/dvpn-quic-bridge/spec.md): the
   `WgPacketTransport` abstraction and the QUIC bridge transport.
-- [`dvpn-tools`](../../../openspec/specs/dvpn-tools/spec.md) — the example CLIs
+- [`dvpn-tools`](../openspec/specs/dvpn-tools/spec.md): the example CLIs
   (config export, bandwidth top-up, gRPC/IP/Zcash demos).
 
 Related capabilities in sibling crates:
-[`dvpn-session`](../../../openspec/specs/dvpn-session/spec.md) (provisioning,
+[`dvpn-session`](../openspec/specs/dvpn-session/spec.md) (provisioning,
 `nym-sdk-session`) and
-[`smol-core-stack`](../../../openspec/specs/smol-core-stack/spec.md) (the
+[`smol-core-stack`](../openspec/specs/smol-core-stack/spec.md) (the
 `smol-core` TCP/IP stack).
 
 ## License
 
 `smoldvpn` is licensed under the **Apache License, Version 2.0**
-([`Apache-2.0`](../../../LICENSES/Apache-2.0.txt)). Unless you explicitly state otherwise,
+([`Apache-2.0`](../LICENSES/Apache-2.0.txt)). Unless you explicitly state otherwise,
 any contribution intentionally submitted for inclusion in this crate shall be
 licensed as above, without any additional terms or conditions.
 

--- a/smoldvpn/README.md
+++ b/smoldvpn/README.md
@@ -1,7 +1,7 @@
 # smoldvpn
 
 A pure-Rust, userspace 1-/2-hop WireGuard dVPN datapath built on
-[`boringtun`](https://docs.rs/boringtun) and [`smol-core`](../common/smol-core),
+[`boringtun`](https://docs.rs/boringtun) and [`nym-smol-core`](../common/smol-core),
 with no OS `tun` device and no root. Application traffic flows through the
 tunnel over ordinary tokio socket surfaces (`TcpStream`, `UdpSocket`, and
 `tonic`/`hyper` connectors).
@@ -250,9 +250,9 @@ cargo run --release -p smoldvpn --example two-hop-ip
 - `CancellationToken` aborts setup or tears down the long-lived tunnel;
   `shutdown()` is equivalent. Issued tickets are never touched by this crate.
 - Configurable, runtime-adjustable per-hop MTU via `Tunnel::set_mtu()` (rebuilds
-  the smol-core interface while preserving the WireGuard session; reference
+  the nym-smol-core interface while preserving the WireGuard session; reference
   defaults: overhead 80/hop; desktop 1420/1340; mobile 1360/1280).
-- DNS-in-tunnel by default (configurable), via the `smol-core` resolver.
+- DNS-in-tunnel by default (configurable), via the `nym-smol-core` resolver.
 - Throughput-tuned stack: a 512 KiB TCP window (vs smoltcp's 8 KiB default) and
   an unbounded device burst, so bulk transfers aren't window/BDP-throttled on
   higher-RTT two-hop paths (`StackConfig::with_tcp_buffer` tunes it).
@@ -290,7 +290,7 @@ Related capabilities in sibling crates:
 [`dvpn-session`](../openspec/specs/dvpn-session/spec.md) (provisioning,
 `nym-sdk-session`) and
 [`smol-core-stack`](../openspec/specs/smol-core-stack/spec.md) (the
-`smol-core` TCP/IP stack).
+`nym-smol-core` TCP/IP stack).
 
 ## License
 

--- a/smoldvpn/README.md
+++ b/smoldvpn/README.md
@@ -1,4 +1,4 @@
-# smoldvpn
+# nym-smoldvpn
 
 A pure-Rust, userspace 1-/2-hop WireGuard dVPN datapath built on
 [`boringtun`](https://docs.rs/boringtun) and [`nym-smol-core`](../common/smol-core),
@@ -6,7 +6,7 @@ with no OS `tun` device and no root. Application traffic flows through the
 tunnel over ordinary tokio socket surfaces (`TcpStream`, `UdpSocket`, and
 `tonic`/`hyper` connectors).
 
-## What can I use `smoldvpn` for?
+## What can I use `nym-smoldvpn` for?
 
 Tunnel some or all of your app's internet traffic over the Nym network, in
 1-hop or 2-hop dVPN mode, from Rust. You don't stand up an OS-wide VPN; the
@@ -65,7 +65,7 @@ The datapath is decoupled from provisioning: build a `PeerConfig` per hop
 `TunnelBuilder`.
 
 ```rust
-use smoldvpn::{TunnelBuilder, PeerConfig, BridgeParams};
+use nym_smoldvpn::{TunnelBuilder, PeerConfig, BridgeParams};
 
 // Two-hop over direct UDP:
 let tunnel = TunnelBuilder::two_hop(entry, exit)
@@ -110,7 +110,7 @@ Build `--release`: `boringtun` is much slower in debug, which dominates the
 tunnel timing:
 
 ```sh
-MNEMONIC="<funded mnemonic>" cargo run --release -p smoldvpn --example two-hop-ip
+MNEMONIC="<funded mnemonic>" cargo run --release -p nym-smoldvpn --example two-hop-ip
 ```
 
 ### Command-line options
@@ -146,7 +146,7 @@ Notes:
   QUIC-capable entry matches the requested country/identity, selection fails with
   `NoQuicGateway`.
 
-Examples (`…` = `MNEMONIC="…" cargo run --release -p smoldvpn`):
+Examples (`…` = `MNEMONIC="…" cargo run --release -p nym-smoldvpn`):
 
 ```sh
 # Random two-hop, show the IP relocate:
@@ -207,7 +207,7 @@ repo's sandbox env file and provide a funded sandbox mnemonic:
 set -a; source envs/sandbox.env; set +a      # nyxd / nym-api / contract addresses
 export MNEMONIC="<funded sandbox mnemonic>"   # deposits NYM + issues ticketbooks
 
-cargo run --release -p smoldvpn --example two-hop-ip
+cargo run --release -p nym-smoldvpn --example two-hop-ip
 ```
 
 - Build `--release`: `boringtun`'s userspace crypto is much slower in a debug
@@ -221,13 +221,13 @@ cargo run --release -p smoldvpn --example two-hop-ip
   `data/two-hop-ip/sandbox/`).
 - `DVPN_DIRECTORY_URL` defaults to the sandbox dVPN directory (used for gateway
   monikers and QUIC-bridge discovery); override it for another network.
-- Renamed from `nym-smol-dvpn` (2026-07): the crate is now `smoldvpn` at the
-  repo root, matching `smolmix`. Migration for local state and habits:
-  `RUST_LOG` targets are now `smoldvpn=…` (was `nym_smol_dvpn=…`); the
-  `smol-dvpn-*` examples are now `smoldvpn-*`, so any local
-  `data/smol-dvpn-*` directories should be renamed to `data/smoldvpn-*` to
-  keep their credentials. `zcash-sync`, `two-hop-ip`, `two-hop-quic` and
-  their data directories are unaffected.
+- Renamed to `nym-smoldvpn` (previously `smoldvpn`, and originally
+  `nym-smol-dvpn`); the crate lives at the repo root. Migration for local state
+  and habits: `RUST_LOG` targets are now `nym_smoldvpn=…` (was `smoldvpn=…`, and
+  `nym_smol_dvpn=…` before that); the `smol-dvpn-*` examples are now
+  `smoldvpn-*`, so any local `data/smol-dvpn-*` directories should be renamed to
+  `data/smoldvpn-*` to keep their credentials. `zcash-sync`, `two-hop-ip`,
+  `two-hop-quic` and their data directories are unaffected.
 - Registration reuse: successful gateway registrations are persisted by
   `nym-sdk-session` (`registrations.json` next to `creds.db`, per network +
   gateway + role) and reused on later runs against the same gateways, spending
@@ -239,8 +239,8 @@ cargo run --release -p smoldvpn --example two-hop-ip
 - Logging: the examples emit their progress/results as `tracing` logs (on
   **stderr**) rather than `println!`, and install a subscriber so they appear out
   of the box. The default filter (when `RUST_LOG` is unset) is the running
-  example plus `smoldvpn` and `boringtun` at `info`. Override with
-  `RUST_LOG`, e.g. `RUST_LOG=smoldvpn=debug` for the full datapath/handshake
+  example plus `nym-smoldvpn` and `boringtun` at `info`. Override with
+  `RUST_LOG`, e.g. `RUST_LOG=nym_smoldvpn=debug` for the full datapath/handshake
   detail, or `RUST_LOG=debug` for everything. Stdout is reserved for genuine
   output (the `smoldvpn-config` WireGuard config and `--help` text), so e.g.
   `cargo run … --example smoldvpn-config > wg0.conf` stays clean.
@@ -268,7 +268,7 @@ WG/QUIC dependency surface contained to this crate.
 
 ## Tests
 
-`cargo test -p smoldvpn` includes the QUIC bridge conformance test (framing
+`cargo test -p nym-smoldvpn` includes the QUIC bridge conformance test (framing
 + ed25519-SPKI pinning, positive and negative) against a local mock bridge.
 End-to-end tunnel bring-up against a live Nym gateway is validated separately
 (needs credentials + network).
@@ -294,7 +294,7 @@ Related capabilities in sibling crates:
 
 ## License
 
-`smoldvpn` is licensed under the **Apache License, Version 2.0**
+`nym-smoldvpn` is licensed under the **Apache License, Version 2.0**
 ([`Apache-2.0`](../LICENSES/Apache-2.0.txt)). Unless you explicitly state otherwise,
 any contribution intentionally submitted for inclusion in this crate shall be
 licensed as above, without any additional terms or conditions.

--- a/smoldvpn/examples/common/mod.rs
+++ b/smoldvpn/examples/common/mod.rs
@@ -24,9 +24,9 @@ use nym_network_defaults::NymNetworkDetails;
 use nym_sdk_session::{
     GatewayInfo, GatewaySpec, HopConfig, QuicBridge, Registration, Session, SessionConfig, WgRole,
 };
+use nym_smoldvpn::{BridgeParams, PeerConfig, Tunnel, TunnelBuilder};
 use rustls::pki_types::ServerName;
 use serde_json::Value;
-use smoldvpn::{BridgeParams, PeerConfig, Tunnel, TunnelBuilder};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio_rustls::TlsConnector;
 use tower::Service;
@@ -45,7 +45,7 @@ pub fn init_crypto() {
 
 /// Install a `tracing` subscriber so example narration and the crate's
 /// datapath/handshake logs are visible. Honours `RUST_LOG`
-/// (e.g. `RUST_LOG=smoldvpn=debug`); when unset it defaults to the running
+/// (e.g. `RUST_LOG=nym_smoldvpn=debug`); when unset it defaults to the running
 /// example plus `smoldvpn` and `boringtun` at `info`. Idempotent — the
 /// `try_` initialiser makes a second call a no-op.
 pub fn init_logging() {
@@ -57,7 +57,7 @@ pub fn init_logging() {
                 // root is the example's own log target, so its `info!` shows.
                 let example = module_path!().split("::").next().unwrap_or("");
                 tracing_subscriber::EnvFilter::new(format!(
-                    "{example}=info,smoldvpn=info,boringtun=info"
+                    "{example}=info,nym_smoldvpn=info,boringtun=info"
                 ))
             }),
         )
@@ -172,7 +172,7 @@ pub async fn build_tunnel(reg: &Registration, use_quic: bool) -> Result<Tunnel, 
 /// Bring up a tunnel with gateway-side bandwidth top-up wired in — the recommended default for a
 /// long-lived, session-built tunnel. Spends already-stored tickets (obtained via the session's
 /// bandwidth provider) against the in-tunnel `metadata` endpoint before bandwidth runs out, and
-/// exposes [`smoldvpn::BandwidthEvent`]s via `tunnel.bandwidth_events()`.
+/// exposes [`nym_smoldvpn::BandwidthEvent`]s via `tunnel.bandwidth_events()`.
 ///
 /// The bandwidth top-up meters at the exit gateway (the sole hop for one-hop), so it spends
 /// `WgRole::Exit` tickets there.
@@ -183,7 +183,7 @@ pub async fn build_tunnel_with_topup(
     use_quic: bool,
 ) -> Result<Tunnel, BoxError> {
     use nym_credentials_interface::TicketType;
-    use smoldvpn::{ProviderCredentialSource, TopupConfig};
+    use nym_smoldvpn::{ProviderCredentialSource, TopupConfig};
 
     // The metering gateway is the exit (or the sole gateway for one-hop).
     let (metering, ticket_type) = match reg.exit.as_ref() {

--- a/smoldvpn/examples/quic-probe.rs
+++ b/smoldvpn/examples/quic-probe.rs
@@ -8,24 +8,24 @@
 //!   1. **raw**   — a bare `quinn` handshake (ALPN `hq-29`, cert verification
 //!      DISABLED). Success ⇒ the bridge server is reachable and speaks our
 //!      QUIC/ALPN; a timeout ⇒ infra (UDP unreachable).
-//!   2. **pinned** — our real `smoldvpn::probe_bridge` (ed25519 cert
+//!   2. **pinned** — our real `nym_smoldvpn::probe_bridge` (ed25519 cert
 //!      pinning + `open_bi`). A failure here while raw succeeds ⇒ our bug.
 //!
 //! Defaults to the two known sandbox QUIC gateways; override with
 //! `--addr <ip:port> --sni <host> --id <base64-ed25519>`.
 //!
 //! Usage (no mnemonic/network needed — this only touches the bridge):
-//!   cargo run --release -p smoldvpn --example quic-probe
+//!   cargo run --release -p nym-smoldvpn --example quic-probe
 
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use nym_smoldvpn::{probe_bridge, BridgeParams};
 use quinn::crypto::rustls::QuicClientConfig;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{DigitallySignedStruct, SignatureScheme};
-use smoldvpn::{probe_bridge, BridgeParams};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -152,7 +152,7 @@ async fn probe_target(name: &str, addr: &str, sni: &str, id_b64: &str) {
 
 /// Install a `tracing` subscriber so example narration and the crate's
 /// datapath/handshake logs are visible. Honours `RUST_LOG`
-/// (e.g. `RUST_LOG=smoldvpn=debug`); when unset it defaults to this example
+/// (e.g. `RUST_LOG=nym_smoldvpn=debug`); when unset it defaults to this example
 /// plus `smoldvpn` and `boringtun` at `info`.
 fn init_logging() {
     let _ = tracing_subscriber::fmt()
@@ -162,7 +162,7 @@ fn init_logging() {
                 // `module_path!()` is this example's crate — its own log target.
                 let example = module_path!().split("::").next().unwrap_or("");
                 tracing_subscriber::EnvFilter::new(format!(
-                    "{example}=info,smoldvpn=info,boringtun=info"
+                    "{example}=info,nym_smoldvpn=info,boringtun=info"
                 ))
             }),
         )

--- a/smoldvpn/examples/smoldvpn-config.rs
+++ b/smoldvpn/examples/smoldvpn-config.rs
@@ -11,7 +11,7 @@
 //!
 //! Usage:
 //!   MNEMONIC="<funded mnemonic>" \
-//!   cargo run -p smoldvpn --example smoldvpn-config -- --gateway <spec>
+//!   cargo run -p nym-smoldvpn --example smoldvpn-config -- --gateway <spec>
 //!
 //! `<spec>` is `random`, a two-letter country code (e.g. `CH`), or a gateway
 //! ed25519 identity (base58). The network defaults to sandbox; override with
@@ -65,7 +65,7 @@ fn base64_encode(input: &[u8]) -> String {
 
 /// Install a `tracing` subscriber so example narration and the crate's
 /// datapath/handshake logs are visible. Honours `RUST_LOG`
-/// (e.g. `RUST_LOG=smoldvpn=debug`); when unset it defaults to this example
+/// (e.g. `RUST_LOG=nym_smoldvpn=debug`); when unset it defaults to this example
 /// plus `smoldvpn` and `boringtun` at `info`. The emitted WireGuard config
 /// still goes to stdout via `println!`, so it can be redirected to a file.
 fn init_logging() {
@@ -76,7 +76,7 @@ fn init_logging() {
                 // `module_path!()` is this example's crate — its own log target.
                 let example = module_path!().split("::").next().unwrap_or("");
                 tracing_subscriber::EnvFilter::new(format!(
-                    "{example}=info,smoldvpn=info,boringtun=info"
+                    "{example}=info,nym_smoldvpn=info,boringtun=info"
                 ))
             }),
         )

--- a/smoldvpn/examples/smoldvpn-grpc.rs
+++ b/smoldvpn/examples/smoldvpn-grpc.rs
@@ -12,7 +12,7 @@
 //!
 //! Usage:
 //!   MNEMONIC="<funded mnemonic>" \
-//!   cargo run -p smoldvpn --example smoldvpn-grpc -- \
+//!   cargo run -p nym-smoldvpn --example smoldvpn-grpc -- \
 //!     --gateway <spec> --target <host:port> [--service <name>]
 
 use std::process::ExitCode;
@@ -20,7 +20,7 @@ use std::process::ExitCode;
 use nym_crypto::asymmetric::{ed25519, x25519};
 use nym_network_defaults::NymNetworkDetails;
 use nym_sdk_session::{GatewaySpec, HopConfig, Session, SessionConfig, WgRole};
-use smoldvpn::{PeerConfig, TunnelBuilder};
+use nym_smoldvpn::{PeerConfig, TunnelBuilder};
 use tokio_util::sync::CancellationToken;
 use tonic::transport::Endpoint;
 use tonic_health::pb::{health_client::HealthClient, HealthCheckRequest};
@@ -32,7 +32,7 @@ const ESTABLISH_BOUND: std::time::Duration = std::time::Duration::from_secs(15);
 
 /// Install a `tracing` subscriber so example narration and the crate's
 /// datapath/handshake logs are visible. Honours `RUST_LOG`
-/// (e.g. `RUST_LOG=smoldvpn=debug`); when unset it defaults to this example
+/// (e.g. `RUST_LOG=nym_smoldvpn=debug`); when unset it defaults to this example
 /// plus `smoldvpn` and `boringtun` at `info`.
 fn init_logging() {
     let _ = tracing_subscriber::fmt()
@@ -42,7 +42,7 @@ fn init_logging() {
                 // `module_path!()` is this example's crate — its own log target.
                 let example = module_path!().split("::").next().unwrap_or("");
                 tracing_subscriber::EnvFilter::new(format!(
-                    "{example}=info,smoldvpn=info,boringtun=info"
+                    "{example}=info,nym_smoldvpn=info,boringtun=info"
                 ))
             }),
         )

--- a/smoldvpn/examples/smoldvpn-topup.rs
+++ b/smoldvpn/examples/smoldvpn-topup.rs
@@ -9,7 +9,7 @@
 //!
 //! Usage:
 //!   MNEMONIC="<funded mnemonic>" \
-//!   cargo run -p smoldvpn --example smoldvpn-topup -- \
+//!   cargo run -p nym-smoldvpn --example smoldvpn-topup -- \
 //!     --gateway-id <ed25519 base58> --metadata-url <https://gateway:port/>
 //!
 //! `--metadata-url` is the gateway's metadata HTTP endpoint; `--gateway-id` is
@@ -25,7 +25,7 @@ use tracing::{error, info};
 
 /// Install a `tracing` subscriber so example narration and the crate's
 /// datapath/handshake logs are visible. Honours `RUST_LOG`
-/// (e.g. `RUST_LOG=smoldvpn=debug`); when unset it defaults to this example
+/// (e.g. `RUST_LOG=nym_smoldvpn=debug`); when unset it defaults to this example
 /// plus `smoldvpn` and `boringtun` at `info`.
 fn init_logging() {
     let _ = tracing_subscriber::fmt()
@@ -35,7 +35,7 @@ fn init_logging() {
                 // `module_path!()` is this example's crate — its own log target.
                 let example = module_path!().split("::").next().unwrap_or("");
                 tracing_subscriber::EnvFilter::new(format!(
-                    "{example}=info,smoldvpn=info,boringtun=info"
+                    "{example}=info,nym_smoldvpn=info,boringtun=info"
                 ))
             }),
         )
@@ -98,7 +98,7 @@ async fn run() -> Result<(), String> {
             .await
             .map_err(|e| format!("ticketbook issuance failed: {e}"))?;
 
-        let before = smoldvpn::query_available_bandwidth(&metadata_url)
+        let before = nym_smoldvpn::query_available_bandwidth(&metadata_url)
             .await
             .map_err(|e| format!("available-bandwidth query failed: {e}"))?;
         info!("available bandwidth before top-up: {before} bytes");
@@ -109,7 +109,7 @@ async fn run() -> Result<(), String> {
             .await
             .map_err(|e| format!("could not obtain credential: {e}"))?;
 
-        let after = smoldvpn::topup_bandwidth(&metadata_url, credential)
+        let after = nym_smoldvpn::topup_bandwidth(&metadata_url, credential)
             .await
             .map_err(|e| format!("top-up failed: {e}"))?;
         info!("available bandwidth after top-up: {after} bytes");

--- a/smoldvpn/examples/two-hop-ip.rs
+++ b/smoldvpn/examples/two-hop-ip.rs
@@ -10,7 +10,7 @@
 //!
 //! Usage (build `--release`: boringtun is slow in debug):
 //!   MNEMONIC="<funded mnemonic>" \
-//!   cargo run --release -p smoldvpn --example two-hop-ip [-- <options>]
+//!   cargo run --release -p nym-smoldvpn --example two-hop-ip [-- <options>]
 //!
 //! Options (see `common::USAGE` / README): `--one-hop`/`--two-hop`,
 //! `--entry <SPEC>`, `--exit <SPEC>`, `--gateway <SPEC>`, `--quic`. `<SPEC>` is

--- a/smoldvpn/examples/two-hop-quic.rs
+++ b/smoldvpn/examples/two-hop-quic.rs
@@ -12,7 +12,7 @@
 //!
 //! Usage (build `--release`: boringtun is slow in debug):
 //!   MNEMONIC="<funded mnemonic>" \
-//!   cargo run --release -p smoldvpn --example two-hop-quic
+//!   cargo run --release -p nym-smoldvpn --example two-hop-quic
 //!
 //! The QUIC gateway set comes from the dVPN directory (see
 //! `common::DEFAULT_DVPN_DIRECTORY`; override with `DVPN_DIRECTORY_URL`).

--- a/smoldvpn/examples/zcash-sync.rs
+++ b/smoldvpn/examples/zcash-sync.rs
@@ -14,13 +14,13 @@
 //!
 //! Usage:
 //!   MNEMONIC="<funded mnemonic>" \
-//!   cargo run --release -p smoldvpn --example zcash-sync [-- --blocks <N> <options>]
+//!   cargo run --release -p nym-smoldvpn --example zcash-sync [-- --blocks <N> <options>]
 
 use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use http::uri::PathAndQuery;
-use smoldvpn::Tunnel;
+use nym_smoldvpn::Tunnel;
 use tonic::client::Grpc;
 use tonic::transport::{Channel, Endpoint};
 use tonic::Request;

--- a/smoldvpn/src/connectors.rs
+++ b/smoldvpn/src/connectors.rs
@@ -26,7 +26,7 @@ use std::task::{Context, Poll};
 
 use http::Uri;
 use hyper_util::rt::TokioIo;
-use smol_core::{Stack, TcpStream};
+use nym_smol_core::{Stack, TcpStream};
 use tower::Service;
 
 use crate::error::DvpnError;

--- a/smoldvpn/src/connectors.rs
+++ b/smoldvpn/src/connectors.rs
@@ -10,7 +10,7 @@
 //! `Client`. `reqwest` can be layered on top of the same `hyper` client.
 //!
 //! ```no_run
-//! # async fn example_connect(tunnel: &smoldvpn::Tunnel) -> Result<(), Box<dyn std::error::Error>> {
+//! # async fn example_connect(tunnel: &nym_smoldvpn::Tunnel) -> Result<(), Box<dyn std::error::Error>> {
 //! let channel = tonic::transport::Endpoint::from_static("http://10.0.0.1:50051")
 //!     .connect_with_connector(tunnel.connector())
 //!     .await?;

--- a/smoldvpn/src/error.rs
+++ b/smoldvpn/src/error.rs
@@ -12,7 +12,7 @@ pub enum DvpnError {
 
     /// The underlying smol-core stack errored.
     #[error("stack error: {0}")]
-    Stack(#[from] smol_core::SmolCoreError),
+    Stack(#[from] nym_smol_core::SmolCoreError),
 
     /// Socket / IO error.
     #[error("IO error: {0}")]

--- a/smoldvpn/src/lib.rs
+++ b/smoldvpn/src/lib.rs
@@ -15,9 +15,9 @@
 //! and QUIC-tunnelling two-hop (see [`BridgeParams`]).
 //!
 //! ```no_run
-//! # async fn example(entry: smoldvpn::PeerConfig, exit: smoldvpn::PeerConfig)
+//! # async fn example(entry: nym_smoldvpn::PeerConfig, exit: nym_smoldvpn::PeerConfig)
 //! # -> Result<(), Box<dyn std::error::Error>> {
-//! use smoldvpn::TunnelBuilder;
+//! use nym_smoldvpn::TunnelBuilder;
 //!
 //! let tunnel = TunnelBuilder::two_hop(entry, exit).connect().await?;
 //! let mut tcp = tunnel.tcp_connect("1.1.1.1:443".parse()?).await?;

--- a/smoldvpn/src/lib.rs
+++ b/smoldvpn/src/lib.rs
@@ -4,7 +4,7 @@
 //! # smoldvpn
 //!
 //! A pure-Rust, userspace 1-/2-hop WireGuard dVPN datapath built on
-//! [`boringtun`](https://docs.rs/boringtun) and [`smol_core`], with **no OS
+//! [`boringtun`](https://docs.rs/boringtun) and [`nym_smol_core`], with **no OS
 //! `tun` device and no root**. Application traffic flows through the tunnel via
 //! ordinary tokio socket surfaces ([`TcpStream`], [`UdpSocket`], and the
 //! `tonic`/`hyper`/`reqwest` connectors in [`connectors`]).
@@ -49,4 +49,4 @@ pub use transport::SocketProtector;
 pub use tunnel::{NotEstablished, Tunnel, TunnelBuilder};
 
 /// tokio socket types produced by the tunnel (re-exported from `smol-core`).
-pub use smol_core::{TcpStream, UdpSocket};
+pub use nym_smol_core::{TcpStream, UdpSocket};

--- a/smoldvpn/src/tunnel.rs
+++ b/smoldvpn/src/tunnel.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use futures::channel::mpsc;
 use futures::StreamExt;
-use smol_core::{ChannelDevice, DnsConfig, Stack, StackConfig, TcpStream, UdpSocket};
+use nym_smol_core::{ChannelDevice, DnsConfig, Stack, StackConfig, TcpStream, UdpSocket};
 
 use crate::connectors::TunnelConnector;
 use crate::topup::{

--- a/smoldvpn/tests/await_established.rs
+++ b/smoldvpn/tests/await_established.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use boringtun::noise::{Tunn, TunnResult};
 use boringtun::x25519::{PublicKey, StaticSecret};
 use nym_crypto::asymmetric::x25519;
-use smoldvpn::{NotEstablished, PeerConfig, TunnelBuilder};
+use nym_smoldvpn::{NotEstablished, PeerConfig, TunnelBuilder};
 
 /// Run an async test body on a manually-built runtime and force-stop it after.
 /// The smol-core stack parks workers in tokio's blocking pool that outlive the

--- a/smoldvpn/tests/live_bringup.rs
+++ b/smoldvpn/tests/live_bringup.rs
@@ -10,7 +10,7 @@
 //! ```sh
 //! set -a; source envs/sandbox.env; source .claude/.secrets/sandbox.env; set +a
 //! MNEMONIC="$NYX_ACCOUNT_MNEMONIC" \
-//!   cargo test -p smoldvpn --test live_bringup -- --ignored --nocapture --test-threads=1
+//!   cargo test -p nym-smoldvpn --test live_bringup -- --ignored --nocapture --test-threads=1
 //! ```
 //!
 //! Run with `--test-threads=1`: both tests deposit from the same chain account, so running
@@ -26,7 +26,7 @@ use std::net::IpAddr;
 
 use nym_network_defaults::NymNetworkDetails;
 use nym_sdk_session::{GatewaySpec, HopConfig, Registration, Session, SessionConfig};
-use smoldvpn::{MtuConfig, PeerConfig, Tunnel, TunnelBuilder};
+use nym_smoldvpn::{MtuConfig, PeerConfig, Tunnel, TunnelBuilder};
 use tokio_util::sync::CancellationToken;
 
 /// Map a session hop into the datapath's transport-agnostic peer config.

--- a/smolmix/core/Cargo.toml
+++ b/smolmix/core/Cargo.toml
@@ -13,7 +13,7 @@ readme = "src/ARCHITECTURE.md"
 publish = true
 
 [dependencies]
-smol-core = { workspace = true }
+nym-smol-core = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }

--- a/smolmix/core/Cargo.toml
+++ b/smolmix/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "smolmix"
+name = "nym-smolmix"
 description = "Tunnel for TCP and UDP traffic to be sent over Nym mixnet to clearnet remote hosts"
 version.workspace = true
 authors.workspace = true

--- a/smolmix/core/examples/tcp.rs
+++ b/smolmix/core/examples/tcp.rs
@@ -10,14 +10,14 @@
 //! ```text
 //! hyper (HTTP/1.1 client)
 //!   └─ tokio-rustls (TLS encryption)
-//!        └─ smolmix::TcpStream (TCP over mixnet)
+//!        └─ nym_smolmix::TcpStream (TCP over mixnet)
 //!             └─ smoltcp (userspace TCP/IP)
 //!                  └─ Nym mixnet → IPR exit gateway → internet
 //! ```
 //!
 //! ```sh
-//! cargo run -p smolmix --example tcp
-//! cargo run -p smolmix --example tcp -- --ipr <IPR_ADDRESS>
+//! cargo run -p nym-smolmix --example tcp
+//! cargo run -p nym-smolmix --example tcp -- --ipr <IPR_ADDRESS>
 //! ```
 
 use std::sync::Arc;
@@ -26,8 +26,8 @@ use http_body_util::BodyExt;
 use hyper::body::Bytes;
 use hyper::Request;
 use hyper_util::rt::TokioIo;
+use nym_smolmix::Tunnel;
 use rustls::pki_types::ServerName;
-use smolmix::Tunnel;
 use tokio_rustls::TlsConnector;
 use tracing::info;
 
@@ -60,7 +60,7 @@ async fn main() -> Result<(), BoxError> {
     let clearnet_duration = clearnet_start.elapsed();
     info!("Clearnet: {} in {:?}", clearnet_status, clearnet_duration);
 
-    // TCP source is smolmix::TcpStream; everything above is the same as the
+    // TCP source is nym_smolmix::TcpStream; everything above is the same as the
     // clearnet path.
     let args: Vec<String> = std::env::args().collect();
     let ipr_addr = args

--- a/smolmix/core/examples/tcp_download.rs
+++ b/smolmix/core/examples/tcp_download.rs
@@ -12,14 +12,14 @@
 //! ```text
 //! hyper (HTTP/1.1 client, keep-alive)
 //!   └─ tokio-rustls (TLS encryption)
-//!        └─ smolmix::TcpStream (TCP over mixnet)
+//!        └─ nym_smolmix::TcpStream (TCP over mixnet)
 //!             └─ smoltcp (userspace TCP/IP)
 //!                  └─ Nym mixnet → IPR exit gateway → internet
 //! ```
 //!
 //! ```sh
-//! cargo run -p smolmix --example tcp_download
-//! cargo run -p smolmix --example tcp_download -- --ipr <IPR_ADDRESS>
+//! cargo run -p nym-smolmix --example tcp_download
+//! cargo run -p nym-smolmix --example tcp_download -- --ipr <IPR_ADDRESS>
 //! ```
 
 use std::net::Ipv4Addr;
@@ -31,8 +31,8 @@ use http_body_util::{BodyExt, Empty};
 use hyper::body::Bytes;
 use hyper::client::conn::http1;
 use hyper_util::rt::TokioIo;
+use nym_smolmix::Tunnel;
 use rustls::pki_types::ServerName;
-use smolmix::Tunnel;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 

--- a/smolmix/core/examples/udp.rs
+++ b/smolmix/core/examples/udp.rs
@@ -4,19 +4,19 @@
 //!
 //! Resolves `example.com` twice: once via the system path with
 //! `hickory-resolver`, and once by sending a raw DNS query to Cloudflare's
-//! 1.1.1.1 over a `smolmix::UdpSocket`. The resolved IPs and timings are
+//! 1.1.1.1 over a `nym_smolmix::UdpSocket`. The resolved IPs and timings are
 //! printed for comparison.
 //!
 //! ```text
 //! DNS query / response (application-layer UDP)
-//!   └─ smolmix::UdpSocket (UDP over mixnet)
+//!   └─ nym_smolmix::UdpSocket (UDP over mixnet)
 //!        └─ smoltcp (userspace IP stack)
 //!             └─ Nym mixnet → IPR exit gateway → internet
 //! ```
 //!
 //! ```sh
-//! cargo run -p smolmix --example udp
-//! cargo run -p smolmix --example udp -- --ipr <IPR_ADDRESS>
+//! cargo run -p nym-smolmix --example udp
+//! cargo run -p nym-smolmix --example udp -- --ipr <IPR_ADDRESS>
 //! ```
 
 use std::net::Ipv4Addr;
@@ -26,7 +26,7 @@ use hickory_proto::{
     rr::{Name, RData, RecordType},
 };
 use hickory_resolver::TokioResolver;
-use smolmix::Tunnel;
+use nym_smolmix::Tunnel;
 use tracing::info;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/smolmix/core/examples/websocket.rs
+++ b/smolmix/core/examples/websocket.rs
@@ -10,19 +10,19 @@
 //! tokio-tungstenite (WebSocket framing)
 //!   └─ tokio-rustls (TLS encryption)
 //!        ├─ tokio::net::TcpStream  (clearnet)
-//!        └─ smolmix::TcpStream     (mixnet)
+//!        └─ nym_smolmix::TcpStream     (mixnet)
 //! ```
 //!
 //! ```sh
-//! cargo run -p smolmix --example websocket
-//! cargo run -p smolmix --example websocket -- --ipr <IPR_ADDRESS>
+//! cargo run -p nym-smolmix --example websocket
+//! cargo run -p nym-smolmix --example websocket -- --ipr <IPR_ADDRESS>
 //! ```
 
 use std::sync::Arc;
 
 use futures::{SinkExt, StreamExt};
+use nym_smolmix::Tunnel;
 use rustls::pki_types::ServerName;
-use smolmix::Tunnel;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::info;
 
@@ -74,7 +74,7 @@ async fn main() -> Result<(), BoxError> {
 
     info!("Clearnet: \"{clearnet_text}\" in {clearnet_duration:?}");
 
-    // TCP source is smolmix::TcpStream; everything above is the same.
+    // TCP source is nym_smolmix::TcpStream; everything above is the same.
     let args: Vec<String> = std::env::args().collect();
     let ipr_addr = args
         .iter()

--- a/smolmix/core/src/error.rs
+++ b/smolmix/core/src/error.rs
@@ -19,11 +19,11 @@ pub enum SmolmixError {
 
 // Map smol-core stack errors onto the existing public variants, so refactoring
 // smolmix onto smol-core does not change SmolmixError's public surface.
-impl From<smol_core::SmolCoreError> for SmolmixError {
-    fn from(err: smol_core::SmolCoreError) -> Self {
+impl From<nym_smol_core::SmolCoreError> for SmolmixError {
+    fn from(err: nym_smol_core::SmolCoreError) -> Self {
         match err {
-            smol_core::SmolCoreError::Io(e) => SmolmixError::Io(e),
-            smol_core::SmolCoreError::ChannelClosed => SmolmixError::ChannelClosed,
+            nym_smol_core::SmolCoreError::Io(e) => SmolmixError::Io(e),
+            nym_smol_core::SmolCoreError::ChannelClosed => SmolmixError::ChannelClosed,
             // DNS/other stack errors surface as IO (smolmix exposes no DNS API).
             other => SmolmixError::Io(std::io::Error::other(other.to_string())),
         }

--- a/smolmix/core/src/lib.rs
+++ b/smolmix/core/src/lib.rs
@@ -23,7 +23,7 @@ pub use tunnel::Recipient;
 ///
 /// ```no_run
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// # let tunnel = smolmix::Tunnel::new().await?;
+/// # let tunnel = nym_smolmix::Tunnel::new().await?;
 /// use tokio::io::{AsyncReadExt, AsyncWriteExt};
 ///
 /// let mut stream = tunnel.tcp_connect("1.1.1.1:80".parse()?).await?;
@@ -49,7 +49,7 @@ pub use tunnel::TunnelBuilder;
 ///
 /// ```no_run
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// # let tunnel = smolmix::Tunnel::new().await?;
+/// # let tunnel = nym_smolmix::Tunnel::new().await?;
 /// let udp = tunnel.udp_socket().await?;
 /// udp.send_to(b"hello", "1.1.1.1:9999".parse()?).await?;
 ///

--- a/smolmix/core/src/tunnel.rs
+++ b/smolmix/core/src/tunnel.rs
@@ -56,7 +56,7 @@ struct TunnelInner {
 ///
 /// ```no_run
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// use smolmix::Tunnel;
+/// use nym_smolmix::Tunnel;
 /// use tokio::io::{AsyncReadExt, AsyncWriteExt};
 ///
 /// let tunnel = Tunnel::new().await?;
@@ -96,13 +96,13 @@ pub struct Tunnel {
 ///
 /// ```no_run
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// use smolmix::Tunnel;
+/// use nym_smolmix::Tunnel;
 ///
 /// // Auto-discover the best IPR:
 /// let tunnel = Tunnel::builder().build().await?;
 ///
 /// // Or specify an IPR exit node:
-/// use smolmix::Recipient;
+/// use nym_smolmix::Recipient;
 /// let ipr: Recipient = "gateway-address...".parse()?;
 /// let tunnel = Tunnel::builder().ipr_address(ipr).build().await?;
 /// # Ok(())
@@ -141,7 +141,7 @@ impl Tunnel {
     ///
     /// ```no_run
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// use smolmix::Tunnel;
+    /// use nym_smolmix::Tunnel;
     /// let tunnel = Tunnel::builder().build().await?;
     /// # Ok(())
     /// # }
@@ -156,7 +156,7 @@ impl Tunnel {
     ///
     /// ```no_run
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// use smolmix::Tunnel;
+    /// use nym_smolmix::Tunnel;
     /// let tunnel = Tunnel::new().await?;
     /// let tcp = tunnel.tcp_connect("1.1.1.1:443".parse()?).await?;
     /// # Ok(())
@@ -172,7 +172,7 @@ impl Tunnel {
     ///
     /// ```no_run
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// use smolmix::{Recipient, Tunnel};
+    /// use nym_smolmix::{Recipient, Tunnel};
     /// let ipr: Recipient = "gateway-address...".parse()?;
     /// let tunnel = Tunnel::new_with_ipr(ipr).await?;
     /// # Ok(())
@@ -253,7 +253,7 @@ impl Tunnel {
     /// Raw HTTP request:
     /// ```no_run
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let tunnel = smolmix::Tunnel::new().await?;
+    /// # let tunnel = nym_smolmix::Tunnel::new().await?;
     /// use tokio::io::{AsyncReadExt, AsyncWriteExt};
     ///
     /// let mut tcp = tunnel.tcp_connect("1.1.1.1:80".parse()?).await?;
@@ -268,7 +268,7 @@ impl Tunnel {
     /// TLS via tokio-rustls (the stream stands in for `tokio::net::TcpStream`):
     /// ```no_run
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let tunnel = smolmix::Tunnel::new().await?;
+    /// # let tunnel = nym_smolmix::Tunnel::new().await?;
     /// use rustls::pki_types::ServerName;
     /// use tokio_rustls::TlsConnector;
     ///
@@ -296,7 +296,7 @@ impl Tunnel {
     /// Send a DNS query and read the response:
     /// ```no_run
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let tunnel = smolmix::Tunnel::new().await?;
+    /// # let tunnel = nym_smolmix::Tunnel::new().await?;
     /// let udp = tunnel.udp_socket().await?;
     ///
     /// // Send a raw DNS query to Cloudflare

--- a/smolmix/core/src/tunnel.rs
+++ b/smolmix/core/src/tunnel.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use futures::channel::mpsc;
 pub use nym_ip_packet_requests::IpPair;
 use nym_sdk::ipr_wrapper::IpMixStream;
-use smol_core::{ChannelDevice, Stack, StackConfig};
+use nym_smol_core::{ChannelDevice, Stack, StackConfig};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tracing::info;
@@ -23,7 +23,7 @@ use crate::bridge::{BridgeShutdownHandle, NymIprBridge};
 use crate::SmolmixError;
 
 pub use nym_sdk::mixnet::Recipient;
-pub use smol_core::{TcpStream, UdpSocket};
+pub use nym_smol_core::{TcpStream, UdpSocket};
 
 struct ShutdownState {
     bridge_shutdown: BridgeShutdownHandle,

--- a/smolmix/core/tests/public_api.rs
+++ b/smolmix/core/tests/public_api.rs
@@ -8,7 +8,7 @@
 //! catching an accidental API break without needing a live mixnet. Behavioural
 //! regression is covered by the crate's examples run against a live mixnet.
 
-use smolmix::{IpPair, Recipient, SmolmixError, TcpStream, Tunnel, TunnelBuilder, UdpSocket};
+use nym_smolmix::{IpPair, Recipient, SmolmixError, TcpStream, Tunnel, TunnelBuilder, UdpSocket};
 
 // Every referenced path must exist with its current name and arity.
 #[allow(unused, clippy::no_effect)]

--- a/wasm/smolmix/Cargo.toml
+++ b/wasm/smolmix/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "smolmix-wasm"
+name = "nym-smolmix-wasm"
 version = "0.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -86,7 +86,7 @@ features = ["wasm_js"]
 [features]
 # Default: build all three JS entry points (mixFetch, mixWebSocket, mixDNS).
 # TS SDK packages that only need a subset can disable defaults and opt in:
-#   smolmix-wasm = { ..., default-features = false, features = ["fetch"] }
+#   nym-smolmix-wasm = { ..., default-features = false, features = ["fetch"] }
 default = ["dns", "fetch", "websocket"]
 
 # Expose the JS `mixDNS(hostname)` entry point.

--- a/wasm/smolmix/Makefile
+++ b/wasm/smolmix/Makefile
@@ -7,10 +7,11 @@ TASKSET ?= taskset -c 0-11
 .PHONY: build build-rust build-debug build-release-opt check-fmt dev dev-build \
         internal-dev-install mark-pkg-private test test\:smoke test\:suite
 
-build: build-rust mark-pkg-private
+build: build-rust
 
 build-rust:
 	$(TASKSET) wasm-pack build --scope nymproject --target web --out-name smolmix_wasm
+	$(MAKE) mark-pkg-private
 
 build-debug:
 	$(TASKSET) wasm-pack build --debug --scope nymproject --target web --out-name smolmix_wasm --features debug

--- a/wasm/smolmix/Makefile
+++ b/wasm/smolmix/Makefile
@@ -10,24 +10,30 @@ TASKSET ?= taskset -c 0-11
 build: build-rust mark-pkg-private
 
 build-rust:
-	$(TASKSET) wasm-pack build --scope nymproject --target web
+	$(TASKSET) wasm-pack build --scope nymproject --target web --out-name smolmix_wasm
 
 build-debug:
-	$(TASKSET) wasm-pack build --debug --scope nymproject --target web --features debug
+	$(TASKSET) wasm-pack build --debug --scope nymproject --target web --out-name smolmix_wasm --features debug
 	$(MAKE) mark-pkg-private
 
 build-release-opt:
-	$(TASKSET) wasm-pack build --scope nymproject --target web
+	$(TASKSET) wasm-pack build --scope nymproject --target web --out-name smolmix_wasm
 	$(TASKSET) wasm-opt -Oz -o pkg/smolmix_wasm_bg.wasm pkg/smolmix_wasm_bg.wasm
 	$(MAKE) mark-pkg-private
 
-# smolmix-wasm is workspace-internal: its bytes are base64-inlined into
+# nym-smolmix-wasm is workspace-internal: its bytes are base64-inlined into
 # @nymproject/mix-tunnel at build time, so it must never reach npm. wasm-pack
 # does not write `"private": true` itself, so we patch the generated package.json
 # in place. Guard against re-application so the target stays idempotent.
+#
+# The generated package name is also pinned to @nymproject/smolmix-wasm (not the
+# derived @nymproject/nym-smolmix-wasm). The crate carries the nym- prefix, but
+# the private artifact keeps its established name so mix-tunnel's imports stay
+# unchanged; `--out-name smolmix_wasm` on the wasm-pack calls above pins the file
+# basenames to match.
 mark-pkg-private:
 	@if [ -f pkg/package.json ]; then \
-		jq '. + {private: true}' pkg/package.json > pkg/package.json.tmp \
+		jq '. + {private: true, name: "@nymproject/smolmix-wasm"}' pkg/package.json > pkg/package.json.tmp \
 			&& mv pkg/package.json.tmp pkg/package.json; \
 	fi
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/6996)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bumped workspace dependency releases to **1.21.5-rc.2**.
  * Added workspace support and naming for the **`nym-smoldvpn`** package family.

* **Documentation**
  * Updated installation commands, example snippets, API/design references, and OpenSpec “Purpose” text to use the **`nym-`** crate naming and locations (including corrected in-repo links).

* **Chores**
  * Standardized crate identity and release/WASM build naming to align WebAssembly package outputs with the updated **`nym-*`** scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->