### PR TITLE
HTTP Error handling 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7174,6 +7174,7 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "fastrand",
+ "h2 0.4.14",
  "hickory-resolver",
  "http 1.4.1",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,6 +289,7 @@ getrandom = "0.2.10"
 getrandom03 = { package = "getrandom", version = "=0.3.3" }
 getrandom04 = { package = "getrandom", version = "0.4" }
 glob = "0.3"
+h2 = "0.4.14"
 handlebars = "3.5.5"
 hex = "0.4.3"
 hickory-proto = { version = "0.26.1", default-features = false }

--- a/common/http-api-client/Cargo.toml
+++ b/common/http-api-client/Cargo.toml
@@ -50,6 +50,7 @@ nym-network-defaults = { workspace = true, optional = true }
 nym-http-api-client-macro = { workspace = true }
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies]
+h2 = { workspace = true }
 hickory-resolver = { workspace = true, features = ["https-ring", "tls-ring", "webpki-roots"] }
 
 # for request timeout until https://github.com/seanmonstar/reqwest/issues/1135 is fixed

--- a/common/http-api-client/src/lib.rs
+++ b/common/http-api-client/src/lib.rs
@@ -316,7 +316,7 @@ impl Display for ReqwestErrorWrapper {
         }
 
         if let Some(source) = self.0.source() {
-            write!(f, " source: {source}")?;
+            write!(f, " source: {source:?}")?;
         } else {
             write!(f, " unknown lower-level error source")?;
         }
@@ -959,7 +959,9 @@ impl Client {
 
     #[cfg(feature = "tunneling")]
     fn matches_current_host(&self, url: &Url) -> bool {
-        if self.front.is_enabled() {
+        // Only compare against the front host if the current url actually has one configured -
+        // otherwise requests to it go out unfronted, so the offending host will be the real one.
+        if self.front.is_enabled() && self.current_url().has_front() {
             url.host_str() == self.current_url().front_str()
         } else {
             url.host_str() == self.current_url().host_str()
@@ -1279,7 +1281,7 @@ pub(crate) fn is_http_rate_limit_err(resp: &Response) -> bool {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-const MAX_ERR_SOURCE_ITERATIONS: usize = 4;
+const MAX_ERR_SOURCE_ITERATIONS: usize = 6;
 
 /// This functions attempts to check the error returned by reqwest to see if rotating host
 /// information (for clients with multiple hosts defined) could be helpful. This looks for
@@ -1329,6 +1331,16 @@ pub(crate) fn might_be_network_interference(err: &reqwest::Error) -> bool {
             } else if let Some(resolve_err) = e.downcast_ref::<hickory_resolver::net::NetError>() {
                 // try downcast to DNS error
                 return resolve_err.is_nx_domain();
+            } else if let Some(h2_err) = e.downcast_ref::<h2::Error>() {
+                // try downcast to a h2 (HTTP/2) error. hyper only wraps these as io::Error
+                // when they are actually backed by one (see `hyper::Error::new_h2`), so if we
+                // get here it's a protocol-level RST_STREAM or GOAWAY. TLS integrity protection
+                // means this can only have been sent by whichever party actually terminates the
+                // TLS connection - for a fronted request that's the front's CDN edge. So it
+                // indicates that host/front may have actively rejected the connection (e.g.
+                // detected fronting, rate limiting, or its own backend failing). This has enough
+                // potentially to continue breaking things that we should rotate hosts if we can.
+                return h2_err.is_remote() && (h2_err.is_reset() || h2_err.is_go_away());
             } else {
                 inner = e.source();
             }

--- a/common/http-api-client/src/tests.rs
+++ b/common/http-api-client/src/tests.rs
@@ -251,6 +251,46 @@ fn fronted_host_updating() {
     assert_eq!(current_url.front_str(), Some("cdn1.test"));
 }
 
+// Reproduces the exact url-list shape used for the nymvpn-api config:
+//   [{ "url": "https://nymvpn.com/api/" },
+//    { "url": "https://nymvpn-frontdoor.global.ssl.fastly.net/api",
+//      "fronts": ["yelp.global.ssl.fastly.net"] }]
+//
+// When fronting is enabled and the CURRENT url is the one with no `fronts`
+// configured, `matches_current_host` must consider the fact that the domain
+// doesn't have fronts and compare properly. This test ensures the correct
+// behavior, rotating to the next (fronted) entry in the list.
+#[test]
+#[cfg(feature = "tunneling")]
+fn fronting_enabled_stuck_on_unfronted_first_url() {
+    let plain_url = Url::new("https://nymvpn.com/api/", None).unwrap();
+    let fronted_url = Url::new(
+        "https://nymvpn-frontdoor.global.ssl.fastly.net/api",
+        Some(vec!["https://yelp.global.ssl.fastly.net"]),
+    )
+    .unwrap();
+
+    let client = ClientBuilder::new_with_urls(vec![plain_url, fronted_url])
+        .unwrap()
+        .with_fronting(Some(crate::fronted::FrontPolicy::Always))
+        .build()
+        .unwrap();
+
+    // client starts on the first, unfronted url.
+    assert_eq!(client.current_url().as_str(), "https://nymvpn.com/api/");
+
+    // offending url matches the plain url
+    let offending = Url::parse("https://nymvpn.com/api/").unwrap();
+    client.maybe_rotate_hosts(Some(offending));
+
+    // should rotate urls.
+    assert_eq!(
+        client.current_url().as_str(),
+        "https://nymvpn-frontdoor.global.ssl.fastly.net/api",
+        "client failed to rotate away from the unfronted url after an error"
+    );
+}
+
 #[test]
 #[cfg(feature = "network-defaults")]
 fn from_network_configures_multiple_urls_and_retries() {


### PR DESCRIPTION
Add several potential bug fixes contributing to API instability in censoring regions. While none of these are necessarily being actively triggered they make the behavior of the HTTP client more predictable. 

- [x] Log full inner error text in http error `Display` impl
- [x] Ensure domains rotate when fronting is defined, but the current domain has no fronts.
- [x] Ensure domain rotation happens on h2 failures that may have been uncaught before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7006)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/2 network error handling by recognizing remote stream resets and connection shutdowns before switching hosts.
  * Refined error reporting to provide clearer underlying network error details.
  * Fixed host selection when tunneling is enabled, ensuring clients switch to an appropriate fallback connection when required.

* **Tests**
  * Added regression coverage for host rotation and fallback behavior when fronting is required.
  * Verified handling of mixed direct and fronted connection options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->