### PR TITLE
Add several more API options

### DIFF
--- a/common/http-api-client/src/dns/constants.rs
+++ b/common/http-api-client/src/dns/constants.rs
@@ -39,6 +39,20 @@ pub const YELP_FASTLY_IPS: &[IpAddr] = &[
     IpAddr::V4(Ipv4Addr::new(151, 101, 65, 194)),
 ];
 
+pub const FASTLY_SUPPORT_DOMAIN: &str = "fastly-support.global.ssl.fastly.net";
+pub const FASTLY_SUPPORT_IPS: &[IpAddr] = &[
+    IpAddr::V4(Ipv4Addr::new(151, 101, 193, 194)),
+    IpAddr::V4(Ipv4Addr::new(151, 101, 129, 194)),
+    IpAddr::V4(Ipv4Addr::new(151, 101, 1, 194)),
+    IpAddr::V4(Ipv4Addr::new(151, 101, 65, 194)),
+];
+
+pub const PYPI_FASTLY_DOMAIN: &str = "pypi.global.ssl.fastly.net";
+pub const PYPI_FASTLY_IPS: &[IpAddr] = &[
+    IpAddr::V4(Ipv4Addr::new(199, 232, 65, 194)),
+    IpAddr::V4(Ipv4Addr::new(151, 101, 65, 194)),
+];
+
 pub const VERCEL_APP_DOMAIN: &str = "vercel.app";
 pub const VERCEL_APP_IPS: &[IpAddr] = &[
     IpAddr::V4(Ipv4Addr::new(64, 29, 17, 195)),
@@ -95,6 +109,11 @@ pub fn default_static_addrs() -> HashMap<String, Vec<IpAddr>> {
         NYMVPN_FRONTDOOR_FASTLY_IPS.to_vec(),
     );
     m.insert(YELP_FASTLY_DOMAIN.to_string(), YELP_FASTLY_IPS.to_vec());
+    m.insert(PYPI_FASTLY_DOMAIN.to_string(), PYPI_FASTLY_IPS.to_vec());
+    m.insert(
+        FASTLY_SUPPORT_DOMAIN.to_string(),
+        FASTLY_SUPPORT_IPS.to_vec(),
+    );
     m.insert(VERCEL_APP_DOMAIN.to_string(), VERCEL_APP_IPS.to_vec());
     m.insert(VERCEL_COM_DOMAIN.to_string(), VERCEL_COM_IPS.to_vec());
     m.insert(NYM_API_CDN.to_string(), NYM_API_CDN_IPS.to_vec());

--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -53,7 +53,11 @@ pub const NYM_APIS: &[ApiUrlConst] = &[
     },
     ApiUrlConst {
         url: "https://nym-frontdoor.global.ssl.fastly.net/api/",
-        front_hosts: Some(&["yelp.global.ssl.fastly.net"]),
+        front_hosts: Some(&[
+            "fastly-support.global.ssl.fastly.net",
+            "yelp.global.ssl.fastly.net",
+            "pypi.global.ssl.fastly.net",
+        ]),
     },
     ApiUrlConst {
         url: "https://cdn1.media-platform.net/api/",
@@ -76,7 +80,11 @@ pub const NYM_VPN_APIS: &[ApiUrlConst] = &[
     },
     ApiUrlConst {
         url: "https://nymvpn-frontdoor.global.ssl.fastly.net/api/",
-        front_hosts: Some(&["yelp.global.ssl.fastly.net"]),
+        front_hosts: Some(&[
+            "fastly-support.global.ssl.fastly.net",
+            "yelp.global.ssl.fastly.net",
+            "pypi.global.ssl.fastly.net",
+        ]),
     },
 ];
 


### PR DESCRIPTION
Add multiple API options to the network defaults for usage in short order.

This applies to client builds that this gets included in as well as any rebuilds of the Nym API that include this for `api/network/details`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7007)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fastly support for improved connectivity to supported services.
  * Added PyPI Fastly endpoints and fallback addresses.
  * Added Fastly front hosts to mainnet API endpoint configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->