### PR TITLE
Bugfix: don't report end-of-stream from ChannelDevice

### DIFF
--- a/common/smol-core/src/device.rs
+++ b/common/smol-core/src/device.rs
@@ -39,6 +39,8 @@ pub struct ChannelDevice {
     rx: mpsc::UnboundedReceiver<Vec<u8>>,
     tx: mpsc::UnboundedSender<Vec<u8>>,
     capabilities: DeviceCapabilities,
+    /// Latched once the inbound channel terminates; see [`Stream::poll_next`].
+    rx_terminated: bool,
 }
 
 impl ChannelDevice {
@@ -64,6 +66,7 @@ impl ChannelDevice {
             rx,
             tx,
             capabilities,
+            rx_terminated: false,
         }
     }
 }
@@ -91,8 +94,26 @@ pub(crate) fn client_mtu(negotiated: Option<usize>) -> usize {
 impl Stream for ChannelDevice {
     type Item = io::Result<Vec<u8>>;
 
+    /// Yields inbound packets, and **never terminates**: once the transport's sender is gone this
+    /// parks forever rather than reporting end-of-stream.
+    ///
+    /// The reactor awaits this stream as one arm of a `select!` and discards the arm's result. A
+    /// `Ready(None)` there is permanently ready, so the reactor would complete that arm on every
+    /// iteration and spin without ever returning `Poll::Pending` - pegging a core and, because a
+    /// tokio worker can only be reclaimed between polls, wedging runtime shutdown forever. Parking
+    /// is safe: the reactor's other arms (poll-delay timer, socket notify, stopper) still drive it,
+    /// and a dead transport has no further packets to deliver.
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.rx).poll_next(cx).map(|opt| opt.map(Ok))
+        if self.rx_terminated {
+            return Poll::Pending;
+        }
+        match Pin::new(&mut self.rx).poll_next(cx) {
+            Poll::Ready(None) => {
+                self.rx_terminated = true;
+                Poll::Pending
+            }
+            other => other.map(|opt| opt.map(Ok)),
+        }
     }
 }
 

--- a/common/smol-core/tests/stack.rs
+++ b/common/smol-core/tests/stack.rs
@@ -310,11 +310,53 @@ async fn dns_v4_only_stack_skips_aaaa() {
         .expect("resolve");
     assert!(addrs.contains(&IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8))));
 
-    let seen = seen.lock().unwrap();
+    // Copy out and release the lock before asserting: a panic while holding it would poison the
+    // mutex and make the still-running mock server panic on its next lock, burying this message.
+    let seen = seen.lock().unwrap().clone();
     assert!(
         seen.iter().all(|t| *t == RecordType::A),
         "a v4-only stack must not send AAAA queries, saw {seen:?}"
     );
+}
+
+/// A stack whose inbound transport has gone away must not wedge runtime shutdown.
+///
+/// If the device reported end-of-stream to the smoltcp reactor, the reactor's `select!` would
+/// complete instantly on every iteration - a loop that never returns `Poll::Pending`, so the tokio
+/// worker running it can never be reclaimed and `Runtime::drop` blocks forever. Every test in this
+/// file hit this on teardown: the first stack to drop closes its peer's inbound channel.
+#[test]
+fn dead_inbound_transport_does_not_wedge_runtime_shutdown() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("build runtime");
+
+    // Kept alive past the runtime drop below: the point is a live stack whose transport is dead.
+    let _stack = rt.block_on(async {
+        let (out_tx, _out_rx) = mpsc::unbounded::<Vec<u8>>();
+        let (in_tx, in_rx) = mpsc::unbounded::<Vec<u8>>();
+        let stack = Stack::new(
+            ChannelDevice::new(in_rx, out_tx, None),
+            StackConfig::new(A_IP.parse().unwrap()),
+        );
+        // Get the reactor running, then kill the inbound transport under it.
+        let _sock = stack.udp_socket().await.expect("bind udp");
+        drop(in_tx);
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        (stack, _out_rx)
+    });
+
+    // Drop the runtime off-thread so a wedged shutdown fails the test instead of hanging it.
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        drop(rt);
+        let _ = done_tx.send(());
+    });
+    done_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("runtime shutdown wedged by a stack whose inbound transport was dropped");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]


### PR DESCRIPTION
## Summary

Fixes an indefinite hang in the `smol-core` stack teardown path, and adds a regression test for it. Also documents a separate, still-open upstream stall (see "Known remaining issue" below) that this PR deliberately does not attempt to fix.

The `common/smol-core/tests/stack.rs` suite was hanging in **7 of 8 full-suite runs** - on a randomly different test each time, and always *after* the test body had already reported `ok`. That randomness is why it read as a per-test bug; it is actually one teardown bug affecting every test in the file.

## Root cause

`tokio-smoltcp`'s reactor awaits the device stream as one arm of a `select!` **and discards the arm's result**. A `Poll::Ready(None)` there is therefore permanently ready: once the transport's sender was dropped, the reactor completed that arm on every iteration and spun without ever returning `Poll::Pending`. A tokio worker can only be reclaimed *between* polls, so that worker pegged a CPU core and `Runtime::drop` -> `BlockingPool::shutdown` blocked forever.

`Net::drop`'s `stopper.notify_waiters()` could not recover it either: it stores no permit, and a spinning reactor is never a registered waiter, so the stop signal was simply lost.

In the tests, `pair()` crosses the two stacks' channels, so whichever stack drops first closes its peer's inbound channel during teardown - which is what triggered the spin.

Evidence: a `sample` of a hung process showed the test thread parked in `Runtime::drop` -> `BlockingPool::shutdown` -> condvar wait, with a worker thread at **2205 of 2240 samples on-CPU** inside `tokio_smoltcp::reactor::run`.

## The fix

`ChannelDevice::poll_next` now latches termination and parks (`Poll::Pending`) instead of reporting end-of-stream. This is safe because the reactor's other arms (poll-delay timer, socket notify, stopper) still drive it, and a dead transport has no further packets to deliver. Nothing else in the workspace consumes `ChannelDevice` as a `Stream`, and the reactor discards that arm's result, so no consumer could have relied on the stream terminating.

## Impact beyond the tests

This is not a test-only fix. `smolmix/core/src/tunnel.rs` and `smoldvpn/src/tunnel.rs` both build a `ChannelDevice` over their transport channels, so any transport teardown would have pegged a core and left an unshutdownable tokio runtime in production.

## Verification

| | Before | After |
|---|---|---|
| Full-suite runs hung | 7 of 8 | **0 of 110** |
| New regression test | 10.21s wedge | 0.20s pass |

The regression test (`dead_inbound_transport_does_not_wedge_runtime_shutdown`) isolates the wedge deterministically by dropping the inbound sender directly, rather than depending on peer-teardown timing. It drops the runtime off-thread and asserts on a `recv_timeout`, so a wedged shutdown *fails* the test instead of hanging CI.

## Known remaining issue: 60s datapath stall (upstream, not fixed here)

Fixing the hang unmasked a pre-existing, unrelated flake that shows up roughly **1 run in 30** as `connect timed out` or `server recv timed out`.

This is an upstream `tokio-smoltcp` bug, already tracked as **https://github.com/spacemeowx2/tokio-smoltcp/issues/18** (open, no maintainer response). `Reactor::notify()` uses `Notify::notify_waiters()`, which stores no permit when no waiter is registered. A socket write landing in the gap between the reactor computing `poll_delay` and registering its `notified()` future loses the wakeup, and the reactor then sleeps the full `default_timeout` of 60 seconds.

Confirmed independently here by direct measurement: a 2000-iteration UDP round-trip probe showed ~1.2ms typical latency versus **exactly 60.002867s** on the stalled iteration - `default_timeout` to the microsecond.

**Impact on our code:** any tunnel operation whose reactor wakeup is lost stalls for up to 60 seconds - a DNS lookup, a TCP connect, or a datagram send in `smolmix`/`smoldvpn` can freeze the datapath for a full minute. The race window is narrow, so it is rare and load-sensitive, but the consequence when it hits is severe and user-visible, not a graceful slowdown. It is also the source of the residual test flake, so CI will still see occasional red on this suite until it is addressed.

**Why it is not fixed in this PR:** the fix is a one-word upstream change (`notify_waiters()` -> `notify_one()`, correct because exactly one reactor loop waits on it), but `tokio-smoltcp` **0.6.0 carries the identical code**, so a version bump does not help. Resolving it on our side means a `[patch.crates-io]` fork, which is a dependency decision worth making deliberately and separately from this bugfix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7009)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a runtime shutdown issue that could cause the application to hang when an inbound connection closes.
  - Improved handling of terminated inbound transports to prevent unnecessary reactor activity.

- **Tests**
  - Added coverage confirming runtime shutdown completes successfully after an inbound transport is dropped.
  - Improved test cleanup to avoid lock-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->