### PR TITLE
docs: add RPC URL warning and update faucet link for sandbox

### DIFF
--- a/documentation/docs/pages/operators/sandbox.mdx
+++ b/documentation/docs/pages/operators/sandbox.mdx
@@ -8,7 +8,7 @@ lastUpdated: "2026-02-01"
 
 import { Callout } from 'nextra/components';
 import { VarInfo } from 'components/variable-info.tsx';
-import { Steps } from 'nextra/components';import { Tabs } from 'nextra/components'
+import { Tabs } from 'nextra/components'
 
 # Sandbox Testnet
 
@@ -26,8 +26,6 @@ This page is for Nym node operators. If you want to run NymVPN CLI over Sandbox 
 
 To run Nym binaries in Sandbox testnet, you need to get `sandbox.env` configuration file and point your binary to it. Follow the steps below:
 
-<Steps>
-
 ###### 1. Create Sandbox environment config file by saving [this](https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env) as `sandbox.env` in the same directory as your binaries:
 ```sh
 curl -o sandbox.env -L https://raw.githubusercontent.com/nymtech/nym/develop/envs/sandbox.env
@@ -35,8 +33,10 @@ curl -o sandbox.env -L https://raw.githubusercontent.com/nymtech/nym/develop/env
 - In case you want to save the file elsewhere, change the path in '-o' flag
 
 - Make sure your `sandbox.env` file contains the correct RPC URL. If not, add this line. If it already exists, replace it with the correct URL:
+
 ```sh
 NYM_VALIDATOR_RPC_URL=https://validator-sandbox-1.nymtech.net
+```
 
 ###### 2. Run your `nym-node` with an additional flag `-c` or `--config-env-file`
 - Specify a path to `sandbox.env`
@@ -61,8 +61,6 @@ NYM_VALIDATOR_RPC_URL=https://validator-sandbox-1.nymtech.net
 - Follow the steps on the [bonding page](nodes/nym-node/bonding.mdx)
 
 ![](/images/operators/sandbox.png)
-
-</Steps>
 
 <Callout>
 1. If you [built Nym from source](binaries/building-nym), you already have `sandbox.env` as a part of the monorepo (`nym/envs/sandbox.env`). Giving that you are likely to run `nym-node` from `nym/target/release`, the flag will look like this `--config-env-file ../../envs/sandbox.env`

--- a/documentation/docs/pages/operators/sandbox.mdx
+++ b/documentation/docs/pages/operators/sandbox.mdx
@@ -34,6 +34,10 @@ curl -o sandbox.env -L https://raw.githubusercontent.com/nymtech/nym/develop/env
 ```
 - In case you want to save the file elsewhere, change the path in '-o' flag
 
+- Make sure your `sandbox.env` file contains the correct RPC URL. If not, add this line:
+```sh
+NYM_VALIDATOR_RPC_URL=https://validator-sandbox-1.nymtech.net
+
 ###### 2. Run your `nym-node` with an additional flag `-c` or `--config-env-file`
 - Specify a path to `sandbox.env`
 - Add all needed commands and options - for example:
@@ -56,7 +60,7 @@ curl -o sandbox.env -L https://raw.githubusercontent.com/nymtech/nym/develop/env
 
 ###### 3. Bond your node to Nym Sandbox environment
 - Open [Nym Wallet](https://nym.com/wallet) and switch to testnet
-- Go to [faucet.nymtech.net](https://faucet.nymtech.net) and aquire 101 testnet NYM tokens
+- Go to [https://sandbox-faucet.nymtech.net/](https://sandbox-faucet.nymtech.net/) and aquire 101 testnet NYM tokens
 - Follow the steps on the [bonding page](nodes/nym-node/bonding.mdx)
 
 ![](/images/operators/sandbox.png)
@@ -74,6 +78,6 @@ export NYMNODE_CONFIG_ENV_FILE_ARG=<PATH>/sandbox.env
 
 ## Sandbox Token Faucet
 
-To run your nodes in Sandbox environment, you need testnet version of NYM token, that can be aquired from [faucet.nymtech.net](https://faucet.nymtech.net).
+To run your nodes in Sandbox environment, you need testnet version of NYM token, that can be aquired from [https://sandbox-faucet.nymtech.net/](https://sandbox-faucet.nymtech.net/).
 
 To prevent abuse, the faucet is rate-limited - your request will fail if the requesting wallet already has 101 NYM tokens.

--- a/documentation/docs/pages/operators/sandbox.mdx
+++ b/documentation/docs/pages/operators/sandbox.mdx
@@ -43,18 +43,15 @@ NYM_VALIDATOR_RPC_URL=https://validator-sandbox-1.nymtech.net
 - Add all needed commands and options - for example:
 
 <Tabs items={[<code>mixnode</code>, <code>exit-gateway</code>]}>
-  <Tabs.Tab>
   This example is for `nym-node --mode mixnode`.
   ```sh
   ./nym-node --config-env-file <PATH>/sandbox.env run --mode mixnode
   ```
-  </Tabs.Tab>
-  <Tabs.Tab>
+
   This example is for `nym-node --mode exit-gateway`.
   ```sh
   ./nym-node --config-file-env <PATH>/sandbox.env run --mode exit-gateway --id <ID> --public-ips "$(curl -4 https://ifconfig.me)" --hostname "<HOSTNAME>" --http-bind-address 0.0.0.0:8080 --mixnet-bind-address 0.0.0.0:1789 true --location <CLOCATION>
   ```
-  </Tabs.Tab>
 </Tabs>
 - In case you downloaded `sandbox.env` to same directory, `<PATH>` is not needed
 

--- a/documentation/docs/pages/operators/sandbox.mdx
+++ b/documentation/docs/pages/operators/sandbox.mdx
@@ -34,7 +34,7 @@ curl -o sandbox.env -L https://raw.githubusercontent.com/nymtech/nym/develop/env
 ```
 - In case you want to save the file elsewhere, change the path in '-o' flag
 
-- Make sure your `sandbox.env` file contains the correct RPC URL. If not, add this line:
+- Make sure your `sandbox.env` file contains the correct RPC URL. If not, add this line. If it already exists, replace it with the correct URL:
 ```sh
 NYM_VALIDATOR_RPC_URL=https://validator-sandbox-1.nymtech.net
 
@@ -60,7 +60,7 @@ NYM_VALIDATOR_RPC_URL=https://validator-sandbox-1.nymtech.net
 
 ###### 3. Bond your node to Nym Sandbox environment
 - Open [Nym Wallet](https://nym.com/wallet) and switch to testnet
-- Go to [https://sandbox-faucet.nymtech.net/](https://sandbox-faucet.nymtech.net/) and aquire 101 testnet NYM tokens
+- Go to [https://sandbox-faucet.nymtech.net/](https://sandbox-faucet.nymtech.net/) and acquire 101 testnet NYM tokens
 - Follow the steps on the [bonding page](nodes/nym-node/bonding.mdx)
 
 ![](/images/operators/sandbox.png)
@@ -78,6 +78,6 @@ export NYMNODE_CONFIG_ENV_FILE_ARG=<PATH>/sandbox.env
 
 ## Sandbox Token Faucet
 
-To run your nodes in Sandbox environment, you need testnet version of NYM token, that can be aquired from [https://sandbox-faucet.nymtech.net/](https://sandbox-faucet.nymtech.net/).
+To run your nodes in Sandbox environment, you need testnet version of NYM token, that can be acquired from [https://sandbox-faucet.nymtech.net/](https://sandbox-faucet.nymtech.net/).
 
 To prevent abuse, the faucet is rate-limited - your request will fail if the requesting wallet already has 101 NYM tokens.


### PR DESCRIPTION
## Summary

- Add RPC URL warning to `sandbox.env` setup with set/replace instruction
- Update faucet link from `faucet.nymtech.net` to `sandbox-faucet.nymtech.net`
- Fix spelling: `aquire` → `acquire`, `aquired` → `acquired`

This helps node operators avoid RPC connection errors when setting up a node on Sandbox testnet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7028)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Sandbox setup instructions with the required validator RPC URL configuration.
  * Corrected the faucet URL for obtaining testnet NYM tokens.
  * Simplified node command examples and corrected a spelling error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->