### PR TITLE
bugfix: change constraints on stress testing results table to allow for orchestrator database reset

### DIFF
--- a/nym-api/migrations/20260806120000_stress_testing_result_identity.sql
+++ b/nym-api/migrations/20260806120000_stress_testing_result_identity.sql
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+-- Rebuild `nym_node_stress_testing_result` so that a measurement's identity no longer depends on
+-- an orchestrator-local row counter.
+--
+-- The original primary key was `(testrun_id, submitter_pubkey)`. `testrun.id` is an AUTOINCREMENT
+-- counter in the orchestrator's own SQLite database, which is not treated as durable state: if it
+-- is wiped the counter restarts from 1 while the orchestrator keeps its (durable, on-chain)
+-- ed25519 identity. Every resubmitted id then collided with a row already stored here and was
+-- discarded by `INSERT OR IGNORE`, silently, behind a 200 response, until the counter climbed back
+-- past its previous high-water mark - which takes about as long as the wiped database had been
+-- alive. Restoring that database from a backup was worse: an id was reused for a *different*
+-- measurement, so the stored row and the orchestrator's row disagreed about what the id meant.
+--
+-- Identity is therefore now the measurement itself, `(node_id, test_timestamp, submitter_pubkey)`,
+-- which a wipe cannot repeat. Dedupe of the orchestrator's at-least-once retries is unaffected: a
+-- resent row carries the identical triple, since it is read back from the same source row.
+CREATE TABLE nym_node_stress_testing_result_new
+(
+    -- Stable, store-assigned handle for this measurement, used by the read endpoints.
+    -- AUTOINCREMENT (rather than a bare rowid alias) so that ids are never reused once a
+    -- retention sweep starts deleting rows - reuse would recreate, one layer up, exactly the
+    -- id-collision bug this migration exists to fix.
+    id               INTEGER                     NOT NULL PRIMARY KEY AUTOINCREMENT,
+
+    -- Orchestrator-local testrun id that produced this result. Retained so a row can be traced
+    -- back to the submitting orchestrator's own read surface, but no longer part of any key.
+    testrun_id       INTEGER                     NOT NULL,
+
+    -- Base58-encoded ed25519 identity key of the submitting orchestrator.
+    submitter_pubkey TEXT                        NOT NULL,
+
+    -- unfortunately, due to legacy reasons we have separate tables for mixnodes and gateways
+    -- so that we can't put a reference constraint here
+    node_id          INTEGER                     NOT NULL,
+
+    result           REAL                        NOT NULL,
+
+    was_reachable    BOOLEAN                     NOT NULL,
+
+    test_timestamp   TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+
+    -- Column order is deliberate: the constraint is on the set, so it holds regardless, but
+    -- leading with `(node_id, test_timestamp)` lets this index also serve the per-node windowed
+    -- average that is the only read query against this table. The previous primary key led with
+    -- `testrun_id` and could not serve it at all.
+    UNIQUE (node_id, test_timestamp, submitter_pubkey)
+);
+
+-- `INSERT OR IGNORE` rather than a plain insert: the old primary key permitted two distinct
+-- testrun ids from one submitter to carry the same (node, timestamp) pair. That should not exist
+-- in practice - a node can hold only one in-progress run at a time and timestamps are
+-- sub-microsecond - but if it does, dropping the duplicate is correct and, more importantly, keeps
+-- the migration from aborting and wedging nym-api startup.
+-- Ordering by test_timestamp assigns ids oldest-measurement-first.
+INSERT OR IGNORE INTO nym_node_stress_testing_result_new (testrun_id, submitter_pubkey, node_id,
+                                                          result, was_reachable, test_timestamp)
+SELECT testrun_id, submitter_pubkey, node_id, result, was_reachable, test_timestamp
+FROM nym_node_stress_testing_result
+ORDER BY test_timestamp;
+
+DROP TABLE nym_node_stress_testing_result;
+
+ALTER TABLE nym_node_stress_testing_result_new RENAME TO nym_node_stress_testing_result;

--- a/nym-api/nym-api-requests/src/models/network_monitor.rs
+++ b/nym-api/nym-api-requests/src/models/network_monitor.rs
@@ -91,11 +91,33 @@ pub mod v3 {
     /// registered in the network-monitors contract.
     pub type StressTestBatchSubmission = SignedMessage<StressTestBatchSubmissionContent>;
 
-    /// Confirmation returned to an orchestrator after a successful submission.
-    /// Currently empty — exists to give the response an explicit type rather than
-    /// relying on `Json(())`.
-    #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
-    pub struct StressTestBatchSubmissionResponse {}
+    /// Confirmation returned to an orchestrator after a successful submission, reporting what
+    /// became of the individual results. The three counts sum to the number of results submitted.
+    ///
+    /// Reporting these matters because an accepted batch can still store nothing: rows deduplicate
+    /// at the database with insert-or-ignore semantics, so without a count the submitter cannot
+    /// distinguish "stored" from "silently discarded" - both are a `200`.
+    ///
+    /// Every field is optional so that a newer orchestrator can still read the empty body returned
+    /// by a nym-api predating these counts. `None` therefore means "not reported", which is a
+    /// different signal from `Some(0)`.
+    #[derive(Clone, Debug, Default, Serialize, Deserialize, ToSchema)]
+    pub struct StressTestBatchSubmissionResponse {
+        /// Results newly stored by this submission.
+        #[serde(default)]
+        pub accepted: Option<usize>,
+
+        /// Results that were already stored, i.e. this submission re-sent a measurement nym-api had
+        /// seen before. Expected to be non-zero on the orchestrator's at-least-once retry path; a
+        /// persistently non-zero value means measurements are being discarded.
+        #[serde(default)]
+        pub duplicates: Option<usize>,
+
+        /// Results dropped by per-entry validation (a non-mixnode entry, or a performance score
+        /// outside `[0.0, 1.0]`).
+        #[serde(default)]
+        pub rejected: Option<usize>,
+    }
 
     /// Single stress-test measurement for one node, produced by a network monitor orchestrator.
     #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
@@ -340,6 +362,64 @@ pub mod v3 {
             assert_eq!(
                 signed_bytes, resigned_bytes,
                 "deserialise-then-re-serialise was not a fixed point"
+            );
+        }
+
+        // nym-api and the orchestrator are deployed independently, so an orchestrator carrying the
+        // submission counts may talk to a nym-api that predates them and answers a bare `{}`. That
+        // must deserialise rather than error - a hard failure here would break submissions outright,
+        // which is worse than the missing telemetry - and it must land as `None` rather than
+        // `Some(0)`, because the orchestrator warns on a non-zero duplicate count and "not reported"
+        // must not be mistaken for "nothing was stored".
+        #[test]
+        fn submission_response_tolerates_a_body_without_counts() {
+            let old: StressTestBatchSubmissionResponse = serde_json::from_str("{}")
+                .expect("a response body predating the counts must still deserialise");
+            assert_eq!(old.accepted, None);
+            assert_eq!(old.duplicates, None);
+            assert_eq!(old.rejected, None);
+
+            // and a populated body round-trips with its counts intact
+            let reported = StressTestBatchSubmissionResponse {
+                accepted: Some(48),
+                duplicates: Some(1),
+                rejected: Some(1),
+            };
+            let json = serde_json::to_string(&reported).unwrap();
+            let parsed: StressTestBatchSubmissionResponse = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed.accepted, Some(48));
+            assert_eq!(parsed.duplicates, Some(1));
+            assert_eq!(parsed.rejected, Some(1));
+        }
+
+        // The mirror of the above: a nym-api reporting the counts, answering an orchestrator that
+        // predates them and whose type carried no fields at all. Serde must ignore the unknown keys
+        // rather than error.
+        //
+        // This is the more dangerous of the two directions. The client parses with a plain
+        // `serde_json::from_slice`, so a decode failure surfaces as a failed POST, and the
+        // submission watermark is only advanced after a POST succeeds - an old orchestrator would
+        // therefore treat every batch as failed, resubmit the same rows forever and never make
+        // forward progress, while nym-api quietly stored them on the first attempt.
+        #[test]
+        fn submission_response_counts_are_ignored_by_a_reader_predating_them() {
+            // faithful copy of the previously deployed shape
+            #[derive(Deserialize)]
+            struct OldStressTestBatchSubmissionResponse {}
+
+            let json = serde_json::to_string(&StressTestBatchSubmissionResponse {
+                accepted: Some(48),
+                duplicates: Some(1),
+                rejected: Some(1),
+            })
+            .unwrap();
+
+            let parsed: Result<OldStressTestBatchSubmissionResponse, _> =
+                serde_json::from_str(&json);
+            assert!(
+                parsed.is_ok(),
+                "a reader predating the counts rejected {json}: {:?}",
+                parsed.err(),
             );
         }
     }

--- a/nym-api/src/nym_nodes/handlers/v3.rs
+++ b/nym-api/src/nym_nodes/handlers/v3.rs
@@ -13,7 +13,7 @@ use nym_api_requests::models::v3::{
 use nym_crypto::asymmetric::ed25519;
 use std::time::Duration;
 use time::OffsetDateTime;
-use tracing::error;
+use tracing::{error, warn};
 
 /// Accept a batch of stress-test results from an authorised network monitor orchestrator.
 ///
@@ -26,13 +26,17 @@ use tracing::error;
 ///
 /// Individual result entries that fail per-entry validation (non-mixnode role, performance score
 /// outside `[0.0, 1.0]`) are logged as errors and dropped, but do not fail the batch.
+///
+/// The response reports how many results were stored, deduplicated against an already-stored
+/// measurement, and dropped by validation, so that a submitter can tell an accepted-and-stored
+/// batch from an accepted-but-discarded one.
 #[utoipa::path(
     tag = "Nym Nodes",
     post,
     path = "/stress-testing/batch-submit",
     context_path = "/v3/nym-nodes",
     responses(
-        (status = 200, description = "the submitted batch has been accepted and stored"),
+        (status = 200, body = StressTestBatchSubmissionResponse, description = "the submitted batch has been accepted, with a per-result breakdown of what was stored"),
         (status = 400, description = "the submitted request is stale or replayed"),
         (status = 401, description = "the submitted request was unauthorised or failed integrity check"),
     ),
@@ -98,7 +102,8 @@ async fn batch_submit_stress_testing_results(
 
     // 6. process received results
     let signer = body.body.signer;
-    let mut mixnode_results = Vec::with_capacity(body.body.results.len());
+    let submitted = body.body.results.len();
+    let mut mixnode_results = Vec::with_capacity(submitted);
     for result in body.body.results {
         if !result.is_mixnode {
             error!(
@@ -120,12 +125,34 @@ async fn batch_submit_stress_testing_results(
         mixnode_results.push(NymNodeStressTestingResult::from_submission(&signer, result));
     }
 
-    state
+    // anything dropped above never reaches the database, so it must not be counted as a duplicate
+    let attempted = mixnode_results.len();
+    let rejected = submitted - attempted;
+
+    let accepted = state
         .storage()
         .insert_nym_node_stress_testing_results(mixnode_results)
-        .await?;
+        .await? as usize;
 
-    Ok(Json(StressTestBatchSubmissionResponse {}))
+    // insert-or-ignore means a batch can be fully accepted yet store nothing, so report the split
+    // rather than leaving the submitter to infer it from a bare 200.
+    let duplicates = attempted.saturating_sub(accepted);
+    if duplicates > 0 {
+        warn!(
+            %signer,
+            accepted,
+            duplicates,
+            "some submitted stress testing results were already stored and have been discarded - \
+             expected when a batch is retried, but a persistently non-zero count means this \
+             orchestrator's measurements are being dropped"
+        );
+    }
+
+    Ok(Json(StressTestBatchSubmissionResponse {
+        accepted: Some(accepted),
+        duplicates: Some(duplicates),
+        rejected: Some(rejected),
+    }))
 }
 
 /// Report whether the given identity key is currently recognised by this nym-api as an

--- a/nym-api/src/support/storage/manager.rs
+++ b/nym-api/src/support/storage/manager.rs
@@ -821,8 +821,9 @@ impl StorageManager {
     /// submission may legitimately contain no mixnode entries after filtering.
     ///
     /// Uses `INSERT OR IGNORE` so that a retried submission carrying the same
-    /// `(testrun_id, submitter_pubkey)` pair - expected under the orchestrator's at-least-once
-    /// delivery semantics - silently drops the duplicate rows rather than failing the batch.
+    /// `(node_id, test_timestamp, submitter_pubkey)` measurement - expected under the
+    /// orchestrator's at-least-once delivery semantics - silently drops the duplicate rows rather
+    /// than failing the batch.
     pub(super) async fn insert_nym_node_stress_testing_results(
         &self,
         results: Vec<NymNodeStressTestingResult>,

--- a/nym-api/src/support/storage/manager.rs
+++ b/nym-api/src/support/storage/manager.rs
@@ -824,12 +824,16 @@ impl StorageManager {
     /// `(node_id, test_timestamp, submitter_pubkey)` measurement - expected under the
     /// orchestrator's at-least-once delivery semantics - silently drops the duplicate rows rather
     /// than failing the batch.
+    ///
+    /// Returns the number of rows actually inserted, which under `INSERT OR IGNORE` excludes the
+    /// ignored duplicates. The caller reports the difference back to the submitter, so that a batch
+    /// which stored nothing is distinguishable from one that stored everything.
     pub(super) async fn insert_nym_node_stress_testing_results(
         &self,
         results: Vec<NymNodeStressTestingResult>,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<u64, sqlx::Error> {
         if results.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
 
         let mut query_builder = sqlx::QueryBuilder::new(
@@ -845,8 +849,8 @@ impl StorageManager {
                 .push_bind(entry.test_timestamp);
         });
 
-        query_builder.build().execute(&self.connection_pool).await?;
-        Ok(())
+        let res = query_builder.build().execute(&self.connection_pool).await?;
+        Ok(res.rows_affected())
     }
 
     /// Obtains number of network monitor test runs that have occurred within the specified interval.

--- a/nym-api/src/support/storage/mod.rs
+++ b/nym-api/src/support/storage/mod.rs
@@ -731,15 +731,16 @@ impl NymApiStorage {
     }
 
     /// Persist the given stress-testing results, produced by an authorised network monitor
-    /// orchestrator, into the database.
+    /// orchestrator, into the database. Returns the number of rows actually inserted, i.e. excluding
+    /// any that deduplicated against a measurement already stored.
     pub(crate) async fn insert_nym_node_stress_testing_results(
         &self,
         results: Vec<NymNodeStressTestingResult>,
-    ) -> Result<(), NymApiStorageError> {
-        self.manager
+    ) -> Result<u64, NymApiStorageError> {
+        Ok(self
+            .manager
             .insert_nym_node_stress_testing_results(results)
-            .await?;
-        Ok(())
+            .await?)
     }
 
     /// Obtains number of network monitor test runs that have occurred within the specified interval.

--- a/nym-api/src/support/storage/models.rs
+++ b/nym-api/src/support/storage/models.rs
@@ -153,8 +153,9 @@ pub struct HistoricalUptime {
 ///
 /// Produced from the wire-level [`StressTestResult`] via [`Self::from_submission`], which also
 /// renames `test_performance` to `result` to match the on-disk column name and attaches the
-/// submitting orchestrator's identity key so that `(testrun_id, submitter_pubkey)` dedupes
-/// retried at-least-once submissions.
+/// submitting orchestrator's identity key so that `(node_id, test_timestamp, submitter_pubkey)`
+/// dedupes retried at-least-once submissions. `testrun_id` is carried for traceability only and is
+/// not part of any key.
 #[derive(FromRow)]
 pub struct NymNodeStressTestingResult {
     pub testrun_id: i64,

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/prometheus.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/prometheus.rs
@@ -243,6 +243,19 @@ pub enum PrometheusMetric {
         help = "The total number of test packets received back across all submitted testruns"
     ))]
     TestPacketsReceived,
+
+    #[strum(props(help = "The number of submitted stress-test results that nym-api newly stored"))]
+    SubmittedResultsAccepted,
+
+    #[strum(props(
+        help = "The number of submitted stress-test results that nym-api discarded because it had already stored that measurement. Expected to be non-zero when a batch is retried; a persistently non-zero value means measurements are being lost"
+    ))]
+    SubmittedResultsDuplicate,
+
+    #[strum(props(
+        help = "The number of submitted stress-test results that nym-api dropped in per-entry validation (non-mixnode entry, or performance score outside [0, 1])"
+    ))]
+    SubmittedResultsRejected,
 }
 
 impl PrometheusMetric {
@@ -312,6 +325,9 @@ impl PrometheusMetric {
             PrometheusMetric::KnownAgentsAnnounced => Metric::new_int_gauge(&name, help),
             PrometheusMetric::TestPacketsSent => Metric::new_int_counter(&name, help),
             PrometheusMetric::TestPacketsReceived => Metric::new_int_counter(&name, help),
+            PrometheusMetric::SubmittedResultsAccepted => Metric::new_int_counter(&name, help),
+            PrometheusMetric::SubmittedResultsDuplicate => Metric::new_int_counter(&name, help),
+            PrometheusMetric::SubmittedResultsRejected => Metric::new_int_counter(&name, help),
         }
     }
 
@@ -425,7 +441,7 @@ mod tests {
         // a sanity check for anyone adding new metrics. if this test fails,
         // make sure any methods on `PrometheusMetric` enum don't need updating
         // or require custom Display impl
-        assert_eq!(29, PrometheusMetric::COUNT)
+        assert_eq!(32, PrometheusMetric::COUNT)
     }
 
     #[test]

--- a/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/result_submitter.rs
+++ b/nym-network-monitor-v3/nym-network-monitor-orchestrator/src/orchestrator/result_submitter.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::orchestrator::config::Config;
+use crate::orchestrator::prometheus::{PROMETHEUS_METRICS, PrometheusMetric};
 use crate::storage::NetworkMonitorStorage;
 use anyhow::Context;
-use nym_api_requests::models::v3::{StressTestBatchSubmissionContent, StressTestResult};
+use nym_api_requests::models::v3::{
+    StressTestBatchSubmissionContent, StressTestBatchSubmissionResponse, StressTestResult,
+};
 use nym_crypto::asymmetric::ed25519;
 use nym_node_requests::api::Client;
 use nym_task::ShutdownToken;
@@ -14,7 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use time::OffsetDateTime;
 use tokio::time::{Instant, MissedTickBehavior, interval_at};
-use tracing::info;
+use tracing::{info, warn};
 
 /// Background task that periodically drains freshly-completed test run results from the local
 /// storage, wraps them into a signed [`StressTestBatchSubmission`][batch], and POSTs the batch to
@@ -125,7 +128,8 @@ impl ResultSubmitter {
             };
             let signed = body.sign(self.identity_keys.private_key());
 
-            self.client
+            let response = self
+                .client
                 .submit_stress_testing_results(&signed)
                 .await
                 .context("failed to POST stress-test batch submission to nym-api")?;
@@ -134,9 +138,50 @@ impl ResultSubmitter {
             info!(
                 "submitted {batch_size} stress-test results batch to nym-api (testrun ids up to {max_id})"
             );
+            Self::report_submission_outcome(batch_size, response);
         }
 
         Ok(())
+    }
+
+    /// Records what nym-api did with a submitted batch: how many results it stored, how many it
+    /// discarded as measurements it had already seen, and how many it dropped in validation.
+    ///
+    /// A batch is accepted as a whole even when every result in it deduplicates away, so without
+    /// this the orchestrator cannot tell a stored batch from a silently discarded one. Duplicates
+    /// are expected whenever a batch is resent, since the watermark only advances after a successful
+    /// POST, but a count that stays non-zero across cycles means measurements are being lost.
+    ///
+    /// A count is absent when talking to a nym-api predating this reporting, which is distinct from
+    /// zero and so is neither logged nor counted.
+    fn report_submission_outcome(batch_size: usize, response: StressTestBatchSubmissionResponse) {
+        if let Some(accepted) = response.accepted {
+            PROMETHEUS_METRICS.inc_by(PrometheusMetric::SubmittedResultsAccepted, accepted as i64);
+        }
+
+        if let Some(rejected) = response.rejected {
+            PROMETHEUS_METRICS.inc_by(PrometheusMetric::SubmittedResultsRejected, rejected as i64);
+            if rejected > 0 {
+                warn!(
+                    "nym-api dropped {rejected} of {batch_size} submitted stress-test results in \
+                     per-entry validation"
+                );
+            }
+        }
+
+        if let Some(duplicates) = response.duplicates {
+            PROMETHEUS_METRICS.inc_by(
+                PrometheusMetric::SubmittedResultsDuplicate,
+                duplicates as i64,
+            );
+            if duplicates > 0 {
+                warn!(
+                    "nym-api had already stored {duplicates} of {batch_size} submitted stress-test \
+                     results and discarded them - expected if this batch was retried, but if it \
+                     persists then these measurements are being lost"
+                );
+            }
+        }
     }
 
     /// Run the submission loop until the shutdown token is cancelled.

--- a/openspec/specs/nym-network-monitor/spec.md
+++ b/openspec/specs/nym-network-monitor/spec.md
@@ -261,15 +261,23 @@ Because the per-signer high-water mark is held in memory, it resets to the proce
 
 ### Requirement: Per-entry validation drops invalid rows without failing the batch, and rows deduplicate at the database
 
-Within an accepted batch, nym-api SHALL validate each result independently: an entry that is not a mixnode, or whose `test_performance` lies outside the range `[0.0, 1.0]`, MUST be logged and skipped WITHOUT failing the batch. Surviving rows MUST be inserted into the `nym_node_stress_testing_result` table keyed by `(testrun_id, submitter_pubkey)` using an insert-or-ignore semantics, so an at-least-once resend of the same testrun is deduplicated at the database. An empty result set MUST be a no-op.
+Within an accepted batch, nym-api SHALL validate each result independently: an entry that is not a mixnode, or whose `test_performance` lies outside the range `[0.0, 1.0]`, MUST be logged and skipped WITHOUT failing the batch. Surviving rows MUST be inserted into the `nym_node_stress_testing_result` table using an insert-or-ignore semantics, so an at-least-once resend of the same testrun is deduplicated at the database. An empty result set MUST be a no-op.
+
+A measurement's identity MUST be the measurement itself - `(node_id, test_timestamp, submitter_pubkey)`, held as a UNIQUE constraint - and MUST NOT be the submitting orchestrator's `testrun_id`, which is an AUTOINCREMENT counter in that orchestrator's own database and is NOT durable: the orchestrator's storage may be wiped, restarting the counter from 1 while its on-chain ed25519 identity persists. Keying on it meant every resubmitted id collided with a stored row and was discarded silently behind a 200 response until the counter climbed back past its previous high-water mark, which takes about as long as the wiped database had been alive. `testrun_id` MUST still be stored, for tracing a row back to the orchestrator's own read surface, but carries no uniqueness guarantee. Each row MUST additionally carry an `id INTEGER PRIMARY KEY AUTOINCREMENT` as a stable store-assigned handle; AUTOINCREMENT (rather than a bare rowid alias) is required so that ids are not reused once retention pruning deletes rows, since reuse would reintroduce the same class of collision one layer up.
+
+The UNIQUE constraint's column order MUST lead with `(node_id, test_timestamp)` so that its backing index also serves the per-node windowed average, which is the only read query against the table and which the previous `(testrun_id, submitter_pubkey)` key could not serve at all.
 
 #### Scenario: An out-of-range performance value is skipped
 - **WHEN** an entry's `test_performance` is outside `[0.0, 1.0]`
 - **THEN** it is logged and skipped while the rest of the batch is inserted
 
 #### Scenario: A resent testrun does not duplicate rows
-- **WHEN** the same `(testrun_id, submitter_pubkey)` is submitted twice due to an at-least-once retry
+- **WHEN** the same measurement, `(node_id, test_timestamp, submitter_pubkey)`, is submitted twice due to an at-least-once retry
 - **THEN** the second insert is ignored and no duplicate row is created
+
+#### Scenario: A wiped orchestrator's restarted counter does not lose measurements
+- **WHEN** an orchestrator's database is wiped, so it re-emits `testrun_id` values it has already used, against a nym-api still holding rows under those ids
+- **THEN** each new measurement is stored, because its identity is its `(node_id, test_timestamp, submitter_pubkey)` triple rather than the reused id
 
 ### Requirement: The signed submission payload is a JSON-signed SignedMessage envelope
 

--- a/openspec/specs/nym-network-monitor/spec.md
+++ b/openspec/specs/nym-network-monitor/spec.md
@@ -129,6 +129,16 @@ The result submitter SHALL forward completed testruns to nym-api at `POST /v3/ny
 - **WHEN** two batches are produced within the same clock tick
 - **THEN** the second batch's timestamp is bumped so it is strictly greater than the first, satisfying nym-api's replay check
 
+The submitter MUST NOT treat a successful POST as proof that the batch was stored: rows deduplicate at the database, so an accepted batch can store nothing. It MUST therefore read the per-result counts nym-api returns (`accepted`, `duplicates`, `rejected`), record each as a counter, and log a warning whenever `duplicates` or `rejected` is non-zero. A count that is absent (an older nym-api that does not report them) MUST be treated as "not reported" rather than as zero, and so neither logged nor counted.
+
+#### Scenario: A batch that stored nothing is reported rather than silently accepted
+- **WHEN** nym-api accepts a batch but deduplicates every result in it away
+- **THEN** the submitter records the duplicate count and logs a warning, rather than inferring success from the 200 response
+
+#### Scenario: Absent counts are not mistaken for zero
+- **WHEN** the submitting orchestrator is talking to a nym-api that does not report the per-result counts
+- **THEN** submission proceeds normally and no count is recorded or warned about, because "not reported" is distinct from "nothing stored"
+
 ### Requirement: Stale in-flight dispatches and old results are evicted
 
 The stale-data eviction task SHALL clear `testrun_in_progress` rows older than `test_timeout` (default 5 minutes), so that a dispatch abandoned by a crashed or hung agent frees its node for reassignment, and MUST delete completed testruns older than `testrun_eviction_age` (default 7 days). One eviction sweep MUST run before the HTTP server begins serving.
@@ -266,6 +276,12 @@ Within an accepted batch, nym-api SHALL validate each result independently: an e
 A measurement's identity MUST be the measurement itself - `(node_id, test_timestamp, submitter_pubkey)`, held as a UNIQUE constraint - and MUST NOT be the submitting orchestrator's `testrun_id`, which is an AUTOINCREMENT counter in that orchestrator's own database and is NOT durable: the orchestrator's storage may be wiped, restarting the counter from 1 while its on-chain ed25519 identity persists. Keying on it meant every resubmitted id collided with a stored row and was discarded silently behind a 200 response until the counter climbed back past its previous high-water mark, which takes about as long as the wiped database had been alive. `testrun_id` MUST still be stored, for tracing a row back to the orchestrator's own read surface, but carries no uniqueness guarantee. Each row MUST additionally carry an `id INTEGER PRIMARY KEY AUTOINCREMENT` as a stable store-assigned handle; AUTOINCREMENT (rather than a bare rowid alias) is required so that ids are not reused once retention pruning deletes rows, since reuse would reintroduce the same class of collision one layer up.
 
 The UNIQUE constraint's column order MUST lead with `(node_id, test_timestamp)` so that its backing index also serves the per-node windowed average, which is the only read query against the table and which the previous `(testrun_id, submitter_pubkey)` key could not serve at all.
+
+Because insert-or-ignore makes "accepted" and "stored" different outcomes, the response MUST report the split: how many results were newly stored, how many deduplicated against an already-stored measurement, and how many were dropped by per-entry validation, the three summing to the number submitted. nym-api MUST additionally log a warning when any result deduplicated away. Every count MUST be optional on the wire so that this response stays readable by an orchestrator predating it, and so that adding the counts cannot turn a stored batch into a decode failure at a reader that ignores them.
+
+#### Scenario: A batch that stores nothing is distinguishable from one that stores everything
+- **WHEN** every result in an accepted batch deduplicates against an already-stored measurement
+- **THEN** the response reports zero accepted and a non-zero duplicate count, and nym-api logs a warning, rather than returning an indistinguishable success
 
 #### Scenario: An out-of-range performance value is skipped
 - **WHEN** an entry's `test_performance` is outside `[0.0, 1.0]`


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7035)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch stress-test submissions now report accepted, duplicate, and rejected result counts.
  * Added monitoring metrics for tracking submission outcomes.

* **Bug Fixes**
  * Improved result deduplication to preserve distinct measurements when counters are reused.
  * Added stable result identifiers and stronger duplicate detection based on node, timestamp, and submitter.

* **Documentation**
  * Updated monitoring and storage guidance for revised measurement identity and traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->