### PR TITLE
feat(mixnet-contract): atomic redelegation between nodes

### DIFF
--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/error.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/error.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use cosmwasm_std::{Addr, Coin, Decimal, Uint128};
 use cw_controllers::AdminError;
-use nym_contracts_common::Percent;
 use nym_contracts_common::signing::verifier::ApiVerifierError;
+use nym_contracts_common::Percent;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -168,6 +168,24 @@ pub enum MixnetContractError {
         address: String,
         proxy: Option<String>,
     },
+
+    #[error("A redelegation must specify at least one target node")]
+    EmptyRedelegationTargets,
+
+    #[error("A redelegation may target at most {max} nodes, got {got}")]
+    TooManyRedelegationTargets { max: usize, got: usize },
+
+    #[error("A redelegation target weight must be greater than zero")]
+    ZeroRedelegationWeight,
+
+    #[error("A redelegation lists node {node_id} as a target more than once")]
+    DuplicateRedelegationTarget { node_id: NodeId },
+
+    #[error("A redelegation with a single target equal to the source has no destination change")]
+    RedelegationSingleTargetToSelf { node_id: NodeId },
+
+    #[error("No funds should be attached to a redelegation; the stake being moved already lives in the contract")]
+    UnexpectedFundsOnRedelegation,
 
     #[error("Provided message to update rewarding params did not contain any updates")]
     EmptyParamsChangeMsg,

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/events.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/events.rs
@@ -8,7 +8,7 @@ use crate::nym_node::Role;
 use crate::reward_params::{ActiveSetUpdate, IntervalRewardParams, IntervalRewardingParamsUpdate};
 use crate::rewarding::RewardDistribution;
 use crate::{BlockHeight, ContractStateParamsUpdate, EpochId, IdentityKeyRef, Interval, NodeId};
-use cosmwasm_std::{Addr, Coin, Decimal, Event, attr};
+use cosmwasm_std::{attr, Addr, Coin, Decimal, Event};
 pub use nym_contracts_common::events::*;
 use std::fmt::Display;
 
@@ -44,6 +44,9 @@ pub enum MixnetEventType {
     Delegation,
     DelegationOnUnbonding,
     Undelegation,
+    PendingRedelegation,
+    Redelegation,
+    RedelegationFailed,
     ContractSettingsUpdate,
     NymNodeSemverUpdate,
     RewardingValidatorUpdate,
@@ -97,6 +100,9 @@ impl Display for MixnetEventType {
             MixnetEventType::PendingUndelegation => "pending_undelegation",
             MixnetEventType::Delegation => "delegation",
             MixnetEventType::Undelegation => "undelegation",
+            MixnetEventType::PendingRedelegation => "pending_redelegation",
+            MixnetEventType::Redelegation => "redelegation",
+            MixnetEventType::RedelegationFailed => "redelegation_failed",
             MixnetEventType::ContractSettingsUpdate => "settings_update",
             MixnetEventType::NymNodeSemverUpdate => "nym_node_semver_update",
             MixnetEventType::RewardingValidatorUpdate => "rewarding_validator_address_update",
@@ -126,6 +132,7 @@ pub const ERROR_MESSAGE_KEY: &str = "error_message";
 // delegation/undelegation
 pub const DELEGATOR_KEY: &str = "delegator";
 pub const DELEGATION_TARGET_KEY: &str = "delegation_target";
+pub const REDELEGATION_SOURCE_KEY: &str = "redelegation_source";
 pub const UNIT_REWARD_KEY: &str = "unit_reward";
 
 // bonding/unbonding
@@ -208,6 +215,42 @@ pub fn new_pending_delegation_event(delegator: &Addr, amount: &Coin, mix_id: Nod
         .add_attribute(DELEGATOR_KEY, delegator)
         .add_attribute(AMOUNT_KEY, amount.to_string())
         .add_attribute(DELEGATION_TARGET_KEY, mix_id.to_string())
+}
+
+pub fn new_pending_redelegation_event(delegator: &Addr, from_node_id: NodeId) -> Event {
+    Event::new(MixnetEventType::PendingRedelegation)
+        .add_attribute(DELEGATOR_KEY, delegator)
+        .add_attribute(REDELEGATION_SOURCE_KEY, from_node_id.to_string())
+}
+
+/// Emitted for each target share.
+pub fn new_redelegation_event(
+    created_at: BlockHeight,
+    delegator: &Addr,
+    from_node_id: NodeId,
+    to_node_id: NodeId,
+    amount: &Coin,
+) -> Event {
+    Event::new(MixnetEventType::Redelegation)
+        .add_attribute(EVENT_CREATION_HEIGHT_KEY, created_at.to_string())
+        .add_attribute(DELEGATOR_KEY, delegator)
+        .add_attribute(REDELEGATION_SOURCE_KEY, from_node_id.to_string())
+        .add_attribute(DELEGATION_TARGET_KEY, to_node_id.to_string())
+        .add_attribute(AMOUNT_KEY, amount.to_string())
+}
+
+/// Emitted when a queued redelegation does not move the source delegation.
+pub fn new_redelegation_failed_event(
+    created_at: BlockHeight,
+    delegator: &Addr,
+    from_node_id: NodeId,
+    reason: &str,
+) -> Event {
+    Event::new(MixnetEventType::RedelegationFailed)
+        .add_attribute(EVENT_CREATION_HEIGHT_KEY, created_at.to_string())
+        .add_attribute(DELEGATOR_KEY, delegator)
+        .add_attribute(REDELEGATION_SOURCE_KEY, from_node_id.to_string())
+        .add_attribute(ERROR_MESSAGE_KEY, reason)
 }
 
 pub fn new_withdraw_operator_reward_event(owner: &Addr, amount: Coin, mix_id: NodeId) -> Event {

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/msg.rs
@@ -20,7 +20,7 @@ use crate::{
 use crate::{OperatingCostRange, ProfitMarginRange};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Coin, Decimal};
-use nym_contracts_common::{IdentityKey, Percent, signing::MessageSignature};
+use nym_contracts_common::{signing::MessageSignature, IdentityKey, Percent};
 use std::time::Duration;
 
 #[cfg(feature = "schema")]
@@ -57,7 +57,7 @@ use crate::{
 #[cfg(feature = "schema")]
 use cosmwasm_schema::QueryResponses;
 #[cfg(feature = "schema")]
-use nym_contracts_common::{ContractBuildInformation, signing::Nonce};
+use nym_contracts_common::{signing::Nonce, ContractBuildInformation};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -282,6 +282,17 @@ pub enum ExecuteMsg {
         delegate: String,
     },
 
+    /// Move an existing delegation from one node onto one or more other nodes in a
+    /// single settlement, without the stake returning to the wallet first. The accrued
+    /// reward on the source is settled and the full amount (original stake + reward) is
+    /// split across `targets` proportionally to their weights, then delegated. Resolved
+    /// at the epoch rollover, like a normal delegation. A single target moves everything;
+    /// a target may be the source node itself to keep a share in place.
+    Redelegate {
+        from_node_id: NodeId,
+        targets: Vec<RedelegationTarget>,
+    },
+
     // reward-related
     RewardNode {
         #[serde(alias = "mix_id")]
@@ -398,6 +409,13 @@ impl ExecuteMsg {
             ExecuteMsg::UndelegateFromMixnodeOnBehalf { mix_id, .. } => {
                 format!("removing delegation from mixnode {mix_id} on behalf")
             }
+            ExecuteMsg::Redelegate {
+                from_node_id,
+                targets,
+            } => format!(
+                "redelegating from node {from_node_id} onto {} target(s)",
+                targets.len()
+            ),
             ExecuteMsg::RewardNode { node_id, .. } => format!("rewarding node {node_id}"),
             ExecuteMsg::WithdrawOperatorReward { .. } => "withdrawing operator reward".into(),
             ExecuteMsg::WithdrawOperatorRewardOnBehalf { .. } => {
@@ -911,6 +929,20 @@ pub enum QueryMsg {
 pub struct VestedDelegationMigrationEntry {
     pub mix_id: NodeId,
     pub owner: String,
+}
+
+/// Maximum number of targets in a single redelegation.
+pub const MAX_REDELEGATION_TARGETS: usize = 16;
+
+/// A single destination for a redelegation, alongside the weight of the share it
+/// should receive. The moved amount (original stake + accrued reward) is split across
+/// all targets proportionally to the sum of their weights.
+#[cw_serde]
+pub struct RedelegationTarget {
+    /// Destination node for this share of the delegation.
+    pub to_node_id: NodeId,
+    /// Relative weight of this share. Must be greater than zero.
+    pub weight: u32,
 }
 
 #[cw_serde]

--- a/common/cosmwasm-smart-contracts/mixnet-contract/src/pending_events.rs
+++ b/common/cosmwasm-smart-contracts/mixnet-contract/src/pending_events.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::mixnode::NodeCostParams;
+use crate::msg::RedelegationTarget;
 use crate::reward_params::{ActiveSetUpdate, IntervalRewardingParamsUpdate};
 use crate::{BlockHeight, NodeId};
 use cosmwasm_schema::cw_serde;
@@ -69,6 +70,20 @@ pub enum PendingEpochEventKind {
         /// Entity who made the delegation on behalf of the owner.
         /// If present, it's most likely the address of the vesting contract.
         proxy: Option<Addr>,
+    },
+
+    /// Request to move a delegation from one node onto one or more other nodes in a
+    /// single settlement, without the stake leaving the contract.
+    #[non_exhaustive]
+    Redelegate {
+        /// The address of the owner of the delegation.
+        owner: Addr,
+
+        /// The id of the node the delegation is currently on.
+        from_node_id: NodeId,
+
+        /// The destinations to spread the moved amount across, by weight.
+        targets: Vec<RedelegationTarget>,
     },
 
     /// Request to pledge more tokens (by the node operator) towards its node.
@@ -148,6 +163,18 @@ impl PendingEpochEventKind {
             owner,
             node_id,
             proxy: None,
+        }
+    }
+
+    pub fn new_redelegate(
+        owner: Addr,
+        from_node_id: NodeId,
+        targets: Vec<RedelegationTarget>,
+    ) -> Self {
+        PendingEpochEventKind::Redelegate {
+            owner,
+            from_node_id,
+            targets,
         }
     }
 }

--- a/contracts/mixnet/schema/nym-mixnet-contract.json
+++ b/contracts/mixnet/schema/nym-mixnet-contract.json
@@ -1126,6 +1126,37 @@
         "additionalProperties": false
       },
       {
+        "description": "Move an existing delegation from one node onto one or more other nodes in a single settlement, without the stake returning to the wallet first. The accrued reward on the source is settled and the full amount (original stake + reward) is split across `targets` proportionally to their weights, then delegated. Resolved at the epoch rollover, like a normal delegation. A single target moves everything; a target may be the source node itself to keep a share in place.",
+        "type": "object",
+        "required": [
+          "redelegate"
+        ],
+        "properties": {
+          "redelegate": {
+            "type": "object",
+            "required": [
+              "from_node_id",
+              "targets"
+            ],
+            "properties": {
+              "from_node_id": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "targets": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/RedelegationTarget"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "type": "object",
         "required": [
           "reward_node"
@@ -1945,6 +1976,29 @@
           },
           "minimum": {
             "$ref": "#/definitions/Uint128"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RedelegationTarget": {
+        "description": "A single destination for a redelegation, alongside the weight of the share it should receive. The moved amount (original stake + accrued reward) is split across all targets proportionally to the sum of their weights.",
+        "type": "object",
+        "required": [
+          "to_node_id",
+          "weight"
+        ],
+        "properties": {
+          "to_node_id": {
+            "description": "Destination node for this share of the delegation.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "weight": {
+            "description": "Relative weight of this share. Must be greater than zero.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
           }
         },
         "additionalProperties": false
@@ -8884,6 +8938,48 @@
               "additionalProperties": false
             },
             {
+              "description": "Request to move a delegation from one node onto one or more other nodes in a single settlement, without the stake leaving the contract.",
+              "type": "object",
+              "required": [
+                "redelegate"
+              ],
+              "properties": {
+                "redelegate": {
+                  "type": "object",
+                  "required": [
+                    "from_node_id",
+                    "owner",
+                    "targets"
+                  ],
+                  "properties": {
+                    "from_node_id": {
+                      "description": "The id of the node the delegation is currently on.",
+                      "type": "integer",
+                      "format": "uint32",
+                      "minimum": 0.0
+                    },
+                    "owner": {
+                      "description": "The address of the owner of the delegation.",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Addr"
+                        }
+                      ]
+                    },
+                    "targets": {
+                      "description": "The destinations to spread the moved amount across, by weight.",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/RedelegationTarget"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
               "description": "Request to pledge more tokens (by the node operator) towards its node.",
               "type": "object",
               "required": [
@@ -9092,6 +9188,29 @@
               "additionalProperties": false
             }
           ]
+        },
+        "RedelegationTarget": {
+          "description": "A single destination for a redelegation, alongside the weight of the share it should receive. The moved amount (original stake + accrued reward) is split across all targets proportionally to the sum of their weights.",
+          "type": "object",
+          "required": [
+            "to_node_id",
+            "weight"
+          ],
+          "properties": {
+            "to_node_id": {
+              "description": "Destination node for this share of the delegation.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "weight": {
+              "description": "Relative weight of this share. Must be greater than zero.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
         },
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
@@ -9336,6 +9455,48 @@
               "additionalProperties": false
             },
             {
+              "description": "Request to move a delegation from one node onto one or more other nodes in a single settlement, without the stake leaving the contract.",
+              "type": "object",
+              "required": [
+                "redelegate"
+              ],
+              "properties": {
+                "redelegate": {
+                  "type": "object",
+                  "required": [
+                    "from_node_id",
+                    "owner",
+                    "targets"
+                  ],
+                  "properties": {
+                    "from_node_id": {
+                      "description": "The id of the node the delegation is currently on.",
+                      "type": "integer",
+                      "format": "uint32",
+                      "minimum": 0.0
+                    },
+                    "owner": {
+                      "description": "The address of the owner of the delegation.",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Addr"
+                        }
+                      ]
+                    },
+                    "targets": {
+                      "description": "The destinations to spread the moved amount across, by weight.",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/RedelegationTarget"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
               "description": "Request to pledge more tokens (by the node operator) towards its node.",
               "type": "object",
               "required": [
@@ -9544,6 +9705,29 @@
               "additionalProperties": false
             }
           ]
+        },
+        "RedelegationTarget": {
+          "description": "A single destination for a redelegation, alongside the weight of the share it should receive. The moved amount (original stake + accrued reward) is split across all targets proportionally to the sum of their weights.",
+          "type": "object",
+          "required": [
+            "to_node_id",
+            "weight"
+          ],
+          "properties": {
+            "to_node_id": {
+              "description": "Destination node for this share of the delegation.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "weight": {
+              "description": "Relative weight of this share. Must be greater than zero.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
         },
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/mixnet/schema/raw/execute.json
+++ b/contracts/mixnet/schema/raw/execute.json
@@ -831,6 +831,37 @@
       "additionalProperties": false
     },
     {
+      "description": "Move an existing delegation from one node onto one or more other nodes in a single settlement, without the stake returning to the wallet first. The accrued reward on the source is settled and the full amount (original stake + reward) is split across `targets` proportionally to their weights, then delegated. Resolved at the epoch rollover, like a normal delegation. A single target moves everything; a target may be the source node itself to keep a share in place.",
+      "type": "object",
+      "required": [
+        "redelegate"
+      ],
+      "properties": {
+        "redelegate": {
+          "type": "object",
+          "required": [
+            "from_node_id",
+            "targets"
+          ],
+          "properties": {
+            "from_node_id": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "targets": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RedelegationTarget"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "type": "object",
       "required": [
         "reward_node"
@@ -1650,6 +1681,29 @@
         },
         "minimum": {
           "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RedelegationTarget": {
+      "description": "A single destination for a redelegation, alongside the weight of the share it should receive. The moved amount (original stake + accrued reward) is split across all targets proportionally to the sum of their weights.",
+      "type": "object",
+      "required": [
+        "to_node_id",
+        "weight"
+      ],
+      "properties": {
+        "to_node_id": {
+          "description": "Destination node for this share of the delegation.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "weight": {
+          "description": "Relative weight of this share. Must be greater than zero.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/contracts/mixnet/schema/raw/response_to_get_pending_epoch_event.json
+++ b/contracts/mixnet/schema/raw/response_to_get_pending_epoch_event.json
@@ -202,6 +202,48 @@
           "additionalProperties": false
         },
         {
+          "description": "Request to move a delegation from one node onto one or more other nodes in a single settlement, without the stake leaving the contract.",
+          "type": "object",
+          "required": [
+            "redelegate"
+          ],
+          "properties": {
+            "redelegate": {
+              "type": "object",
+              "required": [
+                "from_node_id",
+                "owner",
+                "targets"
+              ],
+              "properties": {
+                "from_node_id": {
+                  "description": "The id of the node the delegation is currently on.",
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "owner": {
+                  "description": "The address of the owner of the delegation.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  ]
+                },
+                "targets": {
+                  "description": "The destinations to spread the moved amount across, by weight.",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/RedelegationTarget"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
           "description": "Request to pledge more tokens (by the node operator) towards its node.",
           "type": "object",
           "required": [
@@ -410,6 +452,29 @@
           "additionalProperties": false
         }
       ]
+    },
+    "RedelegationTarget": {
+      "description": "A single destination for a redelegation, alongside the weight of the share it should receive. The moved amount (original stake + accrued reward) is split across all targets proportionally to the sum of their weights.",
+      "type": "object",
+      "required": [
+        "to_node_id",
+        "weight"
+      ],
+      "properties": {
+        "to_node_id": {
+          "description": "Destination node for this share of the delegation.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "weight": {
+          "description": "Relative weight of this share. Must be greater than zero.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/mixnet/schema/raw/response_to_get_pending_epoch_events.json
+++ b/contracts/mixnet/schema/raw/response_to_get_pending_epoch_events.json
@@ -235,6 +235,48 @@
           "additionalProperties": false
         },
         {
+          "description": "Request to move a delegation from one node onto one or more other nodes in a single settlement, without the stake leaving the contract.",
+          "type": "object",
+          "required": [
+            "redelegate"
+          ],
+          "properties": {
+            "redelegate": {
+              "type": "object",
+              "required": [
+                "from_node_id",
+                "owner",
+                "targets"
+              ],
+              "properties": {
+                "from_node_id": {
+                  "description": "The id of the node the delegation is currently on.",
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "owner": {
+                  "description": "The address of the owner of the delegation.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  ]
+                },
+                "targets": {
+                  "description": "The destinations to spread the moved amount across, by weight.",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/RedelegationTarget"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
           "description": "Request to pledge more tokens (by the node operator) towards its node.",
           "type": "object",
           "required": [
@@ -443,6 +485,29 @@
           "additionalProperties": false
         }
       ]
+    },
+    "RedelegationTarget": {
+      "description": "A single destination for a redelegation, alongside the weight of the share it should receive. The moved amount (original stake + accrued reward) is split across all targets proportionally to the sum of their weights.",
+      "type": "object",
+      "required": [
+        "to_node_id",
+        "weight"
+      ],
+      "properties": {
+        "to_node_id": {
+          "description": "Destination node for this share of the delegation.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "weight": {
+          "description": "Relative weight of this share. Must be greater than zero.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
     },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/mixnet/src/contract.rs
+++ b/contracts/mixnet/src/contract.rs
@@ -287,6 +287,16 @@ pub fn execute(
                 deps, env, info, node_id,
             )
         }
+        ExecuteMsg::Redelegate {
+            from_node_id,
+            targets,
+        } => crate::delegations::transactions::try_redelegate_between_nodes(
+            deps,
+            env,
+            info,
+            from_node_id,
+            targets,
+        ),
 
         // reward-related
         ExecuteMsg::RewardNode { node_id, params } => {

--- a/contracts/mixnet/src/delegations/transactions.rs
+++ b/contracts/mixnet/src/delegations/transactions.rs
@@ -10,8 +10,9 @@ use crate::support::helpers::{
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
 use mixnet_contract_common::error::MixnetContractError;
 use mixnet_contract_common::events::{
-    new_pending_delegation_event, new_pending_undelegation_event,
+    new_pending_delegation_event, new_pending_redelegation_event, new_pending_undelegation_event,
 };
+use mixnet_contract_common::msg::{RedelegationTarget, MAX_REDELEGATION_TARGETS};
 use mixnet_contract_common::pending_events::PendingEpochEventKind;
 use mixnet_contract_common::{Delegation, NodeId};
 
@@ -71,6 +72,72 @@ pub(crate) fn try_remove_delegation_from_node(
     let cosmos_event = new_pending_undelegation_event(&info.sender, node_id);
 
     let epoch_event = PendingEpochEventKind::new_undelegate(info.sender, node_id);
+    interval_storage::push_new_epoch_event(deps.storage, &env, epoch_event)?;
+
+    Ok(Response::new().add_event(cosmos_event))
+}
+
+pub(crate) fn try_redelegate_between_nodes(
+    deps: DepsMut<'_>,
+    env: Env,
+    info: MessageInfo,
+    from_node_id: NodeId,
+    targets: Vec<RedelegationTarget>,
+) -> Result<Response, MixnetContractError> {
+    // like delegate/undelegate, not allowed while the epoch is being advanced
+    ensure_epoch_in_progress_state(deps.storage)?;
+
+    // Redelegation uses funds already held by the contract.
+    if !info.funds.is_empty() {
+        return Err(MixnetContractError::UnexpectedFundsOnRedelegation);
+    }
+
+    // Validate the bounded payload before storing it.
+    if targets.is_empty() {
+        return Err(MixnetContractError::EmptyRedelegationTargets);
+    }
+    if targets.len() > MAX_REDELEGATION_TARGETS {
+        return Err(MixnetContractError::TooManyRedelegationTargets {
+            max: MAX_REDELEGATION_TARGETS,
+            got: targets.len(),
+        });
+    }
+    // Recreating the same delegation would only truncate accrued fractional rewards.
+    if targets.len() == 1 && targets[0].to_node_id == from_node_id {
+        return Err(MixnetContractError::RedelegationSingleTargetToSelf {
+            node_id: from_node_id,
+        });
+    }
+    let mut seen = Vec::with_capacity(targets.len());
+    for target in &targets {
+        if target.weight == 0 {
+            return Err(MixnetContractError::ZeroRedelegationWeight);
+        }
+        if seen.contains(&target.to_node_id) {
+            return Err(MixnetContractError::DuplicateRedelegationTarget {
+                node_id: target.to_node_id,
+            });
+        }
+        seen.push(target.to_node_id);
+        // A multi-target split may include the source node.
+        ensure_any_node_bonded(deps.storage, target.to_node_id)?;
+    }
+
+    let storage_key = Delegation::generate_storage_key(from_node_id, &info.sender, None);
+    if storage::delegations()
+        .may_load(deps.storage, storage_key)?
+        .is_none()
+    {
+        return Err(MixnetContractError::NodeDelegationNotFound {
+            node_id: from_node_id,
+            address: info.sender.into_string(),
+            proxy: None,
+        });
+    }
+
+    // push the event onto the queue and wait for it to be picked up at the end of the epoch
+    let cosmos_event = new_pending_redelegation_event(&info.sender, from_node_id);
+    let epoch_event = PendingEpochEventKind::new_redelegate(info.sender, from_node_id, targets);
     interval_storage::push_new_epoch_event(deps.storage, &env, epoch_event)?;
 
     Ok(Response::new().add_event(cosmos_event))
@@ -448,6 +515,166 @@ mod tests {
                 mix_id_unbonded_leftover,
             );
             assert!(res.is_ok());
+        }
+    }
+
+    #[cfg(test)]
+    mod redelegating_between_nodes {
+        use super::*;
+        use crate::interval::transactions::perform_pending_epoch_actions;
+        use crate::support::tests::fixtures::TEST_COIN_DENOM;
+        use crate::support::tests::test_helpers::TestSetup;
+        use cosmwasm_std::testing::message_info;
+        use cosmwasm_std::{coin, Uint128};
+        use mixnet_contract_common::{EpochState, EpochStatus};
+
+        fn target(to_node_id: NodeId, weight: u32) -> RedelegationTarget {
+            RedelegationTarget { to_node_id, weight }
+        }
+
+        #[test]
+        fn rejects_invalid_target_shapes_and_attached_funds() {
+            let mut test = TestSetup::new();
+            let source = test.add_rewarded_legacy_mixnode(&test.make_addr("source-owner"), None);
+            let destination =
+                test.add_rewarded_legacy_mixnode(&test.make_addr("destination-owner"), None);
+            let owner = test.make_addr("delegator");
+            test.add_immediate_delegation(&owner, 120_000_000u128, source);
+            let env = test.env();
+
+            let result = try_redelegate_between_nodes(
+                test.deps_mut(),
+                env.clone(),
+                message_info(&owner, &[]),
+                source,
+                vec![],
+            );
+            assert_eq!(result, Err(MixnetContractError::EmptyRedelegationTargets));
+
+            let too_many = (0..=MAX_REDELEGATION_TARGETS)
+                .map(|i| target(i as NodeId + 10_000, 1))
+                .collect::<Vec<_>>();
+            let result = try_redelegate_between_nodes(
+                test.deps_mut(),
+                env.clone(),
+                message_info(&owner, &[]),
+                source,
+                too_many,
+            );
+            assert_eq!(
+                result,
+                Err(MixnetContractError::TooManyRedelegationTargets {
+                    max: MAX_REDELEGATION_TARGETS,
+                    got: MAX_REDELEGATION_TARGETS + 1,
+                })
+            );
+
+            let result = try_redelegate_between_nodes(
+                test.deps_mut(),
+                env.clone(),
+                message_info(&owner, &[]),
+                source,
+                vec![target(source, 1)],
+            );
+            assert_eq!(
+                result,
+                Err(MixnetContractError::RedelegationSingleTargetToSelf { node_id: source })
+            );
+
+            let result = try_redelegate_between_nodes(
+                test.deps_mut(),
+                env.clone(),
+                message_info(&owner, &[]),
+                source,
+                vec![target(destination, 0)],
+            );
+            assert_eq!(result, Err(MixnetContractError::ZeroRedelegationWeight));
+
+            let result = try_redelegate_between_nodes(
+                test.deps_mut(),
+                env.clone(),
+                message_info(&owner, &[]),
+                source,
+                vec![target(destination, 1), target(destination, 2)],
+            );
+            assert_eq!(
+                result,
+                Err(MixnetContractError::DuplicateRedelegationTarget {
+                    node_id: destination,
+                })
+            );
+
+            let result = try_redelegate_between_nodes(
+                test.deps_mut(),
+                env,
+                message_info(&owner, &[coin(1, TEST_COIN_DENOM)]),
+                source,
+                vec![target(destination, 1)],
+            );
+            assert_eq!(
+                result,
+                Err(MixnetContractError::UnexpectedFundsOnRedelegation)
+            );
+        }
+
+        #[test]
+        fn queued_redelegation_executes_through_epoch_reconciliation() {
+            let mut test = TestSetup::new();
+            let source = test.add_rewarded_legacy_mixnode(&test.make_addr("source-owner"), None);
+            let destination =
+                test.add_rewarded_legacy_mixnode(&test.make_addr("destination-owner"), None);
+            let owner = test.make_addr("delegator");
+            let amount = 120_000_000u128;
+            test.add_immediate_delegation(&owner, amount, source);
+            let env = test.env();
+
+            try_redelegate_between_nodes(
+                test.deps_mut(),
+                env.clone(),
+                message_info(&owner, &[]),
+                source,
+                vec![target(destination, 1)],
+            )
+            .unwrap();
+
+            let (_, executed) = perform_pending_epoch_actions(test.deps_mut(), &env, None).unwrap();
+            assert_eq!(executed, 1);
+
+            let source_key = Delegation::generate_storage_key(source, &owner, None);
+            assert!(storage::delegations()
+                .may_load(test.deps().storage, source_key)
+                .unwrap()
+                .is_none());
+
+            let destination_delegation = test.delegation(destination, &owner, &None);
+            assert_eq!(destination_delegation.amount.amount, Uint128::new(amount));
+        }
+
+        #[test]
+        fn rejects_redelegation_during_epoch_advancement() {
+            let mut test = TestSetup::new();
+            let source = test.add_rewarded_legacy_mixnode(&test.make_addr("source-owner"), None);
+            let destination =
+                test.add_rewarded_legacy_mixnode(&test.make_addr("destination-owner"), None);
+            let owner = test.make_addr("delegator");
+            test.add_immediate_delegation(&owner, 120_000_000u128, source);
+
+            let mut status = EpochStatus::new(test.rewarding_validator().sender);
+            status.state = EpochState::ReconcilingEvents;
+            interval_storage::save_current_epoch_status(test.deps_mut().storage, &status).unwrap();
+
+            let env = test.env();
+            let result = try_redelegate_between_nodes(
+                test.deps_mut(),
+                env,
+                message_info(&owner, &[]),
+                source,
+                vec![target(destination, 1)],
+            );
+            assert!(matches!(
+                result,
+                Err(MixnetContractError::EpochAdvancementInProgress { .. })
+            ));
         }
     }
 }

--- a/contracts/mixnet/src/interval/pending_events.rs
+++ b/contracts/mixnet/src/interval/pending_events.rs
@@ -1,21 +1,24 @@
 // Copyright 2022 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: Apache-2.0
 
-use cosmwasm_std::{Addr, BankMsg, Coin, DepsMut, Env, Response};
+use cosmwasm_std::{Addr, BankMsg, Coin, DepsMut, Env, Response, Uint128, Uint256};
 
 use mixnet_contract_common::error::MixnetContractError;
 use mixnet_contract_common::events::{
     new_active_set_update_event, new_active_set_update_failure, new_cost_params_update_event,
     new_delegation_event, new_delegation_on_unbonded_node_event, new_mixnode_unbonding_event,
     new_nym_node_unbonding_event, new_pledge_decrease_event, new_pledge_increase_event,
-    new_rewarding_params_update_event, new_undelegation_event,
+    new_redelegation_event, new_redelegation_failed_event, new_rewarding_params_update_event,
+    new_undelegation_event,
 };
 use mixnet_contract_common::mixnode::NodeCostParams;
+use mixnet_contract_common::msg::{RedelegationTarget, MAX_REDELEGATION_TARGETS};
 use mixnet_contract_common::pending_events::{
     PendingEpochEventData, PendingEpochEventKind, PendingIntervalEventData,
     PendingIntervalEventKind,
 };
 use mixnet_contract_common::reward_params::{ActiveSetUpdate, IntervalRewardingParamsUpdate};
+use mixnet_contract_common::rewarding::helpers::truncate_reward;
 use mixnet_contract_common::{BlockHeight, Delegation, NodeId};
 use nym_contracts_common::helpers::ResponseExt;
 
@@ -23,6 +26,7 @@ use crate::delegations;
 use crate::delegations::storage as delegations_storage;
 use crate::interval::helpers::change_interval_config;
 use crate::interval::storage;
+use crate::mixnet_contract_settings::storage as mixnet_params_storage;
 use crate::mixnodes::helpers::{cleanup_post_unbond_mixnode_storage, get_mixnode_details_by_id};
 use crate::mixnodes::storage as mixnodes_storage;
 use crate::nodes::helpers::{cleanup_post_unbond_nym_node_storage, get_node_details_by_id};
@@ -46,24 +50,21 @@ pub(crate) fn delegate(
     node_id: NodeId,
     amount: Coin,
 ) -> Result<Response, MixnetContractError> {
-    // first check - see if we have any rewarding information in the storage, if not, the node has fully unbonded
-    // (and also didn't have any delegations)
-    let Some(mut node_rewarding) =
-        rewards_storage::NYMNODE_REWARDING.may_load(deps.storage, node_id)?
-    else {
+    // if the node has fully unbonded (no rewarding info) or is mid-unbonding, a plain delegation
+    // has nowhere to land, so return the tokens to the owner's wallet
+    if rewards_storage::NYMNODE_REWARDING
+        .may_load(deps.storage, node_id)?
+        .is_none()
+    {
         return Ok(Response::new()
             .send_tokens(&owner, amount)
             .add_event(new_delegation_on_unbonded_node_event(&owner, node_id)));
-    };
+    }
 
-    // more extensive check to see if node is still bonded, however, this time we have to unfortunately check
-    // BOTH nym-node and legacy nym-node.
-    // the underlying target node might have unbonded between this event getting created
-    // and being executed. Do note that it's absolutely possible for a node to get immediately
-    // unbonded at this very block (if the event was pending), but that's tough luck, then it's up
-    // to the delegator to click the undelegate button
+    // the underlying node might have unbonded between this event getting created and executed;
+    // we have to check both nym-node and legacy nym-node
     match ensure_any_node_bonded(deps.storage, node_id) {
-        // cosmwasm-std errors are critical and recoverable because they imply issues with the underlying storage
+        // cosmwasm-std errors are critical because they imply issues with the underlying storage
         Err(MixnetContractError::StdErr { source }) => return Err(source.into()),
         Err(_unbonded) => {
             return Ok(Response::new()
@@ -73,31 +74,41 @@ pub(crate) fn delegate(
         Ok(_) => {}
     }
 
+    delegate_to_bonded_node(deps, env, created_at, owner, node_id, amount)
+}
+
+/// Places `amount` on a bonded node, compounding any existing delegation.
+/// The caller must verify that bonding and rewarding data exist.
+pub(crate) fn delegate_to_bonded_node(
+    deps: DepsMut<'_>,
+    env: &Env,
+    created_at: BlockHeight,
+    owner: Addr,
+    node_id: NodeId,
+    amount: Coin,
+) -> Result<Response, MixnetContractError> {
+    let mut node_rewarding = rewards_storage::NYMNODE_REWARDING
+        .may_load(deps.storage, node_id)?
+        .ok_or(MixnetContractError::inconsistent_state(
+            "delegating to a node with no rewarding info despite it being checked as bonded",
+        ))?;
+
     let new_delegation_amount = amount.clone();
 
-    // the delegation_amount might get increased if there's already a pre-existing delegation on this mixnode
-    // (in that case we just create a fresh delegation with the sum of both)
+    // if there's an existing delegation, withdraw its full reward and create a fresh delegation
+    // with the sum of both (the compound)
     let mut stored_delegation_amount = amount;
-
-    // if there's an existing delegation, then withdraw the full reward and create a new delegation
-    // with the sum of both
     let storage_key = Delegation::generate_storage_key(node_id, &owner, None);
     let old_delegation = if let Some(existing_delegation) =
         delegations_storage::delegations().may_load(deps.storage, storage_key.clone())?
     {
-        // completely remove the delegation from the node
         let og_with_reward = node_rewarding.undelegate(&existing_delegation)?;
-
-        // and adjust the new value by the amount removed (which contains the original delegation
-        // alongside any earned rewards)
         stored_delegation_amount.amount += og_with_reward.amount;
-
         Some(existing_delegation)
     } else {
         None
     };
 
-    // add the amount we're intending to delegate (whether it's fresh or we're adding to the existing one)
     node_rewarding.add_base_delegation(stored_delegation_amount.amount)?;
 
     let cosmos_event = new_delegation_event(
@@ -116,7 +127,6 @@ pub(crate) fn delegate(
         env.block.height,
     );
 
-    // save on reading since `.save()` would have attempted to read old data that we already have on hand
     delegations_storage::delegations().replace(
         deps.storage,
         storage_key,
@@ -158,6 +168,239 @@ pub(crate) fn undelegate(
         .add_event(new_undelegation_event(created_at, &owner, mix_id));
 
     Ok(response)
+}
+
+pub(crate) fn redelegate(
+    deps: DepsMut<'_>,
+    env: &Env,
+    created_at: BlockHeight,
+    owner: Addr,
+    from_node_id: NodeId,
+    targets: Vec<RedelegationTarget>,
+) -> Result<Response, MixnetContractError> {
+    let mut deps = deps;
+
+    // Validate stored events defensively so malformed input cannot block reconciliation.
+    if let Err(reason) = validate_redelegation_shape(&targets, from_node_id) {
+        return Ok(Response::new().add_event(new_redelegation_failed_event(
+            created_at,
+            &owner,
+            from_node_id,
+            reason,
+        )));
+    }
+
+    // An earlier event may already have removed the source delegation.
+    let storage_key = Delegation::generate_storage_key(from_node_id, &owner, None);
+    let Some(delegation) =
+        delegations_storage::delegations().may_load(deps.storage, storage_key)?
+    else {
+        return Ok(Response::new().add_event(new_redelegation_failed_event(
+            created_at,
+            &owner,
+            from_node_id,
+            "source delegation no longer exists",
+        )));
+    };
+
+    // Nym nodes and legacy mixnodes share the rewarding map.
+    let from_rewarding = rewards_storage::NYMNODE_REWARDING
+        .may_load(deps.storage, from_node_id)?
+        .ok_or(MixnetContractError::inconsistent_state(
+            "node rewarding got removed from the storage whilst there's still an existing delegation",
+        ))?;
+
+    let denom = delegation.amount.denom.clone();
+
+    // Calculate the same amount as NodeRewarding::undelegate without changing state.
+    let settled = {
+        let reward = from_rewarding.determine_delegation_reward(&delegation)?;
+        let full = reward + delegation.dec_amount()?;
+        truncate_reward(full, &denom).amount
+    };
+
+    // Complete all fallible availability checks before removing the source.
+    for target in &targets {
+        match ensure_any_node_bonded(deps.storage, target.to_node_id) {
+            Ok(()) => {}
+            Err(
+                MixnetContractError::MixnodeIsUnbonding { .. }
+                | MixnetContractError::NymNodeBondNotFound { .. }
+                | MixnetContractError::NodeIsUnbonding { .. },
+            ) => {
+                let reason = format!("target node {} is no longer bonded", target.to_node_id);
+                return Ok(Response::new().add_event(new_redelegation_failed_event(
+                    created_at,
+                    &owner,
+                    from_node_id,
+                    &reason,
+                )));
+            }
+            Err(err) => return Err(err),
+        }
+
+        if rewards_storage::NYMNODE_REWARDING
+            .may_load(deps.storage, target.to_node_id)?
+            .is_none()
+        {
+            let reason = format!(
+                "target node {} has no rewarding information",
+                target.to_node_id
+            );
+            return Ok(Response::new().add_event(new_redelegation_failed_event(
+                created_at,
+                &owner,
+                from_node_id,
+                &reason,
+            )));
+        }
+    }
+
+    let shares = split_by_weight(settled, &targets)?;
+
+    let minimum = mixnet_params_storage::CONTRACT_STATE
+        .load(deps.storage)?
+        .params
+        .delegations_params
+        .minimum_delegation;
+    for share in &shares {
+        if share.is_zero() {
+            return Ok(Response::new().add_event(new_redelegation_failed_event(
+                created_at,
+                &owner,
+                from_node_id,
+                "a split share is zero",
+            )));
+        }
+        if minimum.as_ref().is_some_and(|min| *share < min.amount) {
+            return Ok(Response::new().add_event(new_redelegation_failed_event(
+                created_at,
+                &owner,
+                from_node_id,
+                "a split share is below the minimum delegation",
+            )));
+        }
+    }
+
+    let moved = delegations::helpers::undelegate(deps.storage, delegation, from_rewarding)?;
+    if moved.amount != settled {
+        return Err(MixnetContractError::inconsistent_state(
+            "settled redelegation amount changed between preflight and execution",
+        ));
+    }
+
+    let mut response = Response::new();
+    for (target, share) in targets.iter().zip(shares.iter()) {
+        let coin = Coin {
+            denom: denom.clone(),
+            amount: *share,
+        };
+        let sub = delegate_to_bonded_node(
+            deps.branch(),
+            env,
+            created_at,
+            owner.clone(),
+            target.to_node_id,
+            coin.clone(),
+        )?;
+        response = response
+            .add_submessages(sub.messages)
+            .add_events(sub.events)
+            .add_event(new_redelegation_event(
+                created_at,
+                &owner,
+                from_node_id,
+                target.to_node_id,
+                &coin,
+            ));
+    }
+
+    Ok(response)
+}
+
+fn validate_redelegation_shape(
+    targets: &[RedelegationTarget],
+    from_node_id: NodeId,
+) -> Result<(), &'static str> {
+    if targets.is_empty() {
+        return Err("no redelegation targets");
+    }
+    if targets.len() > MAX_REDELEGATION_TARGETS {
+        return Err("too many redelegation targets");
+    }
+    if targets.len() == 1 && targets[0].to_node_id == from_node_id {
+        return Err("single target equal to source");
+    }
+    let mut seen = Vec::with_capacity(targets.len());
+    for target in targets {
+        if target.weight == 0 {
+            return Err("zero target weight");
+        }
+        if seen.contains(&target.to_node_id) {
+            return Err("duplicate target");
+        }
+        seen.push(target.to_node_id);
+    }
+    Ok(())
+}
+
+/// Splits `total` by weight. Equal remainders are ordered by node id.
+fn split_by_weight(
+    total: Uint128,
+    targets: &[RedelegationTarget],
+) -> Result<Vec<Uint128>, MixnetContractError> {
+    if targets.is_empty() || targets.iter().any(|target| target.weight == 0) {
+        return Err(MixnetContractError::inconsistent_state(
+            "invalid targets passed to redelegation split",
+        ));
+    }
+    let total_weight = targets.iter().try_fold(0u128, |sum, target| {
+        sum.checked_add(target.weight as u128).ok_or_else(|| {
+            MixnetContractError::inconsistent_state("redelegation weight sum overflowed")
+        })
+    })?;
+    let denom = Uint256::from(total_weight);
+
+    let mut shares = Vec::with_capacity(targets.len());
+    let mut remainders = Vec::with_capacity(targets.len());
+    let mut allocated = Uint128::zero();
+    for (i, target) in targets.iter().enumerate() {
+        let numerator = total.full_mul(target.weight);
+        let floor256 = numerator / denom;
+        let floor = Uint128::try_from(floor256).map_err(|_| {
+            MixnetContractError::inconsistent_state("redelegation floor share overflowed u128")
+        })?;
+        let remainder = numerator - floor256 * denom;
+        allocated = allocated.checked_add(floor).map_err(|_| {
+            MixnetContractError::inconsistent_state("redelegation allocation overflowed")
+        })?;
+        shares.push(floor);
+        remainders.push((remainder, target.to_node_id, i));
+    }
+
+    let mut leftover = total.checked_sub(allocated).map_err(|_| {
+        MixnetContractError::inconsistent_state(
+            "redelegation allocated more than the settled amount",
+        )
+    })?;
+    remainders.sort_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)));
+    let mut rank = 0usize;
+    while !leftover.is_zero() {
+        let Some((_, _, idx)) = remainders.get(rank) else {
+            return Err(MixnetContractError::inconsistent_state(
+                "redelegation leftover exceeded target count",
+            ));
+        };
+        shares[*idx] = shares[*idx].checked_add(Uint128::one()).map_err(|_| {
+            MixnetContractError::inconsistent_state("redelegation share overflowed")
+        })?;
+        leftover = leftover.checked_sub(Uint128::one()).map_err(|_| {
+            MixnetContractError::inconsistent_state("redelegation leftover underflow")
+        })?;
+        rank += 1;
+    }
+
+    Ok(shares)
 }
 
 pub(crate) fn unbond_nym_node(
@@ -472,6 +715,12 @@ impl ContractExecutableEvent for PendingEpochEventData {
                 node_id: mix_id,
                 ..
             } => undelegate(deps, self.created_at, owner, mix_id),
+            PendingEpochEventKind::Redelegate {
+                owner,
+                from_node_id,
+                targets,
+                ..
+            } => redelegate(deps, env, self.created_at, owner, from_node_id, targets),
             PendingEpochEventKind::NymNodePledgeMore { node_id, amount } => {
                 increase_nym_node_pledge(deps, self.created_at, node_id, amount)
             }
@@ -1017,7 +1266,6 @@ mod tests {
             let dist1 = test.reward_with_distribution_ignore_state(mix_id, active_params);
             test.skip_to_next_epoch_end();
             let dist2 = test.reward_with_distribution_ignore_state(mix_id, active_params);
-
             let expected_reward = dist1.delegates + dist2.delegates;
             let truncated_reward = truncate_reward_amount(expected_reward);
 
@@ -1040,6 +1288,376 @@ mod tests {
             let rewarding = test.mix_rewarding(mix_id);
             assert!(rewarding.delegates.is_zero());
             assert_eq!(rewarding.unique_delegations, 0);
+        }
+    }
+
+    #[cfg(test)]
+    mod redelegating {
+        use super::*;
+        use crate::support::tests::fixtures::TEST_COIN_DENOM;
+        use crate::support::tests::test_helpers::get_bank_send_msg;
+        use cosmwasm_std::coin;
+        use mixnet_contract_common::events::MixnetEventType;
+        use mixnet_contract_common::rewarding::helpers::truncate_reward_amount;
+
+        fn target(to_node_id: NodeId, weight: u32) -> RedelegationTarget {
+            RedelegationTarget { to_node_id, weight }
+        }
+
+        fn stored_delegation(
+            test: &TestSetup,
+            node_id: NodeId,
+            owner: &Addr,
+        ) -> Option<Delegation> {
+            let key = Delegation::generate_storage_key(node_id, owner, None);
+            delegations_storage::delegations()
+                .may_load(test.deps().storage, key)
+                .unwrap()
+        }
+
+        #[test]
+        fn largest_remainder_preserves_the_total() {
+            let targets = vec![target(10, 1), target(20, 2), target(30, 3)];
+            let shares = split_by_weight(Uint128::new(10), &targets).unwrap();
+
+            assert_eq!(
+                shares,
+                vec![Uint128::new(2), Uint128::new(3), Uint128::new(5)]
+            );
+            assert_eq!(shares.into_iter().sum::<Uint128>(), Uint128::new(10));
+        }
+
+        #[test]
+        fn equal_remainders_are_tied_by_node_id_not_input_position() {
+            let first_order = vec![target(20, 1), target(10, 1)];
+            let second_order = vec![target(10, 1), target(20, 1)];
+
+            let first = split_by_weight(Uint128::one(), &first_order).unwrap();
+            let second = split_by_weight(Uint128::one(), &second_order).unwrap();
+
+            assert_eq!(first, vec![Uint128::zero(), Uint128::one()]);
+            assert_eq!(second, vec![Uint128::one(), Uint128::zero()]);
+        }
+
+        #[test]
+        fn split_rejects_invalid_inputs_and_handles_maximum_values() {
+            assert!(split_by_weight(Uint128::one(), &[]).is_err());
+            assert!(split_by_weight(Uint128::one(), &[target(10, 0)]).is_err());
+
+            let targets = (0..MAX_REDELEGATION_TARGETS)
+                .map(|i| target(i as NodeId + 10, u32::MAX))
+                .collect::<Vec<_>>();
+            let shares = split_by_weight(Uint128::MAX, &targets).unwrap();
+            assert_eq!(shares.into_iter().sum::<Uint128>(), Uint128::MAX);
+        }
+
+        #[test]
+        fn shape_validation_rejects_invalid_payloads() {
+            assert!(validate_redelegation_shape(&[], 1).is_err());
+            assert!(validate_redelegation_shape(&[target(1, 1)], 1).is_err());
+            assert!(validate_redelegation_shape(&[target(2, 0)], 1).is_err());
+            assert!(validate_redelegation_shape(&[target(2, 1), target(2, 2)], 1).is_err());
+
+            let too_many = (0..=MAX_REDELEGATION_TARGETS)
+                .map(|i| target(i as NodeId + 2, 1))
+                .collect::<Vec<_>>();
+            assert!(validate_redelegation_shape(&too_many, 1).is_err());
+        }
+
+        #[test]
+        fn moves_the_entire_delegation_without_a_bank_send() {
+            let mut test = TestSetup::new();
+            let source = test.add_rewarded_legacy_mixnode(&test.make_addr("source-owner"), None);
+            let destination =
+                test.add_rewarded_legacy_mixnode(&test.make_addr("destination-owner"), None);
+            let owner = test.make_addr("delegator");
+            let amount = 120_000_000u128;
+            test.add_immediate_delegation(&owner, amount, source);
+
+            let env = test.env();
+            let response = redelegate(
+                test.deps_mut(),
+                &env,
+                123,
+                owner.clone(),
+                source,
+                vec![target(destination, 1)],
+            )
+            .unwrap();
+
+            assert!(get_bank_send_msg(&response).is_none());
+            assert!(stored_delegation(&test, source, &owner).is_none());
+            assert_eq!(
+                stored_delegation(&test, destination, &owner)
+                    .unwrap()
+                    .amount
+                    .amount,
+                Uint128::new(amount)
+            );
+            assert_eq!(test.mix_rewarding(source).unique_delegations, 0);
+            assert_eq!(test.mix_rewarding(destination).unique_delegations, 1);
+        }
+
+        #[test]
+        fn missing_source_is_reported_without_touching_the_target() {
+            let mut test = TestSetup::new();
+            let source = test.add_rewarded_legacy_mixnode(&test.make_addr("source-owner"), None);
+            let destination =
+                test.add_rewarded_legacy_mixnode(&test.make_addr("destination-owner"), None);
+            let owner = test.make_addr("delegator");
+            let env = test.env();
+
+            let response = redelegate(
+                test.deps_mut(),
+                &env,
+                123,
+                owner.clone(),
+                source,
+                vec![target(destination, 1)],
+            )
+            .unwrap();
+
+            assert!(get_bank_send_msg(&response).is_none());
+            assert!(stored_delegation(&test, destination, &owner).is_none());
+            assert_eq!(
+                response.events[0].ty,
+                MixnetEventType::RedelegationFailed.to_string()
+            );
+            assert!(response.events[0]
+                .attributes
+                .iter()
+                .any(|attr| attr.key == "error_message"
+                    && attr.value == "source delegation no longer exists"));
+        }
+
+        #[test]
+        fn splits_the_settled_amount_across_targets() {
+            let mut test = TestSetup::new();
+            let source = test.add_rewarded_legacy_mixnode(&test.make_addr("source-owner"), None);
+            let first = test.add_rewarded_legacy_mixnode(&test.make_addr("first-owner"), None);
+            let second = test.add_rewarded_legacy_mixnode(&test.make_addr("second-owner"), None);
+            let owner = test.make_addr("delegator");
+            let amount = 120_000_000u128;
+            test.add_immediate_delegation(&owner, amount, source);
+
+            let env = test.env();
+            let response = redelegate(
+                test.deps_mut(),
+                &env,
+                123,
+                owner.clone(),
+                source,
+                vec![target(first, 1), target(second, 3)],
+            )
+            .unwrap();
+
+            assert!(get_bank_send_msg(&response).is_none());
+            assert!(stored_delegation(&test, source, &owner).is_none());
+            assert_eq!(
+                stored_delegation(&test, first, &owner)
+                    .unwrap()
+                    .amount
+                    .amount,
+                Uint128::new(30_000_000)
+            );
+            assert_eq!(
+                stored_delegation(&test, second, &owner)
+                    .unwrap()
+                    .amount
+                    .amount,
+                Uint128::new(90_000_000)
+            );
+        }
+
+        #[test]
+        fn unavailable_target_leaves_the_source_unchanged() {
+            let mut test = TestSetup::new();
+            let source = test.add_rewarded_legacy_mixnode(&test.make_addr("source-owner"), None);
+            let available =
+                test.add_rewarded_legacy_mixnode(&test.make_addr("available-owner"), None);
+            let destination =
+                test.add_rewarded_legacy_mixnode(&test.make_addr("destination-owner"), None);
+            let owner = test.make_addr("delegator");
+            let amount = 120_000_000u128;
+            test.add_immediate_delegation(&owner, amount, source);
+            let source_rewarding = test.mix_rewarding(source);
+
+            let env = test.env();
+            unbond_mixnode(test.deps_mut(), &env, 123, destination).unwrap();
+            let response = redelegate(
+                test.deps_mut(),
+                &env,
+                124,
+                owner.clone(),
+                source,
+                vec![target(available, 1), target(destination, 1)],
+            )
+            .unwrap();
+
+            assert!(get_bank_send_msg(&response).is_none());
+            assert_eq!(
+                stored_delegation(&test, source, &owner)
+                    .unwrap()
+                    .amount
+                    .amount,
+                Uint128::new(amount)
+            );
+            assert_eq!(test.mix_rewarding(source), source_rewarding);
+            assert!(stored_delegation(&test, available, &owner).is_none());
+            assert!(stored_delegation(&test, destination, &owner).is_none());
+        }
+
+        #[test]
+        fn share_below_minimum_leaves_the_source_unchanged() {
+            let mut test = TestSetup::new();
+            let source = test.add_rewarded_legacy_mixnode(&test.make_addr("source-owner"), None);
+            let first = test.add_rewarded_legacy_mixnode(&test.make_addr("first-owner"), None);
+            let second = test.add_rewarded_legacy_mixnode(&test.make_addr("second-owner"), None);
+            let owner = test.make_addr("delegator");
+            let amount = 200u128;
+            test.add_immediate_delegation(&owner, amount, source);
+
+            let mut state = mixnet_params_storage::CONTRACT_STATE
+                .load(test.deps().storage)
+                .unwrap();
+            state.params.delegations_params.minimum_delegation = Some(coin(150, TEST_COIN_DENOM));
+            mixnet_params_storage::CONTRACT_STATE
+                .save(test.deps_mut().storage, &state)
+                .unwrap();
+
+            let env = test.env();
+            let response = redelegate(
+                test.deps_mut(),
+                &env,
+                123,
+                owner.clone(),
+                source,
+                vec![target(first, 1), target(second, 1)],
+            )
+            .unwrap();
+
+            assert!(get_bank_send_msg(&response).is_none());
+            assert_eq!(
+                stored_delegation(&test, source, &owner)
+                    .unwrap()
+                    .amount
+                    .amount,
+                Uint128::new(amount)
+            );
+            assert!(stored_delegation(&test, first, &owner).is_none());
+            assert!(stored_delegation(&test, second, &owner).is_none());
+        }
+
+        #[test]
+        fn zero_share_is_rejected_even_when_the_configured_minimum_is_zero() {
+            let mut test = TestSetup::new();
+            let source = test.add_rewarded_legacy_mixnode(&test.make_addr("source-owner"), None);
+            let first = test.add_rewarded_legacy_mixnode(&test.make_addr("first-owner"), None);
+            let second = test.add_rewarded_legacy_mixnode(&test.make_addr("second-owner"), None);
+            let owner = test.make_addr("delegator");
+            test.add_immediate_delegation(&owner, 1u128, source);
+
+            let mut state = mixnet_params_storage::CONTRACT_STATE
+                .load(test.deps().storage)
+                .unwrap();
+            state.params.delegations_params.minimum_delegation = Some(coin(0, TEST_COIN_DENOM));
+            mixnet_params_storage::CONTRACT_STATE
+                .save(test.deps_mut().storage, &state)
+                .unwrap();
+
+            let env = test.env();
+            let response = redelegate(
+                test.deps_mut(),
+                &env,
+                123,
+                owner.clone(),
+                source,
+                vec![target(first, 1), target(second, 1)],
+            )
+            .unwrap();
+
+            assert!(get_bank_send_msg(&response).is_none());
+            assert_eq!(
+                stored_delegation(&test, source, &owner)
+                    .unwrap()
+                    .amount
+                    .amount,
+                Uint128::one()
+            );
+            assert!(stored_delegation(&test, first, &owner).is_none());
+            assert!(stored_delegation(&test, second, &owner).is_none());
+        }
+
+        #[test]
+        fn moves_accrued_reward_with_the_source_stake() {
+            let mut test = TestSetup::new();
+            let source = test.add_rewarded_legacy_mixnode(
+                &test.make_addr("source-owner"),
+                Some(100_000_000_000u128.into()),
+            );
+            let destination =
+                test.add_rewarded_legacy_mixnode(&test.make_addr("destination-owner"), None);
+            let owner = test.make_addr("delegator");
+            let amount = 120_000_000u128;
+            test.add_immediate_delegation(&owner, amount, source);
+
+            let active_params = test.active_node_params(100.0);
+            test.force_change_mix_rewarded_set(vec![source]);
+            test.skip_to_next_epoch_end();
+            let distribution = test.reward_with_distribution_ignore_state(source, active_params);
+            let expected = amount + truncate_reward_amount(distribution.delegates).u128();
+
+            let env = test.env();
+            redelegate(
+                test.deps_mut(),
+                &env,
+                123,
+                owner.clone(),
+                source,
+                vec![target(destination, 1)],
+            )
+            .unwrap();
+
+            assert!(stored_delegation(&test, source, &owner).is_none());
+            assert_eq!(
+                stored_delegation(&test, destination, &owner)
+                    .unwrap()
+                    .amount
+                    .amount,
+                Uint128::new(expected)
+            );
+        }
+
+        #[test]
+        fn compounds_into_an_existing_target_delegation() {
+            let mut test = TestSetup::new();
+            let source = test.add_rewarded_legacy_mixnode(&test.make_addr("source-owner"), None);
+            let destination =
+                test.add_rewarded_legacy_mixnode(&test.make_addr("destination-owner"), None);
+            let owner = test.make_addr("delegator");
+            test.add_immediate_delegation(&owner, 120_000_000u128, source);
+            test.add_immediate_delegation(&owner, 80_000_000u128, destination);
+
+            let env = test.env();
+            redelegate(
+                test.deps_mut(),
+                &env,
+                123,
+                owner.clone(),
+                source,
+                vec![target(destination, 1)],
+            )
+            .unwrap();
+
+            assert!(stored_delegation(&test, source, &owner).is_none());
+            assert_eq!(
+                stored_delegation(&test, destination, &owner)
+                    .unwrap()
+                    .amount
+                    .amount,
+                Uint128::new(200_000_000)
+            );
+            assert_eq!(test.mix_rewarding(destination).unique_delegations, 1);
         }
     }
 


### PR DESCRIPTION
## What

Adds a `Redelegate` execute message to the mixnet contract that moves an
existing delegation from one node to one or more targets in a single
transaction, without sending the stake back to the delegator's wallet in
between.

- single target — full move of the settled delegation
- multiple targets — split by integer weights (largest-remainder,
  deterministic tie-break by node id), up to 16 targets

## Why

Re-delegating today requires Undelegate → wait for the epoch → Delegate
again. That returns the funds to the wallet and skips a reward epoch.
Redelegate makes it one atomic action, so delegators can move stake away
from a saturated or underperforming node without the round-trip.

## Behaviour / safety

- All-or-nothing: the source delegation is removed only after every target
  passes validation (bonded, resulting share above the configured minimum).
  On any failure the source is left untouched and a failure event is emitted.
- Stake never leaves the contract balance — the transfer uses the
  bonded-node delegation path with no bank send.
- Accrued reward on the source is settled and moved together with the stake.
- Rejected up front: empty target list, more than 16 targets, zero weight,
  duplicate targets, single target equal to the source, attached funds,
  and shares below the minimum / zero.
- Executes through the normal pending-epoch-event reconciliation, exactly
  like Delegate/Undelegate.

## Testing

- 15 new unit tests: full move, split (sum preservation, largest-remainder,
  node-id tie-break), min-share and zero-share rejection, unavailable
  target, missing source, reward migration, epoch reconciliation, and
  payload/funds validation.
- Full contract suite green (331/331), clippy --all-targets -D warnings
  clean, schema regenerated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7039)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added redelegation, allowing delegations to be moved from one node to up to 16 bonded target nodes using weighted allocations.
  - Added proportional splitting, reward settlement, compounding, and epoch-based processing for redelegated funds.
  - Added pending, successful, and failed redelegation events with relevant transaction details.

- **Bug Fixes**
  - Added validation for missing, duplicate, self-targeting, zero-weight, excessive, and improperly funded redelegation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->