### PR TITLE
fix(gateway-probe): CanHandshake must reflect a real WireGuard handshake, not local interface state

### DIFF
--- a/nym-gateway-probe/netstack_ping/lib.go
+++ b/nym-gateway-probe/netstack_ping/lib.go
@@ -22,6 +22,7 @@ import (
 	"net/netip"
 	netUrl "net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -200,6 +201,32 @@ func wgPingTwoHop(cReq *C.char) *C.char {
 	return jsonResponse(response)
 }
 
+// hasHandshaked reports whether dev has completed at least one real
+// WireGuard handshake with its configured peer. dev.Up() succeeding only
+// means the local interface came up -- it says nothing about whether the
+// remote peer ever responded, so it must not be used on its own as evidence
+// of a working handshake. This checks the actual per-peer
+// last_handshake_time exposed by the WireGuard userspace configuration
+// protocol (see IpcGetOperation in the amneziawg-go/wireguard-go device
+// package), which is only set once a Noise handshake response has been
+// received from the peer.
+func hasHandshaked(dev *device.Device) bool {
+	config, err := dev.IpcGet()
+	if err != nil {
+		log.Printf("hasHandshaked: IpcGet failed: %v", err)
+		return false
+	}
+	for _, line := range strings.Split(config, "\n") {
+		if secStr, ok := strings.CutPrefix(line, "last_handshake_time_sec="); ok {
+			sec, err := strconv.ParseInt(strings.TrimSpace(secStr), 10, 64)
+			if err == nil && sec > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func pingTwoHop(req TwoHopNetstackRequest) (NetstackResponse, error) {
 	log.Printf("=== Two-Hop WireGuard Probe ===")
 	log.Printf("Entry endpoint: %s", req.EntryEndpoint)
@@ -324,9 +351,6 @@ func pingTwoHop(req TwoHopNetstackRequest) (NetstackResponse, error) {
 		return response, fmt.Errorf("failed to bring up exit device: %w", err)
 	}
 	log.Printf("Exit tunnel up (via forwarder)")
-
-	// If we got here, both tunnels and forwarder are set up
-	response.CanHandshake = true
 	log.Printf("Two-hop tunnel setup complete!")
 
 	// ============================================
@@ -409,6 +433,11 @@ func pingTwoHop(req TwoHopNetstackRequest) (NetstackResponse, error) {
 	response.DownloadDurationMilliseconds = uint64(downloadDuration.Milliseconds())
 	response.DownloadedFile = usedURL
 
+	// The exit device is the node under test in this call; its handshake
+	// only happens once real traffic has been forwarded through it, which
+	// is why this is checked here rather than right after exitDev.Up().
+	response.CanHandshake = hasHandshaked(exitDev)
+
 	log.Printf("=== Two-Hop Probe Complete ===")
 	return response, nil
 }
@@ -468,12 +497,13 @@ func ping(req NetstackRequestGo) (NetstackResponse, error) {
 		return NetstackResponse{}, err
 	}
 
-	response.CanHandshake = true
-
 	// port-check-only mode: skip pings/download, only test TCP port reachability
 	if req.PortCheckOnly && len(req.PortCheckPorts) > 0 {
 		log.Printf("=== Port Check Only Mode ===")
 		response.PortCheckResults = checkPorts(req.PortCheckTarget, req.PortCheckPorts, req.PortCheckTimeoutSec, tnet)
+		// checkPorts already dialed through the tunnel, which is enough to
+		// trigger a handshake attempt if the peer is reachable.
+		response.CanHandshake = hasHandshaked(dev)
 		return response, nil
 	}
 
@@ -585,6 +615,8 @@ func ping(req NetstackRequestGo) (NetstackResponse, error) {
 		response.DownloadError = ""
 		response.DownloadedFileSizeBytes = uint64(len(fileContent))
 	}
+
+	response.CanHandshake = hasHandshaked(dev)
 
 	return response, nil
 }

--- a/nym-gateway-probe/netstack_ping/lib_test.go
+++ b/nym-gateway-probe/netstack_ping/lib_test.go
@@ -3,6 +3,11 @@ package main
 import (
 	"math"
 	"testing"
+
+	"github.com/amnezia-vpn/amneziawg-go/conn"
+	"github.com/amnezia-vpn/amneziawg-go/device"
+	"github.com/amnezia-vpn/amneziawg-go/tun/netstack"
+	"net/netip"
 )
 
 // Test the abs helper function
@@ -210,9 +215,14 @@ func TestNetstackRequestGo(t *testing.T) {
 	}
 }
 
-// Test the ping function with valid request (will fail due to network setup)
+// Test the ping function against an address that is not a real WireGuard
+// peer, so no handshake can ever complete. CanHandshake must reflect that:
+// dev.Up() succeeding (a local interface coming up) is not evidence of a
+// working handshake with the remote peer -- see hasHandshaked.
 func TestPingFunction(t *testing.T) {
-	// Create a request with valid IP but will fail due to network setup
+	// 1.1.1.1:51820 is not a WireGuard endpoint, and the all-zero key pair
+	// cannot produce a valid Noise session either way, so this can never
+	// handshake with anything.
 	req := NetstackRequestGo{
 		WgIp:               "10.0.0.1",
 		PrivateKey:         "0000000000000000000000000000000000000000000000000000000000000000",
@@ -235,12 +245,13 @@ func TestPingFunction(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	// Check that we got a valid response structure
-	if response.CanHandshake != true {
-		t.Error("Expected CanHandshake to be true")
+	// No peer ever responded, so CanHandshake must be false. Before the fix
+	// this was unconditionally true here, despite every ping and download
+	// attempt failing -- this is exactly the bug hasHandshaked corrects.
+	if response.CanHandshake {
+		t.Error("Expected CanHandshake to be false: no real peer was ever reachable")
 	}
 
-	// The response should show the retry attempts worked
 	t.Logf("Response: CanHandshake=%v, SentHosts=%d, ReceivedHosts=%d, DownloadedFile=%s",
 		response.CanHandshake, response.SentHosts, response.ReceivedHosts, response.DownloadedFile)
 }
@@ -317,4 +328,36 @@ func TestConsecutiveFailureExit(t *testing.T) {
 	}
 
 	t.Logf("Test completed cleanly: sent %d pings, received %d pings", response.SentIps, response.ReceivedIps)
+}
+
+// Test hasHandshaked against a real (never-connected) device: a device that
+// has never exchanged a Noise handshake with its peer must report false,
+// matching last_handshake_time_sec=0. This is the state right after Up(),
+// which is exactly the case the fix moves the CanHandshake check past.
+func TestHasHandshakedBeforeAnyTraffic(t *testing.T) {
+	tun, _, err := netstack.CreateNetTUN(
+		[]netip.Addr{netip.MustParseAddr("10.0.0.2")},
+		[]netip.Addr{netip.MustParseAddr("1.1.1.1")},
+		1280)
+	if err != nil {
+		t.Fatalf("failed to create test TUN: %v", err)
+	}
+	dev := device.NewDevice(tun, conn.NewDefaultBind(), device.NewLogger(device.LogLevelError, ""))
+	defer dev.Close()
+
+	// A syntactically valid peer that nothing will ever respond to.
+	ipc := "private_key=0000000000000000000000000000000000000000000000000000000000000000\n" +
+		"public_key=0000000000000000000000000000000000000000000000000000000000000000\n" +
+		"endpoint=192.0.2.1:51820\n" +
+		"allowed_ip=0.0.0.0/0\n"
+	if err := dev.IpcSet(ipc); err != nil {
+		t.Fatalf("IpcSet failed: %v", err)
+	}
+	if err := dev.Up(); err != nil {
+		t.Fatalf("Up failed: %v", err)
+	}
+
+	if hasHandshaked(dev) {
+		t.Error("hasHandshaked should be false immediately after Up(), before any traffic")
+	}
 }


### PR DESCRIPTION
## Context

Found while debugging a gateway with completely broken mixnet peering (zero established peer connections, every Noise handshake attempt rejected). Despite that, this probe's own WireGuard-specific tests reported full success on both IPv4 and IPv6 for that same gateway -- which is what prompted reading `netstack_ping/lib.go` closely enough to see what `CanHandshake` actually verifies.

## Summary

`CanHandshake` was set to `true` immediately after `dev.Up()` (and `exitDev.Up()` in the two-hop path) succeeded. `Up()` only brings the local userspace WireGuard interface online -- it says nothing about whether the remote peer ever responded to a Noise handshake. In practice this made `CanHandshake` close to always-true, since local interface setup essentially never fails.

This is demonstrated by the repo's own pre-existing `TestPingFunction`: it points at `1.1.1.1:51820` (not a WireGuard endpoint at all -- 1.1.1.1 is used elsewhere in this codebase purely as a DNS resolver / ping target) with an all-zero key pair. Every ping and download attempt fails over ~36s of real network timeouts. The test's *own* prior assertion still required `CanHandshake == true`.

Fix: added `hasHandshaked(dev)`, which reads the actual `last_handshake_time_sec` exposed by the WireGuard userspace configuration protocol (`IpcGet()`) -- only nonzero once the peer has genuinely responded. `CanHandshake` is now set from this after real traffic has had a chance to trigger a handshake attempt (after the port-check / ping / download calls), rather than immediately after `Up()`, in both `ping()` and `pingTwoHop()` (checking `exitDev`, the node actually under test in that path).

## Testing

- `TestPingFunction` updated to assert the correct outcome (`CanHandshake == false`, since no real peer is ever reachable) -- this is the same scenario as above, and is exactly the regression this fix targets.
- Added `TestHasHandshakedBeforeAnyTraffic`, which brings up a real (never-connected) device and confirms `hasHandshaked` reports `false` before any traffic.
- Full package suite: `go test ./netstack_ping/...` -- 11 passed, 0 failed.

*Work done by Claude (Anthropic), guided by a human.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7047)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection status reporting by confirming that a WireGuard handshake has actually occurred.
  * Prevented interfaces from being marked as connected immediately after startup.
  * Updated single-hop, two-hop, and port-check flows to report handshake status after traffic testing.
  * Corrected results for unreachable peers and connections that have not exchanged traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->