### PR TITLE
chore: removed support for outfox packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8641,6 +8641,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "thiserror 2.0.19",
+ "tracing",
  "zeroize",
 ]
 
@@ -8761,7 +8762,6 @@ dependencies = [
 name = "nym-sphinx-types"
 version = "1.21.5-rc.3"
 dependencies = [
- "nym-outfox",
  "sphinx-packet",
  "thiserror 2.0.19",
 ]

--- a/clients/socks5/src/commands/init.rs
+++ b/clients/socks5/src/commands/init.rs
@@ -90,7 +90,6 @@ impl From<Init> for OverrideConfig {
             medium_toggle: false,
             nyxd_urls: init_config.common_args.nyxd_urls,
             enabled_credentials_mode: init_config.common_args.enabled_credentials_mode,
-            outfox: false,
             stats_reporting_address: init_config.common_args.stats_reporting_address,
             forget_me: init_config.common_args.forget_me.into(),
         }

--- a/clients/socks5/src/commands/mod.rs
+++ b/clients/socks5/src/commands/mod.rs
@@ -110,7 +110,6 @@ pub(crate) struct OverrideConfig {
     medium_toggle: bool,
     nyxd_urls: Option<Vec<url::Url>>,
     enabled_credentials_mode: Option<bool>,
-    outfox: bool,
     stats_reporting_address: Option<Recipient>,
     forget_me: ForgetMe,
 }
@@ -137,11 +136,7 @@ pub(crate) fn override_config(config: Config, args: OverrideConfig) -> Config {
     let secondary_packet_size = args.medium_toggle.then_some(PacketSize::ExtendedPacket16);
     let no_per_hop_delays = args.medium_toggle;
 
-    let packet_type = if args.outfox {
-        PacketType::Outfox
-    } else {
-        PacketType::Mix
-    };
+    let packet_type = PacketType::Mix;
     config
         .with_base(
             BaseClientConfig::with_high_default_traffic_volume,

--- a/clients/socks5/src/commands/run.rs
+++ b/clients/socks5/src/commands/run.rs
@@ -40,9 +40,6 @@ pub(crate) struct Run {
     /// This includes things like disabling cover traffic, no per hop delays, etc.
     #[clap(long, hide = true)]
     medium_toggle: bool,
-
-    #[clap(long, hide = true, action)]
-    outfox: bool,
 }
 
 impl From<Run> for OverrideConfig {
@@ -57,7 +54,6 @@ impl From<Run> for OverrideConfig {
             medium_toggle: run_config.medium_toggle,
             nyxd_urls: run_config.common_args.nyxd_urls,
             enabled_credentials_mode: run_config.common_args.enabled_credentials_mode,
-            outfox: run_config.outfox,
             stats_reporting_address: run_config.common_args.stats_reporting_address,
             forget_me: run_config.common_args.forget_me.into(),
         }

--- a/common/client-libs/gateway-client/src/traits.rs
+++ b/common/client-libs/gateway-client/src/traits.rs
@@ -16,8 +16,6 @@ pub trait GatewayPacketRouter {
         // data he takes the SURB-ACK and first hop address.
         // currently SURB-ACKs are attached in EVERY packet, even cover, so this is always true
         let sphinx_ack_overhead = PacketSize::AckPacket.size() + MAX_NODE_ADDRESS_UNPADDED_LEN;
-        let outfox_ack_overhead =
-            PacketSize::OutfoxAckPacket.size() + MAX_NODE_ADDRESS_UNPADDED_LEN;
 
         for received_packet in unwrapped_packets {
             // note: if we ever fail to route regular outfox, it might be because I've removed a match on
@@ -30,23 +28,8 @@ pub trait GatewayPacketRouter {
                     received_acks.push(received_packet);
                 }
 
-                n if n <= PacketSize::OutfoxAckPacket.plaintext_size() => {
-                    // we don't know the real size of the payload, it could be anything <= 48 bytes
-                    trace!("received outfox ack");
-                    received_acks.push(received_packet);
-                }
-
                 n if n == PacketSize::RegularPacket.plaintext_size() - sphinx_ack_overhead => {
                     trace!("received regular sphinx packet");
-                    received_messages.push(received_packet);
-                }
-
-                n if n
-                    == PacketSize::OutfoxRegularPacket
-                        .plaintext_size()
-                        .saturating_sub(outfox_ack_overhead) =>
-                {
-                    trace!("received regular outfox packet");
                     received_messages.push(received_packet);
                 }
 

--- a/common/nymsphinx/Cargo.toml
+++ b/common/nymsphinx/Cargo.toml
@@ -56,7 +56,3 @@ sphinx = [
     "nym-sphinx-params/sphinx",
     "nym-sphinx-types/sphinx",
 ]
-outfox = [
-    "nym-sphinx-params/outfox",
-    "nym-sphinx-types/outfox",
-]

--- a/common/nymsphinx/acknowledgements/Cargo.toml
+++ b/common/nymsphinx/acknowledgements/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 generic-array = { workspace = true, optional = true, features = ["serde"] }
 thiserror = { workspace = true }
 zeroize = { workspace = true }
+tracing = { workspace = true }
 
 nym-crypto = { workspace = true, features = ["stream_cipher", "rand"] }
 nym-pemstore = { workspace = true }
@@ -26,6 +27,7 @@ nym-sphinx-params = { workspace = true }
 nym-sphinx-routing = { workspace = true }
 nym-sphinx-types = { workspace = true, features = ["sphinx"] }
 nym-topology = { workspace = true }
+
 
 [features]
 serde = ["dep:serde", "generic-array"]

--- a/common/nymsphinx/acknowledgements/src/surb_ack.rs
+++ b/common/nymsphinx/acknowledgements/src/surb_ack.rs
@@ -57,6 +57,10 @@ impl SurbAck {
     where
         R: RngCore + CryptoRng,
     {
+        let PacketType::Mix = packet_type else {
+            return Err(NymTopologyError::OutfoxNotSupported);
+        };
+
         let route = if disable_mix_hops {
             topology.empty_route_to_egress(recipient.gateway())?
         } else {
@@ -67,10 +71,6 @@ impl SurbAck {
         let destination = recipient.as_sphinx_destination();
 
         let surb_ack_payload = prepare_identifier(rng, ack_key, marshaled_fragment_id);
-
-        let PacketType::Mix = packet_type else {
-            return Err(NymTopologyError::OutfoxNotSupported);
-        };
 
         let packet_size = PacketSize::AckPacket.payload_size();
         let surb_ack_packet = NymPacket::sphinx_build(

--- a/common/nymsphinx/acknowledgements/src/surb_ack.rs
+++ b/common/nymsphinx/acknowledgements/src/surb_ack.rs
@@ -58,7 +58,7 @@ impl SurbAck {
         R: RngCore + CryptoRng,
     {
         let PacketType::Mix = packet_type else {
-            return Err(NymTopologyError::OutfoxNotSupported);
+            return Err(NymTopologyError::PacketTypeNotSupported);
         };
 
         let route = if disable_mix_hops {

--- a/common/nymsphinx/acknowledgements/src/surb_ack.rs
+++ b/common/nymsphinx/acknowledgements/src/surb_ack.rs
@@ -10,12 +10,12 @@ use nym_sphinx_addressing::nodes::{
 use nym_sphinx_params::PacketType;
 use nym_sphinx_params::packet_sizes::PacketSize;
 use nym_sphinx_types::delays::Delay;
-use nym_sphinx_types::{MIN_PACKET_SIZE, NymPacket, NymPacketError};
+use nym_sphinx_types::{NymPacket, NymPacketError};
 use nym_topology::{NymRouteProvider, NymTopologyError};
 use rand::{CryptoRng, RngCore};
-
 use std::time;
 use thiserror::Error;
+use tracing::error;
 
 #[derive(Debug)]
 pub struct SurbAck {
@@ -26,6 +26,9 @@ pub struct SurbAck {
 
 #[derive(Debug, Error)]
 pub enum SurbAckRecoveryError {
+    #[error("attempted to use outfox, but it is currently not supported by the network")]
+    OutfoxNotSupported,
+
     #[error(
         "received an invalid number of bytes to deserialize the SURB-Ack. Got {received}, expected {expected}"
     )]
@@ -64,27 +67,20 @@ impl SurbAck {
         let destination = recipient.as_sphinx_destination();
 
         let surb_ack_payload = prepare_identifier(rng, ack_key, marshaled_fragment_id);
-        let packet_size = match packet_type {
-            PacketType::Outfox => surb_ack_payload.len().max(MIN_PACKET_SIZE),
-            PacketType::Mix => PacketSize::AckPacket.payload_size(),
+
+        let PacketType::Mix = packet_type else {
+            return Err(NymTopologyError::OutfoxNotSupported);
         };
 
-        let surb_ack_packet = match packet_type {
-            PacketType::Outfox => NymPacket::outfox_build(
-                surb_ack_payload,
-                route.as_slice(),
-                &destination,
-                Some(packet_size),
-            )?,
-            PacketType::Mix => NymPacket::sphinx_build(
-                use_legacy_sphinx_format,
-                packet_size,
-                surb_ack_payload,
-                &route,
-                &destination,
-                &delays,
-            )?,
-        };
+        let packet_size = PacketSize::AckPacket.payload_size();
+        let surb_ack_packet = NymPacket::sphinx_build(
+            use_legacy_sphinx_format,
+            packet_size,
+            surb_ack_payload,
+            &route,
+            &destination,
+            &delays,
+        )?;
 
         // in our case, the last hop is a gateway that does NOT do any delays
         let expected_total_delay = delays.iter().take(delays.len() - 1).sum();
@@ -99,15 +95,13 @@ impl SurbAck {
     }
 
     pub fn len(packet_type: Option<PacketType>) -> usize {
+        if let Some(PacketType::Outfox) = packet_type {
+            error!("attempted to use an outfox packet - setting it back to sphinx.")
+        };
+
         // TODO: this will be variable once/if we decide to introduce optimization described
         // in common/nymsphinx/chunking/src/lib.rs:available_plaintext_size()
-        let packet_type = packet_type.unwrap_or(PacketType::Mix);
-        match packet_type {
-            PacketType::Outfox => {
-                PacketSize::OutfoxAckPacket.size() + MAX_NODE_ADDRESS_UNPADDED_LEN
-            }
-            PacketType::Mix => PacketSize::AckPacket.size() + MAX_NODE_ADDRESS_UNPADDED_LEN,
-        }
+        PacketSize::AckPacket.size() + MAX_NODE_ADDRESS_UNPADDED_LEN
     }
 
     pub fn expected_total_delay(&self) -> Delay {
@@ -136,7 +130,7 @@ impl SurbAck {
         // in common/nymsphinx/chunking/src/lib.rs:available_plaintext_size()
         let address_offset = MAX_NODE_ADDRESS_UNPADDED_LEN;
         let packet = match packet_type {
-            PacketType::Outfox => NymPacket::outfox_from_bytes(&b[address_offset..])?,
+            PacketType::Outfox => return Err(SurbAckRecoveryError::OutfoxNotSupported),
             PacketType::Mix => NymPacket::sphinx_from_bytes(&b[address_offset..])?,
         };
 

--- a/common/nymsphinx/cover/src/lib.rs
+++ b/common/nymsphinx/cover/src/lib.rs
@@ -146,7 +146,7 @@ where
         )?,
         PacketType::Outfox => {
             return Err(CoverMessageError::InvalidTopologyError(
-                NymTopologyError::OutfoxNotSupported,
+                NymTopologyError::PacketTypeNotSupported,
             ));
         }
     };

--- a/common/nymsphinx/cover/src/lib.rs
+++ b/common/nymsphinx/cover/src/lib.rs
@@ -134,6 +134,7 @@ where
         NymNodeRoutingAddress::try_from(route.first().unwrap().address).unwrap();
 
     // once merged, that's an easy rng injection point for sphinx packets : )
+    #[allow(deprecated)]
     let packet = match packet_type {
         PacketType::Mix => NymPacket::sphinx_build(
             use_legacy_sphinx_format,
@@ -143,12 +144,11 @@ where
             &destination,
             &delays,
         )?,
-        PacketType::Outfox => NymPacket::outfox_build(
-            packet_payload,
-            &route,
-            &destination,
-            Some(packet_size.plaintext_size()),
-        )?,
+        PacketType::Outfox => {
+            return Err(CoverMessageError::InvalidTopologyError(
+                NymTopologyError::OutfoxNotSupported,
+            ));
+        }
     };
 
     Ok(MixPacket::new(

--- a/common/nymsphinx/forwarding/Cargo.toml
+++ b/common/nymsphinx/forwarding/Cargo.toml
@@ -15,6 +15,6 @@ publish = true
 [dependencies]
 nym-sphinx-addressing = { workspace = true }
 nym-sphinx-params = { workspace = true }
-nym-sphinx-types = { workspace = true, features = ["sphinx", "outfox"] }
+nym-sphinx-types = { workspace = true, features = ["sphinx"] }
 nym-sphinx-anonymous-replies = { workspace = true }
 thiserror = { workspace = true }

--- a/common/nymsphinx/forwarding/src/packet.rs
+++ b/common/nymsphinx/forwarding/src/packet.rs
@@ -14,6 +14,9 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum MixPacketFormattingError {
+    #[error("attempted to use outfox, but it is currently not supported by the network")]
+    OutfoxNotSupported,
+
     #[error("too few bytes provided to recover from bytes")]
     TooFewBytesProvided,
 
@@ -120,9 +123,10 @@ impl MixPacket {
         // make sure the received data length corresponds to a valid packet
         let _ = PacketSize::get_type(packet_size)?;
 
+        #[allow(deprecated)]
         let packet = match packet_type {
             PacketType::Mix => NymPacket::sphinx_from_bytes(packet_data)?,
-            PacketType::Outfox => NymPacket::outfox_from_bytes(packet_data)?,
+            PacketType::Outfox => return Err(MixPacketFormattingError::OutfoxNotSupported),
         };
 
         Ok(MixPacket {
@@ -161,9 +165,10 @@ impl MixPacket {
         // make sure the received data length corresponds to a valid packet
         let _ = PacketSize::get_type(packet_size)?;
 
+        #[allow(deprecated)]
         let packet = match packet_type {
             PacketType::Mix => NymPacket::sphinx_from_bytes(packet_data)?,
-            PacketType::Outfox => NymPacket::outfox_from_bytes(packet_data)?,
+            PacketType::Outfox => return Err(MixPacketFormattingError::OutfoxNotSupported),
         };
 
         Ok(MixPacket {

--- a/common/nymsphinx/forwarding/src/packet.rs
+++ b/common/nymsphinx/forwarding/src/packet.rs
@@ -138,6 +138,10 @@ impl MixPacket {
     }
 
     pub fn into_v1_bytes(self) -> Result<Vec<u8>, MixPacketFormattingError> {
+        #[allow(deprecated)]
+        if self.packet_type == PacketType::Outfox {
+            return Err(MixPacketFormattingError::OutfoxNotSupported);
+        }
         Ok(std::iter::once(self.packet_type as u8)
             .chain(self.next_hop.as_bytes())
             .chain(self.packet.to_bytes()?)
@@ -180,6 +184,10 @@ impl MixPacket {
     }
 
     pub fn into_v2_bytes(self) -> Result<Vec<u8>, MixPacketFormattingError> {
+        #[allow(deprecated)]
+        if self.packet_type == PacketType::Outfox {
+            return Err(MixPacketFormattingError::OutfoxNotSupported);
+        }
         Ok(std::iter::once(self.packet_type as u8)
             .chain(std::iter::once(self.key_rotation as u8))
             .chain(self.next_hop.as_bytes())

--- a/common/nymsphinx/framing/Cargo.toml
+++ b/common/nymsphinx/framing/Cargo.toml
@@ -19,8 +19,8 @@ tokio-util = { workspace = true, features = ["codec"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
-nym-sphinx-types = { workspace = true, features = ["sphinx", "outfox"] }
-nym-sphinx-params = { workspace = true, features = ["sphinx", "outfox"] }
+nym-sphinx-types = { workspace = true, features = ["sphinx"] }
+nym-sphinx-params = { workspace = true, features = ["sphinx"] }
 nym-sphinx-forwarding = { workspace = true }
 nym-sphinx-addressing = { workspace = true }
 nym-sphinx-acknowledgements = { workspace = true }

--- a/common/nymsphinx/framing/src/codec.rs
+++ b/common/nymsphinx/framing/src/codec.rs
@@ -15,6 +15,9 @@ use tokio_util::codec::{Decoder, Encoder};
 
 #[derive(Error, Debug)]
 pub enum NymCodecError {
+    #[error("attempted to use outfox, but it is currently not supported by the network")]
+    OutfoxNotSupported,
+
     #[error("the packet size information was malformed: {0}")]
     InvalidPacketSize(#[from] InvalidPacketSize),
 
@@ -99,8 +102,9 @@ impl Decoder for NymCodec {
         let packet = if let Some(slice) = packet_bytes.get(..) {
             // here it could be debatable whether stream is corrupt or not,
             // but let's go with the safer approach and assume it is.
+            #[allow(deprecated)]
             match header.packet_type {
-                PacketType::Outfox => NymPacket::outfox_from_bytes(slice)?,
+                PacketType::Outfox => return Err(NymCodecError::OutfoxNotSupported),
                 PacketType::Mix => NymPacket::sphinx_from_bytes(slice)?,
             }
         } else {
@@ -144,9 +148,7 @@ impl Decoder for NymCodec {
 mod packet_encoding {
     use super::*;
     use nym_sphinx_params::PacketType;
-    use nym_sphinx_params::packet_version::{
-        CURRENT_PACKET_VERSION, INITIAL_PACKET_VERSION_NUMBER,
-    };
+    use nym_sphinx_params::packet_version::CURRENT_PACKET_VERSION;
     use nym_sphinx_types::{
         DESTINATION_ADDRESS_LENGTH, Delay as SphinxDelay, Destination, DestinationAddressBytes,
         IDENTIFIER_LENGTH, NODE_ADDRESS_LENGTH, Node, NodeAddressBytes, NymPacket, PrivateKey,
@@ -161,61 +163,9 @@ mod packet_encoding {
         }
     }
 
-    fn dummy_outfox() -> Header {
-        Header {
-            packet_type: PacketType::Outfox,
-            packet_size: PacketSize::OutfoxRegularPacket,
-            ..dummy_legacy_header()
-        }
-    }
-
-    fn dummy_legacy_header() -> Header {
-        Header {
-            packet_version: PacketVersion::try_from(INITIAL_PACKET_VERSION_NUMBER).unwrap(),
-            packet_size: Default::default(),
-            key_rotation: Default::default(),
-            packet_type: Default::default(),
-        }
-    }
-
     fn random_pubkey() -> nym_sphinx_types::PublicKey {
         let private_key = PrivateKey::random();
         (&private_key).into()
-    }
-
-    fn make_valid_outfox_packet(size: PacketSize) -> NymPacket {
-        let node1_pk = random_pubkey();
-        let node1 = Node::new(
-            NodeAddressBytes::from_bytes([5u8; NODE_ADDRESS_LENGTH]),
-            node1_pk,
-        );
-        let node2_pk = random_pubkey();
-        let node2 = Node::new(
-            NodeAddressBytes::from_bytes([4u8; NODE_ADDRESS_LENGTH]),
-            node2_pk,
-        );
-        let node3_pk = random_pubkey();
-        let node3 = Node::new(
-            NodeAddressBytes::from_bytes([2u8; NODE_ADDRESS_LENGTH]),
-            node3_pk,
-        );
-
-        let node4_pk = random_pubkey();
-        let node4 = Node::new(
-            NodeAddressBytes::from_bytes([2u8; NODE_ADDRESS_LENGTH]),
-            node4_pk,
-        );
-
-        let destination = Destination::new(
-            DestinationAddressBytes::from_bytes([3u8; DESTINATION_ADDRESS_LENGTH]),
-            [4u8; IDENTIFIER_LENGTH],
-        );
-
-        let route = &[node1, node2, node3, node4];
-
-        let payload = vec![1; 48];
-
-        NymPacket::outfox_build(payload, route, &destination, Some(size.plaintext_size())).unwrap()
     }
 
     fn make_valid_sphinx_packet(size: PacketSize) -> NymPacket {
@@ -273,24 +223,6 @@ mod packet_encoding {
 
         assert_eq!(decoded.header, header);
         assert_eq!(decoded.packet.to_bytes().unwrap(), sphinx_bytes)
-    }
-
-    #[test]
-    fn whole_outfox_can_be_decoded_from_a_valid_encoded_instance() {
-        let header = dummy_outfox();
-        let packet = make_valid_outfox_packet(PacketSize::OutfoxRegularPacket);
-        let packet_bytes = packet.to_bytes().unwrap();
-
-        NymPacket::outfox_from_bytes(packet_bytes.as_slice()).unwrap();
-
-        let packet = FramedNymPacket { header, packet };
-
-        let mut bytes = BytesMut::new();
-        NymCodec.encode(packet, &mut bytes).unwrap();
-        let decoded = NymCodec.decode(&mut bytes).unwrap().unwrap();
-
-        assert_eq!(decoded.header, header);
-        assert_eq!(decoded.packet.to_bytes().unwrap(), packet_bytes)
     }
 
     #[cfg(test)]

--- a/common/nymsphinx/framing/src/processing.rs
+++ b/common/nymsphinx/framing/src/processing.rs
@@ -418,19 +418,4 @@ mod tests {
         assert!(ack.is_none());
         assert_eq!(data, message)
     }
-
-    #[test]
-    #[allow(deprecated)]
-    fn splitting_into_ack_and_message_returns_whole_data_for_ack_outfox() {
-        let data = vec![42u8; SurbAck::len(Some(PacketType::Outfox)) + 10];
-        let (ack, message) = split_into_ack_and_message(
-            data.clone(),
-            PacketSize::OutfoxAckPacket,
-            PacketType::Outfox,
-            SphinxKeyRotation::EvenRotation,
-        )
-        .unwrap();
-        assert!(ack.is_none());
-        assert_eq!(data, message)
-    }
 }

--- a/common/nymsphinx/framing/src/processing.rs
+++ b/common/nymsphinx/framing/src/processing.rs
@@ -9,8 +9,8 @@ use nym_sphinx_params::{PacketSize, PacketType, SphinxKeyRotation};
 use nym_sphinx_types::header::shared_secret::ExpandedSharedSecret;
 use nym_sphinx_types::{
     Delay as SphinxDelay, DestinationAddressBytes, NodeAddressBytes, NymPacket, NymPacketError,
-    NymProcessedPacket, OutfoxError, OutfoxProcessedPacket, PrivateKey, ProcessedPacketData,
-    REPLAY_TAG_SIZE, SphinxError, Version as SphinxPacketVersion,
+    NymProcessedPacket, PrivateKey, ProcessedPacketData, REPLAY_TAG_SIZE, SphinxError,
+    Version as SphinxPacketVersion,
 };
 use std::fmt::Display;
 use thiserror::Error;
@@ -97,9 +97,6 @@ pub enum PacketProcessingError {
     #[error("failed to recover the expected SURB-Ack packet: {0}")]
     MalformedSurbAck(#[from] SurbAckRecoveryError),
 
-    #[error("failed to process received outfox packet: {0}")]
-    OutfoxProcessingError(#[from] OutfoxError),
-
     #[error("attempted to partially process an outfox packet")]
     PartialOutfoxProcessing,
 
@@ -108,6 +105,9 @@ pub enum PacketProcessingError {
 
     #[error("this packet has already been processed before")]
     PacketReplay,
+
+    #[error("encountered a packet type that is not currently supported by the network")]
+    UnsupportedPacketType,
 }
 
 impl PacketProcessingError {
@@ -151,8 +151,7 @@ impl PartiallyUnwrappedPacket {
                     expanded_shared_secret,
                 }
             }
-
-            NymPacket::Outfox(_) => PartialMixProcessingResult::Outfox,
+            _ => return Err((received_data, PacketProcessingError::UnsupportedPacketType)),
         };
         Ok(PartiallyUnwrappedPacket {
             received_data,
@@ -281,43 +280,6 @@ fn wrap_processed_sphinx_packet(
     })
 }
 
-fn wrap_processed_outfox_packet(
-    packet: OutfoxProcessedPacket,
-    packet_size: PacketSize,
-    packet_type: PacketType,
-    key_rotation: SphinxKeyRotation,
-) -> Result<MixProcessingResult, PacketProcessingError> {
-    let next_address = *packet.next_address();
-    let packet = packet.into_packet();
-    if packet.is_final_hop() {
-        let processing_data = process_final_hop(
-            DestinationAddressBytes::from_bytes(next_address),
-            packet.recover_plaintext()?.to_vec(),
-            packet_size,
-            packet_type,
-            key_rotation,
-        )?;
-        Ok(MixProcessingResult {
-            packet_version: MixPacketVersion::Outfox,
-            processing_data,
-        })
-    } else {
-        let packet = MixPacket::new(
-            NymNodeRoutingAddress::try_from_bytes(&next_address)?,
-            NymPacket::Outfox(packet),
-            PacketType::Outfox,
-            SphinxKeyRotation::Unknown,
-        );
-        Ok(MixProcessingResult {
-            packet_version: MixPacketVersion::Outfox,
-            processing_data: MixProcessingResultData::ForwardHop {
-                packet,
-                delay: None,
-            },
-        })
-    }
-}
-
 fn perform_final_processing(
     packet: NymProcessedPacket,
     packet_size: PacketSize,
@@ -328,9 +290,7 @@ fn perform_final_processing(
         NymProcessedPacket::Sphinx(packet) => {
             wrap_processed_sphinx_packet(packet, packet_size, packet_type, key_rotation)
         }
-        NymProcessedPacket::Outfox(packet) => {
-            wrap_processed_outfox_packet(packet, packet_size, packet_type, key_rotation)
-        }
+        _ => Err(PacketProcessingError::UnsupportedPacketType),
     }
 }
 
@@ -359,16 +319,19 @@ fn split_into_ack_and_message(
     packet_type: PacketType,
     key_rotation: SphinxKeyRotation,
 ) -> Result<(Option<MixPacket>, Vec<u8>), PacketProcessingError> {
+    #[allow(deprecated)]
     match packet_size {
-        PacketSize::AckPacket | PacketSize::OutfoxAckPacket => {
+        PacketSize::OutfoxAckPacket | PacketSize::OutfoxRegularPacket => {
+            Err(PacketProcessingError::UnsupportedPacketType)
+        }
+        PacketSize::AckPacket => {
             trace!("received an ack packet!");
             Ok((None, data))
         }
         PacketSize::RegularPacket
         | PacketSize::ExtendedPacket8
         | PacketSize::ExtendedPacket16
-        | PacketSize::ExtendedPacket32
-        | PacketSize::OutfoxRegularPacket => {
+        | PacketSize::ExtendedPacket32 => {
             trace!("received a normal packet!");
             let (ack_data, message) = split_hop_data_into_ack_and_message(data, packet_type)?;
             let (ack_first_hop, ack_packet) =
@@ -382,6 +345,7 @@ fn split_into_ack_and_message(
             let forward_ack = MixPacket::new(ack_first_hop, ack_packet, packet_type, key_rotation);
             Ok((Some(forward_ack), message))
         }
+        _ => Err(PacketProcessingError::UnsupportedPacketType),
     }
 }
 
@@ -424,8 +388,8 @@ fn process_forward_hop(
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn splitting_hop_data_works_for_sufficiently_long_payload() {
+    #[test]
+    fn splitting_hop_data_works_for_sufficiently_long_payload() {
         let short_data = vec![42u8];
         assert!(split_hop_data_into_ack_and_message(short_data, PacketType::Mix).is_err());
 
@@ -441,27 +405,8 @@ mod tests {
         assert_eq!(data.len(), SurbAck::len(Some(PacketType::Mix)) * 4)
     }
 
-    #[tokio::test]
-    async fn splitting_hop_data_works_for_sufficiently_long_payload_outfox() {
-        let short_data = vec![42u8];
-        assert!(split_hop_data_into_ack_and_message(short_data, PacketType::Outfox).is_err());
-
-        let sufficient_data = vec![42u8; SurbAck::len(Some(PacketType::Outfox))];
-        let (ack, data) =
-            split_hop_data_into_ack_and_message(sufficient_data.clone(), PacketType::Outfox)
-                .unwrap();
-        assert_eq!(sufficient_data, ack);
-        assert!(data.is_empty());
-
-        let long_data = vec![42u8; SurbAck::len(Some(PacketType::Outfox)) * 5];
-        let (ack, data) =
-            split_hop_data_into_ack_and_message(long_data, PacketType::Outfox).unwrap();
-        assert_eq!(ack.len(), SurbAck::len(Some(PacketType::Outfox)));
-        assert_eq!(data.len(), SurbAck::len(Some(PacketType::Outfox)) * 4)
-    }
-
-    #[tokio::test]
-    async fn splitting_into_ack_and_message_returns_whole_data_for_ack() {
+    #[test]
+    fn splitting_into_ack_and_message_returns_whole_data_for_ack() {
         let data = vec![42u8; SurbAck::len(Some(PacketType::Mix)) + 10];
         let (ack, message) = split_into_ack_and_message(
             data.clone(),
@@ -474,8 +419,9 @@ mod tests {
         assert_eq!(data, message)
     }
 
-    #[tokio::test]
-    async fn splitting_into_ack_and_message_returns_whole_data_for_ack_outfox() {
+    #[test]
+    #[allow(deprecated)]
+    fn splitting_into_ack_and_message_returns_whole_data_for_ack_outfox() {
         let data = vec![42u8; SurbAck::len(Some(PacketType::Outfox)) + 10];
         let (ack, message) = split_into_ack_and_message(
             data.clone(),

--- a/common/nymsphinx/params/Cargo.toml
+++ b/common/nymsphinx/params/Cargo.toml
@@ -21,5 +21,4 @@ nym-sphinx-types = { workspace = true }
 
 [features]
 default = ["sphinx"]
-sphinx = ["nym-sphinx-types/outfox"]
-outfox = ["nym-sphinx-types/outfox"]
+sphinx = []

--- a/common/nymsphinx/params/src/packet_sizes.rs
+++ b/common/nymsphinx/params/src/packet_sizes.rs
@@ -2,16 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::PacketType;
-#[cfg(feature = "outfox")]
-use nym_sphinx_types::{MIN_PACKET_SIZE, MIX_PARAMS_LEN, OUTFOX_PACKET_OVERHEAD};
-#[cfg(feature = "sphinx")]
-use nym_sphinx_types::{PAYLOAD_OVERHEAD_SIZE, header::HEADER_SIZE};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 use thiserror::Error;
+
+#[cfg(feature = "sphinx")]
+use nym_sphinx_types::{PAYLOAD_OVERHEAD_SIZE, header::HEADER_SIZE};
 
 // each sphinx packet contains mandatory header and payload padding + markers
 #[cfg(feature = "sphinx")]
@@ -37,11 +35,6 @@ const EXTENDED_PACKET_SIZE_16: usize = 16 * 1024 + SPHINX_PACKET_OVERHEAD;
 #[cfg(feature = "sphinx")]
 const EXTENDED_PACKET_SIZE_32: usize = 32 * 1024 + SPHINX_PACKET_OVERHEAD;
 
-#[cfg(feature = "outfox")]
-const OUTFOX_ACK_PACKET_SIZE: usize = MIN_PACKET_SIZE + OUTFOX_PACKET_OVERHEAD;
-#[cfg(feature = "outfox")]
-const OUTFOX_REGULAR_PACKET_SIZE: usize = 2 * 1024 + OUTFOX_PACKET_OVERHEAD;
-
 #[derive(Debug, Error)]
 pub enum InvalidPacketSize {
     #[error("{received} is not a valid packet size tag")]
@@ -56,6 +49,7 @@ pub enum InvalidPacketSize {
 
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum PacketSize {
     // for example instant messaging use case
     #[default]
@@ -78,11 +72,14 @@ pub enum PacketSize {
     #[serde(rename = "extended16")]
     ExtendedPacket16 = 5,
 
+    // make sure to retain old values to never reuse them
     #[serde(rename = "outfox_regular")]
+    #[deprecated]
     OutfoxRegularPacket = 6,
 
     // for sending SURB-ACKs
     #[serde(rename = "outfox_ack")]
+    #[deprecated]
     OutfoxAckPacket = 7,
 }
 
@@ -110,8 +107,6 @@ impl FromStr for PacketSize {
             "extended8" => Ok(Self::ExtendedPacket8),
             "extended16" => Ok(Self::ExtendedPacket16),
             "extended32" => Ok(Self::ExtendedPacket32),
-            "outfox_regular" => Ok(Self::OutfoxRegularPacket),
-            "outfox_ack" => Ok(Self::OutfoxAckPacket),
             s => Err(InvalidPacketSize::UnknownExtendedPacketVariant {
                 received: s.to_string(),
             }),
@@ -120,6 +115,7 @@ impl FromStr for PacketSize {
 }
 
 impl Display for PacketSize {
+    #[allow(deprecated)]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             PacketSize::RegularPacket => write!(f, "regular"),
@@ -153,8 +149,6 @@ impl TryFrom<u8> for PacketSize {
             _ if value == (PacketSize::ExtendedPacket8 as u8) => Ok(Self::ExtendedPacket8),
             _ if value == (PacketSize::ExtendedPacket16 as u8) => Ok(Self::ExtendedPacket16),
             _ if value == (PacketSize::ExtendedPacket32 as u8) => Ok(Self::ExtendedPacket32),
-            _ if value == (PacketSize::OutfoxRegularPacket as u8) => Ok(Self::OutfoxRegularPacket),
-            _ if value == (PacketSize::OutfoxAckPacket as u8) => Ok(Self::OutfoxAckPacket),
             v => Err(InvalidPacketSize::UnknownPacketTag { received: v }),
         }
     }
@@ -174,10 +168,6 @@ impl PacketSize {
             PacketSize::ExtendedPacket16 => EXTENDED_PACKET_SIZE_16,
             #[cfg(feature = "sphinx")]
             PacketSize::ExtendedPacket32 => EXTENDED_PACKET_SIZE_32,
-            #[cfg(feature = "outfox")]
-            PacketSize::OutfoxRegularPacket => OUTFOX_REGULAR_PACKET_SIZE,
-            #[cfg(feature = "outfox")]
-            PacketSize::OutfoxAckPacket => OUTFOX_ACK_PACKET_SIZE,
             _ => 0,
         }
     }
@@ -191,8 +181,6 @@ impl PacketSize {
             | PacketSize::ExtendedPacket8
             | PacketSize::ExtendedPacket16
             | PacketSize::ExtendedPacket32 => HEADER_SIZE,
-            #[cfg(feature = "outfox")]
-            PacketSize::OutfoxRegularPacket | PacketSize::OutfoxAckPacket => MIX_PARAMS_LEN,
             _ => 0,
         }
     }
@@ -206,10 +194,7 @@ impl PacketSize {
             | PacketSize::ExtendedPacket8
             | PacketSize::ExtendedPacket16
             | PacketSize::ExtendedPacket32 => PAYLOAD_OVERHEAD_SIZE,
-            #[cfg(feature = "outfox")]
-            PacketSize::OutfoxRegularPacket | PacketSize::OutfoxAckPacket => {
-                OUTFOX_PACKET_OVERHEAD - MIX_PARAMS_LEN // Mix params are calculated into the total overhead so we take them out here
-            }
+
             _ => 0,
         }
     }
@@ -233,17 +218,12 @@ impl PacketSize {
             Ok(PacketSize::ExtendedPacket16)
         } else if PacketSize::ExtendedPacket32.size() == size {
             Ok(PacketSize::ExtendedPacket32)
-        } else if PacketSize::OutfoxRegularPacket.size() == size
-            || PacketSize::OutfoxRegularPacket.size() == size + 6
-        {
-            Ok(PacketSize::OutfoxRegularPacket)
-        } else if PacketSize::OutfoxAckPacket.size() == size {
-            Ok(PacketSize::OutfoxAckPacket)
         } else {
             Err(InvalidPacketSize::UnknownPacketSize { received: size })
         }
     }
 
+    #[allow(deprecated)]
     pub fn is_extended_size(&self) -> bool {
         match self {
             PacketSize::RegularPacket
@@ -272,8 +252,6 @@ impl PacketSize {
         let overhead = match packet_type {
             #[cfg(feature = "sphinx")]
             PacketType::Mix => SPHINX_PACKET_OVERHEAD,
-            #[cfg(feature = "outfox")]
-            PacketType::Outfox => OUTFOX_PACKET_OVERHEAD,
             _ => 0,
         };
         let packet_size = plaintext_size + overhead;

--- a/common/nymsphinx/params/src/packet_types.rs
+++ b/common/nymsphinx/params/src/packet_types.rs
@@ -28,6 +28,7 @@ pub enum PacketType {
     Mix = 0,
 
     /// Abusing this to add Outfox support
+    #[deprecated]
     #[serde(rename = "outfox")]
     Outfox = 2,
 }

--- a/common/nymsphinx/src/message.rs
+++ b/common/nymsphinx/src/message.rs
@@ -17,8 +17,6 @@ use std::fmt::{Display, Formatter};
 use thiserror::Error;
 
 pub(crate) const ACK_OVERHEAD: usize = MAX_NODE_ADDRESS_UNPADDED_LEN + PacketSize::AckPacket.size();
-pub(crate) const OUTFOX_ACK_OVERHEAD: usize =
-    MAX_NODE_ADDRESS_UNPADDED_LEN + PacketSize::OutfoxAckPacket.size();
 
 #[derive(Debug, Error)]
 pub enum NymMessageError {
@@ -193,11 +191,10 @@ impl NymMessage {
         let packet_type = PacketType::from(packet_size);
 
         // each packet will contain an ack + variant specific data (as described above)
+        #[allow(deprecated)]
         match packet_type {
-            PacketType::Outfox => {
-                packet_size.plaintext_size() - OUTFOX_ACK_OVERHEAD - variant_overhead
-            }
-            _ => packet_size.plaintext_size() - ACK_OVERHEAD - variant_overhead,
+            PacketType::Mix => packet_size.plaintext_size() - ACK_OVERHEAD - variant_overhead,
+            PacketType::Outfox => 0,
         }
     }
 

--- a/common/nymsphinx/src/preparer/mod.rs
+++ b/common/nymsphinx/src/preparer/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::NymPayloadBuilder;
-use crate::message::{ACK_OVERHEAD, NymMessage, OUTFOX_ACK_OVERHEAD};
+use crate::message::{ACK_OVERHEAD, NymMessage};
 use nym_crypto::Digest;
 use nym_crypto::asymmetric::x25519;
 use nym_sphinx_acknowledgements::AckKey;
@@ -113,10 +113,10 @@ pub trait FragmentPreparer {
         // each reply attaches the digest of the encryption key so that the recipient could
         // lookup correct key for decryption,
         let reply_overhead = ReplySurbKeyDigestAlgorithm::output_size();
-        let expected_plaintext = match packet_type {
-            PacketType::Outfox => fragment.serialized_size() + OUTFOX_ACK_OVERHEAD + reply_overhead,
-            _ => fragment.serialized_size() + ACK_OVERHEAD + reply_overhead,
+        let PacketType::Mix = packet_type else {
+            return Err(NymTopologyError::OutfoxNotSupported);
         };
+        let expected_plaintext = fragment.serialized_size() + ACK_OVERHEAD + reply_overhead;
 
         // the reason we're unwrapping (or rather 'expecting') here rather than handling the error
         // more gracefully is that this error should never be reached as it implies incorrect chunking
@@ -200,12 +200,10 @@ pub trait FragmentPreparer {
         monitoring::fragment_sent(&fragment, self.nonce(), destination);
 
         let non_reply_overhead = x25519::PUBLIC_KEY_SIZE;
-        let expected_plaintext = match packet_type {
-            PacketType::Outfox => {
-                fragment.serialized_size() + OUTFOX_ACK_OVERHEAD + non_reply_overhead
-            }
-            _ => fragment.serialized_size() + ACK_OVERHEAD + non_reply_overhead,
+        let PacketType::Mix = packet_type else {
+            return Err(NymTopologyError::OutfoxNotSupported);
         };
+        let expected_plaintext = fragment.serialized_size() + ACK_OVERHEAD + non_reply_overhead;
 
         // the reason we're unwrapping (or rather 'expecting') here rather than handling the error
         // more gracefully is that this error should never be reached as it implies incorrect chunking
@@ -257,13 +255,9 @@ pub trait FragmentPreparer {
 
         // create the actual sphinx packet here. With valid route and correct payload size,
         // there's absolutely no reason for this call to fail.
+        #[allow(deprecated)]
         let packet = match packet_type {
-            PacketType::Outfox => NymPacket::outfox_build(
-                packet_payload,
-                route.as_slice(),
-                &destination,
-                Some(packet_size.plaintext_size()),
-            )?,
+            PacketType::Outfox => return Err(NymTopologyError::OutfoxNotSupported),
             PacketType::Mix => NymPacket::sphinx_build(
                 self.use_legacy_sphinx_format(),
                 packet_size.payload_size(),

--- a/common/nymsphinx/src/preparer/mod.rs
+++ b/common/nymsphinx/src/preparer/mod.rs
@@ -114,7 +114,7 @@ pub trait FragmentPreparer {
         // lookup correct key for decryption,
         let reply_overhead = ReplySurbKeyDigestAlgorithm::output_size();
         let PacketType::Mix = packet_type else {
-            return Err(NymTopologyError::OutfoxNotSupported);
+            return Err(NymTopologyError::PacketTypeNotSupported);
         };
         let expected_plaintext = fragment.serialized_size() + ACK_OVERHEAD + reply_overhead;
 
@@ -201,7 +201,7 @@ pub trait FragmentPreparer {
 
         let non_reply_overhead = x25519::PUBLIC_KEY_SIZE;
         let PacketType::Mix = packet_type else {
-            return Err(NymTopologyError::OutfoxNotSupported);
+            return Err(NymTopologyError::PacketTypeNotSupported);
         };
         let expected_plaintext = fragment.serialized_size() + ACK_OVERHEAD + non_reply_overhead;
 
@@ -257,7 +257,7 @@ pub trait FragmentPreparer {
         // there's absolutely no reason for this call to fail.
         #[allow(deprecated)]
         let packet = match packet_type {
-            PacketType::Outfox => return Err(NymTopologyError::OutfoxNotSupported),
+            PacketType::Outfox => return Err(NymTopologyError::PacketTypeNotSupported),
             PacketType::Mix => NymPacket::sphinx_build(
                 self.use_legacy_sphinx_format(),
                 packet_size.payload_size(),

--- a/common/nymsphinx/types/Cargo.toml
+++ b/common/nymsphinx/types/Cargo.toml
@@ -14,10 +14,8 @@ publish = true
 
 [dependencies]
 sphinx-packet = { workspace = true, optional = true }
-nym-outfox = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
 [features]
 default = ["sphinx"]
 sphinx = ["sphinx-packet"]
-outfox = ["nym-outfox"]

--- a/common/nymsphinx/types/src/lib.rs
+++ b/common/nymsphinx/types/src/lib.rs
@@ -4,18 +4,8 @@
 use std::{array::TryFromSliceError, fmt};
 use thiserror::Error;
 
-#[cfg(feature = "outfox")]
-pub use nym_outfox::packet::{OutfoxPacket, OutfoxProcessedPacket};
-
 #[cfg(feature = "sphinx")]
 pub use sphinx_packet::{SphinxPacket, SphinxPacketBuilder};
-
-#[cfg(feature = "outfox")]
-pub use nym_outfox::{
-    constants::MIN_PACKET_SIZE, constants::MIX_PARAMS_LEN, constants::OUTFOX_PACKET_OVERHEAD,
-    error::OutfoxError,
-};
-// re-exporting types and constants available in sphinx
 
 #[cfg(feature = "sphinx")]
 pub use sphinx_packet::{
@@ -42,28 +32,22 @@ pub enum NymPacketError {
     #[cfg(feature = "sphinx")]
     Sphinx(#[from] sphinx_packet::Error),
 
-    #[error("Outfox error: {0}")]
-    #[cfg(feature = "outfox")]
-    Outfox(#[from] nym_outfox::error::OutfoxError),
-
     #[error("{0}")]
     FromSlice(#[from] TryFromSliceError),
 }
 
 // TODO: wrap that guy and add extra metadata to indicate key rotation?
 #[allow(clippy::large_enum_variant)]
+#[non_exhaustive]
 pub enum NymPacket {
     #[cfg(feature = "sphinx")]
     Sphinx(SphinxPacket),
-    #[cfg(feature = "outfox")]
-    Outfox(OutfoxPacket),
 }
 
+#[non_exhaustive]
 pub enum NymProcessedPacket {
     #[cfg(feature = "sphinx")]
     Sphinx(ProcessedPacket),
-    #[cfg(feature = "outfox")]
-    Outfox(OutfoxProcessedPacket),
 }
 
 impl fmt::Debug for NymPacket {
@@ -73,11 +57,6 @@ impl fmt::Debug for NymPacket {
             #[cfg(feature = "sphinx")]
             NymPacket::Sphinx(packet) => f
                 .debug_struct("NymPacket::Sphinx")
-                .field("len", &packet.len())
-                .finish(),
-            #[cfg(feature = "outfox")]
-            NymPacket::Outfox(packet) => f
-                .debug_struct("NymPacket::Outfox")
                 .field("len", &packet.len())
                 .finish(),
             _ => write!(f, ""),
@@ -113,33 +92,11 @@ impl NymPacket {
         Ok(NymPacket::Sphinx(SphinxPacket::from_bytes(bytes)?))
     }
 
-    #[cfg(feature = "outfox")]
-    pub fn outfox_build<M: AsRef<[u8]>>(
-        payload: M,
-        route: &[Node],
-        destination: &Destination,
-        size: Option<usize>,
-    ) -> Result<NymPacket, NymPacketError> {
-        Ok(NymPacket::Outfox(OutfoxPacket::build(
-            payload,
-            route.try_into()?,
-            destination,
-            size,
-        )?))
-    }
-
-    #[cfg(feature = "outfox")]
-    pub fn outfox_from_bytes(bytes: &[u8]) -> Result<NymPacket, NymPacketError> {
-        Ok(NymPacket::Outfox(OutfoxPacket::try_from(bytes)?))
-    }
-
     pub fn len(&self) -> usize {
         #[allow(unreachable_patterns)]
         match self {
             #[cfg(feature = "sphinx")]
             NymPacket::Sphinx(packet) => packet.len(),
-            #[cfg(feature = "outfox")]
-            NymPacket::Outfox(packet) => packet.len(),
             _ => 0,
         }
     }
@@ -153,8 +110,6 @@ impl NymPacket {
         match self {
             #[cfg(feature = "sphinx")]
             NymPacket::Sphinx(packet) => Ok(packet.to_bytes()),
-            #[cfg(feature = "outfox")]
-            NymPacket::Outfox(packet) => Ok(packet.to_bytes()?),
             _ => Ok(vec![]),
         }
     }
@@ -167,14 +122,6 @@ impl NymPacket {
         match self {
             NymPacket::Sphinx(packet) => {
                 Ok(NymProcessedPacket::Sphinx(packet.process(node_secret_key)?))
-            }
-            #[cfg(feature = "outfox")]
-            NymPacket::Outfox(mut packet) => {
-                let next_address = packet.decode_next_layer(node_secret_key)?;
-                Ok(NymProcessedPacket::Outfox(OutfoxProcessedPacket::new(
-                    packet,
-                    next_address,
-                )))
             }
         }
     }

--- a/common/topology/Cargo.toml
+++ b/common/topology/Cargo.toml
@@ -34,10 +34,7 @@ wasm-bindgen = { workspace = true, optional = true }
 nym-crypto = { workspace = true }
 nym-mixnet-contract-common = { workspace = true }
 nym-sphinx-addressing = { workspace = true }
-nym-sphinx-types = { workspace = true, features = [
-    "sphinx",
-    "outfox",
-] }
+nym-sphinx-types = { workspace = true, features = ["sphinx"] }
 
 
 # I'm not sure how to feel about pulling in this dependency here...

--- a/common/topology/src/error.rs
+++ b/common/topology/src/error.rs
@@ -10,6 +10,9 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum NymTopologyError {
+    #[error("attempted to use outfox, but it is currently not supported by the network")]
+    OutfoxNotSupported,
+
     #[error(
         "the provided network topology is empty - there are no valid nodes on it - the network request(s) probably failed"
     )]
@@ -63,9 +66,6 @@ pub enum NymTopologyError {
     // We can't import SurbAckRecoveryError due to cyclic dependency, this is a bit dirty
     #[error("Could not build payload")]
     PayloadBuilder,
-
-    #[error("Outfox: {0}")]
-    Outfox(#[from] nym_sphinx_types::OutfoxError),
 
     #[error("{0}")]
     FromSlice(#[from] TryFromSliceError),

--- a/common/topology/src/error.rs
+++ b/common/topology/src/error.rs
@@ -10,8 +10,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum NymTopologyError {
-    #[error("attempted to use outfox, but it is currently not supported by the network")]
-    OutfoxNotSupported,
+    #[error("attempted to an unsupported packet type (probably outfox)")]
+    PacketTypeNotSupported,
 
     #[error(
         "the provided network topology is empty - there are no valid nodes on it - the network request(s) probably failed"

--- a/common/wasm/client-core/src/config/mod.rs
+++ b/common/wasm/client-core/src/config/mod.rs
@@ -191,9 +191,6 @@ pub struct TrafficWasm {
     /// in the case of reply surbs, the recipient must also understand the new encoding
     pub use_legacy_sphinx_format: bool,
 
-    /// Controls whether the sent packets should use outfox as opposed to the default sphinx.
-    pub use_outfox: bool,
-
     /// Indicates whether to mix hops or not. If mix hops are enabled, traffic
     /// will be routed as usual, to the entry gateway, through three mix nodes, egressing
     /// through the exit gateway. If mix hops are disabled, traffic will be routed directly
@@ -216,11 +213,7 @@ impl From<TrafficWasm> for ConfigTraffic {
             .use_extended_packet_size
             .then_some(PacketSize::ExtendedPacket32);
 
-        let packet_type = if traffic.use_outfox {
-            PacketType::Outfox
-        } else {
-            PacketType::Mix
-        };
+        let packet_type = PacketType::Mix;
 
         ConfigTraffic {
             average_packet_delay: Duration::from_millis(traffic.average_packet_delay_ms as u64),

--- a/common/wasm/client-core/src/config/mod.rs
+++ b/common/wasm/client-core/src/config/mod.rs
@@ -213,8 +213,6 @@ impl From<TrafficWasm> for ConfigTraffic {
             .use_extended_packet_size
             .then_some(PacketSize::ExtendedPacket32);
 
-        let packet_type = PacketType::Mix;
-
         ConfigTraffic {
             average_packet_delay: Duration::from_millis(traffic.average_packet_delay_ms as u64),
             message_sending_average_delay: Duration::from_millis(
@@ -227,7 +225,7 @@ impl From<TrafficWasm> for ConfigTraffic {
             primary_packet_size: PacketSize::RegularPacket,
             secondary_packet_size: use_extended_packet_size,
             use_legacy_sphinx_format: traffic.use_legacy_sphinx_format,
-            packet_type,
+            packet_type: PacketType::Mix,
             disable_mix_hops: traffic.disable_mix_hops,
         }
     }
@@ -245,7 +243,6 @@ impl From<ConfigTraffic> for TrafficWasm {
                 .disable_main_poisson_packet_distribution,
             use_legacy_sphinx_format: traffic.use_legacy_sphinx_format,
             use_extended_packet_size: traffic.secondary_packet_size.is_some(),
-            use_outfox: traffic.packet_type == PacketType::Outfox,
             disable_mix_hops: traffic.disable_mix_hops,
         }
     }

--- a/common/wasm/client-core/src/config/override.rs
+++ b/common/wasm/client-core/src/config/override.rs
@@ -150,7 +150,6 @@ impl From<TrafficWasmOverride> for TrafficWasm {
             use_extended_packet_size: value
                 .use_extended_packet_size
                 .unwrap_or(def.use_extended_packet_size),
-            use_outfox: value.use_outfox.unwrap_or(def.use_outfox),
             disable_mix_hops: false, // not configured from js config override yet
         }
     }

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -3127,9 +3127,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3293,7 +3293,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.15",
  "hickory-proto",
  "http 1.3.1",
  "idna",
@@ -3571,7 +3571,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.8",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -5229,6 +5229,7 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "fastrand",
+ "h2 0.4.15",
  "hickory-resolver",
  "http 1.3.1",
  "inventory",
@@ -7077,7 +7078,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7048)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed support for Outfox packet types and related traffic configuration.
  * SOCKS5 and WASM clients now use Mix packets exclusively.
  * Outfox packet creation, decoding, routing, and acknowledgements now return explicit “not supported” errors.
  * Outfox-related options and public exports have been removed or deprecated.
* **Bug Fixes**
  * Improved handling and reporting of unsupported packet types across client and networking components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->