### PR TITLE
fix(nym-node): bridge_client_params must survive --write-changes

### DIFF
--- a/nym-node/src/config/template.rs
+++ b/nym-node/src/config/template.rs
@@ -273,6 +273,13 @@ stats_storage = '{{ gateway_tasks.storage_paths.stats_storage }}'
 
 # Path to file containing cosmos account mnemonic used for zk-nym redemption.
 cosmos_mnemonic = '{{ gateway_tasks.storage_paths.cosmos_mnemonic }}'
+{{#if gateway_tasks.storage_paths.bridge_client_params}}
+# Path to file containing bridge client params to be served in the node self-described.
+# Populated externally (e.g. by bridge-cfg) as part of nym-bridge setup; omitted entirely
+# when nym-bridge isn't in use, matching how this field is absent from the config of any
+# node that was never configured for it.
+bridge_client_params = '{{ gateway_tasks.storage_paths.bridge_client_params }}'
+{{/if}}
 
 ##### service providers nym-node config options #####
 
@@ -383,3 +390,87 @@ gateway_registrations = '{{ service_providers.storage_paths.authenticator.gatewa
 
 
 "#;
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{Config, ConfigBuilder};
+    use nym_config::NymConfigTemplate;
+    use std::path::PathBuf;
+
+    // Builds a config rooted at a fresh temp directory, unique per call so
+    // parallel test runs don't collide.
+    fn test_config(name: &str) -> (Config, PathBuf) {
+        let dir = std::env::temp_dir().join(format!(
+            "nym-node-template-test-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let config_path = dir.join("config.toml");
+        let cfg = ConfigBuilder::new("test-node".to_string(), config_path.clone(), dir)
+            .build()
+            .unwrap();
+        (cfg, config_path)
+    }
+
+    // bridge_client_params must round-trip through save + reload unchanged.
+    // This is the regression covered by
+    // https://github.com/nymtech/nym/issues/7026: the field is part of the
+    // Config struct and loads fine, but the template used to render every
+    // save() never mentioned it, so it silently vanished from config.toml
+    // on the very next `nym-node run --write-changes`, even though nothing
+    // in memory ever lost it.
+    #[test]
+    fn bridge_client_params_survives_a_save_reload_round_trip() {
+        let (mut cfg, config_path) = test_config("bridge-set");
+        let expected = PathBuf::from("/var/lib/nym-node/bridge_client_params.json");
+        cfg.gateway_tasks.storage_paths.bridge_client_params = Some(expected.clone());
+
+        let rendered = cfg.format_to_string();
+        assert!(
+            rendered.contains("bridge_client_params ="),
+            "rendered config.toml is missing the bridge_client_params key entirely:\n{rendered}"
+        );
+
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(&config_path, &rendered).unwrap();
+        let reloaded = Config::read_from_toml_file(&config_path).unwrap();
+
+        assert_eq!(
+            reloaded.gateway_tasks.storage_paths.bridge_client_params,
+            Some(expected),
+            "bridge_client_params did not survive a save+reload round trip"
+        );
+
+        std::fs::remove_dir_all(config_path.parent().unwrap()).ok();
+    }
+
+    // A node that never configured nym-bridge must keep working exactly as
+    // it does today: no bridge_client_params key in config.toml at all, and
+    // it must still load cleanly (this is the status quo for every gateway
+    // that isn't running nym-bridge, so the fix must not disturb it).
+    #[test]
+    fn absent_bridge_client_params_stays_absent_and_still_loads() {
+        let (cfg, config_path) = test_config("bridge-unset");
+        assert_eq!(cfg.gateway_tasks.storage_paths.bridge_client_params, None);
+
+        let rendered = cfg.format_to_string();
+        assert!(
+            !rendered.contains("bridge_client_params"),
+            "bridge_client_params should be omitted entirely when unset:\n{rendered}"
+        );
+
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(&config_path, &rendered).unwrap();
+        let reloaded = Config::read_from_toml_file(&config_path).unwrap();
+
+        assert_eq!(
+            reloaded.gateway_tasks.storage_paths.bridge_client_params,
+            None
+        );
+
+        std::fs::remove_dir_all(config_path.parent().unwrap()).ok();
+    }
+}


### PR DESCRIPTION
## Context

This is the same field/bug already root-caused and worked around downstream in our own fleet's Ansible role (a self-healing task that re-adds `bridge_client_params` after every deploy, since there was no way to fix it at the source). Filed as #7026 after reproducing it directly, twice, on a live exit-gateway node. This PR fixes it at the actual source instead of continuing to patch around it operator-side.

## Summary

`gateway_tasks.storage_paths.bridge_client_params` is part of `GatewayTasksPaths` and loads correctly from `config.toml` -- the bug isn't in loading, or in `override_config` (which passes the loaded `gateway_tasks` through untouched, confirmed by reading `nym-node/src/cli/commands/run/args.rs`). It's in `save()`: `Config` doesn't serialize via serde -- it implements `NymConfigTemplate`, which renders a hand-written Handlebars template (`nym-node/src/config/template.rs`) against the struct. Handlebars only emits what the template text explicitly references, and `[gateway_tasks.storage_paths]` only ever listed `clients_storage`, `stats_storage`, and `cosmos_mnemonic`.

So every `save()` -- including the one `--write-changes` triggers on `nym-node run` -- silently drops the field from `config.toml`, regardless of what's still correct in memory. The break isn't visible until the *next* restart, since the already-running process keeps serving `/api/v1/bridges/client-params` from the value it loaded before the overwrite -- which matches the issue's own reproduction exactly (endpoint still 200 after the first `--write-changes` restart, 404 after the second).

The template file's own header comment states the invariant that broke: *"any changes to the template must be reflected in the appropriate structs"* -- this was the inverse direction, a struct field added without a matching template entry.

## Fix

Added the missing template line, wrapped in `{{#if gateway_tasks.storage_paths.bridge_client_params}}` so it's emitted only when the field is set, and omitted entirely otherwise. This matters: `bridge_client_params` has no `#[serde(default)]`, and every gateway that's never configured for nym-bridge already relies on the key being fully absent from its config (that's the pre-existing, correct status quo for the majority of the fleet). An unconditional placeholder value would have broken every one of those nodes on their next `--write-changes` instead of fixing the bridge case.

## Testing

Two round-trip tests in `nym-node/src/config/template.rs`, both going through the actual production path -- `format_to_string()` -> write to a real file -> `Config::read_from_toml_file()` -- not a synthetic check:

- `bridge_client_params_survives_a_save_reload_round_trip`: sets the field, renders, reloads, asserts it's unchanged.
- `absent_bridge_client_params_stays_absent_and_still_loads`: confirms the field stays fully omitted (not an empty string) when unset, and the config still loads cleanly -- protects the non-bridge fleet from a regression in the other direction.

Confirmed the fix actually does something: reverted just the template change (test module left in place) and re-ran -- `bridge_client_params_survives_a_save_reload_round_trip` fails exactly as the issue describes, with the rendered config genuinely missing the field. Re-applied the fix, both tests pass.

`cargo test -p nym-node --lib config::template::tests`: 2 passed.

*Work done by Claude (Anthropic), guided by a human.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7049)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration templates now preserve configured bridge client storage paths when saved and reloaded.
  * Unset storage path settings are omitted cleanly, allowing configurations to load successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->