### PR TITLE
Como Network Details v2 Endpoint Type

### DIFF
--- a/common/client-libs/validator-client/src/nym_api/mod.rs
+++ b/common/client-libs/validator-client/src/nym_api/mod.rs
@@ -53,7 +53,7 @@ pub use nym_api_requests::{
         PaginatedCachedNodesResponseV1, PaginatedCachedNodesResponseV2, SemiSkimmedNodeV1,
         SemiSkimmedNodeV3, SemiSkimmedNodesWithMetadata, SkimmedNodeV1,
     },
-    NymNetworkDetailsResponse,
+    NymNetworkDetailsResponse, NymNetworkDetailsV2Response,
 };
 pub use nym_coconut_dkg_common::types::EpochId;
 
@@ -1426,6 +1426,15 @@ pub trait NymApiClientExt: ApiClient {
     async fn get_network_details(&self) -> Result<NymNetworkDetailsResponse, NymAPIError> {
         self.get_json(
             &[routes::V1_API_VERSION, routes::NETWORK, routes::DETAILS],
+            NO_PARAMS,
+        )
+        .await
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    async fn get_network_details_v2(&self) -> Result<NymNetworkDetailsV2Response, NymAPIError> {
+        self.get_json(
+            &[routes::V2_API_VERSION, routes::NETWORK, routes::DETAILS],
             NO_PARAMS,
         )
         .await

--- a/nym-api/nym-api-requests/src/lib.rs
+++ b/nym-api/nym-api-requests/src/lib.rs
@@ -18,6 +18,12 @@ pub struct NymNetworkDetailsResponse {
     pub network: nym_config::defaults::NymNetworkDetails,
 }
 
+// The response type we fetch from the v2 network details endpoint.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NymNetworkDetailsV2Response {
+    pub network: nym_config::defaults::v2::NymNetworkDetails,
+}
+
 pub trait Deprecatable {
     fn deprecate(self) -> Deprecated<Self>
     where

--- a/nym-api/src/network/handlers/v2.rs
+++ b/nym-api/src/network/handlers/v2.rs
@@ -37,9 +37,5 @@ async fn network_details(
 ) -> FormattedResponse<NetworkDetailsV2> {
     let output = output.output.unwrap_or_default();
 
-    let details = state.network_details().to_owned();
-    output.to_response(NetworkDetailsV2::new(
-        details.connected_nyxd,
-        details.network.into(),
-    ))
+    output.to_response(state.network_details().to_owned().into())
 }

--- a/nym-api/src/network/handlers/v2.rs
+++ b/nym-api/src/network/handlers/v2.rs
@@ -40,6 +40,6 @@ async fn network_details(
     let details = state.network_details().to_owned();
     output.to_response(NetworkDetailsV2::new(
         details.connected_nyxd,
-        details.network,
+        details.network.into(),
     ))
 }

--- a/nym-api/src/network/models.rs
+++ b/nym-api/src/network/models.rs
@@ -33,6 +33,7 @@ pub struct NetworkDetailsV2 {
 }
 
 impl NetworkDetailsV2 {
+    #[allow(unused)]
     pub fn new(connected_nyxd: String, network: NymNetworkDetailsV2) -> Self {
         Self {
             connected_nyxd,

--- a/nym-api/src/network/models.rs
+++ b/nym-api/src/network/models.rs
@@ -1,8 +1,8 @@
 // Copyright 2023 - Nym Technologies SA <contact@nymtech.net>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use nym_network_defaults::v2::NymNetworkDetails as NymNetworkDetailsV2;
 use nym_network_defaults::NymNetworkDetails;
-use nym_network_defaults::NymNetworkDetails as NymNetworkDetailsV2;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -37,6 +37,28 @@ impl NetworkDetailsV2 {
         Self {
             connected_nyxd,
             network,
+        }
+    }
+}
+
+/// Converts down to the v1 shape for the `/v1/network/details` handler. Loses whatever
+/// `network.networking.dns_fallbacks` carries, since v1 has nowhere to put it.
+impl From<NetworkDetailsV2> for NetworkDetails {
+    fn from(v2: NetworkDetailsV2) -> Self {
+        NetworkDetails {
+            connected_nyxd: v2.connected_nyxd,
+            network: v2.network.into(),
+        }
+    }
+}
+
+/// Converts up to the v2 shape, deriving `network.networking` from the v1 struct's
+/// `nym_api_urls()` / `nym_vpn_api_urls()` accessors (`dns_fallbacks` starts out empty).
+impl From<NetworkDetails> for NetworkDetailsV2 {
+    fn from(v1: NetworkDetails) -> Self {
+        NetworkDetailsV2 {
+            connected_nyxd: v1.connected_nyxd,
+            network: v1.network.into(),
         }
     }
 }


### PR DESCRIPTION
Changes of #7051 applied to release branch

When the changes in https://github.com/nymtech/nym/pull/6901 were merged there was a modification made to the endpoint for the NetworkDetailsV2 that swapped it to serve the v1 struct instead of the v2 struct. this is a small fix that ensures the new endpoint servers the updated struct as intended.

Also adds a minimal function to the validator client to use the new v2 endpoint.

Follow-up patch to https://github.com/nymtech/nym/pull/6901

✔️ Tested by running nym-api run locally and browsing to 127.0.0.1:8000/v2/network/details and validating presence of updated struct

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7052)
<!-- Reviewable:end -->
