### PR TITLE
docs: document the ecash ticketbook protocol

### DIFF
--- a/docs/ecash/README.md
+++ b/docs/ecash/README.md
@@ -1,0 +1,134 @@
+# Ecash ticketbooks
+
+This directory documents how ecash credentials ("ticketbooks") currently work in the Nym platform: how the distributed signing keys come into existence (DKG), how ticketbooks are issued, how individual tickets are spent and verified, and what happens (and currently does not happen) when gateways try to get paid for them.
+
+Audience: internal engineers. The underlying cryptography (the offline compact ecash scheme implemented in `common/nym_offline_compact_ecash`) is treated as a black box; this documentation describes what the protocol layers do with it, not how the pairings work.
+
+These documents describe the code as of branch point `941f8311aa` (2026-08). Statements are derived from source, with code references given as `path` (`symbol`) so they survive line drift.
+
+## Reading order
+
+| Document | Covers |
+|---|---|
+| [dkg.md](dkg.md) | The coconut-dkg contract, the epoch state machine, epoch advancement, dealer exchange, verification key derivation, resharing, and how DKG gates issuance |
+| [issuance.md](issuance.md) | Deposits, withdrawal requests, blind signing by the nym-api quorum, aggregation into a ticketbook, auxiliary global signatures, and the credential-proxy acquisition path |
+| [spending.md](spending.md) | Ticket selection, the spend payload, gateway-side verification, bandwidth crediting, and the layered double-spend protection |
+| [redemption.md](redemption.md) | The redemption design (gateway batching, multisig voting, payout) and its current disabled state |
+| [upgrade-mode.md](upgrade-mode.md) | The ticket-free bypass used during chain upgrades: attestation, proxy-issued JWT, gateway metering shutdown |
+
+Two further documents are maintained alongside these for internal use only: a gap analysis recording known limitations and design debt, and a remediation plan sequencing the work to address them. They are not part of this protocol description and are not distributed with it.
+
+## Ticketbooks in principle
+
+A ticketbook is an anonymous bandwidth credential. A client pays a fixed deposit on the Nyx chain and, in exchange, obtains a book of **50 tickets** (`TICKETBOOK_SIZE`, `common/network-defaults/src/ecash.rs`) blind-signed by a quorum of nym-api signers. Blind signing means no individual signer, nor the chain, can link the resulting tickets back to the deposit that paid for them. Each ticket can later be presented to a gateway in exchange for a fixed amount of bandwidth, and each ticket carries a deterministic serial number that makes double-spending detectable without revealing who spent it.
+
+The scheme is a threshold construction: the signing key is *never held by any single party*. It is generated collectively by the nym-apis through a distributed key generation ceremony (DKG) coordinated on-chain, such that any `threshold = ceil(2n/3)` of the `n` participating signers can jointly issue credentials and no smaller coalition can. Verification requires only the aggregated master verification key, which anyone can reconstruct from the on-chain verification key shares.
+
+Four ticket types exist, differing only in the bandwidth one ticket buys (`TicketTypeRepr`, `common/network-defaults/src/ecash.rs`):
+
+| Type | Bandwidth per ticket |
+|---|---|
+| `V1MixnetEntry` | 200 MB |
+| `V1MixnetExit` | 100 MB |
+| `V1WireguardEntry` | 500 MB |
+| `V1WireguardExit` | 500 MB |
+
+A ticketbook is valid for **7 days including its issuance day** (`TICKETBOOK_VALIDITY_DAYS`); its expiration date is a signed attribute of the credential. All ecash timestamps are floored to UTC midnight (`common/ecash-time`).
+
+## Actors and components
+
+```mermaid
+flowchart LR
+    subgraph clients [Client side]
+        C[Client / SDK<br/>bandwidth-controller]
+        CP[nym-credential-proxy<br/>deposits + fan-out for VPN clients]
+    end
+
+    subgraph chain [Nyx chain]
+        EC[ecash contract<br/>deposits, redemption entry]
+        DKG[coconut-dkg contract<br/>epochs, dealings, VK shares]
+        CW3[cw3 multisig<br/>VK-share + redemption votes]
+        CW4[cw4 group<br/>signer membership]
+    end
+
+    subgraph signers [Signer quorum]
+        API1[nym-api 1]
+        API2[nym-api 2]
+        APIN[nym-api n]
+    end
+
+    GW[Gateway / nym-node<br/>credential-verification]
+
+    C -- deposit --> EC
+    CP -- batched deposits --> EC
+    C -- blind-sign --> API1 & API2 & APIN
+    CP -- blind-sign fan-out --> API1
+    API1 & API2 & APIN <-- dealings, VK shares --> DKG
+    API1 -- votes --> CW3
+    CW4 -- membership --> DKG & CW3
+    C -- spend ticket --> GW
+    GW -- async verify --> API1 & API2 & APIN
+    GW -. redemption proposal (disabled) .-> EC
+    EC -- propose --> CW3
+```
+
+- **Client** (`common/bandwidth-controller`, `common/bandwidth-fetcher`, `common/credentials`): makes deposits, drives blind signing, aggregates and stores ticketbooks, spends tickets against gateways.
+- **nym-credential-proxy** (`nym-credential-proxy/`, `common/credential-proxy`): a Nym-operated service that performs deposits and the blind-sign fan-out on behalf of (VPN) clients that cannot or should not talk to the chain themselves. The withdrawal request stays blind; the proxy never learns the wallet secrets.
+- **ecash contract** (`contracts/ecash`): holds deposits, assigns deposit ids, exposes the redemption entry point. Fully specified in [`openspec/specs/ecash-contract/spec.md`](../../openspec/specs/ecash-contract/spec.md).
+- **coconut-dkg contract** (`contracts/coconut-dkg`): coordinates the DKG ceremony: epoch state machine, dealer registration, on-chain chunked dealings, verification key shares.
+- **cw3 multisig + cw4 group** (`contracts/multisig/`): the group contract defines who the signers are; the multisig validates VK shares during DKG and (by design) redemption proposals.
+- **nym-api signers** (`nym-api/src/ecash`): each runs a `DkgController` participating in key generation, a blind-sign endpoint issuing partial credentials, endpoints serving aggregated global data, a ticket-verification endpoint used by gateways, and an issued-ticketbook audit trail.
+- **Gateway** (`common/credential-verification`, wired in `gateway/src/node`): verifies presented tickets locally and synchronously, credits bandwidth, then asynchronously submits each ticket to the signer quorum for cross-gateway double-spend detection and (by design) later redemption.
+
+## Lifecycle at a glance
+
+```mermaid
+flowchart TD
+    A[DKG ceremony<br/>signers jointly derive threshold keys] --> B[Epoch InProgress<br/>issuance enabled]
+    B --> C[Client deposits funds<br/>ecash contract assigns deposit_id]
+    C --> D[Client requests blind signatures<br/>from every signer, needs threshold]
+    D --> E[Client aggregates shares<br/>into a 50-ticket book]
+    E --> F[Client spends tickets at gateways<br/>1 ticket per request]
+    F --> G[Gateway verifies locally + credits bandwidth]
+    G --> H[Gateway submits ticket to signer quorum<br/>async double-spend check]
+    H -.-> I[Redemption: gateway batches verified tickets<br/>multisig votes, contract pays out]
+    B -->|admin triggers reset/resharing<br/>or advance after deadline| A
+
+    style I stroke-dasharray: 5 5
+```
+
+The dashed step is **currently disabled**: since 2026-03-25 gateways no longer create redemption proposals and the contract no longer moves funds on redemption (see [redemption.md](redemption.md)).
+
+One special mode sits outside this lifecycle: during Nyx chain upgrades, a signed attestation switches the network into **upgrade mode**, where gateways stop metering bandwidth and clients present a proxy-issued JWT instead of tickets (see [upgrade-mode.md](upgrade-mode.md)).
+
+A critical property of the current design: **while a DKG round is running (any epoch state other than `InProgress`), every issuance and aggregation endpoint on every nym-api refuses to serve** (`ensure_dkg_not_in_progress`, `nym-api/src/ecash/state/mod.rs`). Ticketbook issuance is therefore halted network-wide for the duration of every DKG ceremony, including issuance against the previous epoch's still-valid keys. Spending is unaffected because gateways verify against cached per-epoch keys.
+
+## Key constants
+
+| Constant | Value | Defined in |
+|---|---|---|
+| `TICKETBOOK_SIZE` | 50 tickets | `common/network-defaults/src/ecash.rs` |
+| `TICKETBOOK_VALIDITY_DAYS` | 7 (including issuance day) | `common/network-defaults/src/ecash.rs` |
+| DKG threshold | `ceil(2/3 * registered_dealers)`, fixed per epoch when entering `DealingExchange` | `contracts/coconut-dkg/.../advance_epoch_state.rs` |
+| DKG phase durations (defaults) | 600 / 300 / 300 / 60 / 60 s; `InProgress` 2 weeks | `common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs` |
+| Tickets per spend request | exactly 1 (hard-rejected otherwise) | `common/credential-verification/src/lib.rs` |
+| Gateway PayInfo timestamp window | ±30 s | `common/credential-verification/src/ecash/mod.rs` |
+| Gateway quorum for a verified ticket | ≥ 0.7 of the epoch's signers accept | `nym-node/src/config/gateway_tasks.rs` |
+| Double-spend revocation penalty | 10× the ticket's bandwidth | `nym-node/src/config/gateway_tasks.rs` |
+| nym-api verified-ticket retention | expiry + 8 days | `nym-api/src/support/config/mod.rs` |
+| Default deposit price | on-chain config (`GetDefaultDepositAmount`), admin-updatable; per-address reduced prices exist | ecash contract spec |
+
+## Glossary
+
+- **Ticketbook**: the aggregated credential (`IssuedTicketBook`, `common/credentials/src/ecash/bandwidth/issued.rs`): a threshold-blind-signed wallet of 50 tickets bound to an expiration date, a ticket type, a DKG epoch id, and the client's ecash secret key.
+- **Ticket**: one spendable unit of a ticketbook, addressed by its index (0..49). Not a stored object; tickets are derived from the wallet at spend time.
+- **Serial number**: a value derived deterministically from the wallet secret and the ticket index, revealed on spending. The same ticket always yields the same serial number, which is what makes double-spending detectable.
+- **Deposit**: an on-chain payment to the ecash contract (`DepositTicketBookFunds`) that entitles the depositor to one ticketbook. Identified by a sequential `deposit_id` and bound to a throwaway ed25519 public key whose private half later proves ownership.
+- **Withdrawal request**: the blind-signing request (`WithdrawalRequest`, `common/nym_offline_compact_ecash/src/scheme/withdrawal.rs`): commitments to the client's secrets plus a zero-knowledge proof, revealing nothing about the resulting tickets.
+- **Partial wallet / wallet share**: one signer's blind signature over a withdrawal request, verified against that signer's VK share and Lagrange-aggregated with others at threshold.
+- **Master verification key**: the aggregated public key of a DKG epoch, reconstructible by anyone from the on-chain VK shares; used by gateways to verify spent tickets.
+- **Expiration-date signatures / coin-index signatures**: auxiliary aggregated signatures over each valid date (per expiration date) and each ticket index (per epoch). Issued by the same quorum, fetched separately from the ticketbook, and required at spend time. They let the verifier check date validity and index validity without learning either.
+- **PayInfo**: a 72-byte spend-binding blob (32 B randomness, 8 B unix timestamp, 32 B provider public key) that ties a payment to a specific gateway and moment (`common/credentials-interface/src/lib.rs`).
+- **DKG epoch**: one generation of the threshold key, identified by `epoch_id`. Credentials embed the epoch id so verifiers know which master key applies.
+- **Signer / dealer / member**: a nym-api that is a voting member of the cw4 group. "Dealer" is its role during a DKG ceremony; "signer" its role during issuance.
+- **Threshold**: the minimum number of partial signatures (or VK shares) needed to aggregate: `ceil(2n/3)` where `n` is the number of dealers registered in the epoch.

--- a/docs/ecash/dkg.md
+++ b/docs/ecash/dkg.md
@@ -1,0 +1,182 @@
+# Distributed key generation (DKG)
+
+The ecash signing key is generated collectively by the nym-apis so that no single party ever holds it. The ceremony is coordinated by the **coconut-dkg contract** (`contracts/coconut-dkg`, shared types in `common/cosmwasm-smart-contracts/coconut-dkg`), the cryptography lives in `common/dkg`, and each nym-api drives its own participation with a `DkgController` (`nym-api/src/ecash/dkg`).
+
+Participation is doubly gated: a nym-api must have `ecash_signer.enabled = true` in its config (default **false**, plus a minimum chain balance check and a mandatory announce address at startup, `nym-api/src/support/cli/run.rs`), and its cosmos account must be a **voting member of the cw4 group contract**. The group contract is the sole membership authority; the DKG contract checks it on every registration (`contracts/coconut-dkg/src/dealers/transactions.rs`, `ensure_group_member`).
+
+## The epoch state machine
+
+An *epoch* is one generation of the threshold key, identified by a monotonically increasing `epoch_id`. The contract tracks `Epoch { state, epoch_id, state_progress, time_configuration, deadline }` and snapshots it every block (`SnapshotItem`, queryable at any historical height via `GetEpochStateAtHeight`).
+
+```mermaid
+stateDiagram-v2
+    [*] --> WaitingInitialisation: instantiate
+    WaitingInitialisation --> PublicKeySubmission: InitiateDkg (admin)
+    PublicKeySubmission --> DealingExchange: advance (threshold fixed here)
+    DealingExchange --> VerificationKeySubmission: advance
+    VerificationKeySubmission --> VerificationKeyValidation: advance
+    VerificationKeyValidation --> VerificationKeyFinalization: advance
+    VerificationKeyFinalization --> InProgress: advance, verified_keys >= threshold
+    VerificationKeyFinalization --> PublicKeySubmission: advance, verified_keys < threshold<br/>(automatic reset, epoch_id + 1)
+    InProgress --> InProgress: advance after deadline<br/>(extends deadline, same epoch_id)
+    InProgress --> PublicKeySubmission: TriggerReset / TriggerResharing (admin)<br/>(epoch_id + 1)
+```
+
+The enum is `EpochState` (`common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs`); every mid-ceremony state carries a `resharing: bool` payload. Issuance is possible **only** in `InProgress` (see "Interaction with issuance" below).
+
+| Phase | What happens | Default duration | Can short-circuit its deadline? |
+|---|---|---|---|
+| `PublicKeySubmission` | dealers register (BTE key + proof, ed25519 identity, announce address) | 600 s | no, always burns the full timer |
+| `DealingExchange` | dealers commit chunked dealings on-chain | 300 s | yes, when every registered dealer submitted all dealings |
+| `VerificationKeySubmission` | each dealer derives its partial keypair and commits its VK share | 300 s | yes, when shares == dealers |
+| `VerificationKeyValidation` | dealers cross-verify shares and vote in the cw3 multisig | 60 s | no (voting is external to the DKG contract) |
+| `VerificationKeyFinalization` | passed proposals are executed, shares flip to `verified` | 60 s | yes, when verified == submitted |
+| `InProgress` | steady state, keys usable, issuance enabled | 2 weeks | n/a |
+
+Durations come from `TimeConfiguration` (`types.rs`), set once at contract instantiation. **There is no execute message to change them afterwards.**
+
+A full cooperative ceremony therefore takes roughly 10-22 minutes of wall clock (the two non-short-circuitable phases guarantee at least 660 s), during which issuance is down network-wide.
+
+## Epoch advancement
+
+`ExecuteMsg::AdvanceEpochState {}` is **permissionless**: the handler (`contracts/coconut-dkg/src/epoch_state/transactions/advance_epoch_state.rs`, `try_advance_epoch_state`) never looks at the sender. Advancement is allowed when the current phase is *complete* (per the short-circuit rules above, `epoch_state/utils.rs`, `check_state_completion`) or its `deadline` has passed; otherwise the call fails with `EarlyEpochStateAdvancement(seconds_remaining)`.
+
+In practice nobody runs a dedicated cron: **every participating nym-api's `DkgController` polls the contract every 30 s** (`DEFAULT_DKG_CONTRACT_POLLING_RATE`, `nym-api/src/support/config/mod.rs`), does its own phase work, then queries `CanAdvanceState`; if advancement is possible it sleeps a random 0-60 s jitter (so the apis don't all race the same tx) and sends `AdvanceEpochState` (`nym-api/src/ecash/dkg/controller/mod.rs`). A nym-api that is not a group member bails out of the whole tick early (`ensure_group_member`).
+
+Two special branches inside the advance handler:
+
+- **Entering `DealingExchange`** computes and freezes the epoch's threshold: `threshold = ceil(2/3 * registered_dealers)`, stored both as the current `THRESHOLD` and in the historical `EPOCH_THRESHOLDS[epoch_id]` map. Both are queryable (`GetCurrentEpochThreshold` / `GetEpochThreshold`).
+- **Entering `InProgress`** first checks `verified_keys >= threshold`. If too few VK shares were verified, the contract concludes no credentials could be issued anyway and **automatically resets**: `epoch_id + 1`, back to `PublicKeySubmission { resharing: false }` (this branch carries a `TODO: is this actually a desired behaviour?`). This is the only automatic epoch bump in the system.
+- When the state is already `InProgress` and the (2-week) deadline lapses, advancing **does not bump the epoch or rotate keys**; it just re-saves `InProgress` with a fresh deadline. Key rotation only ever happens through the admin triggers below.
+
+If a phase deadline lapses with incomplete participation, the state advances anyway with whatever was collected; there is no on-chain penalty for missing dealers. Under-participation only surfaces later, off-chain, as failed key derivation or an insufficient-shares error.
+
+## A DKG round from a dealer's perspective
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant API as nym-api (DkgController)
+    participant DKG as coconut-dkg contract
+    participant MS as cw3 multisig
+    participant Peers as other dealers
+
+    Note over DKG: PublicKeySubmission
+    API->>DKG: RegisterDealer { bte_key_with_proof, identity_key, announce_address, resharing }
+    DKG-->>API: node_index (sticky per address, starts at 1)
+    Note over API: existing ecash keys are invalidated here
+
+    Note over DKG: DealingExchange (threshold frozen on entry)
+    API->>DKG: SubmitDealingsMetadata + CommitDealingsChunk × N (per dealing)
+    Note over API: previous keypair taken + key file archived
+    Peers->>DKG: (their dealings)
+
+    Note over DKG: VerificationKeySubmission
+    API->>DKG: query all dealings, verify each dealer's dealings off-chain
+    API->>API: decrypt own shares, combine, derive partial keypair (persisted to disk first)
+    API->>DKG: CommitVerificationKeyShare { share }
+    DKG->>MS: Propose "Verify VK share..." (24 h expiry)
+
+    Note over DKG: VerificationKeyValidation
+    API->>DKG: query all submitted shares
+    API->>API: check each share against locally derived partials
+    API->>MS: Vote yes/no per proposal (own share: auto-yes)
+
+    Note over DKG: VerificationKeyFinalization
+    API->>MS: execute own proposal (if Passed)
+    MS->>DKG: VerifyVerificationKeyShare (multisig-gated)
+    DKG->>DKG: share.verified = true
+    Note over API: local keypair marked valid, issuance resumes on InProgress
+```
+
+### Registration
+
+`RegisterDealer` requires the matching `PublicKeySubmission { resharing }` state and cw4 voting membership. The dealer submits its BTE (bilinear threshold encryption) public key with a proof of possession, its ed25519 identity key, and the HTTP announce address other parties and clients will use to reach it. Node indices (the x-coordinates of the Shamir shares) are assigned once per address and reused across epochs, starting at 1. Re-registering in the same epoch fails with `AlreadyADealer`. On restart mid-ceremony, a nym-api re-adopts its on-chain registration instead of re-registering (`nym-api/src/ecash/dkg/public_key.rs`).
+
+### Dealing exchange
+
+Dealings are stored **on-chain**, chunked: a dealer first submits metadata declaring the chunk layout, then uploads chunks of at most 2048 bytes each (at most 50 chunks, 100 kB per dealing; constants in `common/cosmwasm-smart-contracts/coconut-dkg/src/dealing.rs`). The contract validates only structure (sizes, indices, no overwrites); it performs **no cryptographic validation of dealing content**. The progress counter increments when a dealer's dealing set is complete, which is what the short-circuit rule checks.
+
+Cryptographic dealing verification happens entirely off-chain, in every receiver, during key derivation (`nym-api/src/ecash/dkg/key_derivation.rs`, `verified_dealer_dealings`): each dealing is checked for ciphertext integrity, proof of chunking, proof of sharing, and (in resharing) consistency with the dealer's previous-epoch key. A dealer with any invalid dealing is dropped entirely, but only **locally**: rejection is recorded in the api's own persisted state (`rejected_dealers`). There are no on-chain complaints, bans, or slashing; the historical complaint states were removed from the state machine (a comment block in `types.rs` documents the old machine). The only adversarial lever is voting *no* on the culprit's VK-share proposal later.
+
+### Key derivation, submission, validation, finalization
+
+Each receiver decrypts its share from every valid dealer's dealings, combines them into its partial signing key, derives the corresponding partial verification key, and sanity-checks the pairing between them. The keypair is persisted to disk *before* the share is submitted on-chain, so a crash between the two is recoverable (`key_derivation.rs` has explicit recovery paths for "share on chain but proposal id unknown" and "keys on disk but tx never sent").
+
+`CommitVerificationKeyShare` stores the share (`verified: false`) and makes the DKG contract propose a cw3 multisig proposal titled "Verify VK share, as ordered by Coconut DKG Contract", expiring after 24 h (`BLOCK_TIME_FOR_VERIFICATION_SECS`, hardcoded). During validation, every dealer independently re-derives what each peer's partial VK *should* be (from the same dealings) and votes yes/no on each proposal; a dealer auto-votes yes on its own share without verification. During finalization each api executes its own passed proposal, which calls back into the DKG contract (`VerifyVerificationKeyShare`, multisig-gated) flipping the share to `verified = true` and incrementing the progress counter.
+
+**Verification is possible only inside the finalization phase.** `try_verify_verification_key_share` begins with `check_epoch_state(.., VerificationKeyFinalization)`, so once that 60-second phase ends a share can *never* become verified. Since a signer must execute its **own** proposal, a node that is offline or simply does not tick inside that window leaves its share permanently unverified, even though the share itself is valid and the ceremony may still conclude successfully on everyone else's. This interacts sharply with discovery, below.
+
+A rejected share does not cryptographically prevent its holder from producing partial signatures; it only means the share is excluded from discovery (see below). The code is explicit about this (`key_finalization.rs`: "technically there's nothing enforcing this...").
+
+## Threshold
+
+`threshold = ceil(2 * registered_dealers / 3)`, computed once per epoch when entering `DealingExchange` and never recomputed. It is both the number of partial signatures a client needs to aggregate a ticketbook and the number of VK shares needed for the epoch to conclude successfully. Note this is distinct from the cw3 multisig's own voting threshold (an `AbsolutePercentage` configured on the multisig contract), which governs proposal passage.
+
+**Production state, as of 2026-08.** Mainnet has run exactly **one** epoch since launch, created with 17 registered dealers and a resulting threshold of `ceil(2 * 17 / 3) = 12`. Consequently **no epoch transition has ever occurred in production**: everything this document describes about resharing, reset, archived keys, multi-epoch overlap and past-epoch material is accurate to the code but unexercised on mainnet. Both ceremony types have been rehearsed on sandbox, where they surfaced the operational issues noted under "Key lifecycle" and "Interaction with issuance" below.
+
+Note that the signer set is public on-chain data, so the count above is not privileged; the number of those signers currently *responding* is deliberately not documented here.
+
+## Resharing vs reset
+
+Both are **manual, admin-gated** (`DKG_ADMIN`) actions on the DKG contract, both require `InProgress`, and both start a new ceremony with `epoch_id + 1`:
+
+- `TriggerReset` → `PublicKeySubmission { resharing: false }`: a from-scratch ceremony. The master key changes; everything issued under previous epochs remains verifiable only via the archived per-epoch material.
+- `TriggerResharing` → `PublicKeySubmission { resharing: true }`: the existing master key is **preserved** while individual shares change (verified by the `reshare_preserves_master_key` test, `nym-api/src/ecash/dkg/mod.rs`). Only addresses that were dealers in `epoch - 1` may submit dealings; their dealings embed the previous secret as the polynomial constant term, and receivers verify this against the dealer's previous-epoch *verified* VK share. New group members can join a resharing epoch as receivers (they register, receive shares, and become full signers) without contributing dealings.
+
+Nothing in the tree calls either trigger automatically; key rotation is an operational decision. The signer *set* itself changes via cw4 group membership updates, which take effect at the next ceremony.
+
+### Why prefer one over the other
+
+**Resharing is the routine-maintenance option.** Because the master key survives while every individual share is replaced, it delivers proactive share refresh: any sub-threshold set of shares an attacker may have accumulated from the old epoch becomes useless the moment the new epoch concludes, since old and new shares cannot be combined (shares are only meaningful within their epoch's polynomial). It is also the mechanism for graceful membership churn: joiners receive shares without the key changing, leavers simply stop being dealt to. The assumption underneath is that the master key itself was never reconstructed by an adversary; resharing refreshes *shares*, not the key.
+
+**Resharing depends on the previous dealer set.** Only addresses that were dealers in `epoch - 1` may deal (contract-enforced), each resharing dealing must be consistent with that dealer's previous-epoch *verified* VK share, and a nym-api whose stored key is not from exactly the previous epoch skips resharing dealings entirely (`nym-api/src/ecash/dkg/dealing.rs`). If too few old dealers participate, receivers cannot derive valid keys, too few VK shares get verified, and the ceremony ends in the contract's automatic sub-threshold branch, which is a **reset**. Resharing is therefore only available while the old quorum is substantially alive and cooperative.
+
+**Reset is the bootstrap and recovery option.** It needs no continuity with any prior epoch (any current group member deals fresh), which is why it is what `InitiateDkg` starts with, what the contract falls back to automatically, and the only choice when the old dealer set has decayed below threshold or when the master key itself must be discarded (i.e. a suspected compromise of threshold-many shares, against which resharing offers nothing).
+
+**What a key change does and does not cost in this system.** Nothing in the codebase pins the master key across epochs: every consumer (gateways, clients, apis) resolves verification material by the epoch id embedded in each credential, so a reset does not break existing ticketbooks any more than a resharing does; both simply open a new epoch alongside the old ones. The flip side is that a reset also does **not** revoke the old key: old epochs remain fetchable, aggregatable verification anchors indefinitely, and gateways will happily build verification state for any historical epoch id a ticket claims. A reset performed *in response to* a key compromise stops future issuance under the old key but does not stop verification against it; the implications of that are gap-analysis material, not described further here.
+
+## What happens in the rest of the system while a ceremony runs
+
+All three ceremony kinds (initial setup, reset, resharing) run the same state machine; the `resharing` flag changes only who may deal and how dealings are constructed. From every other component's perspective they are the same kind of outage, differing only in whether the master key changes at the end (reset: yes, resharing: no; either way the epoch id changes and every consumer keys off epoch ids, so even that difference is invisible to verifiers).
+
+- **New issuance is down network-wide** for the whole ceremony; see "Interaction with issuance" below.
+- **Global data becomes unfetchable from nym-apis, even for old epochs.** The aggregated-data endpoints (`master-verification-key`, `aggregated-coin-indices-signatures`, `aggregated-expiration-date-signatures`) and both partial-signature endpoints sit behind the same `ensure_dkg_not_in_progress` gate as blind-sign (`nym-api/src/ecash/api_routes/aggregation.rs`, `partial_signing.rs`). A client holding a perfectly valid ticketbook but missing its `(epoch, expiration)` aux data in local storage cannot provision it mid-ceremony and is unable to spend until the ceremony ends; clients with warm caches are unaffected.
+- **Spending at gateways continues.** Gateways build per-epoch verification state from the *chain*, not from nym-apis, and the DKG contract never deletes per-epoch state: `reset_dkg_state` removes only the current `THRESHOLD` item, while dealings, dealer details, VK shares and the historical `EPOCH_THRESHOLDS` map are all keyed by epoch id and preserved indefinitely (`contracts/coconut-dkg/src/epoch_state/transactions/mod.rs`). Even an old-epoch ticket seen for the first time mid-ceremony is verifiable, provided the gateway can reach the chain.
+- **Existing ticketbooks survive both reset and resharing.** A book is bound to the epoch id it was aggregated under; gateways look up VK material by the epoch id embedded in each spend, so books remain spendable until their natural expiration regardless of how many ceremonies happen in between. After a ceremony there is consequently an overlap window (up to the 7-day validity) during which tickets from two or more epochs circulate simultaneously, which is why the gateway's epoch cache is a map, not a single slot.
+- **The old epoch's signing capability ends the moment the ceremony starts.** Each signer invalidates its keypair when it registers as a dealer and archives the key file during dealing exchange; archived keys are never read back. Previously aggregated per-epoch material continues to be served from the apis' SQL storage after the ceremony, but nothing new can ever be produced for a past epoch (notably fresh partial coin-index signatures, which enforce a key-epoch match).
+- **In-flight acquisitions straddle the boundary awkwardly.** A deposit is not epoch-bound, so a deposit made before the trigger survives (clients persist it in `pending_issuance` and retry after the ceremony); it will then be blind-signed with the *new* epoch's keys and stamped with the new epoch id. The sharp edge is a client that had already collected some (but fewer than threshold) shares before the flip: signers that issued for that deposit pre-flip return their stored old-key share verbatim (the idempotency check precedes everything and has no epoch awareness), while the rest sign with new-epoch keys, and the two kinds cannot be aggregated together. Details and impact belong to the gap analysis.
+
+## Key lifecycle on a nym-api
+
+The local ecash keypair is wrapped in a `KeyPair { keys, valid: AtomicBool }` (`nym-api/src/ecash/keys/mod.rs`); every signing path goes through `get()` which returns nothing unless the `valid` flag is set (surfacing as `KeyPairNotDerivedYet`).
+
+- **Invalidated** the moment the node registers for a new ceremony (`public_key_submission`), so old keys stop signing as soon as a new epoch begins.
+- **Archived** during dealing exchange: the keypair is taken out of memory and the on-disk PEM (which embeds the epoch id) is renamed to `epoch-{id}-{filename}.archived` (`controller/keys.rs`, `archive_coconut_keypair`). **Nothing ever reads archived keys back**; requests requiring a past epoch's signing key fail (see issuance.md on coin-index signatures).
+- **Validated** only at finalization, after the node's own VK-share proposal executed. This is the sole runtime path that sets the flag, and it lives inside a 60-second phase.
+- **At startup**, a key found on disk is validated under a *more permissive* rule: issued for the current chain epoch, and the state is `InProgress` or `VerificationKeyFinalization`.
+
+The two rules disagree, and the disagreement is load-bearing. A node that misses the finalization window, or errors on that path, keeps `valid = false` and refuses to sign **indefinitely**, while a restart of the very same process re-reads the key from disk and accepts it. This is why signers have needed manual restarts after the sandbox ceremonies. It is reachable only by running a ceremony, which is an admin-triggered operation.
+
+Aggregated per-epoch public material (master VK, coin-index signatures, expiration-date signatures) is persisted in the api's SQL storage per epoch and continues to be served for old epochs; only the *signing* side of old epochs is archived away.
+
+## Interaction with issuance
+
+Every issuance and aggregation endpoint on the nym-api calls `ensure_dkg_not_in_progress()` (`nym-api/src/ecash/state/mod.rs`), which consults `dkg_in_progress()` (`nym-api/src/ecash/comm.rs`), returning "in progress" for **every state except `InProgress`** (including `WaitingInitialisation`). Gated endpoints: `POST /v1/ecash/blind-sign`, both partial-signature endpoints, and all three aggregated-data endpoints. The error message is explicit: "all ticket issuance is halted until that's completed".
+
+Consequences worth internalising:
+
+- During any DKG ceremony (roughly 11-22 min cooperative, up to ~21 min of pure deadlines plus multisig latency otherwise), **no new ticketbooks can be issued anywhere**, for any epoch. There is no "issue against the previous epoch" path, even though prior-epoch keys exist on disk in archived form.
+- A deposit made just before a ceremony starts is stranded until it completes; the client-side mitigation is a blocking wait loop that polls the chain until the epoch state is `InProgress` again (`common/bandwidth-fetcher/src/credentials.rs`, `block_until_ecash_is_available`).
+- Spending and verification are unaffected: gateways verify against per-epoch VK material they fetch from the chain and cache, keyed by the epoch id embedded in each ticket.
+- The nym-api caches its view of the current epoch for up to 5 minutes (or until the phase deadline, whichever is sooner, `comm.rs`), so both the issuance gate and the epoch id recorded in the api's audit rows can lag the chain by up to 5 minutes around transitions.
+- **Per-epoch caches, unlike the epoch cache above, never expire.** `is_dkg_signer` and `ecash_clients` memoise their result under the epoch id in a `CachedImmutableItems` map with no TTL, on the assumption that facts about an epoch are constant once known. That assumption breaks mid-ceremony: a new epoch id exists from the moment the admin command lands, but its VK shares do not, so a lookup performed during the ceremony resolves to an empty signer set and caches that emptiness for the process lifetime. The credential-proxy memoises its own signer list the same way. Note the cache stores only *successful* results, so anything that errors self-heals; it is the degenerate successes (`false`, `vec![]`) that stick. This is why nym-apis and the proxy have required restarts *after* a ceremony completes. Like the key-validity issue above, it is reachable only by running a ceremony.
+- Because `ensure_signer()` runs **before** the DKG gate on both `blind-sign` and `verify-ticket`, the error surfaced mid-ceremony is typically `NotASigner` rather than the more descriptive `DkgInProgress`.
+
+## Signer-set and key discovery
+
+The single source of truth for "who are the signers of epoch N and what are their keys" is the DKG contract's VK-share storage: `GetVerificationKeys { epoch_id }` returns `ContractVKShare { share, announce_address, node_index, owner, epoch_id, verified }` for every registered dealer of that epoch.
+
+Consumers convert shares into `EcashApiClient`s (`common/client-libs/validator-client/src/coconut/mod.rs`): the conversion **fails on any unverified share**, and the collective helper `all_ecash_api_clients` propagates a single failure into an error for the whole epoch (a known sharp edge, flagged with a TODO in source). Gateways build their per-epoch verification state by fetching the epoch's threshold and all VK shares, requiring at least `threshold` clients, and Lagrange-aggregating the master key (`common/credential-verification/src/ecash/state.rs`); clients do the equivalent when aggregating ticketbooks and fetching global data.
+
+For operational visibility (not authoritative): `GET /v1/ecash/signer-status` on each api, and the signer-liveness sweep served under `GET /v1/network/signers/status` (backed by `common/ecash-signer-check`).

--- a/docs/ecash/issuance.md
+++ b/docs/ecash/issuance.md
@@ -1,0 +1,172 @@
+# Ticketbook issuance
+
+Issuance turns an on-chain deposit into an anonymous 50-ticket credential. It requires the DKG epoch to be in `InProgress` (see [dkg.md](dkg.md)); every step below assumes a settled epoch with a known threshold.
+
+Two acquisition paths exist. The **direct path** (client talks to the chain and the signers itself) is implemented across `common/bandwidth-fetcher`, `common/credentials` and `common/bandwidth-controller`. The **credential-proxy path** delegates the deposit and the fan-out to a Nym-operated service (`nym-credential-proxy`). Both converge on the same nym-api endpoint and the same cryptography; they differ in who pays and who aggregates.
+
+The contract layer (deposits, pricing, ids, events) is authoritatively specified in [`openspec/specs/ecash-contract/spec.md`](../../openspec/specs/ecash-contract/spec.md); this document does not restate it.
+
+## Direct path
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant EC as ecash contract
+    participant S as each nym-api signer (n total)
+
+    Note over C: generate throwaway ed25519 keypair (per deposit)
+    C->>EC: DepositTicketBookFunds { identity_key: pubkey } + funds
+    EC-->>C: deposit_id (sequential u32, in tx data + event)
+
+    Note over C: build WithdrawalRequest from ecash secret key<br/>(commitments + zk proof, wallet secret v stays local)
+    Note over C: sign (withdrawal_request || deposit_id) with the deposit's ed25519 key
+
+    loop until >= threshold shares (sequential, 2 attempts each)
+        C->>S: POST /v1/ecash/blind-sign { request, deposit_id, signature, ecash_pubkey, expiration_date, ticketbook_type }
+        S->>EC: GetDeposit { deposit_id } (first issuance only)
+        S->>S: verify ed25519 sig against deposited pubkey,<br/>blind-sign, persist audit row (merkle leaf)
+        S-->>C: blinded signature share
+        C->>C: unblind + verify share against this signer's VK share
+    end
+
+    Note over C: epoch_id := chain query at aggregation time
+    C->>C: Lagrange-aggregate shares -> IssuedTicketBook { wallet, epoch_id, expiration_date, type }
+    C->>S: fetch aggregated master VK, coin-index sigs (per epoch),<br/>expiration-date sigs (per date) - separately, cached locally
+```
+
+### 1. Deposit
+
+The client generates a **fresh random ed25519 keypair per deposit** (`common/bandwidth-fetcher/src/credentials.rs`, `make_deposit`); this is not its long-term identity. The bs58 public key is sent as the `identity_key` of `DepositTicketBookFunds`, along with funds matching the price obtained from `GetDefaultDepositAmount` (the direct path never queries the reduced/whitelisted price). The contract validates the amount, assigns the next sequential `deposit_id`, and returns it in the tx response data; the contract does **not** verify control of the ed25519 key; that proof is deferred to the signers.
+
+The private half of the keypair is retained inside the client-side `IssuanceTicketBook` (`common/credentials/src/ecash/bandwidth/issuance.rs`) and is the only thing that proves deposit ownership from here on. Deposits are serialised behind a lock to avoid racing the account sequence number, and pending (deposited but not yet issued) books are persisted so a crash or a DKG blackout does not lose the deposit (`pending_issuance` storage).
+
+### 2. Withdrawal request
+
+`IssuanceTicketBook::prepare_for_signing` produces the blind-signing payload via `withdrawal_request()` (`common/nym_offline_compact_ecash/src/scheme/withdrawal.rs`). Inside the black box: a fresh random wallet secret `v` is generated; the private attributes `[sk_user, v]` are Pedersen-committed; the expiration date and ticket type are bound into the commitment hash; and a zero-knowledge proof of well-formedness is attached. The client keeps the `RequestInfo` (openings + wallet secret) needed later for unblinding and aggregation; the signers see only commitments.
+
+The client's ecash keypair (`sk_user`) is derived deterministically from a seed (the client identity), not random, so the same identity re-derives the same ecash key.
+
+**The credential's signed attributes.** The final wallet is a threshold signature over exactly four attributes (`common/nym_offline_compact_ecash/src/scheme/aggregation.rs`, `aggregate_wallets`); the DKG key is sized accordingly ("2 public attributes, 2 private attributes, 1 fixed", `DEFAULT_DEALINGS` in `common/cosmwasm-smart-contracts/coconut-dkg/src/dealing.rs`):
+
+| Attribute | Visibility | Role |
+|---|---|---|
+| `sk_user` (ecash secret key scalar) | private, Pedersen-committed | the client's long-term ecash identity; recoverable by verifiers only from a genuine double-spend (via the identification tags), which is the designed blacklisting hook |
+| `v` (wallet secret) | private, fresh random per book | seeds all 50 serial numbers and identification tags of the book |
+| `expiration_date` (u32 unix timestamp, UTC midnight) | public | bounds the valid spend dates; also signed explicitly by each signer |
+| `t_type` (ticket type) | public | selects the bandwidth value each ticket is worth |
+
+Everything else a ticketbook carries is *not* a signed attribute: notably the `epoch_id` is plaintext metadata stamped client-side at aggregation, telling verifiers which master key to check against. See [spending.md](spending.md) for which of these a spent ticket reveals.
+
+### 3. Expiration dates
+
+All ecash dates are UTC-midnight-floored (`common/ecash-time`). The maximum expiration is `cred_exp_date()` = today + 6 days (7 valid days counting today); the direct path always requests exactly that default. The nym-api enforces only the upper bound at blind-sign time (`expiration_date > cred_exp_date()` → `ExpirationDateTooLate`); there is no lower bound on this path. The expiration date is a signed attribute of the final wallet: the signer both binds it inside the commitment verification and signs it explicitly, so it cannot be altered after issuance.
+
+### 4. Blind signing (per signer)
+
+`POST /v1/ecash/blind-sign` (`nym-api/src/ecash/api_routes/partial_signing.rs`, `post_blind_sign`) performs, in order:
+
+1. `ensure_signer()`: this api is enabled as a signer and is in the current epoch's signer set.
+2. Signing key available (fails with `KeyPairNotDerivedYet` otherwise).
+3. Expiration upper-bound check.
+4. `ensure_dkg_not_in_progress()`: the network-wide DKG gate.
+5. **Idempotency**: if this deposit id was already issued, return the stored blinded share verbatim (note: this happens before any request validation; the share is unusable without the client's `RequestInfo`).
+6. Blacklist check on the ecash public key (the on-chain blacklist is currently unreachable through public execute paths, so this is effectively a no-op guard; see the contract spec).
+7. On-chain deposit lookup (`GetDeposit { deposit_id }`, fails with `NonExistentDeposit`).
+8. **Deposit-ownership proof**: verify the request's ed25519 signature over `withdrawal_request_bytes || deposit_id_be_bytes` against the pubkey stored in the deposit (`nym-api/src/ecash/deposit.rs`, `validate_deposit`). The deposited *amount* is never re-checked here; amount enforcement happened entirely on-chain at deposit time.
+9. Cryptographic issuance: `issue()` re-verifies the withdrawal request's zk-proof and commitment hash (which also catches any mismatch between the body's `expiration_date`/`ticketbook_type` and what is committed inside the request), then produces the blinded partial signature including the explicit expiration and type signatures.
+10. Audit persistence: `store_issued_ticketbook` writes the `issued_ticketbook` row (see "Audit trail" below) before the share is returned.
+
+Notably, **the request carries no epoch id and the signer never checks its key's epoch on this path**: the signer signs with whatever key it currently holds. The epoch recorded in its audit row is its own (up to 5-minute-stale) cached view of the chain epoch.
+
+Note also that step 1 precedes step 4. During a DKG ceremony the current epoch has no verified VK shares yet, so `ensure_signer()` fails first and the caller sees `NotASigner` rather than the self-explanatory `DkgInProgress`. That answer is also memoised per epoch with no expiry, which is the caching behaviour described in [dkg.md](dkg.md).
+
+### 5. Aggregation
+
+`obtain_aggregate_wallet` (`common/credentials/src/ecash/utils.rs`) queries signers **sequentially** (with 2 attempts and linear backoff each), unblinding and cryptographically verifying every share against that signer's individual VK share before counting it, and stops as soon as `threshold` valid shares are collected. Fewer than threshold reachable signers fails the whole operation (`NotEnoughShares`). The shares are Lagrange-combined by node index into the final `WalletSignatures`, which is re-verified against the aggregated master key.
+
+The client then stamps the result: `epoch_id` is read from the chain **at aggregation time** (`common/bandwidth-fetcher/src/credentials.rs`, `obtain_ticketbook`) and stored in the `IssuedTicketBook` together with the wallet, the ecash secret key, the expiration date and the ticket type. This is the epoch id that will later ride along in every spend of this book and tell verifiers which master key to use.
+
+### 6. Auxiliary global data
+
+The ticketbook alone is not spendable. Spending additionally requires, for the book's `(epoch_id, expiration_date)`:
+
+- the **aggregated master verification key** (per epoch),
+- **aggregated coin-index signatures** (per epoch): signatures over each ticket index 0..49,
+- **aggregated expiration-date signatures** (per expiration date): signatures over each of the 7 valid spend dates.
+
+Each signer exposes partial versions (`GET /v1/ecash/partial-coin-indices-signatures`, `.../partial-expiration-date-signatures`) and every api also serves pre-aggregated versions (`GET /v1/ecash/aggregated-*`, `.../master-verification-key`), aggregating on demand from its peers and caching in memory and SQL. Clients fetch from a random api with fallback (`common/bandwidth-fetcher/src/public_data.rs`) and persist the results in local credential storage; the bandwidth controller maintains them for every stored non-expired book and re-fetches lazily at spend time if missing.
+
+Two epoch-related quirks of the partial endpoints, relevant to epoch transitions: the coin-index path **enforces** that the api's signing key matches the requested epoch (`InvalidSigningKeyEpoch` otherwise; archived past-epoch keys are not loaded, per an explicit TODO), while the expiration-date path signs with the current key regardless of the requested epoch id.
+
+### 7. Client-side storage
+
+`common/credential-storage` persists ticketbooks in `ecash_ticketbook` (blob + `ticketbook_type`, `expiration_date`, `epoch_id`, `total_tickets`, `used_tickets`), with the blob column UNIQUE as a duplicate guard. `used_tickets` is the authoritative spent counter (see [spending.md](spending.md)). Aux data lives in sibling tables keyed by epoch and `(expiration_date, epoch_id)`. Since migration `20251104120000` a book may be stored before its aux signatures exist; provisioning is best-effort afterwards. Partial books (index ranges, used for imported/shared books) are encoded by initialising `used_tickets`/`total_tickets` to the allowed range.
+
+## nym-api audit trail
+
+Each signer persists one row per issued share in `issued_ticketbook`, keyed by `deposit_id` (the primary key doubles as the double-issuance guard): the epoch id, the blinded partial credential, the joined private commitments, expiration date, type, and a merkle leaf `sha256(deposit_id || epoch_id || blinded_credential || commitments || expiration || type)` (`common/ticketbooks-merkle`). Leaves are inserted into a per-expiration-day merkle tree whose root and contents back a signer-gated, identity-signed audit API: issued counts, deposit-id lists per expiration date, challenge-commitment merkle proofs, and raw data retrieval (`nym-api/src/ecash/api_routes/issued.rs`). This is the raw material for auditing that a signer issued exactly what deposits entitle.
+
+Retention is short: issued-ticketbook rows are pruned 2 days past expiration and verified-ticket rows 8 days past spend date, by a background cleaner sweeping every 2 h (`nym-api/src/ecash/state/cleaner.rs`).
+
+## Credential-proxy path
+
+`nym-credential-proxy` (binary) over `common/credential-proxy` (logic; also reused by nym-node-status-api) lets clients obtain ticketbooks without touching the chain: the proxy pays deposits from its own mnemonic-derived account and performs the signer fan-out. Access is gated by a single static bearer token for the whole ticketbook subtree.
+
+In production the proxy's sole client is **nym-vpn-api**, a Next.js backend in the `websites` repo at `www/vpn-api`, which fronts it for the VPN apps (`nym-vpn-client/nym-vpn-core`). The full chain is app → nym-vpn-api → proxy → signers, with shares flowing back through a webhook and app-side polling:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant A as VPN app<br/>(nym-vpn-core)
+    participant V as nym-vpn-api<br/>(websites repo)
+    participant P as credential-proxy
+    participant EC as ecash contract
+    participant S as all nym-api signers
+
+    rect rgb(235, 235, 235)
+    Note over P,EC: background: deposit buffer
+    P->>EC: batched DepositTicketBookFunds × up to 32 in one tx<br/>(fresh ed25519 keypair per deposit, target buffer 256)
+    end
+
+    Note over A: blind WithdrawalRequest from the<br/>account-level ecash keypair
+    A->>V: POST .../account/{id}/device/{key}/zknym<br/>(account JWT + device JWT)
+    V->>V: gates: idempotency hash, active subscription,<br/>per-device token bucket, daily bandwidth cap
+    V->>P: POST /api/v1/ticketbook/obtain-async (bearer token,<br/>deviceId/credentialId = DB row ids, fresh webhook secret)
+    P-->>V: { id, uuid }
+    V-->>A: credential row { status: pending }
+
+    P->>P: take buffered deposit, sign (request || deposit_id)
+    par fan-out, 5 s timeout per signer
+        P->>S: POST /v1/ecash/blind-sign
+        S-->>P: blinded share
+    end
+    P->>V: webhook POST /api/private/v1/webhooks/zk-nyms/{clientId}<br/>{ shares, secret }
+    V->>V: verify client id + bearer + per-credential secret <br/>store shares (30 d), credential -> active
+
+    loop poll every 5 s, up to 60 s
+        A->>V: GET .../zknym/{id}
+    end
+    V-->>A: { status: active, blinded_shares, epoch_id }
+    A->>V: GET /directory/zk-nyms/ticketbook/*<br/>(VKs + aggregated sigs unauthenticated pass-through to P)
+    Note over A: unblind + verify each share, aggregate,<br/>hand IssuedTicketBook to BandwidthController
+    A->>V: DELETE .../zknym/{id} (confirm download share row deleted)
+```
+
+Key properties, contrasted with the direct path:
+
+- **Deposits are pre-bought and buffered.** A background task keeps ~256 unused deposits on hand, refilling in single transactions of up to 32 deposits, each with its own fresh ed25519 keypair whose private half is stored in the proxy DB. A request that finds the buffer empty blocks (polling every 500 ms) rather than failing. Unused deposits survive restarts. The proxy uses the reduced (whitelisted) price if its address qualifies.
+- **The request stays blind.** The client builds the `WithdrawalRequest` from its own secrets and sends only the opaque blob; the proxy signs the deposit-ownership proof (it owns the deposit key) and forwards. It does see and store the client's ecash *public* key (deliberately, for future blacklisting) and the device/credential ids of the async flow.
+- **The proxy returns shares, not a wallet.** Wallet aggregation and unblinding require the client's `RequestInfo`, so the proxy returns per-signer `WalletShare`s once at least `threshold` succeeded (per-signer failures are tolerated and persisted). Clients fetch partial verification keys from a dedicated endpoint to verify shares. In contrast, the *auxiliary* data (master VK, coin-index and expiration-date signatures) **is** aggregated proxy-side, cached in memory + SQLite, and optionally embedded in the response via `include-*` query flags.
+- **Fan-out differs from the direct client**: all signers concurrently with a hard 5 s per-signer timeout (vs sequential with retries), and the global data for `(epoch, expiration)` is ensured *before* a deposit is consumed, so cache misses do not burn deposits.
+- **Async flow**: `obtain-async` inserts a `pending` row, spawns the work, returns `{id, uuid}` immediately, and reports the outcome by POSTing to a pre-configured webhook (separate bearer secret; no retries, delivery is fire-and-forget). Polling `GET /shares/...` is the fallback; rows are pruned after 31 days. The sync `obtain` endpoint does the same work inline.
+- **Availability gating**: a background quorum checker (default every 5 min, via `common/ecash-signer-check`) trips after two consecutive failures and makes obtain endpoints fail fast with `UnavailableSigningQuorum`; the epoch must also be `InProgress` (`ensure_credentials_issuable`), mirroring the DKG gate.
+- Upgrade mode: when a chain-upgrade attestation is live, `obtain-async` short-circuits and returns the attestation + a proxy-signed JWT instead of issuing; see [upgrade-mode.md](upgrade-mode.md) for the full flow.
+
+### The outer layers: nym-vpn-api and the VPN apps
+
+These live in other repos (`websites/www/vpn-api`; `nym-vpn-client/nym-vpn-core`, which consumes the monorepo crates as git dependencies pinned to a release branch, so its view can lag this repo). Summarised here because they complete the production picture; treat the external repos as authoritative.
+
+**nym-vpn-api is the business-policy layer.** The proxy issues to whoever holds its bearer token; all entitlement enforcement happens in nym-vpn-api *before* it touches the proxy (its README states this split explicitly). Per request it checks, in order: idempotency by `sha256(withdrawalRequest)` (a duplicate returns the existing credential row, whatever its status); an active subscription; a per-device token bucket (burst 9, refill 1 per 15 min, fail-open on KV outage); and an account-wide daily bandwidth cap (each book is accounted as 25 GB = "0.5 GB per ticket × 50"; cap 2 500 GB/device/day × max 10 devices). Only then does it create the credential row (validity now + 30 days, clamped to subscription end) and call `obtain-async`, passing its own DB row ids as `deviceId`/`credentialId` and a fresh 64-byte `secret`. The webhook receiver authenticates twice (static client id + bearer in the URL/headers, per-credential secret in the body), stores the share blob for 30 days, and flips the credential to `active`; apps learn of completion purely by polling (`GET .../zknym/{id}`) and confirm download with a `DELETE` that removes the share row. The four `directory/zk-nyms/ticketbook/*` routes are unauthenticated 60 s-cached pass-throughs to the proxy's key-material endpoints, which is how apps fetch master/partial VKs and aggregated signatures without account auth.
+
+**The app does the cryptography itself, reusing the monorepo crates.** `nym-vpn-credential-fetcher` implements the monorepo's `CredentialFetcher` trait: it derives the ecash keypair **per account** (seeded from the mnemonic at the cosmos derivation path, so the same recovery phrase re-derives the same ecash identity across devices), builds the blind `WithdrawalRequest`, persists `{id, RequestInfo}` in its own `pending_zk_nym_requests` SQLite table so an interrupted request can be resumed, then on `active` unblinds and verifies each share against the signer's partial VK (`issue_verify`) and aggregates (`aggregate_wallets`) before handing the `IssuedTicketBook` to the monorepo `BandwidthController`, which owns storage and aux-data provisioning. Restocking is driven by the controller's config: check every 3 h (and after every ticket withdrawal), restock a type when its long-lasting tickets (books not expiring within 12 h) drop to 20, one book per fetch, for every type except `V1MixnetExit`; tunnel setup waits up to 120 s for the required types to reach the 5-ticket readiness floor.

--- a/docs/ecash/redemption.md
+++ b/docs/ecash/redemption.md
@@ -1,0 +1,113 @@
+# Redemption
+
+Redemption is how a gateway converts verified spent tickets into on-chain payment. It is documented here in two parts: the flow as designed (most of which is still live code), and the current operational reality.
+
+> **Status: the redemption path is currently severed at both ends.** Two commits from 2026-03-25 disabled it:
+>
+> | Commit | Effect |
+> |---|---|
+> | `f858608ac9` "stop gateways from creating redemption multisig proposals" | deleted all gateway-side batching, proposal creation, vote tracking and proposal execution (~560 lines of `credential_sender.rs`) |
+> | `981582c107` "stop transferring tokens to the holding account after redemption" | removed the payout computation and the `BankMsg::Send` from the contract's `RedeemTickets` |
+>
+> Everything in between (the contract's `RequestRedemption`, the multisig proposal machinery, the nym-api validation + voting endpoint) remains deployed and functional, but has no caller. `grep BankMsg contracts/ecash/src/` returns nothing: the ecash contract currently has **no fund-egress path at all**.
+>
+> **This is a deliberate staging decision, not an oversight.** The per-gateway, per-batch redemption flow described below is being replaced rather than repaired; see "The intended replacement" at the end of this document. The scaffolding is retained because parts of it inform the successor design.
+
+The contract layer is authoritatively specified in [`openspec/specs/ecash-contract/spec.md`](../../openspec/specs/ecash-contract/spec.md) (requirements "RequestRedemption...", "The redemption-proposal reply handler...", "Legacy RedeemTickets...").
+
+## The designed flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant GW as Gateway
+    participant EC as ecash contract
+    participant MS as cw3 multisig
+    participant S as each nym-api signer
+
+    Note over GW: trigger: >= 100 verified tickets,<br/>or ticket expiry approaching (max 6 days between redemptions)
+    GW->>GW: digest = sha256(sn_1 || sn_2 || ... || sn_k)
+    GW->>EC: RequestRedemption { commitment_bs58: digest, number_of_tickets: k }
+    EC->>MS: Propose { title: "ecash-redemption", description: digest,<br/>msg: RedeemTickets { n: k, gw: tx_sender } }
+    MS-->>EC: proposal_id (via reply)
+    EC-->>GW: proposal_id (tx data)
+
+    loop for each signer
+        GW->>S: POST /v1/ecash/batch-redeem-ecash-tickets<br/>{ digest, full serial-number list, proposal_id, gateway_cosmos_addr }
+        S->>MS: query proposal by id
+        S->>S: 10 validation checks (below)
+        S->>MS: Vote yes
+        S-->>GW: proposal_accepted
+    end
+
+    Note over MS: threshold (AbsolutePercentage) reached -> Passed
+    GW->>MS: execute proposal
+    MS->>EC: RedeemTickets { n, gw } (multisig-gated)
+    Note over EC: historically: pay deposit_amount * n / 50 (floored)<br/>to the holding account, today: counter bump only, no funds
+    GW->>GW: clear redeemed ticket data, stamp proposal_id
+```
+
+### On-chain: `RequestRedemption`
+
+Callable by **any address**, no funds, no allowlist. The handler validates only that `commitment_bs58` decodes to exactly 32 bytes (a sha256 digest), then dispatches a cw3 `Propose` submessage: title `"ecash-redemption"`, description = the digest verbatim, and a single embedded `RedeemTickets { n: number_of_tickets, gw: <tx sender> }` targeting the ecash contract itself. The gateway identity thus enters the proposal as the chain-authenticated tx sender and cannot be spoofed. The multisig only accepts proposals from configured addresses (the ecash contract must be registered as its `coconut_bandwidth_addr`, a legacy field name), the proposing contract gets a zero-weight ballot, and the multisig-assigned `proposal_id` flows back to the caller through the reply handler into the tx data.
+
+**Only a digest goes on-chain.** The full serial-number list travels off-chain, over HTTP, to each signer; the proposal description pins it by hash.
+
+### nym-api validation and voting
+
+`POST /v1/ecash/batch-redeem-ecash-tickets` (`nym-api/src/ecash/api_routes/spending.rs`, `batch_redeem_tickets`; still live). The request body is unsigned; validation binds everything to chain state instead. Checks in order:
+
+1. caller api is a signer this epoch (`ensure_signer`);
+2. the gateway (by cosmos address) has previously submitted tickets to this api;
+3. rate limit: at most one batch per gateway per 24 h (`MIN_BATCH_REDEMPTION_DELAY`);
+4. the digest matches the attached serial numbers (recomputed sha256);
+5. on-chain proposal validation (`validate_redemption_proposal`, `nym-api/src/ecash/state/mod.rs`): title is `"ecash-redemption"`; status is exactly `Open`; **description equals the request digest** (the link between the off-chain list and the on-chain commitment); proposer is the ecash contract; exactly one embedded message; it is a funds-free `WasmMsg::Execute` on the ecash contract; it deserialises to `RedeemTickets { n, gw }`; **`gw` equals the requesting gateway's address** (binds the HTTP claim to the chain-authenticated proposer); `n` equals the number of submitted serial numbers;
+6. **every submitted serial number is in this api's own verified-ticket set** for that gateway, within the window since the gateway's previous batch (each api trusts only what it personally verified at spend time; see [spending.md](spending.md)). Tickets the api verified but the gateway did not include are silently forfeited once the cutoff advances (source comment: "tough luck, they're going to lose them");
+7. cast a `Vote::Yes` on the cw3 proposal. A failed vote transaction is logged at debug and swallowed; the endpoint replies `proposal_accepted: true` regardless and advances the gateway's batch cutoff either way.
+
+The cw3 multisig tallies votes with its configured `AbsolutePercentage` threshold over the cw4 group snapshot taken at proposal creation. Proposals expire after the multisig's `max_voting_period`; an expired open proposal degrades to `Rejected`. Signers whose vote arrives after the threshold has passed get `AlreadyPassed` errors from their own validation (step 5 requires `Open`), a known rough edge flagged by a TODO in source.
+
+### Execution and payout
+
+Historically the gateway itself executed the passed proposal. The multisig then calls `RedeemTickets { n, gw }` on the ecash contract (multisig-gated). The payout, before `981582c107`, was pro-rata and floored: `deposit_amount * n / TICKETBOOK_SIZE` (so 1 ticket of a 100 NYM 50-ticket book = 2 NYM), sent **to the holding account**, not the gateway (a still-earlier change, `3cb69780a6`, removed the 95/5 gateway/holding split), and accumulated into `PoolCounters.total_redeemed`.
+
+Today `RedeemTickets` ignores `gw`, increments `PoolCounters.tickets_requested_and_not_redeemed`, emits a `ticket_redemption` event with `moved_to_holding_account = "false"`, and moves nothing. The spec explicitly classifies it as dead code retained for backwards compatibility. `total_redeemed` is zero-initialised and never written; `holding_account` is validated at instantiation and never debited.
+
+### Double-redemption prevention (all layers still live)
+
+- per-api serial-number UNIQUE storage plus the `identify()` replay check at spend-submission time;
+- the per-gateway `verified_at > last_batch_verification` cutoff: once an api votes on a batch, everything verified before that moment leaves the redeemable window irreversibly;
+- digest binding plus the requirement that the proposal be `Open`: a passed or executed proposal cannot be re-voted.
+
+## Current operational reality
+
+With `f858608ac9`, the gateway's `CredentialHandler` does exactly one periodic thing: retry pending *verifications*. Consequences:
+
+- **Gateways are not paid for ticket-metered bandwidth.** Clients deposit; `total_deposited` grows; the contract has no egress; verified tickets are purged by each nym-api 8 days after their spend date with nothing claimed against them.
+- **Gateway-side redemption state decays into dead weight.** The `verified_tickets`, `redemption_proposals` tables and the six storage methods that serve them (`common/gateway-storage`) have zero production callers; `redemption_proposals` stays empty; and because the only deletion path for `ticket_data`/`verified_tickets` rows was post-redemption cleanup, **these tables now grow without bound** on every gateway (the serial-number replay index with them).
+- **Dead configuration**: `minimum_redemption_tickets` (default 100) and `maximum_time_between_redemption` (default 6 days, derived from ticket validity) are still parsed and plumbed into `CredentialHandlerConfig` but never read; node config templates still tell operators the cosmos mnemonic is "used for zk-nym redemption".
+- The nym-api endpoint, contract messages, client helpers (`request_ticket_redemption`, `batch_redeem_ecash_tickets`) and error variants all remain in place, callable, and covered by the checks above; re-enabling the flow is a matter of restoring a driver plus a payout, not rebuilding the machinery.
+
+## Historical gateway batching logic (for context)
+
+The pre-`f858608ac9` driver (recoverable via `git show f858608ac9^:common/credential-verification/src/ecash/credential_sender.rs`) ran on the 300 s poller: skip if any verification is pending; rate-limit one day since the last stored proposal; redeem when ≥ `minimum_redemption_tickets` (100) verified tickets accumulated, with an expiry escape hatch that bypassed the size floor when the oldest proposal was older than `maximum_time_between_redemption`; build the digest; send `RequestRedemption`; persist the proposal id against the included tickets; then fan the serial-number list out to the signers and, on `Passed`, execute the proposal and purge the redeemed rows. Known acknowledged limitations in that code: the first-ever redemption could never take the expiry escape hatch, and crash recovery could not reconcile multiple missed proposals.
+
+## The intended replacement
+
+The flow above is not scheduled to be re-enabled in its current shape; it is being replaced rather than repaired. The design is not yet fully specified, but the direction is settled:
+
+- nym-apis globally agree on the **share of tickets each gateway submitted** over an epoch.
+- That share determines the gateway's **`work_factor`**, which feeds an updated rewarding formula in the mixnet contract.
+- Gateways no longer send requests to the ecash contract at all. The per-gateway, per-batch on-chain negotiation described above would not have scaled.
+
+This also accounts for several loose ends in the current code: `RedeemTickets` surviving as a no-op, `PoolCounters::total_redeemed` never being written, the `holding_account` never being debited, and the gateway-side redemption tables and configuration remaining wired but unread. They are remnants of the superseded design rather than an unfinished implementation of the current one.
+
+## Data retention summary
+
+| Store | Data | Cleanup | Status |
+|---|---|---|---|
+| nym-api `verified_tickets` | serial number + spending metadata per verified ticket | purged 8 days after spend date (2 h sweep) | active |
+| nym-api `issued_ticketbook` | issuance audit rows + merkle leaves | purged 2 days after expiration | active |
+| gateway `ticket_data` | serial numbers (+ blob until quorum) | blob nulled at quorum; row deleted only on rejection or redemption | **grows unbounded** (no redemption) |
+| gateway `verified_tickets` / `redemption_proposals` | redemption bookkeeping | only via post-redemption cleanup | **unreachable code path** |
+| client `ecash_ticketbook` | ticketbooks + spent counters | expired books cleaned up (yesterday cutoff) | active |

--- a/docs/ecash/spending.md
+++ b/docs/ecash/spending.md
@@ -1,0 +1,114 @@
+# Spending and verification
+
+Spending presents one ticket from a stored ticketbook to a gateway in exchange for bandwidth. Verification is deliberately layered: the gateway does everything needed to grant bandwidth locally and synchronously, then reports the ticket to the signer quorum asynchronously for cross-gateway double-spend detection (and, by design, eventual redemption).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant GW as Gateway
+    participant S as nym-api signers (epoch's set)
+
+    Note over C: pick soonest-expiring usable book,<br/>reserve ticket index in DB (used_tickets += 1)
+    Note over C: PayInfo = randomness || timestamp || gateway ed25519 pk
+    Note over C: prepare_for_spending: spend_date = today (UTC midnight),<br/>derive serial number + zk spend proof for index
+    C->>GW: EcashCredential (AEAD-encrypted over shared key)
+
+    rect rgb(235, 235, 235)
+    Note over GW: synchronous, local
+    GW->>GW: spend_value == 1?
+    GW->>GW: spend_date == today (strict)?
+    GW->>GW: serial number unseen in local DB?
+    GW->>GW: PayInfo: pk == mine, |timestamp - now| <= 30 s, not replayed
+    GW->>GW: crypto verify vs aggregated VK for ticket's epoch_id<br/>(VK fetched from chain shares on first use, then cached)
+    GW->>GW: persist ticket (serial number UNIQUE), credit bandwidth
+    end
+    GW-->>C: BandwidthResponse { available_total }
+
+    rect rgb(235, 235, 235)
+    Note over GW,S: asynchronous, off the critical path
+    GW->>S: POST /v1/ecash/verify-ecash-ticket { full spending data, gateway_cosmos_addr } (to every signer)
+    S->>S: date window, identify() double-spend check vs own records,<br/>crypto verify, store serial number bound to gateway
+    S-->>GW: accept / reject
+    GW->>GW: >= 70% accept: mark verified, drop binary data<br/>>= 30% reject: revoke bandwidth × 10 penalty
+    end
+```
+
+## Client side
+
+**Ticket selection** is a small state machine over local storage (`common/credential-storage`): `get_next_unspent_ticketbook` picks the soonest-expiring book of the right type with spare tickets (`used_tickets + n <= total_tickets AND expiration_date >= today`), and `used_tickets` is incremented *in the same transaction* as a reservation, so concurrent tasks cannot take the same index. On a failed spend the counter is reverted with a compare-and-swap (`attempt_revert_ticketbook_withdrawal`), a rollback that is intentionally skipped when the gateway reports the failure as a ticket replay.
+
+**Spend preparation** (`BandwidthController::prepare_ecash_ticket`, `common/bandwidth-controller/src/controller.rs`) first ensures the master VK, coin-index signatures and expiration-date signatures for the book's `(epoch_id, expiration_date)` are in local storage (fetching on miss), then builds the payload:
+
+- **PayInfo** (`common/credentials-interface`): exactly 72 bytes: 32 B randomness, 8 B big-endian unix timestamp, 32 B provider public key = the **gateway's ed25519 identity key**. This binds the payment to one gateway and one moment.
+- `IssuedTicketBook::prepare_for_spending` sets `spend_date = ecash_today()` (UTC midnight) and calls the black-box `spend()`, which derives, for the reserved index: the **serial number** (deterministic in the wallet secret and index; independent of PayInfo, which is what makes replays detectable), an identification tag (enables recovering the spender's public key if the same ticket is spent with two different PayInfos), and a zk spend proof binding everything to the PayInfo. The prerequisite aux signatures (7 date signatures, 50 coin-index signatures) are consumed here.
+- The wire object is `CredentialSpendingData { payment, pay_info, spend_date, epoch_id }`; the embedded `epoch_id` tells the verifier which master key to use.
+
+**Always exactly one ticket per request.** The crypto supports multi-ticket payments, but every client spends 1 (`TICKETS_TO_SPEND = 1`) and both the gateway and the nym-api hard-reject `spend_value != 1` (`MultipleTickets`).
+
+**Transports.** The same payload travels several routes: the mixnet websocket control message `EcashCredential` (AEAD-encrypted with the client-gateway shared key), triggered when remaining bandwidth drops below a threshold (default 20% of a mixnet ticket, i.e. 40 MB); the WireGuard registration flow (`nym-registration-client`); the WG live-tunnel top-up endpoint (`POST /v1/bandwidth/topup`); and the authenticator/probe clients.
+
+## Gateway verification, in order
+
+`CredentialVerifier::verify` (`common/credential-verification/src/lib.rs`):
+
+| # | Check | Failure | Scope |
+|---|---|---|---|
+| 1 | mock-mode short-circuit (`--use-mock-ecash`), a local-testing option that must never be enabled on a production gateway | n/a | local |
+| 2 | `spend_value == 1` | `MultipleTickets` | local |
+| 3 | `spend_date == today` (strict equality, UTC-midnight) | `InvalidCredentialSpendingDate` | local |
+| 4 | serial number not already in this gateway's `ticket_data` | `BandwidthCredentialAlreadySpent` | local DB |
+| 5 | PayInfo: provider pk equals this gateway's identity key | `InvalidPayInfoPublicKey` | local |
+| 6 | PayInfo: timestamp within ±30 s of now | `InvalidPayInfoTimestamp` | local wall clock |
+| 7 | PayInfo: not in the in-memory replay list (a timestamp-sorted vec pruned to the ±30 s window; process-local, lost on restart) | `DuplicatePayInfo` | local memory |
+| 8 | cryptographic verification against the aggregated VK for the ticket's `epoch_id` | `MalformedTicket*` variants | local compute; chain only on epoch cache miss |
+| 9 | persist ticket (`received_ticket` + `ticket_data` with UNIQUE serial number), enqueue async quorum verification | storage errors | local |
+| 10 | credit bandwidth: `ticket_amount(t_type)`, expiring today + 6 days | | local |
+
+What step 8 actually proves (black-box summary of `spend_verify`, `common/nym_offline_compact_ecash/src/scheme/mod.rs`): no duplicate serial numbers within the payment; the zk spend proof is valid for this exact PayInfo (recomputing the PayInfo-derived challenge, which is what makes the ticket non-transferable to another gateway or time); the wallet signature verifies against the epoch's master key including the ticket-type attribute; possession of a valid **expiration-date signature for the claimed spend date** (the verifier never learns the book's expiration date, it only learns "spend_date is within validity"); and batched validity of the coin-index signatures.
+
+**What a spent ticket reveals vs conceals.** Of the four signed attributes ([issuance.md](issuance.md)), only the two public ones surface. Revealed in plaintext: `t_type`, `spend_date`, `epoch_id`, `spend_value`, the serial number(s) and identification tag(s), and the PayInfo. Concealed: `sk_user` and `v` (present only inside randomised/blinded group elements), the book's actual expiration date (the verifier learns only "the claimed spend date is within validity"), the index of the ticket within its book (the coin-index signatures prove index validity without disclosing it), and any linkage to the deposit or issuance session. `sk_user` stops being concealed in exactly one case: spending the same ticket index with two different PayInfos lets `identify()` recover the spender's public key from the two identification tags.
+
+**Per-epoch verification state** (`common/credential-verification/src/ecash/state.rs`): on the first ticket of an unseen epoch the gateway queries the DKG contract for the epoch's threshold and all VK shares, converts them into signer clients, checks that at least threshold remain, aggregates the master key, and caches it in a per-epoch map (also persisting the signer set into `ecash_signer`). Note the conversion step is the stricter of the two: it rejects **any** share still marked unverified and fails the whole call, so in practice an epoch is usable only if *every* submitted share was verified during its ceremony, not merely threshold-many. Everything after that is chain-free, which is why spending keeps working during DKG ceremonies and chain outages, for already-cached epochs. Gateway startup hard-requires the DKG contract to be reachable once.
+
+Note the gateway consumes only the master VK; the aggregated expiration-date and coin-index signatures travel *inside* the payment (`sig_exp`, `omega`), so the gateway never fetches them.
+
+**Ticket type is not matched against the service**: `t_type` is a signed attribute (unforgeable, but freely chosen by the client at issuance) and the gateway uses it only to pick the credited bandwidth amount; nothing asserts that a WireGuard ticket is being spent on WireGuard or a mixnet ticket on the mixnet.
+
+**Bandwidth accounting** (`BandwidthStorageManager`): credited immediately and durably; consumption is decremented per sphinx packet (mixnet) or via polled kernel counters (WireGuard, where exhaustion removes the peer from the interface), with a deliberately lossy flush policy (sync every 512 kB delta or 5 ms on nym-node defaults); credited bandwidth expires at `cred_exp_date()` (today + 6 days) and the row is zeroed on expiry. Two non-ticket paths also exist: a testnet bandwidth grant, gated by the `enforce_zk_nyms` setting that production gateways are expected to enable, and [upgrade mode](upgrade-mode.md), which disables metering during chain upgrades.
+
+## Asynchronous quorum verification
+
+Every accepted ticket is queued (unbounded channel) for the `CredentialHandler` task (`common/credential-verification/src/ecash/credential_sender.rs`), which POSTs the **full spending data** plus the gateway's cosmos address to *every* signer of the ticket's epoch (32-way concurrent), records each vote in `ticket_verification`, and applies quorum arithmetic over the epoch's signer count:
+
+- accepted ratio ≥ `minimum_api_quorum` (default **0.7**): the ticket becomes *verified*; its binary blob is dropped from `ticket_data` (the serial number stays for replay protection).
+- rejected ratio ≥ 0.3: the ticket is marked rejected, its `ticket_data` row (including the serial number) is deleted, and the client's bandwidth is revoked at **10×** the ticket's value (`REVOCATION_BANDWIDTH_PENALTY`), not clamped at zero.
+- in between (too many failures): retried by a poller every 300 s; pending state is rebuilt from the DB on restart.
+
+### nym-api side: `POST /v1/ecash/verify-ecash-ticket`
+
+Each signer independently (`nym-api/src/ecash/api_routes/spending.rs`, `verify_ticket`):
+
+1. `ensure_signer()`.
+2. `spend_value == 1`.
+3. Spend-date window: the code intends "today, or yesterday if before 01:00 UTC". As written, the rejection condition is `spend_date != today && now > 01:00 && spend_date != yesterday`, which accepts yesterday-dated tickets all day and accepts *any* date before 01:00 UTC; deliberately looser than the gateway's strict-today rule either way.
+4. Double-spend detection against its own records: if the serial number is already stored, `identify()` distinguishes an identical replay (`ReplayedTicket`) from a genuine double-spend with a different PayInfo, in which case the spender's public key is recovered from the two identification tags and the ticket is rejected as `DoubleSpend`.
+5. Cryptographic verification against the master key for the embedded epoch.
+6. Store the serial number bound to the submitting gateway's cosmos address (`INSERT OR IGNORE` + UNIQUE; losing a race surfaces as `ReplayedTicket`). This stored set is also what redemption validation later checks against (see [redemption.md](redemption.md)). The api does not validate PayInfo's provider binding or timestamp; first submitter wins the gateway binding.
+
+Verified tickets are retained api-side for spend date + 8 days, then purged by the background cleaner.
+
+## Double-spend protection, summarised
+
+| Layer | Mechanism | Scope | Timing |
+|---|---|---|---|
+| 1 | `ticket_data.serial_number` UNIQUE + pre-insert lookup | per gateway, durable | synchronous |
+| 2 | PayInfo replay list (±30 s, in-memory) | per gateway process | synchronous |
+| 3 | quorum vote over every spent ticket; ≥30% rejections → 10× bandwidth revocation | cross-gateway | asynchronous (seconds to minutes; 300 s retry) |
+| 4 | per-signer serial-number store + `identify()` | per signer, durable (8 days) | at layer-3 submission time |
+
+The historical **double-spending bloom filter is gone**: `GET /v1/ecash/double-spending-filter-v1` is deprecated and permanently returns 410; no filter is built, synced, or consulted anywhere. Cross-gateway protection is therefore the quorum path, which is deliberately asynchronous: this is the standard offline-ecash trade, where verification stays local and fast, and cross-verifier reconciliation plus its penalty (revocation at ten times the ticket's value, and recovery of the spender's public key from the identification tags) follow after the fact rather than gating the request.
+
+## Offline behaviour
+
+Fully offline-capable once warm: client spending (with cached aux data), all gateway synchronous checks, bandwidth accounting. Chain needed only at gateway boot and on first-ticket-of-epoch. nym-apis needed for client acquisition of books/aux data and for the asynchronous layer 3; a nym-api outage degrades cross-gateway double-spend detection and future redeemability, never availability of already-issued tickets.

--- a/docs/ecash/upgrade-mode.md
+++ b/docs/ecash/upgrade-mode.md
@@ -1,0 +1,75 @@
+# Upgrade mode (the JWT bypass)
+
+Upgrade mode is a network-wide escape hatch that keeps bandwidth flowing **without tickets** while the Nyx chain is undergoing an upgrade. During a chain upgrade the entire ticketbook pipeline stalls: deposits cannot be made, signers cannot verify deposits, and clients cannot restock. Spending already-issued tickets at gateways would still work (verification is offline-capable), but clients would run dry. Upgrade mode replaces payment with an authorisation: a Nym-signed attestation, relayed to clients as a JWT, that tells gateways to stop metering until the upgrade is over.
+
+Primitives live in `common/upgrade-mode-check`; gateway-side state in `common/credential-verification/src/upgrade_mode.rs`; the watchers in `gateway/src/node/upgrade_mode/watcher.rs` and `nym-credential-proxy/.../attestation_watcher.rs`.
+
+## Trust chain
+
+1. **Pinned attester key + well-known URL.** Network defaults (`common/network-defaults/src/mainnet.rs`, env-overridable) carry `UPGRADE_MODE_ATTESTATION_URL` (`https://nymtech.net/.wellknown/upgrade-mode/attestation.json`) and `UPGRADE_MODE_ATTESTER_ED25519_BS58_PUBKEY`, the ed25519 key expected to sign attestations. Gateways additionally persist both in their config (`nym-node/src/config/gateway_tasks.rs`, `UpgradeModeWatcher`).
+2. **The attestation.** To begin upgrade mode, Nym publishes an `UpgradeModeAttestation { starting_time, attester_public_key, authorised_jwt_issuers: [ed25519 pks], signature }` at that URL; removing the file (serving `null`) ends it. Consumers verify the signature *and* check the embedded attester key against their pinned expectation, so the attestation is only as trustworthy as the pinned key.
+3. **The JWT.** The credential proxy wraps the attestation in an EdDSA JWT (`issuer = "nym-credential-proxy"`, a configured validity, the signer's public key in the token header) and hands it to clients. A JWT is only accepted if its signing key appears in the attestation's `authorised_jwt_issuers` list, which is how the attester delegates "who may relay this to clients".
+
+## The flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant N as Nym (attester)
+    participant W as well-known URL
+    participant P as credential-proxy
+    participant C as Client
+    participant GW as Gateway
+
+    N->>W: publish signed UpgradeModeAttestation
+    Note over P: AttestationWatcher polls the URL<br/>(expedited cadence once active)
+    Note over GW: UpgradeModeWatcher polls the URL<br/>(15 min regular / 2 min expedited)
+
+    C->>P: ticketbook request (relayed via nym-vpn-api)
+    P-->>C: UpgradeModeResponse { attestation, jwt } instead of shares<br/>(surfaces as credential status "upgrade_mode" on the vpn-api poll)
+    Note over C: stored as an "emergency credential"<br/>(UPGRADE_MODE_JWT_TYPE, with the JWT's expiry)
+
+    C->>GW: ClientControlRequest::UpgradeModeJWT { token }
+    alt gateway already in upgrade mode
+        GW-->>C: Bandwidth { upgrade_mode: true } (token not even validated)
+    else gateway not yet aware
+        GW->>GW: validate JWT (sig, issuer, authorised signer)
+        GW->>W: expedited attestation re-fetch (rate-limited, 30 s min staleness)
+        GW->>GW: fetched attestation must match the JWT's
+        GW-->>C: Bandwidth { upgrade_mode: true }
+    end
+
+    Note over C,GW: metering disabled, all responses carry upgrade_mode: true
+
+    N->>W: remove attestation
+    Note over GW: watcher sees null (or >5 consecutive fetch failures)<br/>flag off, metering resumes
+```
+
+## Gateway behaviour
+
+- **Watcher.** If enabled in config, the gateway polls the attestation URL every 15 min (2 min once upgrade mode is active), verifies each retrieved attestation against its pinned attester key, and flips a process-wide atomic flag (`UpgradeModeState`). A clean `null` disables immediately; retrieval *errors* only disable after more than 5 consecutive failures, guarding against a transiently broken URL ending upgrade mode by accident.
+- **Client-triggered activation.** A client's `UpgradeModeJWT` can only *accelerate* discovery, never substitute for the gateway's own view: the gateway validates the JWT, then performs its own expedited fetch (rate-limited to one per 30 s across all clients, `upgrade_mode_min_staleness_recheck`) and requires the independently fetched attestation to equal the one embedded in the JWT (`try_enable_via_received_jwt`). A gateway already in upgrade mode short-circuits without validating anything.
+- **Effect while enabled.** Bandwidth metering is disabled across all paths: the websocket handler stops decrementing on sphinx forwarding and answers bandwidth queries with `max(current, threshold + 1)` so that *old* clients (unaware of the `upgrade_mode` response field) never think they need to send a ticket; WireGuard peer enforcement is skipped; WG registration accepts `BandwidthCredential::UpgradeModeJWT` in place of a ticket; the authenticator accepts the JWT over the mixnet; and the private-metadata API exposes a `check_upgrade_mode` request. Every relevant response (`Register`, `Authenticate`, `Bandwidth`, `Send`) carries an `upgrade_mode: bool` so aware clients stop spending tickets. Tickets already verified are unaffected; nothing about stored ticketbooks changes.
+
+## Client behaviour
+
+The bandwidth controller treats the JWT as an alternative credential: a fetch can yield `NymCredential::UpgradeModeToken { jwt, expiration }` instead of a ticketbook, stored in credential storage as an *emergency credential* (`UPGRADE_MODE_JWT_TYPE`) with the JWT's expiry. Readiness reporting treats "upgrade mode token present" as its own ready state (so a connect may proceed with zero ticketbooks), and the stored token is served to connection code via `get_upgrade_mode_token`. Presenting it requires a gateway protocol version that supports upgrade mode (`supports_upgrade_mode`).
+
+### How the production VPN stack drives it
+
+The driving logic lives in `nym-vpn-client/nym-vpn-core` (external repo, pinned to a monorepo release branch); summarised here because it determines which of the monorepo's mechanisms are actually exercised.
+
+**Acquisition.** There is no dedicated attestation endpoint for apps. The JWT rides the normal zk-nym request: when the proxy answers `obtain-async` with the upgrade-mode response, nym-vpn-api stores it on the credential row (`status: upgrade_mode`), and the app's poll of `GET .../zknym/{id}` returns `{ upgrade_mode_attestation, upgrade_mode_jwt }`. The client deliberately does **not** verify the attestation's signature (source comment: "we trust our credential-proxy -> VPN API chain to have validated that the attestation had been signed with expected key"); it only decodes the JWT claims to read the expiry, then stores it as the emergency credential. The gateways remain the only parties that validate the full trust chain independently.
+
+**Presentation - what is live and what is not.** Per gateway, the WireGuard bandwidth monitor consults the gateway-reported `upgrade_mode` flag (returned on bandwidth query/top-up responses) before each top-up:
+
+- gateway reports `true`: the client does nothing at all - no ticket spent, no JWT sent; the flag alone suffices (a client may legitimately hold no JWT here, e.g. if it had enough stored books to never ask the vpn-api).
+- gateway reports `false` but the client holds a JWT and was not previously seeing upgrade mode: the client *pushes* the JWT to the gateway via the private-metadata `check_upgrade_mode` request (or the legacy authenticator equivalent) to trigger the gateway's own expedited re-check, and still spends a ticket for this round.
+- gateway reports `false`, the client holds a JWT, and the previous check saw upgrade mode: upgrade mode has ended; the client clears its emergency credentials and resumes normal ticket top-ups.
+- gateway too old to report the flag: the client falls back to spending tickets.
+
+Two monorepo mechanisms are currently *not* exercised by this client: the mixnet-websocket `ClientControlRequest::UpgradeModeJWT` sender (`send_upgrade_mode_jwt`) has no caller, so mixnet-mode bandwidth claims always spend a ticket; and the LP registration path explicitly does not support upgrade mode and always spends its registration ticket (only the legacy authenticator-over-mixnet registration can substitute `BandwidthCredential::UpgradeModeJWT` for it). On upgrade-mode exit the JWT simply expires or is cleared as above, after which normal ticket spending resumes.
+
+## Relationship to the ticketbook lifecycle
+
+Upgrade mode is orthogonal to DKG epochs: it does not touch keys, epochs, or issued books. It exists because a chain upgrade makes both deposits and (chain-dependent) issuance impossible; note that the credential proxy also refuses regular issuance while it holds an attestation, returning the JWT response instead, even if some signers were still reachable. Verification of the trust chain is anchored solely in the pinned attester public key; there is no on-chain component (deliberately, since the chain is the thing being upgraded).


### PR DESCRIPTION
Describes how ecash credentials (ticketbooks) work end to end: the coconut DKG epoch state machine and key ceremonies, ticketbook issuance via both the direct and credential-proxy paths, ticket spending and gateway-side verification, redemption, and the upgrade-mode bypass used during chain upgrades. Includes mermaid diagrams for the main flows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7056)
<!-- Reviewable:end -->
