### PR TITLE
bugfix: reject packets to unknown clients

### DIFF
--- a/common/gateway-storage/Cargo.toml
+++ b/common/gateway-storage/Cargo.toml
@@ -44,6 +44,9 @@ sqlx = { workspace = true, features = [
     "migrate",
 ] }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
 [features]
 default = []
 mock = ["tokio"]

--- a/common/gateway-storage/src/inboxes.rs
+++ b/common/gateway-storage/src/inboxes.rs
@@ -38,19 +38,34 @@ impl InboxManager {
     ///
     /// * `client_address_bs58`: base58-encoded address of the client
     /// * `content`: raw content of the message to store.
+    ///
+    /// Store a message for a client that has registered with this gateway at some point.
+    ///
+    /// Returns `false`, having inserted nothing, when no `shared_keys` entry exists for the
+    /// address. Retrieval requires the shared key established at registration, so a message for
+    /// an address that never registered here can never be collected; and since the recipient is
+    /// chosen freely by whoever sent the packet, inserting it anyway lets an unauthenticated
+    /// sender grow this table without bound (up to the stale-message cutoff).
     pub(crate) async fn insert_message(
         &self,
         client_address_bs58: &str,
         content: Vec<u8>,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query!(
-            "INSERT INTO message_store(client_address_bs58, content) VALUES (?, ?)",
+    ) -> Result<bool, sqlx::Error> {
+        let inserted = sqlx::query!(
+            r#"
+                INSERT INTO message_store(client_address_bs58, content)
+                SELECT ?, ?
+                WHERE EXISTS(SELECT 1 FROM shared_keys WHERE client_address_bs58 = ?)
+            "#,
             client_address_bs58,
             content,
+            client_address_bs58,
         )
         .execute(&self.connection_pool)
-        .await?;
-        Ok(())
+        .await?
+        .rows_affected();
+
+        Ok(inserted > 0)
     }
 
     /// Retrieves messages stored for the particular client specified by the provided address.
@@ -127,6 +142,17 @@ impl InboxManager {
         Ok(())
     }
 
+    #[cfg(test)]
+    async fn message_count(&self, client_address_bs58: &str) -> i64 {
+        sqlx::query_scalar!(
+            "SELECT COUNT(*) FROM message_store WHERE client_address_bs58 = ?",
+            client_address_bs58
+        )
+        .fetch_one(&self.connection_pool)
+        .await
+        .unwrap()
+    }
+
     pub async fn remove_stale(&self, cutoff: OffsetDateTime) -> Result<(), sqlx::Error> {
         let affected = sqlx::query!("DELETE FROM message_store WHERE timestamp < ?", cutoff)
             .execute(&self.connection_pool)
@@ -134,5 +160,89 @@ impl InboxManager {
             .rows_affected();
         debug!("Removed {affected} stale messages");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    const REGISTERED: &str = "registered-client-address";
+    const NEVER_REGISTERED: &str = "never-registered-client-address";
+
+    async fn setup() -> InboxManager {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("failed to create in-memory SQLite pool");
+        let migrations_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+        sqlx::migrate::Migrator::new(migrations_path.as_path())
+            .await
+            .expect("failed to find migrations")
+            .run(&pool)
+            .await
+            .expect("failed to run migrations");
+
+        // stand in for a completed registration handshake
+        sqlx::query!("INSERT INTO clients(id, client_type) VALUES (1, 'entry_mixnet')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query!(
+            "INSERT INTO shared_keys(client_id, client_address_bs58, derived_aes256_gcm_siv_key) VALUES (1, ?, x'00')",
+            REGISTERED
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        InboxManager::new(pool, 100)
+    }
+
+    #[tokio::test]
+    async fn message_for_a_registered_client_is_stored() {
+        let manager = setup().await;
+
+        assert!(
+            manager
+                .insert_message(REGISTERED, vec![1, 2, 3])
+                .await
+                .unwrap()
+        );
+        assert_eq!(1, manager.message_count(REGISTERED).await);
+    }
+
+    #[tokio::test]
+    async fn message_for_a_client_that_never_registered_is_not_stored() {
+        let manager = setup().await;
+
+        assert!(
+            !manager
+                .insert_message(NEVER_REGISTERED, vec![1, 2, 3])
+                .await
+                .unwrap()
+        );
+        assert_eq!(0, manager.message_count(NEVER_REGISTERED).await);
+    }
+
+    #[tokio::test]
+    async fn a_flood_for_unregistered_recipients_stores_nothing() {
+        let manager = setup().await;
+
+        for i in 0..64 {
+            let recipient = format!("{NEVER_REGISTERED}-{i}");
+            assert!(
+                !manager
+                    .insert_message(&recipient, vec![0; 64])
+                    .await
+                    .unwrap()
+            );
+        }
+
+        let total = sqlx::query_scalar!("SELECT COUNT(*) FROM message_store")
+            .fetch_one(&manager.connection_pool)
+            .await
+            .unwrap();
+        assert_eq!(0, total);
     }
 }

--- a/common/gateway-storage/src/lib.rs
+++ b/common/gateway-storage/src/lib.rs
@@ -245,11 +245,12 @@ impl InboxGatewayStorage for GatewayStorage {
         &self,
         client_address: DestinationAddressBytes,
         message: Vec<u8>,
-    ) -> Result<(), GatewayStorageError> {
-        self.inbox_manager
+    ) -> Result<bool, GatewayStorageError> {
+        let stored = self
+            .inbox_manager
             .insert_message(&client_address.as_base58_string(), message)
             .await?;
-        Ok(())
+        Ok(stored)
     }
 
     async fn retrieve_messages(

--- a/common/gateway-storage/src/traits.rs
+++ b/common/gateway-storage/src/traits.rs
@@ -46,11 +46,15 @@ pub trait SharedKeyGatewayStorage {
 
 #[async_trait]
 pub trait InboxGatewayStorage {
+    /// Store a message for the given recipient, returning whether it was stored.
+    ///
+    /// A recipient that has never registered with this gateway could never retrieve the message,
+    /// so nothing is stored for one and `false` is returned.
     async fn store_message(
         &self,
         client_address: DestinationAddressBytes,
         message: Vec<u8>,
-    ) -> Result<(), GatewayStorageError>;
+    ) -> Result<bool, GatewayStorageError>;
     async fn retrieve_messages(
         &self,
         client_address: DestinationAddressBytes,

--- a/common/gateway-storage/src/traits.rs
+++ b/common/gateway-storage/src/traits.rs
@@ -47,9 +47,6 @@ pub trait SharedKeyGatewayStorage {
 #[async_trait]
 pub trait InboxGatewayStorage {
     /// Store a message for the given recipient, returning whether it was stored.
-    ///
-    /// A recipient that has never registered with this gateway could never retrieve the message,
-    /// so nothing is stored for one and `false` is returned.
     async fn store_message(
         &self,
         client_address: DestinationAddressBytes,

--- a/nym-node/nym-node-metrics/src/mixnet.rs
+++ b/nym-node/nym-node-metrics/src/mixnet.rs
@@ -168,6 +168,10 @@ pub struct EgressRecipientStats {
 pub struct EgressMixingStats {
     disk_persisted_packets: AtomicUsize,
 
+    // final hop packets dropped because the recipient has never registered with this gateway,
+    // so the payload could never have been retrieved
+    unknown_recipient_dropped_packets: AtomicUsize,
+
     // this includes ACKS!
     forward_hop_packets_sent: AtomicUsize,
 
@@ -185,6 +189,16 @@ impl EgressMixingStats {
 
     pub fn disk_persisted_packets(&self) -> usize {
         self.disk_persisted_packets.load(Ordering::Relaxed)
+    }
+
+    pub fn add_unknown_recipient_dropped_packet(&self) {
+        self.unknown_recipient_dropped_packets
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn unknown_recipient_dropped_packets(&self) -> usize {
+        self.unknown_recipient_dropped_packets
+            .load(Ordering::Relaxed)
     }
 
     pub fn forward_hop_packets_sent(&self) -> usize {

--- a/nym-node/nym-node-metrics/src/prometheus_wrapper.rs
+++ b/nym-node/nym-node-metrics/src/prometheus_wrapper.rs
@@ -97,6 +97,11 @@ pub enum PrometheusMetric {
     ))]
     MixnetEgressStoredOnDiskFinalHopPackets,
 
+    #[strum(props(
+        help = "The number of unwrapped final hop packets dropped because their recipient has never registered with this gateway"
+    ))]
+    MixnetEgressUnknownRecipientDroppedFinalHopPackets,
+
     #[strum(props(help = "The number of egress forward hop sphinx packets sent/forwarded"))]
     MixnetEgressForwardPacketsSent,
 
@@ -321,6 +326,9 @@ impl PrometheusMetric {
             PrometheusMetric::MixnetEgressStoredOnDiskFinalHopPackets => {
                 Metric::new_int_gauge(&name, help)
             }
+            PrometheusMetric::MixnetEgressUnknownRecipientDroppedFinalHopPackets => {
+                Metric::new_int_gauge(&name, help)
+            }
             PrometheusMetric::MixnetEgressForwardPacketsSent => Metric::new_int_gauge(&name, help),
             PrometheusMetric::MixnetEgressAckSent => Metric::new_int_gauge(&name, help),
             PrometheusMetric::MixnetEgressForwardPacketsDropped => {
@@ -491,7 +499,7 @@ mod tests {
         // a sanity check for anyone adding new metrics. if this test fails,
         // make sure any methods on `PrometheusMetric` enum don't need updating
         // or require custom Display impl
-        assert_eq!(53, PrometheusMetric::COUNT)
+        assert_eq!(54, PrometheusMetric::COUNT)
     }
 
     #[test]

--- a/nym-node/src/node/metrics/handler/global_prometheus_updater/mod.rs
+++ b/nym-node/src/node/metrics/handler/global_prometheus_updater/mod.rs
@@ -91,6 +91,13 @@ impl OnUpdateMetricsHandler for PrometheusGlobalNodeMetricsRegistryUpdater {
             self.metrics.mixnet.egress.disk_persisted_packets() as i64,
         );
         self.prometheus_wrapper.set(
+            MixnetEgressUnknownRecipientDroppedFinalHopPackets,
+            self.metrics
+                .mixnet
+                .egress
+                .unknown_recipient_dropped_packets() as i64,
+        );
+        self.prometheus_wrapper.set(
             MixnetEgressForwardPacketsSent,
             self.metrics.mixnet.egress.forward_hop_packets_sent() as i64,
         );

--- a/nym-node/src/node/mixnet/handler.rs
+++ b/nym-node/src/node/mixnet/handler.rs
@@ -317,9 +317,8 @@ impl ConnectionHandler {
                         self.shared
                             .dropped_final_hop_packet(self.remote_address.ip());
 
-                        // no ack: unlike the disk fallback, this payload is gone for good, so the
-                        // sender must not be told it landed
-                        return;
+                        // the ack is still forwarded below: withholding it would tell the sender
+                        // whether the recipient is registered with this gateway
                     }
                 }
             }
@@ -329,8 +328,8 @@ impl ConnectionHandler {
             }
         }
 
-        // if we managed to either push message directly to the [online] client or store it at
-        // disk, forward the ack
+        // forward the ack regardless of what happened to the payload (pushed, stored, or dropped);
+        // making it conditional would leak the recipient's state to the sender
         self.shared
             .forward_ack_packet(final_hop_data.forward_ack, trace);
         if has_ack {

--- a/nym-node/src/node/mixnet/handler.rs
+++ b/nym-node/src/node/mixnet/handler.rs
@@ -3,6 +3,7 @@
 
 use crate::node::key_rotation::active_keys::SphinxKeyGuard;
 use crate::node::mixnet::shared::SharedData;
+use crate::node::mixnet::shared::final_hop::InboxOutcome;
 use futures::StreamExt;
 use nym_mixnet_client::metrics::{MixnetMetric, PacketTrace, Traced};
 use nym_noise::connection::Connection;
@@ -293,7 +294,7 @@ impl ConnectionHandler {
                     .await
                 {
                     Err(err) => error!("Failed to store client data - {err}"),
-                    Ok(_) => {
+                    Ok(InboxOutcome::Stored) => {
                         Span::current().record("disk_fallback", true);
                         self.shared
                             .metrics
@@ -301,6 +302,24 @@ impl ConnectionHandler {
                             .egress
                             .add_disk_persisted_packet();
                         trace!("Stored packet for {client}")
+                    }
+                    Ok(InboxOutcome::UnknownRecipient) => {
+                        debug!(
+                            event = "packet.dropped.unknown_recipient",
+                            remote_addr = %self.remote_address,
+                            "dropping packet: {client} has never registered with this gateway, so nothing could ever retrieve it"
+                        );
+                        self.shared
+                            .metrics
+                            .mixnet
+                            .egress
+                            .add_unknown_recipient_dropped_packet();
+                        self.shared
+                            .dropped_final_hop_packet(self.remote_address.ip());
+
+                        // no ack: unlike the disk fallback, this payload is gone for good, so the
+                        // sender must not be told it landed
+                        return;
                     }
                 }
             }

--- a/nym-node/src/node/mixnet/handler.rs
+++ b/nym-node/src/node/mixnet/handler.rs
@@ -3,7 +3,6 @@
 
 use crate::node::key_rotation::active_keys::SphinxKeyGuard;
 use crate::node::mixnet::shared::SharedData;
-use crate::node::mixnet::shared::final_hop::InboxOutcome;
 use futures::StreamExt;
 use nym_mixnet_client::metrics::{MixnetMetric, PacketTrace, Traced};
 use nym_noise::connection::Connection;
@@ -294,7 +293,7 @@ impl ConnectionHandler {
                     .await
                 {
                     Err(err) => error!("Failed to store client data - {err}"),
-                    Ok(InboxOutcome::Stored) => {
+                    Ok(true) => {
                         Span::current().record("disk_fallback", true);
                         self.shared
                             .metrics
@@ -303,7 +302,8 @@ impl ConnectionHandler {
                             .add_disk_persisted_packet();
                         trace!("Stored packet for {client}")
                     }
-                    Ok(InboxOutcome::UnknownRecipient) => {
+                    // nothing was stored: the recipient has never registered with this gateway
+                    Ok(false) => {
                         debug!(
                             event = "packet.dropped.unknown_recipient",
                             remote_addr = %self.remote_address,

--- a/nym-node/src/node/mixnet/shared/final_hop.rs
+++ b/nym-node/src/node/mixnet/shared/final_hop.rs
@@ -8,16 +8,6 @@ use nym_sphinx_types::DestinationAddressBytes;
 use tokio::time::Instant;
 use tracing::{debug, warn};
 
-/// Outcome of trying to persist a payload for a recipient with no live session.
-pub(crate) enum InboxOutcome {
-    /// Written to the recipient's inbox.
-    Stored,
-
-    /// Not written: no client has ever registered with this gateway under that address, so nothing
-    /// could ever retrieve it.
-    UnknownRecipient,
-}
-
 #[derive(Clone)]
 pub(crate) struct SharedFinalHopData {
     active_clients: ActiveClientsStore,
@@ -75,11 +65,12 @@ impl SharedFinalHopData {
         }
     }
 
+    /// Returns whether the payload got stored; see [`InboxGatewayStorage::store_message`].
     pub(crate) async fn store_processed_packet_payload(
         &self,
         client_address: DestinationAddressBytes,
         message: Vec<u8>,
-    ) -> Result<InboxOutcome, GatewayStorageError> {
+    ) -> Result<bool, GatewayStorageError> {
         let start = Instant::now();
         debug!("Storing received message for {client_address} on the disk...",);
         let result = self.storage.store_message(client_address, message).await;
@@ -100,12 +91,6 @@ impl SharedFinalHopData {
             ),
         }
 
-        result.map(|stored| {
-            if stored {
-                InboxOutcome::Stored
-            } else {
-                InboxOutcome::UnknownRecipient
-            }
-        })
+        result
     }
 }

--- a/nym-node/src/node/mixnet/shared/final_hop.rs
+++ b/nym-node/src/node/mixnet/shared/final_hop.rs
@@ -8,6 +8,16 @@ use nym_sphinx_types::DestinationAddressBytes;
 use tokio::time::Instant;
 use tracing::{debug, warn};
 
+/// Outcome of trying to persist a payload for a recipient with no live session.
+pub(crate) enum InboxOutcome {
+    /// Written to the recipient's inbox.
+    Stored,
+
+    /// Not written: no client has ever registered with this gateway under that address, so nothing
+    /// could ever retrieve it.
+    UnknownRecipient,
+}
+
 #[derive(Clone)]
 pub(crate) struct SharedFinalHopData {
     active_clients: ActiveClientsStore,
@@ -69,22 +79,33 @@ impl SharedFinalHopData {
         &self,
         client_address: DestinationAddressBytes,
         message: Vec<u8>,
-    ) -> Result<(), GatewayStorageError> {
+    ) -> Result<InboxOutcome, GatewayStorageError> {
         let start = Instant::now();
         debug!("Storing received message for {client_address} on the disk...",);
         let result = self.storage.store_message(client_address, message).await;
         let store_us = start.elapsed().as_micros() as u64;
-        if result.is_ok() {
-            debug!(
+        match &result {
+            Ok(true) => debug!(
                 event = "gateway.disk_store",
                 store_us, "stored message for {client_address} on disk in {store_us}us"
-            );
-        } else {
-            warn!(
+            ),
+            Ok(false) => debug!(
+                event = "gateway.disk_store_skipped",
+                store_us,
+                "not storing message for {client_address}: never registered with this gateway"
+            ),
+            Err(_) => warn!(
                 event = "gateway.disk_store_failed",
                 store_us, "failed to store message for {client_address} on disk after {store_us}us"
-            );
+            ),
         }
-        result
+
+        result.map(|stored| {
+            if stored {
+                InboxOutcome::Stored
+            } else {
+                InboxOutcome::UnknownRecipient
+            }
+        })
     }
 }

--- a/nym-node/src/node/mixnet/shared/mod.rs
+++ b/nym-node/src/node/mixnet/shared/mod.rs
@@ -5,7 +5,6 @@ use crate::config::Config;
 use crate::node::key_rotation::active_keys::ActiveSphinxKeys;
 use crate::node::mixnet::SharedFinalHopData;
 use crate::node::mixnet::handler::ConnectionHandler;
-use crate::node::mixnet::shared::final_hop::InboxOutcome;
 use crate::node::replay_protection::bloomfilter::ReplayProtectionBloomfilters;
 use crate::node::routing_filter::network_filter::RoutableNetworkMonitors;
 use nym_gateway::node::GatewayStorageError;
@@ -270,7 +269,7 @@ impl SharedData {
         &self,
         client_address: DestinationAddressBytes,
         message: Vec<u8>,
-    ) -> Result<InboxOutcome, GatewayStorageError> {
+    ) -> Result<bool, GatewayStorageError> {
         self.final_hop
             .store_processed_packet_payload(client_address, message)
             .await

--- a/nym-node/src/node/mixnet/shared/mod.rs
+++ b/nym-node/src/node/mixnet/shared/mod.rs
@@ -5,6 +5,7 @@ use crate::config::Config;
 use crate::node::key_rotation::active_keys::ActiveSphinxKeys;
 use crate::node::mixnet::SharedFinalHopData;
 use crate::node::mixnet::handler::ConnectionHandler;
+use crate::node::mixnet::shared::final_hop::InboxOutcome;
 use crate::node::replay_protection::bloomfilter::ReplayProtectionBloomfilters;
 use crate::node::routing_filter::network_filter::RoutableNetworkMonitors;
 use nym_gateway::node::GatewayStorageError;
@@ -269,7 +270,7 @@ impl SharedData {
         &self,
         client_address: DestinationAddressBytes,
         message: Vec<u8>,
-    ) -> Result<(), GatewayStorageError> {
+    ) -> Result<InboxOutcome, GatewayStorageError> {
         self.final_hop
             .store_processed_packet_payload(client_address, message)
             .await


### PR DESCRIPTION
do not store mixnet packets for clients that never registered with this gateway. eventually there won't be any offline storage at all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7061)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented messages for unknown recipients from being stored.
  * Continued forwarding acknowledgments even when message delivery is skipped.
  * Preserved handling and reporting of genuine storage failures.

* **Monitoring**
  * Added metrics for final-hop packets dropped because the recipient is unknown.
  * Added logging and counters distinguishing stored, skipped, and failed messages.

* **Tests**
  * Added coverage for valid recipients, unknown recipients, and repeated delivery attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->