### PR TITLE
fix(wireguard): don't crash node startup over one corrupted peer record

### DIFF
--- a/common/wireguard/src/lib.rs
+++ b/common/wireguard/src/lib.rs
@@ -258,7 +258,7 @@ pub async fn start_wireguard(
     use peer_controller::PeerController;
     use std::collections::HashMap;
     use tokio::sync::RwLock;
-    use tracing::info;
+    use tracing::{info, warn};
 
     let ifname = String::from(WG_TUN_BASE_NAME);
     info!(
@@ -267,20 +267,48 @@ pub async fn start_wireguard(
     );
     let mut wg_api = WgApiWrapper::new(&ifname, use_userspace)?;
     let mut peer_bandwidth_managers = HashMap::with_capacity(peers.len());
+    let mut good_peers = Vec::with_capacity(peers.len());
 
-    for peer in peers.iter() {
+    for peer in peers.into_iter() {
+        let bandwidth_manager = match PeerController::generate_bandwidth_manager(
+            ecash_manager.storage(),
+            &peer.public_key,
+        )
+        .await
+        {
+            Ok(manager) => manager,
+            Err(Error::MissingClientBandwidthEntry) => {
+                // Left over from an unclean shutdown: the peer and its bandwidth
+                // entry are supposed to be written together, but a crash between
+                // the two writes can leave one without the other. Previously this
+                // aborted the whole function via `?`, crashing the entire node
+                // over a single corrupted client record. Remove the orphaned
+                // record and continue starting up with the rest of the peers,
+                // matching how build_wireguard_peers_and_networks already handles
+                // a different persisted-peer corruption case (empty allowed_ips).
+                let peer_identity = &peer.public_key;
+                warn!(
+                    "Peer {peer_identity} is missing its wireguard peer or bandwidth storage \
+                     entry (likely left over from an unclean shutdown). Removing it and \
+                     continuing startup instead of failing the whole node."
+                );
+                ecash_manager
+                    .storage()
+                    .remove_wireguard_peer(&peer_identity.to_string())
+                    .await?;
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        };
+
         let bandwidth_manager = peer_handle::SharedBandwidthStorageManager::new(
-            Arc::new(RwLock::new(
-                PeerController::generate_bandwidth_manager(
-                    ecash_manager.storage(),
-                    &peer.public_key,
-                )
-                .await?,
-            )),
+            Arc::new(RwLock::new(bandwidth_manager)),
             peer.allowed_ips.clone(),
         );
         peer_bandwidth_managers.insert(peer.public_key.clone(), (bandwidth_manager, peer.clone()));
+        good_peers.push(peer);
     }
+    let peers = good_peers;
 
     // Initialize IP pool from configuration
     info!("Initializing IP pool for WireGuard peer allocation");


### PR DESCRIPTION
## Summary

`start_wireguard()` rebuilds every persisted wireguard peer's bandwidth
manager in a loop on startup (`common/wireguard/src/lib.rs`), using `?` on
each per-peer call to `PeerController::generate_bandwidth_manager`. That
function does two sequential storage lookups and returns
`Err(MissingClientBandwidthEntry)` if either the `wireguard_peer` row or its
paired `available_bandwidth` row is missing -- and because the loop uses
`?`, **one corrupted client record aborts the whole function and crashes
the entire node**, rather than just failing to restore that one peer.

Found this against a real production incident: an abrupt hypervisor
power-loss left exactly one client record with a `wireguard_peer` row but
no matching `available_bandwidth` row (the two inserts are supposed to
happen together; a crash between them can split them). The node
crash-looped on every subsequent restart, because the corrupted row was
still there each time -- systemd's restart-rate-limit eventually gave up
entirely.

`build_wireguard_peers_and_networks()` (`gateway/src/node/mod.rs`) already
establishes the right pattern for this exact class of problem, for a
different persisted-peer corruption case (empty `allowed_ips`): log a
warning, remove the bad record from storage, and `continue` rather than
failing the whole batch. This PR applies that same, already-established
pattern to `start_wireguard()`'s loop.

## Changes

- On `Err(Error::MissingClientBandwidthEntry)` specifically: log a `warn!`
  naming the peer, remove the orphaned record via
  `storage.remove_wireguard_peer(...)`, and `continue` -- the node starts up
  normally with the rest of its peers intact.
- Any other error from `generate_bandwidth_manager` (e.g. a genuine
  storage-layer failure) still propagates exactly as before via
  `Err(e) => return Err(e.into())` -- this only skips the specific
  "record legitimately doesn't exist" case, not storage outages in general.
- `peers` is filtered to just the surviving peers before its two later uses
  in the function (IP-pool marking, and the move into
  `interface_config.peers`), so a dropped peer is fully excluded from the
  rest of startup, not just from the bandwidth-manager map.

Worth noting as a non-blocking observation, not something this PR changes:
`MissingClientBandwidthEntry` is currently returned for two distinct
lookup failures (the peer record itself missing, or its paired bandwidth
row missing) with no way to tell which from the error alone. Didn't widen
the enum here to keep this patch minimal and focused on the crash.

## Related work

#6728 touches the same general area (`peer_controller/mod.rs`,
`bandwidth_storage_manager.rs`) but is a different bug -- duplicate
`PeerHandle`s double-charging bandwidth on reconnect, not a missing-record
crash on startup. Not a duplicate of this fix.

## Testing

`start_wireguard()` is `#[cfg(target_os = "linux")]` and depends on the
real WireGuard kernel module, so it can't be built or run in my local
(macOS) environment. Verified by careful review against the exact
precedent pattern in `build_wireguard_peers_and_networks()` (same
log-then-remove-then-continue shape, same peer-identity logging style) and
by re-tracing every later use of `peers` in the function to confirm the
filtered list is what's actually used downstream. Relying on CI for the
actual build/test signal.

Co-Authored-By: Claude <claude@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7065)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WireGuard startup now continues when individual peers have missing bandwidth records.
  * Invalid persisted peers are automatically removed instead of preventing startup.
  * Other bandwidth-related errors still stop startup as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->