### PR TITLE
feat: add config score penalty for nodes incapable of sending nyx transactions

### DIFF
--- a/nym-api/src/node_status_api/cache/config_score.rs
+++ b/nym-api/src/node_status_api/cache/config_score.rs
@@ -87,7 +87,7 @@ pub(crate) fn calculate_config_score(
     };
 
     if !chain_interaction.can_send_transactions() {
-        version_score = (1. - chain_interactions_penalty) * version_score;
+        version_score *= 1. - chain_interactions_penalty;
     }
 
     ConfigScoreV2::new(

--- a/nym-api/src/node_status_api/cache/config_score.rs
+++ b/nym-api/src/node_status_api/cache/config_score.rs
@@ -43,6 +43,7 @@ pub(crate) fn calculate_config_score(
     config_score_data: &ConfigScoreData,
     described_data: Option<&NymNodeDescriptionV3>,
     chain_capabilities: &Option<ChainInteractionCapabilitiesDetailed>,
+    chain_interactions_penalty: f64,
 ) -> ConfigScoreV2 {
     let Some(described) = described_data else {
         return ConfigScoreV2::unavailable();
@@ -66,7 +67,7 @@ pub(crate) fn calculate_config_score(
         .auxiliary_details
         .accepted_operator_terms_and_conditions;
 
-    let version_score = if !runs_nym_node || !accepted_terms_and_conditions {
+    let mut version_score = if !runs_nym_node || !accepted_terms_and_conditions {
         0.
     } else {
         versions_behind_factor_to_config_score(
@@ -84,6 +85,10 @@ pub(crate) fn calculate_config_score(
             .map(|c| c.is_feegrant_grantee)
             .unwrap_or_default(),
     };
+
+    if !chain_interaction.can_send_transactions() {
+        version_score = (1. - chain_interactions_penalty) * version_score;
+    }
 
     ConfigScoreV2::new(
         version_score,

--- a/nym-api/src/node_status_api/cache/refresher.rs
+++ b/nym-api/src/node_status_api/cache/refresher.rs
@@ -61,6 +61,9 @@ pub(crate) struct NodeStatusCacheConfig {
 
     /// If use_stress_testing_data is enabled, specifies the weight of the stress testing score in the overall performance score.
     pub(crate) stress_testing_score_weight: f64,
+
+    /// Config score penalty for nodes that do not have a cosmos account capable of interacting with the nyx chain
+    pub(crate) chain_interactions_penalty: f64,
 }
 
 /// A successfully-retrieved chain-capability lookup for a single node, tagged with the instant it
@@ -375,6 +378,7 @@ impl NodeStatusCacheRefresher {
         let minimum_balance = &self.config.minimum_on_chain_balance;
         let use_stress_testing_scores = self.config.use_stress_testing_data;
         let threshold = self.config.minimum_available_stress_testing_results;
+        let chain_interactions_penalty = self.config.chain_interactions_penalty;
 
         // Only mixnodes are currently stress-tested: the orchestrator selects test targets by
         // self-described mixnode capability (see `NodeType::from_roles`), so the availability ratio
@@ -413,6 +417,7 @@ impl NodeStatusCacheRefresher {
                 config_score_data,
                 described,
                 &node_chain_cap,
+                chain_interactions_penalty,
             );
 
             // a node only takes the stress-testing component if it is actually stress-tested (i.e.

--- a/nym-api/src/node_status_api/mod.rs
+++ b/nym-api/src/node_status_api/mod.rs
@@ -75,6 +75,7 @@ pub(crate) async fn start_cache_refresh(
             .performance_provider
             .debug
             .stress_testing_score_weight,
+        chain_interactions_penalty: config.performance_provider.debug.chain_interactions_penalty,
     };
 
     let mut nym_api_cache_refresher = NodeStatusCacheRefresher::new(

--- a/nym-api/src/support/config/mod.rs
+++ b/nym-api/src/support/config/mod.rs
@@ -92,6 +92,7 @@ const DEFAULT_MIN_STRESS_TESTED_NODES: f32 = 0.5;
 const DEFAULT_MIN_STRESS_TESTING_DATA_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 
 const DEFAULT_STRESS_TESTING_SCORE_WEIGHT: f64 = 0.2;
+const DEFAULT_CHAIN_INTERACTIONS_PENALTY: f64 = 0.2;
 
 /// Derive default path to nym-api's config directory.
 /// It should get resolved to `$HOME/.nym/nym-api/<id>/config`
@@ -216,6 +217,7 @@ impl Config {
         }
 
         self.ecash_signer.validate()?;
+        self.performance_provider.validate()?;
 
         Ok(())
     }
@@ -489,6 +491,12 @@ pub struct PerformanceProvider {
     pub debug: PerformanceProviderDebug,
 }
 
+impl PerformanceProvider {
+    fn validate(&self) -> anyhow::Result<()> {
+        self.debug.validate()
+    }
+}
+
 #[allow(clippy::derivable_impls)]
 impl Default for PerformanceProvider {
     fn default() -> Self {
@@ -534,9 +542,24 @@ pub struct PerformanceProviderDebug {
     /// If use_stress_testing_data is enabled, specifies the weight of the stress testing score in the overall performance score.
     pub stress_testing_score_weight: f64,
 
+    /// Config score penalty for nodes that do not have a cosmos account capable of interacting with the nyx chain
+    pub chain_interactions_penalty: f64,
+
     /// Specifies the duration of the rolling average used for stress testing score.
     #[serde(with = "humantime_serde")]
     pub stress_testing_data_period: Duration,
+}
+
+impl PerformanceProviderDebug {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.stress_testing_score_weight < 0.0 || self.stress_testing_score_weight > 1.0 {
+            bail!("the .stress_testing_score_weight field is set to a value outside of the range [0.0, 1.0]");
+        }
+        if self.chain_interactions_penalty < 0.0 || self.chain_interactions_penalty > 1.0 {
+            bail!("the .chain_interactions_penalty field is set to a value outside of the range [0.0, 1.0]");
+        }
+        Ok(())
+    }
 }
 
 #[allow(clippy::derivable_impls)]
@@ -551,6 +574,7 @@ impl Default for PerformanceProviderDebug {
             use_stress_testing_data: false,
             minimum_available_stress_testing_results: DEFAULT_MIN_STRESS_TESTED_NODES,
             stress_testing_score_weight: DEFAULT_STRESS_TESTING_SCORE_WEIGHT,
+            chain_interactions_penalty: DEFAULT_CHAIN_INTERACTIONS_PENALTY,
             stress_testing_data_period: DEFAULT_MIN_STRESS_TESTING_DATA_INTERVAL,
         }
     }

--- a/nym-api/src/support/config/mod.rs
+++ b/nym-api/src/support/config/mod.rs
@@ -552,10 +552,16 @@ pub struct PerformanceProviderDebug {
 
 impl PerformanceProviderDebug {
     pub fn validate(&self) -> anyhow::Result<()> {
-        if self.stress_testing_score_weight < 0.0 || self.stress_testing_score_weight > 1.0 {
+        if self.stress_testing_score_weight < 0.0
+            || self.stress_testing_score_weight > 1.0
+            || !self.stress_testing_score_weight.is_finite()
+        {
             bail!("the .stress_testing_score_weight field is set to a value outside of the range [0.0, 1.0]");
         }
-        if self.chain_interactions_penalty < 0.0 || self.chain_interactions_penalty > 1.0 {
+        if self.chain_interactions_penalty < 0.0
+            || self.chain_interactions_penalty > 1.0
+            || !self.chain_interactions_penalty.is_finite()
+        {
             bail!("the .chain_interactions_penalty field is set to a value outside of the range [0.0, 1.0]");
         }
         Ok(())


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7073)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node status scores now account for whether nodes can successfully send transactions.
  * Added a configurable penalty for limited chain interactions, with a default setting.
* **Bug Fixes**
  * Improved node performance scoring when chain transactions cannot be sent.
* **Configuration**
  * Added validation to ensure performance penalty settings are finite and within the supported 0–1 range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->