### PR TITLE
Network Details DNS Fallback patch

### DIFF
--- a/common/network-defaults/src/mainnet.rs
+++ b/common/network-defaults/src/mainnet.rs
@@ -54,9 +54,9 @@ pub const NYM_APIS: &[ApiUrlConst] = &[
     ApiUrlConst {
         url: "https://nym-frontdoor.global.ssl.fastly.net/api/",
         front_hosts: Some(&[
-            "fastly-support.global.ssl.fastly.net",
+            // "fastly-support.global.ssl.fastly.net",
             "yelp.global.ssl.fastly.net",
-            "pypi.global.ssl.fastly.net",
+            // "pypi.global.ssl.fastly.net",
         ]),
     },
     ApiUrlConst {
@@ -81,9 +81,9 @@ pub const NYM_VPN_APIS: &[ApiUrlConst] = &[
     ApiUrlConst {
         url: "https://nymvpn-frontdoor.global.ssl.fastly.net/api/",
         front_hosts: Some(&[
-            "fastly-support.global.ssl.fastly.net",
+            // "fastly-support.global.ssl.fastly.net",
             "yelp.global.ssl.fastly.net",
-            "pypi.global.ssl.fastly.net",
+            // "pypi.global.ssl.fastly.net",
         ]),
     },
     ApiUrlConst {


### PR DESCRIPTION
Remove two domains from mainnet network/details served by nym-api that can cause issues on older client releases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7083)
<!-- Reviewable:end -->
