### PR TITLE
bugfix: don't use hickory within the credential proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6607,7 +6607,7 @@ dependencies = [
 
 [[package]]
 name = "nym-credential-proxy"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6664,6 +6664,7 @@ dependencies = [
  "nym-crypto",
  "nym-ecash-contract-common",
  "nym-ecash-signer-check",
+ "nym-http-api-client",
  "nym-network-defaults",
  "nym-validator-client",
  "rand 0.8.6",

--- a/common/client-libs/validator-client/src/coconut/mod.rs
+++ b/common/client-libs/validator-client/src/coconut/mod.rs
@@ -20,6 +20,34 @@ pub struct EcashApiClient {
     pub cosmos_address: cosmrs::AccountId,
 }
 
+impl EcashApiClient {
+    pub fn try_construct_from_share(share: ContractVKShare) -> Result<Self, EcashApiError> {
+        if !share.verified {
+            return Err(EcashApiError::UnverifiedShare);
+        }
+
+        let url_address = Url::parse(&share.announce_address)?;
+
+        // The NymApiClient constructed here uses the default (hickory DoT/DoH) resolver because
+        // this EcashApiClient is used by both client and non-client applications.
+        //
+        // In non-client applications this resolver can cause warning logs about H2 connection
+        // failure. This indicates that the long lived https connection was closed by the remote
+        // peer and the resolver will have to reconnect. It should not impact actual functionality
+        let api_client = nym_http_api_client::Client::builder(url_address)
+            .map_err(|e| EcashApiError::ClientError(e.to_string()))?
+            .build()
+            .map_err(|e| EcashApiError::ClientError(e.to_string()))?;
+
+        Ok(EcashApiClient {
+            api_client,
+            verification_key: VerificationKeyAuth::try_from_bs58(&share.share)?,
+            node_id: share.node_index,
+            cosmos_address: share.owner.as_str().parse()?,
+        })
+    }
+}
+
 impl Display for EcashApiClient {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -80,36 +108,6 @@ pub enum EcashApiError {
     },
 }
 
-impl TryFrom<ContractVKShare> for EcashApiClient {
-    type Error = EcashApiError;
-
-    fn try_from(share: ContractVKShare) -> Result<Self, Self::Error> {
-        if !share.verified {
-            return Err(EcashApiError::UnverifiedShare);
-        }
-
-        let url_address = Url::parse(&share.announce_address)?;
-
-        // The NymApiClient constructed here uses the default (hickory DoT/DoH) resolver because
-        // this EcashApiClient is used by both client and non-client applications.
-        //
-        // In non-client applications this resolver can cause warning logs about H2 connection
-        // failure. This indicates that the long lived https connection was closed by the remote
-        // peer and the resolver will have to reconnect. It should not impact actual functionality
-        let api_client = nym_http_api_client::Client::builder(url_address)
-            .map_err(|e| EcashApiError::ClientError(e.to_string()))?
-            .build()
-            .map_err(|e| EcashApiError::ClientError(e.to_string()))?;
-
-        Ok(EcashApiClient {
-            api_client,
-            verification_key: VerificationKeyAuth::try_from_bs58(&share.share)?,
-            node_id: share.node_index,
-            cosmos_address: share.owner.as_str().parse()?,
-        })
-    }
-}
-
 pub async fn all_ecash_api_clients<C>(
     client: &C,
     epoch_id: EpochId,
@@ -122,7 +120,7 @@ where
         .get_all_verification_key_shares(epoch_id)
         .await?
         .into_iter()
-        .map(TryInto::try_into)
+        .map(EcashApiClient::try_construct_from_share)
         .collect::<Result<Vec<_>, _>>()
 
     // ... if not, let's switch to the below:

--- a/common/credential-proxy/Cargo.toml
+++ b/common/credential-proxy/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }
+nym-http-api-client = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate", "time"] }
 time = { workspace = true }
 thiserror = { workspace = true }

--- a/common/credential-proxy/src/shared_state/ecash_state.rs
+++ b/common/credential-proxy/src/shared_state/ecash_state.rs
@@ -10,28 +10,31 @@ use crate::shared_state::nyxd_client::ChainClient;
 use crate::shared_state::required_deposit_cache::RequiredDepositCache;
 use crate::storage::traits::GlobalEcashDataCache;
 use nym_cache::CachedImmutableItems;
+use nym_compact_ecash::Base58;
+pub use nym_compact_ecash::VerificationKeyAuth;
+pub use nym_compact_ecash::scheme::coin_indices_signatures::CoinIndexSignatureShare;
 use nym_compact_ecash::scheme::coin_indices_signatures::aggregate_annotated_indices_signatures;
+pub use nym_compact_ecash::scheme::expiration_date_signatures::ExpirationDateSignatureShare;
 use nym_compact_ecash::scheme::expiration_date_signatures::aggregate_annotated_expiration_signatures;
 use nym_credentials::ecash::utils::EcashTime;
 use nym_credentials::{
     AggregatedCoinIndicesSignatures, AggregatedExpirationDateSignatures, EpochVerificationKey,
 };
+pub use nym_credentials::{IssuanceTicketBook, IssuedTicketBook};
+pub use nym_credentials_interface::{TicketType, TicketTypeRepr};
+use nym_http_api_client::{UserAgent, bin_info};
 use nym_validator_client::EcashApiClient;
 use nym_validator_client::client::NymApiClientExt;
 use nym_validator_client::coconut::EcashApiError;
 use nym_validator_client::nym_api::EpochId;
 use nym_validator_client::nyxd::Coin;
-use nym_validator_client::nyxd::contract_traits::dkg_query_client::Epoch;
+use nym_validator_client::nyxd::contract_traits::dkg_query_client::{ContractVKShare, Epoch};
 use nym_validator_client::nyxd::contract_traits::{DkgQueryClient, PagedDkgQueryClient};
+use std::time::Duration;
 use time::{Date, OffsetDateTime};
 use tokio::sync::{RwLock, RwLockReadGuard};
 use tracing::info;
-
-pub use nym_compact_ecash::VerificationKeyAuth;
-pub use nym_compact_ecash::scheme::coin_indices_signatures::CoinIndexSignatureShare;
-pub use nym_compact_ecash::scheme::expiration_date_signatures::ExpirationDateSignatureShare;
-pub use nym_credentials::{IssuanceTicketBook, IssuedTicketBook};
-pub use nym_credentials_interface::{TicketType, TicketTypeRepr};
+use url::Url;
 
 pub struct EcashState {
     pub required_deposit_cache: RequiredDepositCache,
@@ -50,6 +53,29 @@ pub struct EcashState {
 
     pub expiration_date_signatures:
         CachedImmutableItems<(EpochId, Date), AggregatedExpirationDateSignatures>,
+}
+
+fn construct_ecash_api_client(share: ContractVKShare) -> Result<EcashApiClient, EcashApiError> {
+    if !share.verified {
+        return Err(EcashApiError::UnverifiedShare);
+    }
+
+    let url_address = Url::parse(&share.announce_address)?;
+
+    let api_client = nym_http_api_client::Client::builder(url_address)
+        .map_err(|e| EcashApiError::ClientError(e.to_string()))?
+        .with_timeout(Duration::from_secs(5))
+        .with_user_agent(UserAgent::from(bin_info!()))
+        .no_hickory_dns()
+        .build()
+        .map_err(|e| EcashApiError::ClientError(e.to_string()))?;
+
+    Ok(EcashApiClient {
+        api_client,
+        verification_key: VerificationKeyAuth::try_from_bs58(&share.share)?,
+        node_id: share.node_index,
+        cosmos_address: share.owner.as_str().parse()?,
+    })
 }
 
 impl EcashState {
@@ -110,7 +136,7 @@ impl EcashState {
                     .get_all_verification_key_shares(epoch_id)
                     .await?
                     .into_iter()
-                    .map(TryInto::try_into)
+                    .map(construct_ecash_api_client)
                     .collect::<anyhow::Result<Vec<_>, EcashApiError>>()?)
             })
             .await

--- a/common/ecash-signer-check/src/client_check.rs
+++ b/common/ecash-signer-check/src/client_check.rs
@@ -4,6 +4,7 @@
 use crate::{LocalChainStatus, SignerCheckError, SigningStatus, TypedSignerResult};
 use nym_ecash_signer_check_types::dealer_information::RawDealerInformation;
 use nym_ecash_signer_check_types::status::{SignerStatus, SignerTestResult};
+use nym_http_api_client::{UserAgent, bin_info};
 use nym_validator_client::models::BinaryBuildInformationOwned;
 use nym_validator_client::nym_api::NymApiClientExt;
 use nym_validator_client::nyxd::contract_traits::dkg_query_client::{
@@ -39,7 +40,11 @@ impl ClientUnderTest {
     pub(crate) fn new(api_url: &Url) -> Result<Self, SignerCheckError> {
         // The builder should not fail with a valid URL that's already parsed
         // If it does fail, it's an internal error that we can't recover from
-        let api_client = nym_http_api_client::Client::builder(api_url.clone())?.build()?;
+        let api_client = nym_http_api_client::Client::builder(api_url.clone())?
+            .with_timeout(Duration::from_secs(5))
+            .with_user_agent(UserAgent::from(bin_info!()))
+            .no_hickory_dns()
+            .build()?;
 
         Ok(ClientUnderTest {
             api_client,

--- a/nym-api/src/ecash/tests/mod.rs
+++ b/nym-api/src/ecash/tests/mod.rs
@@ -8,7 +8,7 @@ use crate::ecash::state::EcashState;
 use crate::node_families::cache::NodeFamiliesCacheData;
 use crate::support::caching::cache::SharedCache;
 use crate::support::config;
-use crate::support::nyxd::Client;
+use crate::support::nyxd::{construct_ecash_api_client, Client};
 use crate::support::storage::NymApiStorage;
 use async_trait::async_trait;
 use axum::Router;
@@ -841,7 +841,7 @@ impl super::client::Client for DummyClient {
             .get_verification_key_shares(epoch_id)
             .await?
             .into_iter()
-            .map(|s| s.try_into().unwrap())
+            .map(|s| construct_ecash_api_client(s).unwrap())
             .collect())
     }
 

--- a/nym-api/src/support/nyxd/mod.rs
+++ b/nym-api/src/support/nyxd/mod.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use cw3::{ProposalResponse, VoteResponse};
 use cw4::MemberResponse;
+use nym_bin_common::bin_info;
 use nym_coconut_dkg_common::dealer::RegisteredDealerDetails;
 use nym_coconut_dkg_common::dealing::{
     DealerDealingsStatusResponse, DealingChunkInfo, DealingMetadata, DealingStatusResponse,
@@ -20,10 +21,12 @@ use nym_coconut_dkg_common::{
     types::{EncodedBTEPublicKeyWithProof, Epoch},
     verification_key::{ContractVKShare, VerificationKeyShare},
 };
+use nym_compact_ecash::{Base58, VerificationKeyAuth};
 use nym_config::defaults::{ChainDetails, NymNetworkDetails};
 use nym_dkg::Threshold;
 use nym_ecash_contract_common::blacklist::BlacklistedAccountResponse;
 use nym_ecash_contract_common::deposit::{DepositId, DepositResponse};
+use nym_http_api_client::UserAgent;
 use nym_mixnet_contract_common::gateway::PreassignedId;
 use nym_mixnet_contract_common::mixnode::MixNodeDetails;
 use nym_mixnet_contract_common::nym_node::Role;
@@ -65,8 +68,10 @@ use nym_validator_client::{
 };
 use serde::Deserialize;
 use std::sync::Arc;
+use std::time::Duration;
 use tendermint::abci::response::Info;
 use tokio::sync::{RwLock, RwLockReadGuard};
+use url::Url;
 
 #[macro_export]
 macro_rules! query_guard {
@@ -476,6 +481,31 @@ impl Client {
     }
 }
 
+fn construct_ecash_api_client(
+    share: ContractVKShare,
+) -> std::result::Result<EcashApiClient, EcashApiError> {
+    if !share.verified {
+        return Err(EcashApiError::UnverifiedShare);
+    }
+
+    let url_address = Url::parse(&share.announce_address)?;
+
+    let api_client = nym_http_api_client::Client::builder(url_address)
+        .map_err(|e| EcashApiError::ClientError(e.to_string()))?
+        .with_timeout(Duration::from_secs(5))
+        .with_user_agent(UserAgent::from(bin_info!()))
+        .no_hickory_dns()
+        .build()
+        .map_err(|e| EcashApiError::ClientError(e.to_string()))?;
+
+    Ok(EcashApiClient {
+        api_client,
+        verification_key: VerificationKeyAuth::try_from_bs58(&share.share)?,
+        node_id: share.node_index,
+        cosmos_address: share.owner.as_str().parse()?,
+    })
+}
+
 #[async_trait]
 impl crate::ecash::client::Client for Client {
     async fn address(&self) -> Result<AccountId, EcashError> {
@@ -668,7 +698,7 @@ impl crate::ecash::client::Client for Client {
             .get_verification_key_shares(epoch_id)
             .await?
             .into_iter()
-            .map(TryInto::try_into)
+            .map(construct_ecash_api_client)
             .collect::<Result<Vec<_>, EcashApiError>>()?)
     }
 

--- a/nym-api/src/support/nyxd/mod.rs
+++ b/nym-api/src/support/nyxd/mod.rs
@@ -481,7 +481,7 @@ impl Client {
     }
 }
 
-fn construct_ecash_api_client(
+pub(crate) fn construct_ecash_api_client(
     share: ContractVKShare,
 ) -> std::result::Result<EcashApiClient, EcashApiError> {
     if !share.verified {

--- a/nym-credential-proxy/nym-credential-proxy/Cargo.toml
+++ b/nym-credential-proxy/nym-credential-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nym-credential-proxy"
-version = "0.3.3"
+version = "0.3.4"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/nym-wallet/Cargo.lock
+++ b/nym-wallet/Cargo.lock
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "nym-directory-attestation"
-version = "1.21.5-rc.1"
+version = "1.21.5"
 dependencies = [
  "async-trait",
  "blake3",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "nym-directory-contract-common"
-version = "1.21.5-rc.1"
+version = "1.21.5"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -5262,7 +5262,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-controllers",
  "nym-mixnet-contract-common",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -5345,7 +5345,7 @@ dependencies = [
 
 [[package]]
 name = "nym-lthash"
-version = "1.21.5-rc.1"
+version = "1.21.5"
 dependencies = [
  "blake3",
  "digest 0.10.7",


### PR DESCRIPTION
cherry-picks changes from [release/2026.16.1-como-patched](https://github.com/nymtech/nym/compare/release/2026.16.1-como-patched)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7091)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - eCash clients now reject unverified contract key shares before use.
  - Improved handling of announced service URLs during client setup.
  - Added a five-second network timeout to improve responsiveness when services are unavailable.
  - Network requests now identify the running application and use more consistent DNS handling.

- **Reliability**
  - Updated eCash client creation flows to use consistent validation and connection settings across supported services.
  - Improved resilience when connecting to unavailable or incorrectly configured services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->