### PR TITLE
bugfix: fix various bugs within nym-api making future re-DKG smoother [vol4]

### DIFF
--- a/common/bandwidth-fetcher/src/credentials.rs
+++ b/common/bandwidth-fetcher/src/credentials.rs
@@ -83,8 +83,10 @@ where
 
             // a ceremony running no longer means issuance is unavailable: signers keep issuing
             // under the epoch it is replacing. The only genuine wait is for the very first
-            // ceremony, before any epoch has concluded and there is nothing to issue under.
-            if epoch.state.is_final() || epoch.epoch_id > 0 {
+            // ceremony, before any epoch has concluded and there is nothing to issue under - which
+            // a non-zero epoch id is no proof of, since a failed ceremony moves that id on without
+            // producing any keys.
+            if epoch.issuing_epoch_id().is_some() {
                 break;
             } else if let Some(final_timestamp) = epoch.final_timestamp_secs() {
                 // Use 1 additional second to not start the next iteration immediately and spam get_current_epoch queries
@@ -204,18 +206,15 @@ where
     }
 
     /// The epoch signers are currently issuing under: the most recent whose DKG ceremony has
-    /// concluded. While a ceremony runs that is the epoch before the current one, whose keys exist
-    /// and whose credentials are still circulating - issuance does not stop for the ceremony.
+    /// concluded. While a ceremony runs that is an earlier epoch, whose keys exist and whose
+    /// credentials are still circulating - issuance does not stop for the ceremony. Not
+    /// necessarily the epoch directly below the current id: a ceremony that failed moved that id
+    /// on without producing keys, and the epoch it abandoned is not issuable by anyone.
     async fn issuable_epoch(&self) -> Result<EpochId, NyxdFetcherError> {
-        let epoch = self.client.get_current_epoch().await?;
-
-        if epoch.state.is_in_progress() {
-            return Ok(epoch.epoch_id);
-        }
-
-        epoch
-            .epoch_id
-            .checked_sub(1)
+        self.client
+            .get_current_epoch()
+            .await?
+            .issuing_epoch_id()
             .ok_or(NyxdFetcherError::NoIssuableEpoch)
     }
 }

--- a/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
+++ b/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::derivable_impls)]
 // MAX: surpressing warning for the moment, will be dealt with in a different PR (TODO)
 use cosmwasm_schema::cw_serde;
-use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
@@ -176,6 +175,23 @@ pub struct Epoch {
     /// `None` for an epoch mid-ceremony, and for one that concluded before this field existed.
     #[serde(default)]
     pub ceremony_concluded_at: Option<Timestamp>,
+
+    /// The epoch whose keys signers are issuing under.
+    ///
+    /// Only a concluded ceremony puts keys into service, so this is not `epoch_id - 1` while a
+    /// ceremony runs: the id also increments when a ceremony *fails*, leaving an epoch behind
+    /// with no keys and never any.
+    ///
+    /// `None` before the first ceremony concludes, and on an epoch stored before this field
+    /// existed. Read that as "unknown", never as "none in service".
+    #[serde(default)]
+    pub keys_in_service: Option<EpochId>,
+
+    /// The epoch [`Self::keys_in_service`] replaced, for the window in which a collection begun
+    /// under it may still be completed. Likewise not `keys_in_service - 1`: any number of failed
+    /// ceremonies may sit between the two.
+    #[serde(default)]
+    pub outgoing_keys: Option<EpochId>,
 }
 
 impl Epoch {
@@ -195,6 +211,10 @@ impl Epoch {
             deadline: duration.map(|d| current_timestamp.plus_seconds(d)),
             // a freshly constructed epoch is one whose ceremony is about to run
             ceremony_concluded_at: None,
+            // and one that has produced no keys, so it puts none into service. an epoch
+            // succeeding another carries its predecessor's answer over - see `next_reset`
+            keys_in_service: None,
+            outgoing_keys: None,
         }
     }
 
@@ -207,42 +227,67 @@ impl Epoch {
         // so this is written exactly once per key generation
         if next_state.is_in_progress() {
             self.ceremony_concluded_at = Some(current_timestamp);
+
+            // and it is the moment this epoch's keys come into service, superseding whichever
+            // generation held that position - not `epoch_id - 1`, which may be an epoch that a
+            // failed ceremony abandoned
+            self.outgoing_keys = self.keys_in_service;
+            self.keys_in_service = Some(self.epoch_id);
         }
 
         self
     }
 
     pub fn next_reset(self, current_timestamp: Timestamp) -> Self {
-        Epoch::new(
-            EpochState::PublicKeySubmission { resharing: false },
-            self.epoch_id + 1,
-            self.time_configuration,
+        self.next_ceremony(false, current_timestamp)
+    }
+
+    pub fn next_resharing(self, current_timestamp: Timestamp) -> Self {
+        self.next_ceremony(true, current_timestamp)
+    }
+
+    /// The epoch a fresh ceremony runs under, succeeding `self` whether it concluded or failed.
+    fn next_ceremony(mut self, resharing: bool, current_timestamp: Timestamp) -> Self {
+        self.epoch_id += 1;
+        self.state_progress = Default::default();
+        self.ceremony_concluded_at = None;
+
+        // `keys_in_service` and `outgoing_keys` are deliberately left alone: a ceremony starting -
+        // or failing - retires nothing, so the generation in service keeps serving until a
+        // *successful* ceremony replaces it
+        self.update(
+            EpochState::PublicKeySubmission { resharing },
             current_timestamp,
         )
     }
 
-    pub fn next_resharing(self, current_timestamp: Timestamp) -> Self {
-        Epoch::new(
-            EpochState::PublicKeySubmission { resharing: true },
-            self.epoch_id + 1,
-            self.time_configuration,
-            current_timestamp,
-        )
+    /// The epoch a fresh issuance is signed under, or `None` if no key generation is in service.
+    pub fn issuing_epoch_id(&self) -> Option<EpochId> {
+        // an epoch in service is its own answer, which keeps this honest against an epoch stored
+        // before `keys_in_service` existed
+        if self.state.is_final() {
+            return Some(self.epoch_id);
+        }
+
+        self.keys_in_service
     }
 
     /// Whether the DKG ceremony that establishes `epoch_id`'s keys has finished, judged against
     /// `self` as the current epoch. Note this says nothing about whether that epoch is *over* -
     /// the current epoch's own ceremony is concluded for all of the time it is in use.
     ///
-    /// The ceremony of any epoch before the current one has necessarily finished, and one that
-    /// has not been reached yet certainly has not started. Callers working from a cached copy of
-    /// the current epoch can only get a pessimistic answer out of a stale one, never a premature
+    /// Sitting below the current epoch is not enough: a failed ceremony moves the id on and
+    /// leaves an epoch behind that concluded nothing, and calling that concluded would let
+    /// callers cache its empty signer set for good. So the boundary is the epoch in service,
+    /// which no unconcluded epoch is ever ahead of. Callers working from a cached copy of the
+    /// current epoch can only get a pessimistic answer out of a stale one, never a premature
     /// "yes".
     pub fn is_ceremony_concluded(&self, epoch_id: EpochId) -> bool {
-        match epoch_id.cmp(&self.epoch_id) {
-            Ordering::Less => true,
-            Ordering::Greater => false,
-            Ordering::Equal => self.state.is_in_progress(),
+        match self.issuing_epoch_id() {
+            Some(in_service) => epoch_id <= in_service,
+            // nothing has ever concluded, or a contract predating the field is mid-ceremony,
+            // where refusing to cache is the safe answer
+            None => false,
         }
     }
 
@@ -400,6 +445,96 @@ mod tests {
         )
     }
 
+    /// An epoch whose ceremony concluded, reached the way the chain reaches it: by advancing into
+    /// `InProgress`, never by being constructed there.
+    fn concluded(epoch_id: EpochId) -> Epoch {
+        epoch_at(
+            epoch_id,
+            EpochState::VerificationKeyFinalization { resharing: false },
+        )
+        .update(EpochState::InProgress, Timestamp::from_seconds(1234))
+    }
+
+    /// Nothing is in service until a ceremony finishes, and the epoch id cannot say so on its
+    /// own: it counts ceremonies started, not key generations produced.
+    #[test]
+    fn no_keys_are_in_service_before_the_first_ceremony_concludes() {
+        let uninitialised = epoch_at(0, EpochState::WaitingInitialisation);
+        assert_eq!(None, uninitialised.keys_in_service);
+        assert_eq!(None, uninitialised.issuing_epoch_id());
+
+        let first_ceremony = epoch_at(0, EpochState::DealingExchange { resharing: false });
+        assert_eq!(None, first_ceremony.issuing_epoch_id());
+    }
+
+    #[test]
+    fn concluding_a_ceremony_puts_its_own_keys_into_service() {
+        let concluded = concluded(3);
+
+        assert_eq!(Some(3), concluded.keys_in_service);
+        assert_eq!(Some(3), concluded.issuing_epoch_id());
+    }
+
+    /// B1: the epoch a ceremony is running for has no keys yet, so the generation already in
+    /// service stays there for the duration.
+    #[test]
+    fn a_running_ceremony_leaves_the_keys_already_in_service_alone() {
+        let mid_ceremony = concluded(3).next_reset(Timestamp::from_seconds(2000));
+
+        assert_eq!(4, mid_ceremony.epoch_id);
+        assert_eq!(Some(3), mid_ceremony.issuing_epoch_id());
+    }
+
+    #[test]
+    fn resharing_also_leaves_the_keys_in_service_alone() {
+        let mid_resharing = concluded(3).next_resharing(Timestamp::from_seconds(2000));
+
+        assert_eq!(4, mid_resharing.epoch_id);
+        assert_eq!(Some(3), mid_resharing.issuing_epoch_id());
+    }
+
+    /// A ceremony that fails takes the epoch id with it and leaves the keys where they were.
+    /// Deriving the issuing epoch as `current - 1` instead names epoch 4 here: an epoch that
+    /// never concluded, has no aggregate key, and never will.
+    #[test]
+    fn a_failed_ceremony_does_not_retire_the_keys_in_service() {
+        // epoch 3's keys are in service; the ceremony for 4 runs, fails, and the contract resets
+        // into 5 rather than remaining on an epoch it cannot complete
+        let after_failure = concluded(3)
+            .next_reset(Timestamp::from_seconds(2000))
+            .next_reset(Timestamp::from_seconds(3000));
+
+        assert_eq!(5, after_failure.epoch_id);
+        assert_eq!(Some(3), after_failure.issuing_epoch_id());
+    }
+
+    /// However many failed on the way, the epoch superseded by a conclusion is the one that was
+    /// actually in service - which the grace window then names, so a collection begun under it
+    /// can still be completed.
+    #[test]
+    fn concluding_after_failures_supersedes_the_epoch_that_was_in_service() {
+        let concluded_at_last = concluded(3)
+            .next_reset(Timestamp::from_seconds(2000)) // ceremony 4, fails
+            .next_reset(Timestamp::from_seconds(3000)) // ceremony 5, fails
+            .next_reset(Timestamp::from_seconds(4000)) // ceremony 6, concludes
+            .update(EpochState::InProgress, Timestamp::from_seconds(5000));
+
+        assert_eq!(6, concluded_at_last.epoch_id);
+        assert_eq!(Some(6), concluded_at_last.issuing_epoch_id());
+        assert_eq!(Some(3), concluded_at_last.outgoing_keys);
+    }
+
+    /// A contract that has not been migrated yet reports nothing in service while a ceremony
+    /// runs, which refuses issuance for its duration - the behaviour from before mid-ceremony
+    /// issuance existed, and the safe direction. The conclusion then writes the real value.
+    #[test]
+    fn an_unseeded_epoch_mid_ceremony_reports_nothing_in_service() {
+        let unseeded = epoch_at(5, EpochState::DealingExchange { resharing: false });
+
+        assert_eq!(None, unseeded.keys_in_service);
+        assert_eq!(None, unseeded.issuing_epoch_id());
+    }
+
     /// When a ceremony concluded is the only record of when a key generation came into service.
     /// Nothing else on chain carries it: the epoch id increments when a ceremony *starts*, and
     /// the deadline is per-state. Sizing anything against the age of the current keys - the
@@ -467,6 +602,13 @@ mod tests {
         assert_eq!(epoch.epoch_id, 0);
         assert!(epoch.state.is_in_progress());
         assert_eq!(epoch.ceremony_concluded_at, None);
+
+        // which keys are in service is unrecorded too, but unlike the conclusion time it is
+        // recoverable: an epoch in service is its own answer, so issuance keeps working against
+        // a contract that has not been migrated yet
+        assert_eq!(None, epoch.keys_in_service);
+        assert_eq!(None, epoch.outgoing_keys);
+        assert_eq!(Some(0), epoch.issuing_epoch_id());
     }
 
     /// A fresh ceremony has not concluded, whatever the epoch it replaced had recorded.
@@ -482,31 +624,52 @@ mod tests {
         assert_eq!(reset.ceremony_concluded_at, None);
     }
 
-    /// Signer sets are only settled once a ceremony finishes, and callers cache them per epoch.
-    /// Answering "concluded" for an epoch still mid-ceremony would have them remember a set
-    /// that is empty or partial.
+    /// Signer sets are only settled once a ceremony finishes, and callers cache them per epoch
+    /// with no expiry. Answering "concluded" for an epoch still mid-ceremony - or for one a
+    /// failed ceremony abandoned - would have them remember a set that is empty or partial.
     #[test]
-    fn a_ceremony_is_concluded_only_once_its_epoch_is_in_progress() {
-        let current = epoch_at(5, EpochState::InProgress);
+    fn a_ceremony_is_concluded_only_once_its_keys_are_in_service() {
+        let current = concluded(5);
 
-        // earlier ceremonies are finished by definition, and later ones cannot have started
+        // earlier ceremonies are finished, and later ones cannot have started
         assert!(current.is_ceremony_concluded(4));
         assert!(!current.is_ceremony_concluded(6));
 
         // the current epoch's own ceremony is concluded for all the time it is in use
         assert!(current.is_ceremony_concluded(5));
+
+        // whichever phase a ceremony is in, its own epoch has not concluded
         for state in [
-            EpochState::WaitingInitialisation,
             EpochState::PublicKeySubmission { resharing: false },
             EpochState::DealingExchange { resharing: false },
             EpochState::VerificationKeySubmission { resharing: true },
             EpochState::VerificationKeyValidation { resharing: false },
             EpochState::VerificationKeyFinalization { resharing: false },
         ] {
+            let in_flight = current
+                .next_reset(Timestamp::from_seconds(2000))
+                .update(state, Timestamp::from_seconds(2000));
+
             assert!(
-                !epoch_at(5, state).is_ceremony_concluded(5),
+                !in_flight.is_ceremony_concluded(6),
                 "{state} was treated as a concluded ceremony"
             );
+            // and the generation still in service remains concluded throughout
+            assert!(in_flight.is_ceremony_concluded(5));
         }
+    }
+
+    /// An epoch a failed ceremony left behind sits *below* the current id while having concluded
+    /// nothing, so proximity to the current epoch cannot be what settles this.
+    #[test]
+    fn an_epoch_abandoned_by_a_failed_ceremony_never_counts_as_concluded() {
+        let after_failure = concluded(5)
+            .next_reset(Timestamp::from_seconds(2000))
+            .next_reset(Timestamp::from_seconds(3000));
+
+        assert_eq!(7, after_failure.epoch_id);
+        assert!(!after_failure.is_ceremony_concluded(7));
+        assert!(!after_failure.is_ceremony_concluded(6));
+        assert!(after_failure.is_ceremony_concluded(5));
     }
 }

--- a/common/credential-proxy/src/shared_state/ecash_state.rs
+++ b/common/credential-proxy/src/shared_state/ecash_state.rs
@@ -165,8 +165,9 @@ impl EcashState {
 
         // a ceremony running no longer stops issuance: signers keep issuing under the epoch it is
         // replacing, so the only genuine refusal is when no epoch has ever concluded and there is
-        // nothing to issue under at all
-        if epoch.state.is_final() || epoch.epoch_id > 0 {
+        // nothing to issue under at all. that is not "epoch 0" - a ceremony that fails moves the
+        // id on without producing keys, so the first one can be retried arbitrarily far
+        if epoch.issuing_epoch_id().is_some() {
             Ok(())
         } else if let Some(final_timestamp) = epoch.final_timestamp_secs() {
             // SAFETY: the timestamp values in our DKG contract should be valid timestamps,
@@ -258,8 +259,9 @@ impl EcashState {
     }
 
     /// The epoch signers are issuing under: the most recent whose ceremony has concluded. While a
-    /// ceremony runs that is the epoch before the current one, whose keys exist and whose
-    /// credentials are still circulating.
+    /// ceremony runs that is an earlier epoch, whose keys exist and whose credentials are still
+    /// circulating - not necessarily the one directly below the current id, since a ceremony that
+    /// failed moved that id on without producing any keys.
     ///
     /// Everything about one request has to agree on this - the signers asked, the threshold, the
     /// auxiliary data returned alongside the shares, and the epoch stated on each request - so it
@@ -268,15 +270,9 @@ impl EcashState {
         &self,
         client: &impl EpochSource,
     ) -> Result<EpochId, CredentialProxyError> {
-        let epoch = self.current_epoch(client).await?;
-
-        if epoch.state.is_final() {
-            return Ok(epoch.epoch_id);
-        }
-
-        epoch
-            .epoch_id
-            .checked_sub(1)
+        self.current_epoch(client)
+            .await?
+            .issuing_epoch_id()
             .ok_or(CredentialProxyError::UninitialisedDkg)
     }
 
@@ -507,6 +503,7 @@ impl EcashState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::StatusCode;
     use cosmwasm_std::Timestamp;
     use nym_validator_client::nyxd::contract_traits::dkg_query_client::EpochState;
 
@@ -528,6 +525,7 @@ mod tests {
         FixedEpoch(Epoch {
             state: EpochState::DealingExchange { resharing: true },
             epoch_id,
+            keys_in_service: epoch_id.checked_sub(1),
             ..Default::default()
         })
     }
@@ -537,6 +535,19 @@ mod tests {
         FixedEpoch(Epoch {
             state: EpochState::InProgress,
             epoch_id,
+            keys_in_service: Some(epoch_id),
+            ..Default::default()
+        })
+    }
+
+    /// The ceremony for `epoch_id` failed, so the contract reset into a fresh id while
+    /// `in_service` kept serving - however many attempts it has taken.
+    fn after_failed_ceremony(epoch_id: EpochId, in_service: Option<EpochId>) -> FixedEpoch {
+        FixedEpoch(Epoch {
+            state: EpochState::PublicKeySubmission { resharing: false },
+            epoch_id,
+            keys_in_service: in_service,
+            deadline: Some(Timestamp::from_seconds(1_700_000_000)),
             ..Default::default()
         })
     }
@@ -640,5 +651,44 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, CredentialProxyError::UninitialisedDkg));
+    }
+
+    /// A failed ceremony leaves the epoch id ahead of the keys, by as many attempts as it takes.
+    /// The proxy issues under the generation actually in service rather than the id below the
+    /// current one, which by then names an epoch that concluded nothing.
+    #[tokio::test]
+    async fn issuance_continues_under_the_epoch_in_service_after_failed_ceremonies() {
+        let after_two_failures = after_failed_ceremony(7, Some(4));
+
+        assert!(
+            state()
+                .ensure_credentials_issuable(&after_two_failures)
+                .await
+                .is_ok()
+        );
+        assert_eq!(
+            4,
+            state()
+                .issuable_epoch_id(&after_two_failures)
+                .await
+                .unwrap()
+        );
+    }
+
+    /// When it is the *first* ceremony that keeps failing there is still nothing to issue under,
+    /// however far the epoch id has run on. Refusing as "not yet issuable" makes that retryable:
+    /// the condition clears the moment a ceremony finally concludes.
+    #[tokio::test]
+    async fn issuance_is_refused_while_the_first_ceremony_is_still_being_retried() {
+        let err = state()
+            .ensure_credentials_issuable(&after_failed_ceremony(3, None))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            CredentialProxyError::CredentialsNotYetIssuable { .. }
+        ));
+        assert_eq!(StatusCode::SERVICE_UNAVAILABLE, err.status_code());
     }
 }

--- a/contracts/coconut-dkg/schema/nym-coconut-dkg.json
+++ b/contracts/coconut-dkg/schema/nym-coconut-dkg.json
@@ -1264,6 +1264,26 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "keys_in_service": {
+          "description": "The epoch whose keys signers are issuing under.\n\nOnly a concluded ceremony puts keys into service, so this is not `epoch_id - 1` while a ceremony runs: the id also increments when a ceremony *fails*, leaving an epoch behind with no keys and never any.\n\n`None` before the first ceremony concludes, and on an epoch stored before this field existed. Read that as \"unknown\", never as \"none in service\".",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "outgoing_keys": {
+          "description": "The epoch [`Self::keys_in_service`] replaced, for the window in which a collection begun under it may still be completed. Likewise not `keys_in_service - 1`: any number of failed ceremonies may sit between the two.",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "state": {
           "$ref": "#/definitions/EpochState"
         },
@@ -2171,6 +2191,26 @@
             },
             "epoch_id": {
               "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "keys_in_service": {
+              "description": "The epoch whose keys signers are issuing under.\n\nOnly a concluded ceremony puts keys into service, so this is not `epoch_id - 1` while a ceremony runs: the id also increments when a ceremony *fails*, leaving an epoch behind with no keys and never any.\n\n`None` before the first ceremony concludes, and on an epoch stored before this field existed. Read that as \"unknown\", never as \"none in service\".",
+              "default": null,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "outgoing_keys": {
+              "description": "The epoch [`Self::keys_in_service`] replaced, for the window in which a collection begun under it may still be completed. Likewise not `keys_in_service - 1`: any number of failed ceremonies may sit between the two.",
+              "default": null,
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "uint64",
               "minimum": 0.0
             },

--- a/contracts/coconut-dkg/schema/raw/response_to_get_current_epoch_state.json
+++ b/contracts/coconut-dkg/schema/raw/response_to_get_current_epoch_state.json
@@ -36,6 +36,26 @@
       "format": "uint64",
       "minimum": 0.0
     },
+    "keys_in_service": {
+      "description": "The epoch whose keys signers are issuing under.\n\nOnly a concluded ceremony puts keys into service, so this is not `epoch_id - 1` while a ceremony runs: the id also increments when a ceremony *fails*, leaving an epoch behind with no keys and never any.\n\n`None` before the first ceremony concludes, and on an epoch stored before this field existed. Read that as \"unknown\", never as \"none in service\".",
+      "default": null,
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "outgoing_keys": {
+      "description": "The epoch [`Self::keys_in_service`] replaced, for the window in which a collection begun under it may still be completed. Likewise not `keys_in_service - 1`: any number of failed ceremonies may sit between the two.",
+      "default": null,
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "state": {
       "$ref": "#/definitions/EpochState"
     },

--- a/contracts/coconut-dkg/schema/raw/response_to_get_epoch_state_at_height.json
+++ b/contracts/coconut-dkg/schema/raw/response_to_get_epoch_state_at_height.json
@@ -46,6 +46,26 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "keys_in_service": {
+          "description": "The epoch whose keys signers are issuing under.\n\nOnly a concluded ceremony puts keys into service, so this is not `epoch_id - 1` while a ceremony runs: the id also increments when a ceremony *fails*, leaving an epoch behind with no keys and never any.\n\n`None` before the first ceremony concludes, and on an epoch stored before this field existed. Read that as \"unknown\", never as \"none in service\".",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "outgoing_keys": {
+          "description": "The epoch [`Self::keys_in_service`] replaced, for the window in which a collection begun under it may still be completed. Likewise not `keys_in_service - 1`: any number of failed ceremonies may sit between the two.",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "state": {
           "$ref": "#/definitions/EpochState"
         },

--- a/contracts/coconut-dkg/src/contract.rs
+++ b/contracts/coconut-dkg/src/contract.rs
@@ -18,7 +18,7 @@ use crate::epoch_state::queries::{
     query_can_advance_state, query_current_epoch, query_current_epoch_threshold,
     query_epoch_at_height, query_epoch_threshold,
 };
-use crate::epoch_state::storage::save_epoch;
+use crate::epoch_state::storage::{load_current_epoch, save_epoch};
 use crate::epoch_state::transactions::{
     try_advance_epoch_state, try_initiate_dkg, try_trigger_reset, try_trigger_resharing,
 };
@@ -29,7 +29,7 @@ use crate::verification_key_shares::queries::{query_vk_share, query_vk_shares_pa
 use crate::verification_key_shares::transactions::try_commit_verification_key_share;
 use crate::verification_key_shares::transactions::try_verify_verification_key_share;
 use cosmwasm_std::{
-    entry_point, to_json_binary, Deps, DepsMut, Env, MessageInfo, QueryResponse, Response,
+    entry_point, to_json_binary, Deps, DepsMut, Env, MessageInfo, QueryResponse, Response, Storage,
 };
 use cw4::Cw4Contract;
 use nym_coconut_dkg_common::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
@@ -257,11 +257,136 @@ pub fn query(deps: Deps<'_>, env: Env, msg: QueryMsg) -> Result<QueryResponse, C
 }
 
 #[entry_point]
-pub fn migrate(deps: DepsMut<'_>, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(deps: DepsMut<'_>, env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     set_build_information!(deps.storage)?;
     cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
+    seed_keys_in_service(deps.storage, env.block.height)?;
+
     Ok(Response::new())
+}
+
+/// Record the epoch already in service on a contract stored before [`Epoch::keys_in_service`]
+/// existed.
+///
+/// Only an epoch that is in service is seeded, because that is the only case the chain still
+/// knows the answer to: such an epoch concluded its own ceremony, so it is its own answer. Any
+/// other state is left unknown rather than derived from the epoch id, which is the guess this
+/// field exists to remove. Unknown refuses issuance until the next conclusion writes the truth,
+/// which is the safe direction and self-correcting.
+///
+/// Skipped once anything is recorded: re-deriving it later would overwrite a true value, and
+/// after a failed ceremony would overwrite it with precisely the wrong one.
+fn seed_keys_in_service(storage: &mut dyn Storage, height: u64) -> Result<(), ContractError> {
+    let epoch = load_current_epoch(storage)?;
+    if epoch.keys_in_service.is_some() || !epoch.state.is_final() {
+        return Ok(());
+    }
+
+    save_epoch(
+        storage,
+        height,
+        &Epoch {
+            keys_in_service: Some(epoch.epoch_id),
+            // whatever this epoch superseded is unrecorded and unrecoverable, and no window can
+            // be open on it: the conclusion that would have opened one predates this field
+            outgoing_keys: None,
+            ..epoch
+        },
+    )?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod migration_tests {
+    use super::*;
+    use crate::support::tests::helpers::init_contract;
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{OwnedDeps, Storage};
+    use nym_coconut_dkg_common::types::EpochId;
+
+    /// Stand the contract up as it is on chain today: an epoch stored before `keys_in_service`
+    /// existed, so the field reads as unknown, under a version older than this build.
+    fn contract_before_the_field_existed(
+        state: EpochState,
+        epoch_id: EpochId,
+    ) -> OwnedDeps<impl Storage, impl cosmwasm_std::Api, impl cosmwasm_std::Querier> {
+        let mut deps = init_contract();
+        let env = mock_env();
+
+        let stored = Epoch {
+            keys_in_service: None,
+            outgoing_keys: None,
+            ..Epoch::new(state, epoch_id, Default::default(), env.block.time)
+        };
+        save_epoch(deps.as_mut().storage, env.block.height, &stored).unwrap();
+        cw2::set_contract_version(deps.as_mut().storage, CONTRACT_NAME, "0.0.1").unwrap();
+
+        deps
+    }
+
+    /// An epoch in service concluded its own ceremony, so seeding it is recording a fact rather
+    /// than guessing one. Without this the first ceremony after the migration would run with no
+    /// recorded epoch in service, and issuance would stop for its duration.
+    #[test]
+    fn migrating_seeds_the_epoch_already_in_service() {
+        let mut deps = contract_before_the_field_existed(EpochState::InProgress, 4);
+
+        migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+
+        let epoch = load_current_epoch(deps.as_ref().storage).unwrap();
+        assert_eq!(Some(4), epoch.keys_in_service);
+        assert_eq!(Some(4), epoch.issuing_epoch_id());
+    }
+
+    /// Mid-ceremony there is nothing to record: which epoch is in service is exactly what was
+    /// never stored, and `epoch_id - 1` is the guess this whole change exists to remove. Leaving
+    /// it unknown refuses issuance until the ceremony concludes and writes the truth - the
+    /// behaviour from before mid-ceremony issuance existed, and the safe direction. The
+    /// deployment order (contract first, while no ceremony runs) keeps it off the real path.
+    #[test]
+    fn migrating_mid_ceremony_records_nothing() {
+        let mut deps =
+            contract_before_the_field_existed(EpochState::DealingExchange { resharing: false }, 4);
+
+        migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+
+        let epoch = load_current_epoch(deps.as_ref().storage).unwrap();
+        assert_eq!(None, epoch.keys_in_service);
+        assert_eq!(None, epoch.issuing_epoch_id());
+    }
+
+    /// A later migration must not touch what is already recorded. Re-seeding a concluded epoch
+    /// would put the same value back into `keys_in_service` while clearing `outgoing_keys` along
+    /// with it, dropping the window in which a collection begun under the superseded epoch can
+    /// still be completed.
+    #[test]
+    fn migrating_again_leaves_a_recorded_epoch_alone() {
+        let mut deps = init_contract();
+        let env = mock_env();
+
+        // epoch 10's keys have just come into service, superseding epoch 7's - the ceremonies
+        // in between failed - so 7 is still inside its window
+        let in_grace = Epoch {
+            keys_in_service: Some(10),
+            outgoing_keys: Some(7),
+            ..Epoch::new(
+                EpochState::InProgress,
+                10,
+                Default::default(),
+                env.block.time,
+            )
+        };
+        save_epoch(deps.as_mut().storage, env.block.height, &in_grace).unwrap();
+        cw2::set_contract_version(deps.as_mut().storage, CONTRACT_NAME, "0.0.1").unwrap();
+
+        migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+
+        let epoch = load_current_epoch(deps.as_ref().storage).unwrap();
+        assert_eq!(Some(10), epoch.keys_in_service);
+        assert_eq!(Some(7), epoch.outgoing_keys);
+    }
 }
 
 #[cfg(test)]

--- a/contracts/coconut-dkg/src/epoch_state/transactions/advance_epoch_state.rs
+++ b/contracts/coconut-dkg/src/epoch_state/transactions/advance_epoch_state.rs
@@ -123,7 +123,7 @@ mod tests {
     use crate::support::tests::helpers::{init_contract, ADMIN_ADDRESS};
     use cosmwasm_std::testing::{message_info, mock_env};
     use cosmwasm_std::{Addr, Storage};
-    use nym_coconut_dkg_common::types::TimeConfiguration;
+    use nym_coconut_dkg_common::types::{StateProgress, TimeConfiguration};
 
     fn update_epoch<A>(storage: &mut dyn Storage, env: &Env, action: A)
     where
@@ -594,6 +594,10 @@ mod tests {
         assert_eq!(epoch.ceremony_concluded_at, Some(env.block.time));
         assert_eq!(epoch.deadline, None);
 
+        // and it puts this epoch's keys into service, which is what issuance resolves against
+        assert_eq!(epoch.keys_in_service, Some(epoch.epoch_id));
+        assert_eq!(epoch.issuing_epoch_id(), Some(epoch.epoch_id));
+
         // so however much time passes, it is never advanced again, and the epoch it settled into
         // keeps both its id and its recorded conclusion
         for skip in [100, 50, 60 * 60 * 24 * 365] {
@@ -631,6 +635,47 @@ mod tests {
         );
         assert_eq!(curr_epoch, expected_epoch);
         assert!(THRESHOLD.may_load(&deps.storage).unwrap().is_none());
+    }
+
+    /// A ceremony that fails hands the epoch id on and leaves the keys where they were. Anything
+    /// deriving the issuing epoch from the id alone would name epoch 11 here: an epoch that
+    /// concluded nothing, has no aggregate key, and never will.
+    #[test]
+    fn a_sub_threshold_ceremony_resets_without_retiring_the_keys_in_service() {
+        let mut deps = init_contract();
+        let mut env = mock_env();
+
+        // epoch 7's keys are the ones in service, and the ceremony for 11 is about to fail
+        THRESHOLD.save(deps.as_mut().storage, &42).unwrap();
+        let failing = Epoch {
+            state_progress: StateProgress {
+                verified_keys: 41,
+                ..Default::default()
+            },
+            keys_in_service: Some(7),
+            ..Epoch::new(
+                EpochState::VerificationKeyFinalization { resharing: false },
+                11,
+                TimeConfiguration::default(),
+                env.block.time,
+            )
+        };
+        save_epoch(deps.as_mut().storage, env.block.height, &failing).unwrap();
+
+        env.block.time = env
+            .block
+            .time
+            .plus_seconds(TimeConfiguration::default().verification_key_finalization_time_secs + 1);
+        try_advance_epoch_state(deps.as_mut(), env.clone()).unwrap();
+
+        let after_failure = load_current_epoch(deps.as_mut().storage).unwrap();
+        assert_eq!(12, after_failure.epoch_id);
+        assert_eq!(
+            EpochState::PublicKeySubmission { resharing: false },
+            after_failure.state
+        );
+        assert_eq!(Some(7), after_failure.issuing_epoch_id());
+        assert_eq!(None, after_failure.ceremony_concluded_at);
     }
 
     /// A ceremony nobody took part in must not start, let alone conclude.

--- a/nym-api/src/ecash/comm.rs
+++ b/nym-api/src/ecash/comm.rs
@@ -6,7 +6,7 @@ use crate::ecash::error::{EcashError, Result};
 use crate::ecash::helpers::CachedImmutableEpochItem;
 use crate::support::config::{Config, EcashSignerDebug};
 use async_trait::async_trait;
-use nym_coconut_dkg_common::types::{Epoch, EpochId, Timestamp};
+use nym_coconut_dkg_common::types::{Epoch, EpochId};
 use nym_dkg::Threshold;
 use nym_validator_client::EcashApiClient;
 use std::cmp::min;
@@ -29,16 +29,13 @@ pub trait APICommunicationChannel {
     /// to observe would be pinned for the lifetime of the process.
     async fn ceremony_concluded(&self, epoch_id: EpochId) -> Result<bool>;
 
-    /// When the current epoch's ceremony concluded, i.e. when the keys now in use came into
-    /// service.
+    /// The current epoch as the chain reports it: which epoch's keys are in service, which epoch
+    /// they replaced, and when that happened.
     ///
-    /// Every signer reads the same value, which is what lets them agree on a window measured
-    /// from it without having to agree on when they each noticed.
-    ///
-    /// `None` while a ceremony is still running, and for an epoch that concluded before the
-    /// contract began recording this - which is the epoch mainnet is on until the next ceremony.
-    /// Callers must treat the unknown case as "no window", never as "just now".
-    async fn current_ceremony_concluded_at(&self) -> Result<Option<Timestamp>>;
+    /// Anything needing more than one fact about it must take them from here rather than from
+    /// several narrower calls: those each consult the cache separately, so a ceremony concluding
+    /// between two of them would answer from either side of the change.
+    async fn current_epoch_details(&self) -> Result<Epoch>;
 }
 
 struct CachedEpoch {
@@ -143,22 +140,6 @@ impl QueryCommunicationChannel {
         guard.update(epoch, self.config.epoch_cache_staleness)?;
         Ok(guard)
     }
-
-    /// The current epoch, refreshing the cache if it has gone stale.
-    ///
-    /// The cached copy expires at the epoch's own state deadline (see
-    /// [`CachedEpoch::update`]), so it can never claim a ceremony has finished when it
-    /// has not - at worst it is briefly pessimistic, which only costs an extra query.
-    async fn current_epoch_data(&self) -> Result<Epoch> {
-        let guard = self.cached_epoch.read().await;
-        if guard.is_valid() {
-            return Ok(guard.current_epoch);
-        }
-
-        drop(guard);
-        let guard = self.update_epoch_cache().await?;
-        Ok(guard.current_epoch)
-    }
 }
 
 #[async_trait]
@@ -208,13 +189,23 @@ impl APICommunicationChannel for QueryCommunicationChannel {
 
     async fn ceremony_concluded(&self, epoch_id: EpochId) -> Result<bool> {
         Ok(self
-            .current_epoch_data()
+            .current_epoch_details()
             .await?
             .is_ceremony_concluded(epoch_id))
     }
 
-    async fn current_ceremony_concluded_at(&self) -> Result<Option<Timestamp>> {
-        Ok(self.current_epoch_data().await?.ceremony_concluded_at)
+    /// The cached copy expires at the epoch's own state deadline (see [`CachedEpoch::update`]), so
+    /// it can never claim a ceremony has finished when it has not - at worst it is briefly
+    /// pessimistic, which only costs an extra query.
+    async fn current_epoch_details(&self) -> Result<Epoch> {
+        let guard = self.cached_epoch.read().await;
+        if guard.is_valid() {
+            return Ok(guard.current_epoch);
+        }
+
+        drop(guard);
+        let guard = self.update_epoch_cache().await?;
+        Ok(guard.current_epoch)
     }
 }
 

--- a/nym-api/src/ecash/state/mod.rs
+++ b/nym-api/src/ecash/state/mod.rs
@@ -103,7 +103,8 @@ pub(crate) struct IssuableEpochs {
     pub(crate) issuable: EpochId,
 
     /// The epoch [`Self::issuable`] replaced, while other signers may still be serving it because
-    /// they have not seen the change yet. Always `issuable - 1` when present.
+    /// they have not seen the change yet. Not necessarily `issuable - 1`: any number of failed
+    /// ceremonies may sit between the two, and none of those epochs was ever issuable.
     pub(crate) outgoing_in_grace: Option<EpochId>,
 }
 
@@ -244,29 +245,20 @@ impl EcashState {
     /// the change, so that a client which resolved it - or which is talking to signers that have
     /// not caught up - can finish collecting under it. See [`Self::within_grace_of`].
     pub(crate) async fn issuable_epochs(&self) -> Result<IssuableEpochs> {
-        let current = self.current_dkg_epoch().await?;
+        // one snapshot for the whole answer: a ceremony concluding between two reads would
+        // otherwise be able to name an issuable epoch from one side of the change and a window
+        // from the other
+        let epoch = self.aux.comm_channel.current_epoch_details().await?;
 
-        if !self.aux.comm_channel.ceremony_concluded(current).await? {
-            // a ceremony is running for `current`, so the epoch before it is the one in service.
-            // its own conclusion is long past, and no change of issuable epoch has just happened,
-            // so nothing is in grace - which is why the *start* of a ceremony races with nothing.
-            let Some(issuable) = current.checked_sub(1) else {
-                return Err(EcashError::NoIssuableEpoch);
-            };
-            return Ok(IssuableEpochs {
-                issuable,
-                outgoing_in_grace: None,
-            });
-        }
+        let Some(issuable) = epoch.issuing_epoch_id() else {
+            return Err(EcashError::NoIssuableEpoch);
+        };
 
-        // `current` has concluded, so it is in service and the epoch it replaced may still be
-        // within the window measured from that conclusion
-        let concluded_at = self
-            .aux
-            .comm_channel
-            .current_ceremony_concluded_at()
-            .await?;
-        let outgoing_in_grace = match (current.checked_sub(1), concluded_at) {
+        // a window only opens where a ceremony has just concluded and put a *different* epoch into
+        // service. while one is running - or has failed, leaving the id ahead of the keys - the
+        // issuable epoch has not changed, so there is nothing to overlap with: which is why the
+        // start of a ceremony races with nothing.
+        let outgoing_in_grace = match (epoch.outgoing_keys, epoch.ceremony_concluded_at) {
             (Some(outgoing), Some(concluded_at)) if self.within_grace_of(concluded_at) => {
                 Some(outgoing)
             }
@@ -274,7 +266,7 @@ impl EcashState {
         };
 
         Ok(IssuableEpochs {
-            issuable: current,
+            issuable,
             outgoing_in_grace,
         })
     }
@@ -1276,7 +1268,7 @@ mod issuable_epoch_tests {
         let (state, comm) = state_with_grace(Duration::from_secs(600)).await;
 
         comm.set_current_epoch(2).await;
-        comm.start_ceremony();
+        comm.start_ceremony().await;
 
         let issuable = state.issuable_epochs().await.unwrap();
 
@@ -1326,13 +1318,52 @@ mod issuable_epoch_tests {
         let (state, comm) = state_with_grace(Duration::from_secs(600)).await;
 
         comm.set_current_epoch(2).await;
-        comm.conclude_ceremony();
+        comm.conclude_ceremony().await;
         comm.set_ceremony_concluded_at(None).await;
 
         let issuable = state.issuable_epochs().await.unwrap();
 
         assert_eq!(issuable.issuable, 2);
         assert_eq!(issuable.outgoing_in_grace, None);
+    }
+
+    /// A ceremony that fails moves the epoch id on without producing keys, so the epoch it
+    /// abandons is not issuable - it has no aggregate key and never will. The generation already
+    /// in service keeps serving instead, which is what stops a failed reset from halting issuance
+    /// network-wide until some later ceremony happens to succeed.
+    #[tokio::test]
+    async fn a_failed_ceremony_leaves_the_epoch_in_service_issuable() {
+        let (state, comm) = state_with_grace(Duration::from_secs(600)).await;
+
+        // epoch 1's keys are in service; the ceremony for 2 starts, fails, and the contract
+        // resets into 3
+        comm.set_current_epoch(2).await;
+        comm.start_ceremony().await;
+        comm.fail_ceremony().await;
+
+        let issuable = state.issuable_epochs().await.unwrap();
+
+        assert_eq!(3, comm.current_epoch());
+        assert_eq!(1, issuable.issuable);
+        assert_eq!(None, issuable.outgoing_in_grace);
+    }
+
+    /// And when one finally concludes, the epoch it supersedes is the one that was actually in
+    /// service, not the id below it: that one concluded nothing, so a client cannot have been
+    /// collecting under it and honouring it would extend the window to an epoch with no keys.
+    #[tokio::test]
+    async fn concluding_after_a_failure_grants_grace_to_the_epoch_that_was_in_service() {
+        let (state, comm) = state_with_grace(Duration::from_secs(600)).await;
+
+        comm.set_current_epoch(2).await;
+        comm.start_ceremony().await;
+        comm.fail_ceremony().await;
+        comm.conclude_ceremony_ago(Duration::from_secs(60)).await;
+
+        let issuable = state.issuable_epochs().await.unwrap();
+
+        assert_eq!(3, issuable.issuable);
+        assert_eq!(Some(1), issuable.outgoing_in_grace);
     }
 
     /// Before any ceremony has ever concluded there is nothing to issue under, and no earlier
@@ -1342,7 +1373,7 @@ mod issuable_epoch_tests {
         let (state, comm) = state_with_grace(Duration::from_secs(600)).await;
 
         comm.set_current_epoch(0).await;
-        comm.start_ceremony();
+        comm.start_ceremony().await;
 
         assert!(matches!(
             state.issuable_epochs().await,

--- a/nym-api/src/ecash/tests/mod.rs
+++ b/nym-api/src/ecash/tests/mod.rs
@@ -60,7 +60,6 @@ use nym_validator_client::nyxd::{AccountId, ExecTxResult, Fee, Hash, TxResponse}
 use nym_validator_client::EcashApiClient;
 use rand::rngs::OsRng;
 use rand::RngCore;
-use std::cmp::Ordering as CmpOrdering;
 use std::collections::{BTreeMap, HashMap};
 use std::ops::Deref;
 use std::str::FromStr;
@@ -1117,6 +1116,12 @@ struct CommStateInner {
     /// both a running ceremony and an epoch that concluded before the contract recorded this.
     ceremony_concluded_at: RwLock<Option<Timestamp>>,
 
+    /// Which epoch's keys are in service, and the one they replaced - the chain's answer, kept
+    /// explicitly rather than derived from [`Self::current_epoch`], because the derivation is
+    /// only right while no ceremony has ever failed.
+    keys_in_service: RwLock<Option<EpochId>>,
+    outgoing_keys: RwLock<Option<EpochId>>,
+
     ecash_clients: RwLock<HashMap<EpochId, Vec<EcashApiClient>>>,
 }
 
@@ -1129,8 +1134,29 @@ impl SharedCommState {
                 ceremony_in_flight: AtomicBool::new(false),
                 // as on mainnet today: concluded, but before the chain recorded when
                 ceremony_concluded_at: RwLock::new(None),
+                keys_in_service: RwLock::new(Some(epoch_id)),
+                outgoing_keys: RwLock::new(None),
                 ecash_clients: RwLock::new(HashMap::from([(epoch_id, ecash_clients)])),
             }),
+        }
+    }
+
+    /// The epoch as the chain would report it, so the dummy answers from the same type the real
+    /// channel does rather than reimplementing its rules.
+    pub async fn epoch(&self) -> Epoch {
+        let state = if self.ceremony_in_flight() {
+            EpochState::DealingExchange { resharing: false }
+        } else {
+            EpochState::InProgress
+        };
+
+        Epoch {
+            state,
+            epoch_id: self.current_epoch(),
+            ceremony_concluded_at: self.ceremony_concluded_at().await,
+            keys_in_service: *self.inner.keys_in_service.read().await,
+            outgoing_keys: *self.inner.outgoing_keys.read().await,
+            ..Default::default()
         }
     }
 
@@ -1146,7 +1172,7 @@ impl SharedCommState {
     /// Conclude the current epoch's ceremony `ago` before now, so a test can sit inside or
     /// outside a window measured from it without touching a clock.
     pub async fn conclude_ceremony_ago(&self, ago: std::time::Duration) {
-        self.conclude_ceremony();
+        self.conclude_ceremony().await;
         let now = time::OffsetDateTime::now_utc().unix_timestamp() as u64;
         self.set_ceremony_concluded_at(Some(Timestamp::from_seconds(now - ago.as_secs())))
             .await;
@@ -1157,6 +1183,9 @@ impl SharedCommState {
     }
 
     /// Move to a new epoch, carrying the signers of the old one over to it.
+    ///
+    /// The keys in service stay where they are, as they do on chain: moving to a new epoch id is
+    /// a ceremony *starting*, which retires nothing.
     pub async fn set_current_epoch(&self, epoch_id: EpochId) {
         let previous = self.current_epoch();
         self.inner.current_epoch.store(epoch_id, Ordering::Relaxed);
@@ -1167,15 +1196,33 @@ impl SharedCommState {
         }
     }
 
-    /// Put the current epoch mid-ceremony, as a rotation would.
-    pub fn start_ceremony(&self) {
+    /// Put the current epoch mid-ceremony, as a rotation would: its own keys do not exist yet, so
+    /// the epoch before it is the one in service.
+    pub async fn start_ceremony(&self) {
         self.inner.ceremony_in_flight.store(true, Ordering::Relaxed);
+        *self.inner.keys_in_service.write().await = self.current_epoch().checked_sub(1);
+        *self.inner.outgoing_keys.write().await = None;
     }
 
-    pub fn conclude_ceremony(&self) {
+    /// A ceremony that failed: the contract resets into a fresh epoch id and the keys already in
+    /// service keep serving, however many attempts it takes.
+    pub async fn fail_ceremony(&self) {
+        let next = self.current_epoch() + 1;
+        self.inner.current_epoch.store(next, Ordering::Relaxed);
+        self.inner.ceremony_in_flight.store(true, Ordering::Relaxed);
+        *self.inner.ceremony_concluded_at.write().await = None;
+    }
+
+    pub async fn conclude_ceremony(&self) {
         self.inner
             .ceremony_in_flight
             .store(false, Ordering::Relaxed);
+
+        // concluding puts the current epoch's keys into service, superseding whichever generation
+        // held that position - not `current - 1`, which a failed ceremony leaves behind
+        let superseded = *self.inner.keys_in_service.read().await;
+        *self.inner.outgoing_keys.write().await = superseded;
+        *self.inner.keys_in_service.write().await = Some(self.current_epoch());
     }
 
     pub fn ceremony_in_flight(&self) -> bool {
@@ -1242,16 +1289,13 @@ impl super::comm::APICommunicationChannel for DummyCommunicationChannel {
     }
 
     async fn ceremony_concluded(&self, epoch_id: EpochId) -> Result<bool> {
-        // mirrors the real channel: only the current epoch's ceremony can be unfinished
-        match epoch_id.cmp(&self.state.current_epoch()) {
-            CmpOrdering::Less => Ok(true),
-            CmpOrdering::Greater => Ok(false),
-            CmpOrdering::Equal => Ok(!self.state.ceremony_in_flight()),
-        }
+        // delegated rather than reimplemented, so the dummy cannot drift from the rule the real
+        // channel applies
+        Ok(self.state.epoch().await.is_ceremony_concluded(epoch_id))
     }
 
-    async fn current_ceremony_concluded_at(&self) -> Result<Option<Timestamp>> {
-        Ok(self.state.ceremony_concluded_at().await)
+    async fn current_epoch_details(&self) -> Result<Epoch> {
+        Ok(self.state.epoch().await)
     }
 
     async fn ecash_clients(&self, epoch_id: EpochId) -> Result<Vec<EcashApiClient>> {
@@ -1719,7 +1763,7 @@ mod credential_tests {
 
         // a ceremony begins for epoch 2; this signer still holds only epoch 1's key
         fixture.set_epoch(2).await;
-        fixture.comm_state.start_ceremony();
+        fixture.comm_state.start_ceremony().await;
 
         for pinned in [Some(1), None] {
             let response = fixture
@@ -1754,7 +1798,7 @@ mod credential_tests {
         fixture.add_chain_deposit(&voucher);
 
         fixture.set_epoch(2).await;
-        fixture.comm_state.start_ceremony();
+        fixture.comm_state.start_ceremony().await;
 
         let response = fixture
             .blind_sign(
@@ -2250,7 +2294,7 @@ mod credential_tests {
 
         // a new ceremony begins: the epoch id increments and its keys do not exist yet
         fixture.set_epoch(past_epoch + 1).await;
-        fixture.comm_state.start_ceremony();
+        fixture.comm_state.start_ceremony().await;
         let current_epoch = fixture.comm_state.current_epoch();
 
         let request = |epoch_id: EpochId| {
@@ -2305,7 +2349,7 @@ mod credential_tests {
 
         // a ceremony begins for the next epoch, which has nothing to give yet
         fixture.set_epoch(in_service + 1).await;
-        fixture.comm_state.start_ceremony();
+        fixture.comm_state.start_ceremony().await;
 
         let response = fixture
             .axum

--- a/tools/internal/localnet-orchestrator/dkg-bypass-contract/src/contract.rs
+++ b/tools/internal/localnet-orchestrator/dkg-bypass-contract/src/contract.rs
@@ -126,6 +126,9 @@ pub fn migrate(deps: DepsMut<'_>, env: Env, msg: MigrateMsg) -> Result<Response,
             deadline: None,
             // this bypass exists to hand out a concluded ceremony, so it is concluding it now
             ceremony_concluded_at: Some(env.block.time),
+            // and its keys are the ones in service, with no earlier generation behind them
+            keys_in_service: Some(0),
+            outgoing_keys: None,
         },
     )?;
 


### PR DESCRIPTION
## Record which epoch's keys are in service

The epoch id counts DKG ceremonies *started*, not key generations produced. Three places derived "the epoch signers are issuing under" as `current - 1` while a ceremony runs - the signer, the credential proxy, and the client fetcher - and that
identity is only correct while no ceremony has ever failed. When one does, the contract resets into a fresh id and leaves an epoch behind that concluded nothing.

Consequences, all in the window a reset is riskiest:

- Signers would name that abandoned epoch as issuable. Some hold a derived key for  it and would sign, others refuse, so a client pays a deposit and collects sub-threshold shares bound to an epoch that can never reach threshold.
- The grace window had the same arithmetic, honouring an epoch nobody was collecting under while refusing the one they were.
- `is_ceremony_concluded` treated anything below the current id as concluded, so callers would memoise the abandoned epoch's empty signer set with no expiry
- The proxy and client also read a non-zero epoch id as proof something had concluded, so a *first* ceremony being retried looked healthy while nothing was issuable at all.

`Epoch` now records `keys_in_service` and `outgoing_keys`, written where `ceremony_concluded_at` already is; a ceremony starting or failing leaves both alone. All three resolvers delegate to `Epoch::issuing_epoch_id()`, so the
arithmetic exists once and is tested once.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7096)
<!-- Reviewable:end -->
