### PR TITLE
Max/lwd stream patch

### DIFF
--- a/common/nym-lp-data/src/packet/frame.rs
+++ b/common/nym-lp-data/src/packet/frame.rs
@@ -135,6 +135,9 @@ pub enum SphinxStreamMsgType {
     Open = 0,
     /// Data on an existing stream.
     Data = 1,
+    /// Acknowledges an accepted Open. Sent by the listener side; peers
+    /// without establishment support drop it during parsing.
+    OpenAck = 2,
 }
 
 /// Parsed form of the 14-byte `frame_attributes` for `LpFrameKind::SphinxStream`.
@@ -142,7 +145,7 @@ pub enum SphinxStreamMsgType {
 /// Wire layout (big-endian):
 /// ```text
 /// [0..8 ) stream_id    : u64
-/// [8    ) msg_type      : u8   (0 = Open, 1 = Data)
+/// [8    ) msg_type      : u8   (0 = Open, 1 = Data, 2 = OpenAck)
 /// [9..13) sequence_num  : u32
 /// [13   ) reserved      : u8
 /// ```
@@ -173,6 +176,7 @@ impl SphinxStreamFrameAttributes {
         let msg_type = match attrs[8] {
             0 => SphinxStreamMsgType::Open,
             1 => SphinxStreamMsgType::Data,
+            2 => SphinxStreamMsgType::OpenAck,
             other => {
                 return Err(MalformedLpPacketError::DeserialisationFailure(format!(
                     "invalid stream msg_type: {other}"
@@ -324,5 +328,56 @@ impl ForwardPacketData {
             expected_response_size: ExpectedResponseSize::from_bytes(expected_response_size_bytes),
             inner_packet_bytes,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_attributes_roundtrip_all_msg_types() {
+        for msg_type in [
+            SphinxStreamMsgType::Open,
+            SphinxStreamMsgType::Data,
+            SphinxStreamMsgType::OpenAck,
+        ] {
+            let attrs = SphinxStreamFrameAttributes {
+                stream_id: 0xDEAD_BEEF_CAFE_F00D,
+                msg_type,
+                sequence_num: 0x0102_0304,
+            };
+            let parsed = SphinxStreamFrameAttributes::parse(&attrs.encode()).unwrap();
+            assert_eq!(parsed, attrs);
+        }
+    }
+
+    #[test]
+    fn stream_attributes_reject_unknown_msg_type() {
+        // A peer without a given extension must fail parsing cleanly so the
+        // frame is dropped rather than misinterpreted.
+        let attrs = SphinxStreamFrameAttributes {
+            stream_id: 1,
+            msg_type: SphinxStreamMsgType::Open,
+            sequence_num: 0,
+        };
+        let mut encoded = attrs.encode();
+        encoded[8] = 3; // first unassigned discriminant
+        assert!(SphinxStreamFrameAttributes::parse(&encoded).is_err());
+        encoded[8] = 0xFF;
+        assert!(SphinxStreamFrameAttributes::parse(&encoded).is_err());
+    }
+
+    #[test]
+    fn sequence_num_survives_roundtrip_at_bounds() {
+        for sequence_num in [0, 1, u32::MAX] {
+            let attrs = SphinxStreamFrameAttributes {
+                stream_id: 42,
+                msg_type: SphinxStreamMsgType::Data,
+                sequence_num,
+            };
+            let parsed = SphinxStreamFrameAttributes::parse(&attrs.encode()).unwrap();
+            assert_eq!(parsed.sequence_num, sequence_num);
+        }
     }
 }

--- a/documentation/docs/pages/developers/rust/stream/tutorial.mdx
+++ b/documentation/docs/pages/developers/rust/stream/tutorial.mdx
@@ -158,8 +158,8 @@ async fn main() {
     // server's first data does, so we avoid writing before the server is ready.
     //
     // A timeout leaves the peer's state unknown: an older SDK without
-    // acknowledgement support, no reply SURBs, or an absent server all look the
-    // same. The stream stays usable either way, so proceed after logging.
+    // acknowledgement support, or a slow or absent peer. wait_established is
+    // best-effort, so log the timeout and proceed.
     if let Err(e) = stream.wait_established(Duration::from_secs(30)).await {
         println!("Establishment not confirmed: {e}; proceeding anyway");
     }
@@ -196,7 +196,7 @@ async fn main() {
 ```
 
 <Callout type="info">
-`wait_established(timeout)` confirms the server accepted the stream. The acknowledgement returns over reply SURBs, so `open_stream` needs at least one; the `None` default provides them. Pass zero reply SURBs and the call always times out even though the stream still works, so read a timeout as "peer state unknown", not "stream failed".
+`wait_established(timeout)` confirms the server accepted the stream. The server sends its acknowledgement and the echo data over reply SURBs, so `open_stream` needs at least one; the `None` default provides them. With zero reply SURBs the server cannot answer at all: the acknowledgement never arrives and no echo returns. When SURBs are available, a timeout instead means the peer state is unknown, for example an older SDK, so do not discard the stream on a timeout alone.
 </Callout>
 
 ## Step 4: Run it

--- a/documentation/docs/pages/developers/rust/stream/tutorial.mdx
+++ b/documentation/docs/pages/developers/rust/stream/tutorial.mdx
@@ -146,15 +146,23 @@ async fn main() {
     println!("Client address: {}", client.nym_address());
 
     // Open a stream to the server.
-    // The second argument (None) uses the default number of reply SURBs.
+    // The second argument is the reply SURB count; None uses the default.
+    // The server acknowledges the stream over these SURBs, so at least one
+    // is required. With zero, the acknowledgement has no way back.
     let mut stream = client.open_stream(server_addr, None).await.unwrap();
     println!("Stream opened: {}", stream.id());
 
-    // Give the Open message time to traverse the mixnet and reach the server.
-    // open_stream() returns immediately after sending; it doesn't wait for
-    // the server to accept. Writing too soon risks the data arriving before
-    // the Open, which the server would drop.
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    // Wait for the server to acknowledge before writing. open_stream() returns
+    // as soon as the Open is sent; it does not wait for the server to accept.
+    // wait_established resolves when the acknowledgement arrives, or when the
+    // server's first data does, so we avoid writing before the server is ready.
+    //
+    // A timeout leaves the peer's state unknown: an older SDK without
+    // acknowledgement support, no reply SURBs, or an absent server all look the
+    // same. The stream stays usable either way, so proceed after logging.
+    if let Err(e) = stream.wait_established(Duration::from_secs(30)).await {
+        println!("Establishment not confirmed: {e}; proceeding anyway");
+    }
 
     // Send three payloads of different sizes and verify the echo.
     // Random bytes show that streams are binary-safe, not just text.
@@ -186,6 +194,10 @@ async fn main() {
     println!("Done!");
 }
 ```
+
+<Callout type="info">
+`wait_established(timeout)` confirms the server accepted the stream. The acknowledgement returns over reply SURBs, so `open_stream` needs at least one; the `None` default provides them. Pass zero reply SURBs and the call always times out even though the stream still works, so read a timeout as "peer state unknown", not "stream failed".
+</Callout>
 
 ## Step 4: Run it
 
@@ -254,6 +266,7 @@ See the [Architecture](./architecture) page for the full technical details.
 - `client.listener()` activates stream mode and returns a `MixnetListener`
 - `listener.accept()` blocks until a remote peer opens a stream
 - `client.open_stream(recipient, surbs)` opens an outbound stream to a Nym address
+- `stream.wait_established(timeout)` confirms the server accepted the stream; it needs at least one reply SURB, and a timeout means the peer's state is unknown, not that the stream failed
 - `MixnetStream` implements `AsyncRead + AsyncWrite`, so standard tokio I/O works unchanged
 - Multiple streams are multiplexed over a single client
 - Streams deregister on `drop`; no close handshake is needed
@@ -339,11 +352,15 @@ async fn main() {
     let mut client = mixnet::MixnetClient::connect_new().await.unwrap();
     println!("Client address: {}", client.nym_address());
 
+    // None uses the default reply SURB count; the server needs at least one
+    // to acknowledge the stream (see Step 3).
     let mut stream = client.open_stream(server_addr, None).await.unwrap();
     println!("Stream opened: {}", stream.id());
 
-    // Wait for the Open message to reach the server through the mixnet
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    // Wait for the server to acknowledge before writing (see Step 3).
+    if let Err(e) = stream.wait_established(Duration::from_secs(30)).await {
+        println!("Establishment not confirmed: {e}; proceeding anyway");
+    }
 
     let sizes = [320, 25_000, 1280];
 

--- a/documentation/docs/pages/developers/swizzle.mdx
+++ b/documentation/docs/pages/developers/swizzle.mdx
@@ -55,7 +55,7 @@ Add `nym-swizzle` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-nym-swizzle = "1.21.5"
+nym-swizzle = "1.21.6"
 ```
 
 **Minimum Rust version:** {RUST_MSRV}+

--- a/documentation/docs/pages/developers/swizzle/zcash.mdx
+++ b/documentation/docs/pages/developers/swizzle/zcash.mdx
@@ -136,7 +136,7 @@ Add `nym-swizzle-zcash` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-nym-swizzle-zcash = "1.21.5"
+nym-swizzle-zcash = "1.21.6"
 ```
 
 No network stack and no build script. It compiles for

--- a/openspec/changes/add-stream-establishment-ack/design.md
+++ b/openspec/changes/add-stream-establishment-ack/design.md
@@ -1,0 +1,61 @@
+# Design: Add Stream Establishment Acknowledgement
+
+## Context
+
+The stream module multiplexes byte streams over a `MixnetClient`: a router task demuxes reconstructed mixnet messages by `StreamId` into per-stream channels, with a per-stream reorder buffer (sequence-numbered `Data` frames), an orphan buffer for `Data` overtaking its `Open`, and a stale-stream reaper driven by a cleanup tick. Failures are reported in-band: `StreamFailure` values travel through the same channel as data, so `recv()` sees them in order and `AsyncRead` fails the stream.
+
+Facts established during exploration:
+
+- **The SURB-ack layer cannot provide liveness, by design.** Each fragment carries a prepaid SURB-ack that the recipient's gateway forwards regardless of whether the payload was pushed to a connected client, stored to disk, or dropped for an unregistered recipient (`nym-node/src/node/mixnet/handler.rs`, `handle_final_hop`; the comments state that a conditional ack would leak the recipient's state). It attests "reached the destination gateway", is consumed entirely by the retransmission machinery in `common/client-core/.../acknowledgement_control/`, and is not surfaced to the SDK. Any liveness signal gated on recipient state at this layer would be an online-status oracle usable by anyone who knows the address. Establishment confirmation must come from a layer where the recipient consents by responding.
+- **Frame parsing rejects unknown msg types cleanly.** An unknown `SphinxStreamMsgType` discriminant fails `SphinxStreamFrameAttributes::parse`, so `decode_stream_message` returns `None` and the router drops the frame as a non-stream message. `OpenAck` sent to an old peer degrades to silence, never to an error.
+- The acceptor's reply path (`InputMessage::new_reply(sender_tag)`) already exists and is reused for the `OpenAck` send.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Consumers can distinguish "established" from "unknown" at dial time, without reading logs.
+- Old and new SDKs interoperate in both directions with no coordinated upgrade: an old peer simply never emits the frame this change introduces.
+- The privacy rationale (why acknowledgement is stream-layer) is recorded in the module documentation.
+
+**Non-Goals:**
+
+- Mid-stream liveness (ping/pong, unresponsive-peer failure, arming): deferred to `add-stream-keepalive`.
+- Open retransmission and idempotent re-ack (deferred).
+- A `Gone` frame for fast dead-stream signalling (deferred; silence suffices).
+- Any change to `DEFAULT_NUMBER_OF_SURBS` or non-stream send paths.
+
+## Decisions
+
+All settled interactively on 2026-08-27:
+
+1. **Ack from `accept()`, not from router receipt.** The signal means "a listener took your stream", which is the question consumers ask. Best-effort: a failed ack send (for example SURB starvation from a `reply_surbs = 0` dialer) never fails the accept. The send uses non-blocking `try_send` on the shared input channel, so a channel that is momentarily full cannot stall `accept()`.
+2. **`wait_established` is opt-in; `open_stream` stays non-blocking.** One method, `wait_established(timeout)`, with the caller supplying the budget. No default constant and no builder option: a sensible timeout depends on the application, and the SDK has no basis for choosing one. Timeout is inconclusive by definition (old peer, SURB starvation, or loss) and the stream remains usable after it.
+3. **`established` is a distinct signal from keepalive arming.** Inbound `Data` also resolves `wait_established`, because the peer provably accepted the stream, but this does not arm anything; arming is introduced in `add-stream-keepalive`.
+4. **`OpenAck` stays a distinct frame type** rather than being folded into a later liveness frame; one meaning per variant.
+5. **Passive introspection only**: `last_peer_activity()` exposes the last inbound instant; no active `is_alive()` ping method exists at this layer.
+
+## Backwards compatibility
+
+An old peer does not recognise `OpenAck` and drops it during frame parsing: `wait_established` on the new dialer times out, is reported as inconclusive, and the stream stays usable. An old dialer against a new acceptor receives and silently drops the `OpenAck` the same way, at the cost of one SURB from its pool. Neither direction requires a coordinated upgrade or produces a spurious failure.
+
+## Risks / Trade-offs
+
+- **Multi-fragment `Open`** raises establishment loss-variance slightly (all fragments needed for reconstruction). Nothing times out underneath this `Open` (unlike smoltcp SYN handling over the mixnet), so the cost is latency variance in `wait_established`, not correctness.
+- **The ack consumes one reply SURB per stream.** A dialer attaching the default 10 is unaffected; one attaching zero gets no acknowledgement and `wait_established` times out, which the API documents as inconclusive rather than as failure.
+
+## Deliberately out of scope
+
+- **SURB budgeting.** The acknowledgement is paid for out of the reply SURBs
+  the dialer already attaches to the `Open`, so no SURB-count change is needed
+  to make it work. Sizing `Open` and `Data` SURB counts to the Sphinx packet
+  boundary is a behaviour change for every stream caller and belongs in its own
+  change, kept on `wip/stream-surb-budgeting` with the measurement and its
+  pinning test.
+- **Anything in `common/nymsphinx`.** Reply-SURB serialisation is too
+  fundamental to modify in service of a stream-layer feature.
+- **Mid-stream liveness.** Keepalive is `add-stream-keepalive`.
+- **The IPR path.** `IpMixStream::connect_tunnel` already performs a connect
+  request and response carrying the allocated IPs, which is an establishment
+  handshake one layer up. `OpenAck` would duplicate it. This change targets the
+  client-to-client case, where no application protocol supplies one.

--- a/openspec/changes/add-stream-establishment-ack/proposal.md
+++ b/openspec/changes/add-stream-establishment-ack/proposal.md
@@ -19,7 +19,7 @@ This cannot be fixed at a lower layer. Every Sphinx fragment already carries a p
 
 ### New Capabilities
 
-- `sdk-mixnet-stream`: establishment acknowledgement for the SDK stream module: an `OpenAck` frame type, an opt-in wait for establishment, per-frame SURB allocation for `Open` and `Data`, and the documentation recording why acknowledgement lives at the stream layer.
+- `sdk-mixnet-stream`: establishment acknowledgement for the SDK stream module: an `OpenAck` frame type, an opt-in wait for establishment, and the documentation recording why acknowledgement lives at the stream layer.
 
 ### Modified Capabilities
 

--- a/openspec/changes/add-stream-establishment-ack/proposal.md
+++ b/openspec/changes/add-stream-establishment-ack/proposal.md
@@ -1,0 +1,37 @@
+# Add Stream Establishment Acknowledgement
+
+## Why
+
+The SDK stream module (`sdk/rust/nym-sdk/src/mixnet/stream/`) is fire-and-forget. `open_stream` verifies at dial time that the recipient's gateway is routable, sends `Open`, and returns a usable `MixnetStream`; nothing ever confirms that the peer's client is running or that anyone called `accept()`.
+
+This cannot be fixed at a lower layer. Every Sphinx fragment already carries a prepaid SURB-ack, but the recipient's gateway forwards that ack whether the message was delivered to a connected client, stored to disk for an offline one, or dropped because the recipient never registered (`nym-node/src/node/mixnet/handler.rs`, `handle_final_hop`). The code comments state the reason: an ack conditional on recipient state would let anyone who knows an address probe whether that client is online, without its participation. The ack layer is deliberately liveness-blind. Establishment confirmation must therefore be built at the stream layer, where the recipient actively consents by responding.
+
+## What Changes
+
+- Add `OpenAck = 2` to `SphinxStreamMsgType` in `common/nym-lp-data`, with a parse arm and wire tests. Wire-compatible: a peer running current code drops the unknown discriminant cleanly during frame parsing.
+- `MixnetListener::accept()` sends a best-effort `OpenAck` to the dialer through the existing anonymous reply path (the dialer's supplied SURBs), immediately after registering the inbound stream. A failed send never fails the accept.
+- An `established` watch channel per stream. `MixnetStream::wait_established(timeout)` waits for it; the caller supplies the timeout rather than the SDK imposing a default. `open_stream` itself stays non-blocking. A timeout is reported as inconclusive (older peer, SURB starvation, or an unreachable peer) and the stream stays usable afterwards.
+- Inbound `Data` also resolves `wait_established`: data on the stream proves the peer accepted it, covering a lost ack.
+- A passive `MixnetStream::last_peer_activity()` getter reporting the time of the most recent inbound frame; calling it generates no traffic.
+- Documentation requirement: the SURB-ack privacy rationale (the recipient's gateway forwards acks regardless of recipient state precisely so they cannot become an online-status oracle, so liveness must live at the stream layer where the recipient consents by responding) is recorded in the stream module documentation. It motivates the whole design, including the keepalive follow-up in `add-stream-keepalive`.
+
+## Capabilities
+
+### New Capabilities
+
+- `sdk-mixnet-stream`: establishment acknowledgement for the SDK stream module: an `OpenAck` frame type, an opt-in wait for establishment, per-frame SURB allocation for `Open` and `Data`, and the documentation recording why acknowledgement lives at the stream layer.
+
+### Modified Capabilities
+
+<!-- none: no existing spec covers the stream module -->
+
+## Impact
+
+- `common/nym-lp-data/src/packet/frame.rs`: one enum variant and its parse arm; existing variants and layout untouched.
+- `sdk/rust/nym-sdk/src/mixnet/stream/mod.rs`: `OpenAck` router arm, `established` watch state on `StreamEntry`, `accept()` ack send.
+- `sdk/rust/nym-sdk/src/mixnet/stream/mixnet_stream.rs`: `wait_established(timeout)`, `last_peer_activity`.
+- `sdk/rust/nym-sdk/src/mixnet/native_client.rs`: one doc-comment line. No configuration, no SURB-count changes, and `common/nymsphinx` is untouched.
+- `sdk/rust/nym-sdk/src/mixnet/stream/ARCHITECTURE.md`: establishment section with the SURB-ack privacy rationale.
+- Outstanding: stream tutorial updates (unchecked in tasks.md).
+- Wire compatibility: an old peer never sends the ack; `wait_established` times out and the stream stays usable. An old dialer against a new acceptor drops the incoming `OpenAck` silently, at the cost of one SURB from its pool.
+- Follow-up: `add-stream-keepalive` builds on this change to add mid-stream liveness (ping/pong, in-band unresponsive-peer failure).

--- a/openspec/changes/add-stream-establishment-ack/specs/sdk-mixnet-stream/spec.md
+++ b/openspec/changes/add-stream-establishment-ack/specs/sdk-mixnet-stream/spec.md
@@ -1,0 +1,50 @@
+# sdk-mixnet-stream Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Establishment acknowledgement
+`MixnetListener::accept()` SHALL send an `OpenAck` frame to the dialer through the stream's anonymous reply path immediately after the inbound stream is registered. The ack SHALL be best-effort: a failed send is logged and the accepted stream is returned regardless.
+
+#### Scenario: Listener acknowledges an accepted stream
+- **WHEN** a remote `Open` is accepted and the stream registered
+- **THEN** an `OpenAck` for that stream id is sent via the dialer's supplied SURBs
+
+#### Scenario: Ack failure does not lose the stream
+- **WHEN** the `OpenAck` send fails (for example, no reply SURBs available)
+- **THEN** `accept()` still returns the usable stream and logs the failure
+
+### Requirement: Opt-in establishment wait
+`MixnetStream` SHALL provide `wait_established(timeout)`, resolving when the stream's `OpenAck`, or any subsequent frame from the peer, arrives. The caller supplies the timeout; the SDK SHALL NOT impose a default. `open_stream` SHALL NOT block on establishment. A timeout SHALL be reported as inconclusive (the peer may run an older SDK, be SURB-starved, or be unreachable) and SHALL leave the stream usable.
+
+#### Scenario: Ack arrives
+- **WHEN** the `OpenAck` for an outbound stream is received
+- **THEN** pending and subsequent `wait_established` calls resolve successfully
+
+#### Scenario: Peer data establishes when the ack was lost
+- **WHEN** the `OpenAck` never arrives but a `Data` frame from the peer does
+- **THEN** `wait_established` resolves, because data on the stream proves the peer accepted it
+
+#### Scenario: Timeout is inconclusive
+- **WHEN** `wait_established` times out
+- **THEN** it returns a distinct timeout error and reads and writes on the stream continue to work
+
+### Requirement: Wire compatibility for the establishment ack
+`OpenAck` SHALL be carried in the existing `SphinxStream` LP frame layout with unchanged header size and field positions, such that a peer running code without this change rejects it during attribute parsing and drops it without error, stream disruption, or state creation. Decoding SHALL likewise reject unknown future discriminants cleanly.
+
+#### Scenario: Unknown discriminant is dropped cleanly
+- **WHEN** a frame whose msg-type discriminant is not recognised is received
+- **THEN** it is dropped as a non-stream message with no effect on any stream
+
+### Requirement: Passive liveness introspection
+`MixnetStream` SHALL expose a getter reporting the time of the most recent inbound activity from the peer. Calling it SHALL generate no mixnet traffic.
+
+#### Scenario: Getter reflects inbound frames
+- **WHEN** any frame for the stream is received
+- **THEN** a subsequent call to the getter reflects that activity
+
+### Requirement: Liveness model documentation
+The stream module documentation SHALL record why establishment acknowledgement is implemented at the stream layer: the SURB-ack layer forwards acknowledgements regardless of recipient state precisely so delivery acks cannot become an online-status oracle, so acknowledgement requires the recipient's active consent by responding. The documentation SHALL state that the acknowledgement consumes one of the reply SURBs the dialer already attaches to the `Open`.
+
+#### Scenario: Architecture documentation explains the layer choice
+- **WHEN** a developer reads the stream `ARCHITECTURE.md`
+- **THEN** it explains the gateway's unconditional ack forwarding, the oracle risk of a conditional ack, and the consent-based stream-layer design, with a reference to the gateway's final-hop handling

--- a/openspec/changes/add-stream-establishment-ack/tasks.md
+++ b/openspec/changes/add-stream-establishment-ack/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: Add Stream Establishment Acknowledgement
+
+## 1. Wire protocol
+
+- [x] 1.1 Add `OpenAck = 2` to `SphinxStreamMsgType` in `common/nym-lp-data/src/packet/frame.rs` with a parse arm
+- [x] 1.2 Wire tests: roundtrip for `OpenAck`; unknown discriminant still rejected (old-peer drop path)
+
+## 2. Stream state
+
+- [x] 2.1 Extend `StreamEntry` with the `established` watch channel; `accept()` sends the ack via the `sender_tag` carried on the inbound `Open`
+- [x] 2.2 `register_stream` returns the established watch receiver alongside the data receiver
+
+## 3. Router
+
+- [x] 3.1 `OpenAck` arm: fire the established watch, refresh activity
+- [x] 3.2 Inbound `Data` also resolves `wait_established` (peer provably accepted the stream), covering a lost ack
+
+## 4. Establishment
+
+- [x] 4.1 `MixnetListener::accept()` sends best-effort `OpenAck` via `new_reply(sender_tag)` after successful registration, using non-blocking `try_send`; send failure logs and continues
+- [x] 4.2 The ack is paid for out of the reply SURBs already attached to the `Open`; no SURB-count changes
+
+## 5. Public API
+
+- [x] 5.1 `MixnetStream::wait_established(timeout)`; documented as inconclusive on timeout, stream usable afterwards
+- [x] 5.2 Passive `last_peer_activity()` getter on `MixnetStream`; no traffic generated
+
+## 6. Tests
+
+- [x] 6.1 `OpenAck` roundtrip through `StreamMap`: register, ack, established watch fires
+- [x] 6.2 `wait_established` timeout leaves the stream usable
+- [x] 6.3 `accept()` survives an `OpenAck` send failure
+
+## 7. Documentation
+
+- [x] 7.1 `stream/ARCHITECTURE.md`: establishment section with the SURB-ack privacy rationale (gateway forwards acks regardless of recipient state so they cannot become an online-status oracle; acknowledgement therefore lives at the stream layer, by consent), cross-referencing `handle_final_hop`
+- [ ] 7.2 Stream tutorial: `wait_established(timeout)` usage and the `reply_surbs >= 1` requirement

--- a/openspec/changes/add-stream-establishment-ack/tasks.md
+++ b/openspec/changes/add-stream-establishment-ack/tasks.md
@@ -34,4 +34,4 @@
 ## 7. Documentation
 
 - [x] 7.1 `stream/ARCHITECTURE.md`: establishment section with the SURB-ack privacy rationale (gateway forwards acks regardless of recipient state so they cannot become an online-status oracle; acknowledgement therefore lives at the stream layer, by consent), cross-referencing `handle_final_hop`
-- [ ] 7.2 Stream tutorial: `wait_established(timeout)` usage and the `reply_surbs >= 1` requirement
+- [x] 7.2 Stream tutorial: `wait_established(timeout)` usage and the `reply_surbs >= 1` requirement

--- a/sdk/rust/nym-sdk/src/error.rs
+++ b/sdk/rust/nym-sdk/src/error.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use nym_ip_packet_requests::ConnectFailureReason;
+use nym_sphinx::addressing::clients::Recipient;
+use nym_topology::NymTopologyError;
 use nym_validator_client::nym_api::error::NymAPIError;
 use nym_validator_client::nyxd::error::NyxdError;
 use std::path::PathBuf;
@@ -107,6 +109,13 @@ pub enum Error {
 
     #[error("Stream subsystem failed to initialise: reconstructed_receiver unavailable")]
     StreamInitFailure,
+
+    #[error("cannot route to {recipient}: {source}")]
+    UnroutableRecipient {
+        recipient: Box<Recipient>,
+        #[source]
+        source: NymTopologyError,
+    },
 
     #[error("client not connected")]
     IprStreamClientNotConnected,

--- a/sdk/rust/nym-sdk/src/ipr_wrapper/ip_mix_stream.rs
+++ b/sdk/rust/nym-sdk/src/ipr_wrapper/ip_mix_stream.rs
@@ -248,7 +248,13 @@ impl IpMixStream {
                     return Err(Error::IPRConnectResponseTimeout);
                 }
                 result = stream.recv() => {
-                    let data = result.ok_or(Error::IPRClientStreamClosed)?;
+                    let data = match result.ok_or(Error::IPRClientStreamClosed)? {
+                        Ok(data) => data,
+                        Err(e) => {
+                            debug!("ignoring stream loss during connect: {e}");
+                            continue;
+                        }
+                    };
 
                     // Ignore stragglers from an earlier version; we selected v10
                     // from the node's directory version.
@@ -292,7 +298,13 @@ impl IpMixStream {
                     return Err(Error::IPRConnectResponseTimeout);
                 }
                 result = stream.recv() => {
-                    let data = result.ok_or(Error::IPRClientStreamClosed)?;
+                    let data = match result.ok_or(Error::IPRClientStreamClosed)? {
+                        Ok(data) => data,
+                        Err(e) => {
+                            debug!("ignoring stream loss during connect: {e}");
+                            continue;
+                        }
+                    };
 
                     // Skip frames from another version rather than aborting: in the
                     // v10-to-v9 fallback a late v10 response can land here, and it
@@ -335,7 +347,8 @@ impl IpMixStream {
     /// Handle incoming messages from the mixnet.
     ///
     /// Reads from the underlying `MixnetStream`, parses IPR responses, and
-    /// extracts IP packets. Returns an empty vec on timeout (10 s).
+    /// extracts IP packets. Returns an empty vec on timeout (10 s), on a
+    /// lost or version-mismatched frame, or on an unrecognised response.
     pub async fn handle_incoming(&mut self) -> Result<Vec<Bytes>, Error> {
         let data = match tokio::time::timeout(Duration::from_secs(10), self.stream.recv()).await {
             Err(_) => return Ok(Vec::new()),
@@ -343,7 +356,12 @@ impl IpMixStream {
                 self.connected = false;
                 return Err(Error::IPRClientStreamClosed);
             }
-            Ok(Some(data)) => data,
+            Ok(Some(Err(err))) => {
+                // Lost in transit: drop them, TCP inside the tunnel retransmits.
+                warn!("dropping lost mixnet messages: {err}");
+                return Ok(Vec::new());
+            }
+            Ok(Some(Ok(data))) => data,
         };
 
         // The IPR mirrors the connect-time version on all traffic (data included),

--- a/sdk/rust/nym-sdk/src/mixnet/native_client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/native_client.rs
@@ -389,6 +389,7 @@ impl MixnetClient {
     /// Returns a [`MixnetStream`] implementing `AsyncRead + AsyncWrite`.
     /// `reply_surbs` controls how many reply SURBs are included with each
     /// outbound message so the peer can reply. Defaults to 10 if `None`.
+    /// One of them is spent on the peer's establishment acknowledgement.
     ///
     /// This is a one-way transition: once stream mode is active,
     /// message-mode methods like [`send_plain_message`](MixnetMessageSender::send_plain_message)

--- a/sdk/rust/nym-sdk/src/mixnet/native_client.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/native_client.rs
@@ -412,6 +412,13 @@ impl MixnetClient {
     /// # }
     /// ```
     ///
+    /// # Errors
+    ///
+    /// [`Error::UnroutableRecipient`](crate::Error::UnroutableRecipient) if
+    /// the recipient's gateway is not in the current topology. The source
+    /// distinguishes an empty local view (retry shortly) from an unknown
+    /// gateway (the address may be stale).
+    ///
     /// # Cancel safety
     ///
     /// This method is **not** cancel safe. Cancelling after the `Open`

--- a/sdk/rust/nym-sdk/src/mixnet/stream/ARCHITECTURE.md
+++ b/sdk/rust/nym-sdk/src/mixnet/stream/ARCHITECTURE.md
@@ -63,8 +63,8 @@ For streams, `LpFrameKind` is `SphinxStream` (0x0003) and the 14-byte
 - `OpenAck` (2) acknowledges an accepted `Open` (see Establishment)
 
 There is no `Close` type: streams clean up via `Drop` and idle timeout.
-Sequence numbers enable reorder buffering (up to `MAX_REORDER_BUFFER`
-out-of-order messages per stream). Peers running an SDK without the
+Sequence numbers enable reorder buffering (up to `MAX_REORDER_BUFFER_BYTES`,
+8 MiB of out-of-order data per stream). Peers running an SDK without the
 `OpenAck` frame type reject it during attribute parsing and drop the
 frame, so mixed-version peers interoperate without a coordinated upgrade.
 

--- a/sdk/rust/nym-sdk/src/mixnet/stream/ARCHITECTURE.md
+++ b/sdk/rust/nym-sdk/src/mixnet/stream/ARCHITECTURE.md
@@ -113,6 +113,10 @@ streams, and listener. Methods: `register_stream`, `remove`,
 - **No `Close` message** — there is no explicit stream-close signal.
   Streams clean up locally via `Drop` and idle timeout. A proper
   close/EOF mechanism requires further protocol work.
-- **Reorder buffer cap** — out-of-order messages are buffered up to
-  `MAX_REORDER_BUFFER` (256) per stream. If a sequence number is
-  permanently lost, the buffer skips ahead once full.
+- **Reorder buffer cap** - out-of-order messages are buffered up to
+  `MAX_REORDER_BUFFER_BYTES` (8 MiB) per stream. A full buffer skips the
+  missing range and reports the loss in-band as `InvalidData`. `recv()`
+  surfaces it once and later messages keep flowing; `AsyncRead` fails
+  the stream permanently. The cap is generous relative to per-tunnel
+  throughput, so a late frame with a retransmit in flight does not trip
+  it.

--- a/sdk/rust/nym-sdk/src/mixnet/stream/ARCHITECTURE.md
+++ b/sdk/rust/nym-sdk/src/mixnet/stream/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Stream Multiplexing — Architecture
+# Stream Multiplexing: Architecture
 
 ## Overview
 
@@ -58,17 +58,20 @@ For streams, `LpFrameKind` is `SphinxStream` (0x0003) and the 14-byte
 [StreamId: 8 BE][MsgType: 1][SequenceNum: 4 BE][reserved: 1]
 ```
 
-- `Open` (0) — initiates a new stream
-- `Data` (1) — carries payload for an existing stream
+- `Open` (0) initiates a new stream
+- `Data` (1) carries payload for an existing stream
+- `OpenAck` (2) acknowledges an accepted `Open` (see Establishment)
 
-There is no `Close` type — streams clean up via `Drop` and idle timeout.
+There is no `Close` type: streams clean up via `Drop` and idle timeout.
 Sequence numbers enable reorder buffering (up to `MAX_REORDER_BUFFER`
-out-of-order messages per stream).
+out-of-order messages per stream). Peers running an SDK without the
+`OpenAck` frame type reject it during attribute parsing and drop the
+frame, so mixed-version peers interoperate without a coordinated upgrade.
 
 ## Initialization
 
 Stream mode activates lazily on the first `open_stream()` or `listener()`
-call. This is a one-way transition — message-mode APIs
+call. This is a one-way transition: message-mode APIs
 (`send_plain_message`, `wait_for_messages`, etc.) return
 `Error::StreamModeActive` afterwards.
 
@@ -82,7 +85,10 @@ A background task that reads inbound messages and dispatches them:
 - **Open** → forwarded to `MixnetListener`'s accept channel
 - **Data** → looked up in `StreamMap` by `StreamId`, forwarded to the
   stream's channel
+- **OpenAck** → marks the stream established (fires `wait_established`)
 - Unrecognised messages are silently dropped
+
+The router's periodic tick (every 10 s at most) reaps stale streams.
 
 Shuts down via `CancellationToken` or when the receiver closes.
 
@@ -95,25 +101,75 @@ Shuts down via `CancellationToken` or when the receiver closes.
 router, registers in `StreamMap`, returns a `MixnetStream` using the
 sender's reply SURBs.
 
+## Establishment
+
+Without an acknowledgement, opening a stream is fire-and-forget. The
+dial-time topology check proves the recipient's gateway is routable, and
+nothing after it tells the dialer whether the peer's client is running or
+whether anyone called `accept()`. `OpenAck` closes that gap.
+
+### Why this lives at the stream layer
+
+Every Sphinx fragment already carries a prepaid SURB-ack, but the
+recipient's gateway forwards that ack whether the message was delivered
+to a connected client, stored for an offline one, or dropped because the
+recipient never registered (`handle_final_hop` in
+`nym-node/src/node/mixnet/handler.rs`). This is deliberate: an ack
+conditional on recipient state would let anyone who knows an address
+probe whether that client is online, without its participation. The ack
+layer therefore attests only "reached the destination gateway" and is
+consumed internally by retransmission. End-to-end liveness has to come
+from a layer where the recipient actively consents by responding, which
+is this one.
+
+### How it works
+
+`accept()` sends a best-effort `OpenAck` through the dialer's reply SURBs
+after registering the stream. The send is non-blocking and a failure
+never fails the accept, because the acknowledgement is advisory and the
+stream works without it. `MixnetStream::wait_established(timeout)`
+resolves when the ack arrives. The caller passes the timeout, because a
+sensible budget depends on the application: a mixnet round trip is
+seconds, and a cold establishment takes appreciably longer.
+
+Inbound `Data` also resolves `wait_established`, because data on a stream
+proves the peer accepted it. That covers a lost ack: the single `OpenAck`
+is never retransmitted.
+
+A timeout is inconclusive. It cannot distinguish a peer running an older
+SDK, one with no reply SURBs left, and one that is gone, so it must not
+be read as proof of death, and the stream stays usable afterwards.
+
+`last_peer_activity()` reports when the peer was last heard from. It
+reads local state and sends nothing.
+
 ## Cleanup
 
-- **`Drop` on `MixnetStream`** — deregisters from `StreamMap`
-- **`poll_shutdown`** — same, with a `deregistered` flag to avoid double-remove
-- **Idle timeout** — streams inactive longer than `stream_idle_timeout`
+- **`Drop` on `MixnetStream`**: deregisters from `StreamMap`
+- **`poll_shutdown`**: same, with a `deregistered` flag to avoid double-remove
+- **Idle timeout**: streams inactive longer than `stream_idle_timeout`
   (default 30 min) are reaped every 10s
 
 ## `StreamMap`
 
-`Arc<Mutex<HashMap<StreamId, StreamEntry>>>` — shared between router,
+`Arc<Mutex<HashMap<StreamId, StreamEntry>>>`, shared between router,
 streams, and listener. Methods: `register_stream`, `remove`,
-`send_to_stream`, `cleanup_stale`.
+`send_to_stream`, `cleanup_stale`, `mark_established`, `last_activity`.
 
 ## Known Limitations
 
-- **No `Close` message** — there is no explicit stream-close signal.
+- **No `Close` message**: there is no explicit stream-close signal.
   Streams clean up locally via `Drop` and idle timeout. A proper
   close/EOF mechanism requires further protocol work.
-- **Reorder buffer cap** - out-of-order messages are buffered up to
+- **No mid-stream liveness**: `OpenAck` answers "did anyone accept this
+  stream", not "is the peer still there". A peer that dies mid-stream is
+  only caught by the idle reaper. Keepalive is the follow-up change
+  `add-stream-keepalive`.
+- **The ack costs one reply SURB**, taken from the count the dialer
+  already attaches to the `Open` (10 by default). A dialer that attaches
+  none gets no acknowledgement. Sizing SURB counts to the Sphinx packet
+  boundary is separate work and deliberately not part of this change.
+- **Reorder buffer cap**: out-of-order messages are buffered up to
   `MAX_REORDER_BUFFER_BYTES` (8 MiB) per stream. A full buffer skips the
   missing range and reports the loss in-band as `InvalidData`. `recv()`
   surfaces it once and later messages keep flowing; `AsyncRead` fails

--- a/sdk/rust/nym-sdk/src/mixnet/stream/mixnet_stream.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/stream/mixnet_stream.rs
@@ -5,11 +5,12 @@
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use bytes::BytesMut;
 use futures::{ready, SinkExt};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 use nym_client_core::client::base_client::ClientInput;
 use nym_client_core::client::inbound_messages::InputMessage;
@@ -56,10 +57,15 @@ pub struct MixnetStream {
     /// and writes fail. `recv()` never sets this: it returns the error
     /// once and keeps going.
     failure: Option<StreamFailure>,
+
+    /// Flips to true when the peer acknowledges the stream. Already true
+    /// for inbound streams: we accepted them ourselves.
+    established_rx: watch::Receiver<bool>,
 }
 
 impl MixnetStream {
     /// Create a stream we initiated to a known recipient.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_outbound(
         id: StreamId,
         recipient: Recipient,
@@ -68,6 +74,7 @@ impl MixnetStream {
         packet_type: Option<PacketType>,
         streams: StreamMap,
         inbound_rx: mpsc::UnboundedReceiver<Result<Vec<u8>, StreamFailure>>,
+        established_rx: watch::Receiver<bool>,
     ) -> Self {
         let sender = PollSender::new(client_input.input_sender.clone());
         Self {
@@ -84,10 +91,12 @@ impl MixnetStream {
             deregistered: false,
             next_seq: 0,
             failure: None,
+            established_rx,
         }
     }
 
     /// Create a stream accepted from a remote peer's Open message.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_inbound(
         id: StreamId,
         sender_tag: AnonymousSenderTag,
@@ -95,6 +104,7 @@ impl MixnetStream {
         packet_type: Option<PacketType>,
         streams: StreamMap,
         inbound_rx: mpsc::UnboundedReceiver<Result<Vec<u8>, StreamFailure>>,
+        established_rx: watch::Receiver<bool>,
         initial_data: Vec<u8>,
     ) -> Self {
         let mut read_buf = BytesMut::new();
@@ -113,12 +123,44 @@ impl MixnetStream {
             deregistered: false,
             next_seq: 0,
             failure: None,
+            established_rx,
         }
     }
 
     /// Return the unique identifier for this stream.
     pub fn id(&self) -> StreamId {
         self.id
+    }
+
+    /// Wait up to `timeout` for the peer to acknowledge the stream.
+    ///
+    /// Resolves once the peer's `OpenAck` arrives, or once the peer sends
+    /// data (which proves it accepted the stream, covering a lost ack).
+    /// On an inbound stream it resolves immediately.
+    ///
+    /// A timeout means the peer's state is unknown: it may run an SDK
+    /// without establishment support, have no reply SURBs left, or be
+    /// gone. The stream stays usable after a timeout, so this is not a
+    /// reason to discard it.
+    ///
+    /// Pick the timeout to suit the caller: a mixnet round trip is
+    /// seconds, and a cold establishment can take appreciably longer.
+    pub async fn wait_established(&mut self, timeout: Duration) -> std::io::Result<()> {
+        match tokio::time::timeout(timeout, self.established_rx.wait_for(|v| *v)).await {
+            Ok(Ok(_)) => Ok(()),
+            Ok(Err(_)) => Err(std::io::Error::other("stream closed before establishment")),
+            Err(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "no establishment acknowledgement within timeout (peer state unknown)",
+            )),
+        }
+    }
+
+    /// Instant of the most recent inbound frame from the peer, or `None`
+    /// once the stream is no longer registered. Reads local state only;
+    /// sends nothing.
+    pub async fn last_peer_activity(&self) -> Option<tokio::time::Instant> {
+        self.streams.last_activity(&self.id).await
     }
 
     /// Receive a single message payload directly from the stream channel.

--- a/sdk/rust/nym-sdk/src/mixnet/stream/mixnet_stream.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/stream/mixnet_stream.rs
@@ -22,7 +22,7 @@ use tokio_util::sync::PollSender;
 use nym_lp_data::packet::frame::SphinxStreamMsgType;
 
 use super::protocol::{encode_stream_message, StreamId};
-use super::StreamMap;
+use super::{StreamFailure, StreamMap};
 
 /// How to address outbound messages on this stream.
 enum Destination {
@@ -47,10 +47,15 @@ pub struct MixnetStream {
     packet_type: Option<PacketType>,
     streams: StreamMap,
 
-    inbound_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+    inbound_rx: mpsc::UnboundedReceiver<Result<Vec<u8>, StreamFailure>>,
     read_buf: BytesMut,
     deregistered: bool,
     next_seq: u32,
+
+    /// Set when `poll_read` hits a lost-data marker. Once set, all reads
+    /// and writes fail. `recv()` never sets this: it returns the error
+    /// once and keeps going.
+    failure: Option<StreamFailure>,
 }
 
 impl MixnetStream {
@@ -62,7 +67,7 @@ impl MixnetStream {
         client_input: ClientInput,
         packet_type: Option<PacketType>,
         streams: StreamMap,
-        inbound_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+        inbound_rx: mpsc::UnboundedReceiver<Result<Vec<u8>, StreamFailure>>,
     ) -> Self {
         let sender = PollSender::new(client_input.input_sender.clone());
         Self {
@@ -78,6 +83,7 @@ impl MixnetStream {
             read_buf: BytesMut::new(),
             deregistered: false,
             next_seq: 0,
+            failure: None,
         }
     }
 
@@ -88,7 +94,7 @@ impl MixnetStream {
         client_input: ClientInput,
         packet_type: Option<PacketType>,
         streams: StreamMap,
-        inbound_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+        inbound_rx: mpsc::UnboundedReceiver<Result<Vec<u8>, StreamFailure>>,
         initial_data: Vec<u8>,
     ) -> Self {
         let mut read_buf = BytesMut::new();
@@ -106,6 +112,7 @@ impl MixnetStream {
             read_buf,
             deregistered: false,
             next_seq: 0,
+            failure: None,
         }
     }
 
@@ -116,13 +123,23 @@ impl MixnetStream {
 
     /// Receive a single message payload directly from the stream channel.
     ///
-    /// Returns `None` on EOF (channel closed). Drains any leftover from
-    /// a prior `AsyncRead` call first.
-    pub async fn recv(&mut self) -> Option<Vec<u8>> {
-        if !self.read_buf.is_empty() {
-            return Some(self.read_buf.split().to_vec());
+    /// Returns `None` on EOF (channel closed). Returns `Some(Err(_))`
+    /// when messages were lost at this point in the sequence; later calls
+    /// return the messages that follow. Drains any leftover from a prior
+    /// `AsyncRead` call first.
+    pub async fn recv(&mut self) -> Option<std::io::Result<Vec<u8>>> {
+        if let Some(failure) = &self.failure {
+            return Some(Err(failure.as_io_error()));
         }
-        self.inbound_rx.recv().await
+        if !self.read_buf.is_empty() {
+            return Some(Ok(self.read_buf.split().to_vec()));
+        }
+        Some(
+            self.inbound_rx
+                .recv()
+                .await?
+                .map_err(StreamFailure::as_io_error),
+        )
     }
 
     /// Wrap `data` in the appropriate `InputMessage` for this stream's destination.
@@ -162,6 +179,10 @@ impl AsyncRead for MixnetStream {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf,
     ) -> Poll<std::io::Result<()>> {
+        if let Some(failure) = &self.failure {
+            return Poll::Ready(Err(failure.as_io_error()));
+        }
+
         // Drain spillover first
         if !self.read_buf.is_empty() {
             let n = std::cmp::min(buf.remaining(), self.read_buf.len());
@@ -170,13 +191,17 @@ impl AsyncRead for MixnetStream {
         }
 
         match ready!(self.inbound_rx.poll_recv(cx)) {
-            Some(data) => {
+            Some(Ok(data)) => {
                 let n = std::cmp::min(buf.remaining(), data.len());
                 buf.put_slice(&data[..n]);
                 if n < data.len() {
                     self.read_buf.extend_from_slice(&data[n..]);
                 }
                 Poll::Ready(Ok(()))
+            }
+            Some(Err(failure)) => {
+                self.failure = Some(failure);
+                Poll::Ready(Err(failure.as_io_error()))
             }
             None => Poll::Ready(Ok(())), // EOF
         }
@@ -189,6 +214,10 @@ impl AsyncWrite for MixnetStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
+        if let Some(failure) = &self.failure {
+            return Poll::Ready(Err(failure.as_io_error()));
+        }
+
         if buf.is_empty() {
             return Poll::Ready(Ok(0));
         }

--- a/sdk/rust/nym-sdk/src/mixnet/stream/mod.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/stream/mod.rs
@@ -30,14 +30,16 @@ use std::time::Duration;
 use tokio::time::Instant;
 
 use futures::StreamExt;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::{trace, warn};
 
+use nym_client_core::client::base_client::ClientInput;
 use nym_client_core::client::inbound_messages::InputMessage;
 use nym_client_core::client::received_buffer::ReconstructedMessagesReceiver;
 use nym_sphinx::addressing::clients::Recipient;
 use nym_sphinx::anonymous_replies::requests::AnonymousSenderTag;
+use nym_sphinx::params::PacketType;
 use nym_task::connections::TransmissionLane;
 
 use nym_lp_data::packet::frame::SphinxStreamMsgType;
@@ -86,6 +88,10 @@ struct StreamEntry {
     pending: BTreeMap<u32, Vec<u8>>,
     /// Total payload bytes in `pending`; makes the overflow check O(1).
     pending_bytes: usize,
+
+    /// Flips to true when the peer acknowledges the stream (or, for
+    /// inbound streams, when we accept it ourselves).
+    established_tx: watch::Sender<bool>,
 }
 
 impl StreamEntry {
@@ -162,17 +168,21 @@ impl StreamMap {
         }
     }
 
-    /// Register a new stream, returning the receiver end of its data channel.
-    /// Any orphan frames that arrived before registration are drained into
-    /// the stream immediately. Returns `None` if a stream with this id is
-    /// already active (a duplicate `Open`): replacing the existing entry
-    /// would close its reader and let the old handle's `Drop` deregister
-    /// the replacement.
+    /// Register a new stream, returning the receiver ends of its data and
+    /// established channels. Any orphan frames that arrived before
+    /// registration are drained into the stream immediately. Returns `None`
+    /// if a stream with this id is already active (a duplicate `Open`):
+    /// replacing the existing entry would close its reader and let the old
+    /// handle's `Drop` deregister the replacement.
     async fn register_stream(
         &self,
         stream_id: StreamId,
-    ) -> Option<mpsc::UnboundedReceiver<Result<Vec<u8>, StreamFailure>>> {
+    ) -> Option<(
+        mpsc::UnboundedReceiver<Result<Vec<u8>, StreamFailure>>,
+        watch::Receiver<bool>,
+    )> {
         let (tx, rx) = mpsc::unbounded_channel();
+        let (established_tx, established_rx) = watch::channel(false);
         let mut inner = self.inner.lock().await;
         if inner.streams.contains_key(&stream_id) {
             return None;
@@ -189,11 +199,33 @@ impl StreamMap {
             next_seq: 0,
             pending,
             pending_bytes,
+            established_tx,
         };
         // The receiver cannot have been dropped yet - we still hold it.
         entry.drain_ready();
         inner.streams.insert(stream_id, entry);
-        Some(rx)
+        Some((rx, established_rx))
+    }
+
+    /// Mark a stream established: an OpenAck arrived (outbound), or we
+    /// accepted the stream ourselves (inbound). Unknown ids are ignored;
+    /// acks carry no data worth orphan-buffering.
+    async fn mark_established(&self, stream_id: &StreamId) {
+        let mut inner = self.inner.lock().await;
+        if let Some(entry) = inner.streams.get_mut(stream_id) {
+            let _ = entry.established_tx.send(true);
+            entry.last_activity = Instant::now();
+        }
+    }
+
+    /// Instant of the most recent inbound frame for a stream, or `None` if
+    /// the stream is no longer registered.
+    async fn last_activity(&self, stream_id: &StreamId) -> Option<Instant> {
+        let inner = self.inner.lock().await;
+        inner
+            .streams
+            .get(stream_id)
+            .map(|entry| entry.last_activity)
     }
 
     /// Remove a stream from the map, along with any orphan frames held for
@@ -267,7 +299,10 @@ impl StreamMap {
         if receiver_dropped {
             inner.streams.remove(stream_id);
         } else {
+            // Data from the peer proves it accepted the stream, so it
+            // establishes the stream even when the OpenAck was lost.
             entry.last_activity = Instant::now();
+            let _ = entry.established_tx.send(true);
         }
     }
 
@@ -359,8 +394,8 @@ impl Drop for StreamState {
 /// `listener()` returns [`Error::ListenerAlreadyTaken`].
 pub struct MixnetListener {
     inbound_rx: mpsc::UnboundedReceiver<InboundOpen>,
-    client_input: nym_client_core::client::base_client::ClientInput,
-    packet_type: Option<nym_sphinx::params::PacketType>,
+    client_input: ClientInput,
+    packet_type: Option<PacketType>,
     streams: StreamMap,
 }
 
@@ -388,13 +423,40 @@ impl MixnetListener {
                 }
             };
 
-            let Some(rx) = self.streams.register_stream(req.stream_id).await else {
+            let Some((rx, established_rx)) = self.streams.register_stream(req.stream_id).await
+            else {
                 warn!(
                     "Listener: duplicate Open for active stream {}, ignoring",
                     req.stream_id
                 );
                 continue;
             };
+
+            // We are the accepting side, so the stream is established by
+            // construction; this also lets `wait_established` on the
+            // returned handle resolve immediately.
+            self.streams.mark_established(&req.stream_id).await;
+
+            // Best-effort ack: costs one of the dialer's SURBs and tells it
+            // someone is listening. The stream works without it, so a
+            // failed send (for example a dialer that attached no SURBs)
+            // must not lose the stream.
+            let ack = encode_stream_message(&req.stream_id, SphinxStreamMsgType::OpenAck, 0, &[]);
+            let ack_msg = InputMessage::new_reply(
+                sender_tag,
+                ack,
+                TransmissionLane::General,
+                self.packet_type,
+            );
+            // Non-blocking: accept() must not park behind unrelated
+            // application writes on the bounded input channel for an ack
+            // the protocol treats as optional.
+            if self.client_input.input_sender.try_send(ack_msg).is_err() {
+                warn!(
+                    "Stream {}: could not send OpenAck (channel busy or closed)",
+                    req.stream_id
+                );
+            }
 
             return Some(MixnetStream::new_inbound(
                 req.stream_id,
@@ -403,6 +465,7 @@ impl MixnetListener {
                 self.packet_type,
                 self.streams.clone(),
                 rx,
+                established_rx,
                 req.initial_data,
             ));
         }
@@ -456,6 +519,9 @@ async fn run_router(
                     streams
                         .send_to_stream(&stream_id, frame.sequence_num, frame.data.to_vec())
                         .await;
+                }
+                SphinxStreamMsgType::OpenAck => {
+                    streams.mark_established(&stream_id).await;
                 }
             }
         }
@@ -525,16 +591,18 @@ pub(crate) async fn open_stream(
 
     // Random ids make collisions vanishingly unlikely, but regenerate on
     // the off chance rather than clobbering an active stream.
-    let (stream_id, rx) = loop {
+    let (stream_id, rx, established_rx) = loop {
         let stream_id = StreamId::random();
-        if let Some(rx) = streams.register_stream(stream_id).await {
-            break (stream_id, rx);
+        if let Some((rx, established_rx)) = streams.register_stream(stream_id).await {
+            break (stream_id, rx, established_rx);
         }
     };
 
     // Open message with seq=0. The receiver's reorder buffer starts at
     // next_seq=0 so this could later carry an initial seq to resume a
-    // dropped stream from where it left off.
+    // dropped stream from where it left off. The Open carries more SURBs
+    // than a Data message: it prepays the OpenAck and the peer's first
+    // replies.
     let wire = encode_stream_message(&stream_id, SphinxStreamMsgType::Open, 0, &[]);
     let msg = InputMessage::new_anonymous(
         recipient,
@@ -556,6 +624,7 @@ pub(crate) async fn open_stream(
         client.packet_type,
         streams,
         rx,
+        established_rx,
     ))
 }
 
@@ -580,27 +649,30 @@ pub(crate) fn listener(client: &mut MixnetClient) -> Result<MixnetListener> {
 mod tests {
     use super::*;
 
+    /// Register a stream and return just the data receiver: what most
+    /// reorder-buffer tests care about.
+    async fn register(
+        map: &StreamMap,
+        id: StreamId,
+    ) -> mpsc::UnboundedReceiver<Result<Vec<u8>, StreamFailure>> {
+        map.register_stream(id).await.expect("fresh stream id").0
+    }
+
     #[tokio::test(start_paused = true)]
     async fn cleanup_stale_removes_idle_streams() {
         let map = StreamMap::new();
         let timeout = Duration::from_secs(10);
 
         // Register two streams
-        let _rx_a = map
-            .register_stream(StreamId::random())
-            .await
-            .expect("fresh stream id");
-        let _rx_b = map
-            .register_stream(StreamId::random())
-            .await
-            .expect("fresh stream id");
+        let _rx_a = register(&map, StreamId::random()).await;
+        let _rx_b = register(&map, StreamId::random()).await;
 
         // Advance time past the timeout
         tokio::time::advance(timeout + Duration::from_secs(1)).await;
 
         // Register a fresh stream (should survive cleanup)
         let id_c = StreamId::random();
-        let _rx_c = map.register_stream(id_c).await.expect("fresh stream id");
+        let _rx_c = register(&map, id_c).await;
 
         map.cleanup_stale(timeout).await;
 
@@ -615,7 +687,7 @@ mod tests {
         let timeout = Duration::from_secs(10);
         let id = StreamId::random();
 
-        let _rx = map.register_stream(id).await.expect("fresh stream id");
+        let _rx = register(&map, id).await;
 
         // Advance most of the way through the timeout
         tokio::time::advance(Duration::from_secs(8)).await;
@@ -638,7 +710,7 @@ mod tests {
         let timeout = Duration::from_secs(10);
 
         let id = StreamId::random();
-        let _rx = map.register_stream(id).await.expect("fresh stream id");
+        let _rx = register(&map, id).await;
 
         // Advance less than the timeout
         tokio::time::advance(Duration::from_secs(5)).await;
@@ -659,7 +731,7 @@ mod tests {
         map.cleanup_stale(Duration::from_secs(600)).await;
 
         // The orphan was swept: registering now delivers nothing.
-        let mut rx = map.register_stream(id).await.expect("fresh stream id");
+        let mut rx = register(&map, id).await;
         assert!(rx.try_recv().is_err());
         assert!(map.inner.lock().await.orphans.is_empty());
     }
@@ -693,7 +765,7 @@ mod tests {
         let map = StreamMap::new();
         let id = StreamId::random();
 
-        let mut rx = map.register_stream(id).await.expect("fresh stream id");
+        let mut rx = register(&map, id).await;
         // A duplicate Open for an active stream must not clobber the entry.
         assert!(map.register_stream(id).await.is_none());
 
@@ -732,7 +804,7 @@ mod tests {
     async fn out_of_order_messages_delivered_in_sequence() {
         let map = StreamMap::new();
         let id = StreamId::random();
-        let mut rx = map.register_stream(id).await.expect("fresh stream id");
+        let mut rx = register(&map, id).await;
 
         // Send seq 2, 0, 1 out of order
         map.send_to_stream(&id, 2, vec![20]).await;
@@ -757,7 +829,7 @@ mod tests {
         // the stream is registered. It must be buffered, not dropped.
         map.send_to_stream(&id, 0, vec![42]).await;
 
-        let mut rx = map.register_stream(id).await.expect("fresh stream id");
+        let mut rx = register(&map, id).await;
         assert_eq!(
             rx.try_recv()
                 .expect("early data delivered on registration")
@@ -775,7 +847,7 @@ mod tests {
         map.send_to_stream(&id, 1, vec![10]).await;
         map.send_to_stream(&id, 0, vec![0]).await;
 
-        let mut rx = map.register_stream(id).await.expect("fresh stream id");
+        let mut rx = register(&map, id).await;
         assert_eq!(rx.try_recv().unwrap().unwrap(), vec![0]);
         assert_eq!(rx.try_recv().unwrap().unwrap(), vec![10]);
     }
@@ -784,7 +856,7 @@ mod tests {
     async fn duplicate_seq_is_dropped() {
         let map = StreamMap::new();
         let id = StreamId::random();
-        let mut rx = map.register_stream(id).await.expect("fresh stream id");
+        let mut rx = register(&map, id).await;
 
         map.send_to_stream(&id, 0, vec![0]).await;
         map.send_to_stream(&id, 0, vec![99]).await; // duplicate, dropped
@@ -798,7 +870,7 @@ mod tests {
     async fn reorder_overflow_signals_data_loss_in_order() {
         let map = StreamMap::new();
         let id = StreamId::random();
-        let mut rx = map.register_stream(id).await.expect("fresh stream id");
+        let mut rx = register(&map, id).await;
         let chunk = MAX_REORDER_BUFFER_BYTES / 8;
 
         // seq 0 arrives and is delivered; seq 1 is lost in the mixnet.
@@ -828,7 +900,7 @@ mod tests {
     async fn late_gap_filler_at_capacity_is_not_data_loss() {
         let map = StreamMap::new();
         let id = StreamId::random();
-        let mut rx = map.register_stream(id).await.expect("fresh stream id");
+        let mut rx = register(&map, id).await;
         let chunk = MAX_REORDER_BUFFER_BYTES / 8;
 
         // seq 0 delivered; seq 1 is late; 2..=9 fill the buffer to the cap.
@@ -846,5 +918,82 @@ mod tests {
         }
         // Outer Err: the channel is drained, not a stream failure.
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn open_ack_fires_established_watch() {
+        let map = StreamMap::new();
+        let id = StreamId::random();
+        let (_rx, mut established) = map.register_stream(id).await.expect("fresh stream id");
+        assert!(!*established.borrow());
+
+        // What the router does on OpenAck.
+        map.mark_established(&id).await;
+        assert!(established.wait_for(|v| *v).await.is_ok());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn no_ack_within_timeout_leaves_stream_usable() {
+        let map = StreamMap::new();
+        let id = StreamId::random();
+        let (mut rx, mut established) = map.register_stream(id).await.expect("fresh stream id");
+
+        // No ack arrives: the wait times out.
+        let wait = tokio::time::timeout(Duration::from_secs(15), established.wait_for(|v| *v));
+        assert!(wait.await.is_err());
+
+        // The stream still delivers data afterwards.
+        map.send_to_stream(&id, 0, vec![9]).await;
+        assert_eq!(rx.recv().await.unwrap().unwrap(), vec![9]);
+    }
+
+    #[tokio::test]
+    async fn inbound_data_establishes_the_stream() {
+        let map = StreamMap::new();
+        let id = StreamId::random();
+        let (_rx, established) = map.register_stream(id).await.expect("fresh stream id");
+        assert!(!*established.borrow());
+
+        // Data from the peer proves it accepted the stream, so
+        // wait_established resolves even if the lone OpenAck was lost.
+        map.send_to_stream(&id, 0, vec![1]).await;
+        assert!(*established.borrow());
+    }
+
+    #[tokio::test]
+    async fn accept_survives_open_ack_send_failure() {
+        // A ClientInput whose channels are all closed: every send fails,
+        // as it would for a dialer that attached no reply SURBs.
+        let (input_tx, input_rx) = tokio::sync::mpsc::channel(1);
+        drop(input_rx);
+        let (request_tx, request_rx) = tokio::sync::mpsc::channel(1);
+        drop(request_rx);
+        let (connection_tx, connection_rx) = futures::channel::mpsc::unbounded();
+        drop(connection_rx);
+        let client_input = ClientInput {
+            connection_command_sender: connection_tx,
+            input_sender: input_tx,
+            client_request_sender: request_tx,
+        };
+
+        let (open_tx, open_rx) = mpsc::unbounded_channel();
+        let mut listener = MixnetListener {
+            inbound_rx: open_rx,
+            client_input,
+            packet_type: None,
+            streams: StreamMap::new(),
+        };
+
+        open_tx
+            .send(InboundOpen {
+                stream_id: StreamId::random(),
+                sender_tag: Some(AnonymousSenderTag::from([7u8; 16])),
+                initial_data: Vec::new(),
+            })
+            .expect("listener alive");
+
+        // The ack cannot be sent, but the stream must still be returned.
+        let stream = listener.accept().await;
+        assert!(stream.is_some());
     }
 }

--- a/sdk/rust/nym-sdk/src/mixnet/stream/mod.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/stream/mod.rs
@@ -54,16 +54,38 @@ pub(crate) const DEFAULT_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(30 
 /// are respected promptly rather than waiting up to 60 s for the next sweep.
 const MAX_CLEANUP_INTERVAL: Duration = Duration::from_secs(10);
 
+/// A stream failure, sent through the data channel so it arrives in
+/// order with the data around it. `recv()` returns it once and keeps
+/// delivering later messages; `AsyncRead` fails the stream for good.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum StreamFailure {
+    /// The reorder buffer overflowed and skipped past missing messages.
+    DataLoss,
+}
+
+impl StreamFailure {
+    pub(crate) fn as_io_error(self) -> std::io::Error {
+        match self {
+            StreamFailure::DataLoss => std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "stream data lost: reorder buffer overflow skipped missing messages",
+            ),
+        }
+    }
+}
+
 /// Per-stream state stored in the routing table.
 ///
 /// Reorder buffer uses the same BTreeMap pattern as `OrderedMessageBuffer`
 /// (`common/socks5/ordered-buffer/`) but drains per-message instead of
 /// concatenating, so `recv()` preserves message boundaries.
 struct StreamEntry {
-    sender: mpsc::UnboundedSender<Vec<u8>>,
+    sender: mpsc::UnboundedSender<Result<Vec<u8>, StreamFailure>>,
     last_activity: Instant,
     next_seq: u32,
     pending: BTreeMap<u32, Vec<u8>>,
+    /// Total payload bytes in `pending`; makes the overflow check O(1).
+    pending_bytes: usize,
 }
 
 impl StreamEntry {
@@ -71,7 +93,8 @@ impl StreamEntry {
     /// Returns true if the receiver has been dropped.
     fn drain_ready(&mut self) -> bool {
         while let Some(msg) = self.pending.remove(&self.next_seq) {
-            if self.sender.send(msg).is_err() {
+            self.pending_bytes -= msg.len();
+            if self.sender.send(Ok(msg)).is_err() {
                 return true;
             }
             self.next_seq += 1;
@@ -101,13 +124,18 @@ const MAX_ORPHAN_STREAMS: usize = 64;
 /// Maximum frames buffered per orphan stream.
 const MAX_ORPHAN_MESSAGES: usize = 32;
 
-/// Maximum number of out-of-order messages buffered per stream before we
+/// Maximum bytes of out-of-order messages buffered per stream before we
 /// skip ahead. Without this cap, a malicious sender that deliberately skips
 /// a sequence number (e.g. never sends seq 1) could cause the buffer to
 /// grow indefinitely while the drain loop waits for the missing seq.
 /// The idle timeout only reaps *inactive* streams, so an actively-sending
 /// attacker would bypass it.
-const MAX_REORDER_BUFFER: usize = 256;
+///
+/// Sized so a late frame with a retransmit in flight cannot trip it:
+/// 8 MiB is minutes of buffering at per-tunnel throughput, against
+/// second-scale retransmits. A skip means real loss, and a skip fails
+/// the stream (see [`StreamFailure`]).
+const MAX_REORDER_BUFFER_BYTES: usize = 8 * 1024 * 1024;
 
 /// The stream and orphan-frame tables, always locked together.
 struct StreamMapInner {
@@ -143,7 +171,7 @@ impl StreamMap {
     async fn register_stream(
         &self,
         stream_id: StreamId,
-    ) -> Option<mpsc::UnboundedReceiver<Vec<u8>>> {
+    ) -> Option<mpsc::UnboundedReceiver<Result<Vec<u8>, StreamFailure>>> {
         let (tx, rx) = mpsc::unbounded_channel();
         let mut inner = self.inner.lock().await;
         if inner.streams.contains_key(&stream_id) {
@@ -154,11 +182,13 @@ impl StreamMap {
             .remove(&stream_id)
             .map(|orphan| orphan.pending)
             .unwrap_or_default();
+        let pending_bytes = pending.values().map(Vec::len).sum();
         let mut entry = StreamEntry {
             sender: tx,
             last_activity: Instant::now(),
             next_seq: 0,
             pending,
+            pending_bytes,
         };
         // The receiver cannot have been dropped yet - we still hold it.
         entry.drain_ready();
@@ -174,7 +204,7 @@ impl StreamMap {
         inner.orphans.remove(stream_id);
     }
 
-    /// Remove a stream without awaiting — for use in `Drop` and `poll_shutdown`
+    /// Remove a stream without awaiting: for use in `Drop` and `poll_shutdown`
     /// where we cannot `.await`. Spawns a lightweight background task.
     fn remove_background(&self, stream_id: StreamId) {
         let inner = self.inner.clone();
@@ -202,19 +232,33 @@ impl StreamMap {
                 entry.next_seq
             );
         } else {
-            entry.pending.insert(seq, data);
+            entry.pending_bytes += data.len();
+            if let Some(replaced) = entry.pending.insert(seq, data) {
+                // Duplicate seq: the replaced payload leaves the buffer.
+                entry.pending_bytes -= replaced.len();
+            }
         }
 
-        // If the buffer has grown too large, skip ahead to the lowest
-        // buffered seq so we don't accumulate unbounded memory.
-        if entry.pending.len() > MAX_REORDER_BUFFER {
-            if let Some(&lowest) = entry.pending.keys().next() {
+        // Over the cap: skip ahead to the lowest buffered seq and report
+        // the discarded range in-band. `lowest == next_seq` means the
+        // arriving frame filled the gap; everything drains below, so no
+        // skip and no failure.
+        if entry.pending_bytes > MAX_REORDER_BUFFER_BYTES {
+            let lowest = entry
+                .pending
+                .keys()
+                .next()
+                .copied()
+                .unwrap_or(entry.next_seq);
+            if lowest > entry.next_seq {
                 warn!(
-                    "Stream {stream_id}: reorder buffer overflow ({} pending), \
-                     skipping seq {} -> {lowest}",
+                    "Stream {stream_id}: reorder buffer overflow ({} messages, \
+                     {} bytes pending), skipping seq {} -> {lowest}",
                     entry.pending.len(),
+                    entry.pending_bytes,
                     entry.next_seq
                 );
+                let _ = entry.sender.send(Err(StreamFailure::DataLoss));
                 entry.next_seq = lowest;
             }
         }
@@ -311,7 +355,7 @@ impl Drop for StreamState {
 /// Created via [`MixnetClient::listener`]. Each `accept()` returns a
 /// `MixnetStream` ready for reading and writing.
 ///
-/// Only one `MixnetListener` can exist per client — a second call to
+/// Only one `MixnetListener` can exist per client; a second call to
 /// `listener()` returns [`Error::ListenerAlreadyTaken`].
 pub struct MixnetListener {
     inbound_rx: mpsc::UnboundedReceiver<InboundOpen>,
@@ -584,7 +628,7 @@ mod tests {
 
         map.cleanup_stale(timeout).await;
 
-        // Stream should survive — last activity was 5s ago, not 13s
+        // Stream should survive: last activity was 5s ago, not 13s
         assert_eq!(map.inner.lock().await.streams.len(), 1);
     }
 
@@ -655,7 +699,7 @@ mod tests {
 
         // The original stream still receives data.
         map.send_to_stream(&id, 0, vec![1]).await;
-        assert_eq!(rx.try_recv().unwrap(), vec![1]);
+        assert_eq!(rx.try_recv().unwrap().unwrap(), vec![1]);
     }
 
     #[tokio::test]
@@ -695,12 +739,12 @@ mod tests {
         map.send_to_stream(&id, 0, vec![0]).await;
 
         // seq 0 should be delivered now, but 2 is buffered (gap at 1)
-        assert_eq!(rx.recv().await.unwrap(), vec![0]);
+        assert_eq!(rx.recv().await.unwrap().unwrap(), vec![0]);
 
-        // Fill the gap — both 1 and 2 should flush
+        // Fill the gap: both 1 and 2 should flush
         map.send_to_stream(&id, 1, vec![10]).await;
-        assert_eq!(rx.recv().await.unwrap(), vec![10]);
-        assert_eq!(rx.recv().await.unwrap(), vec![20]);
+        assert_eq!(rx.recv().await.unwrap().unwrap(), vec![10]);
+        assert_eq!(rx.recv().await.unwrap().unwrap(), vec![20]);
     }
 
     #[tokio::test]
@@ -715,7 +759,9 @@ mod tests {
 
         let mut rx = map.register_stream(id).await.expect("fresh stream id");
         assert_eq!(
-            rx.try_recv().expect("early data delivered on registration"),
+            rx.try_recv()
+                .expect("early data delivered on registration")
+                .unwrap(),
             vec![42]
         );
     }
@@ -730,8 +776,8 @@ mod tests {
         map.send_to_stream(&id, 0, vec![0]).await;
 
         let mut rx = map.register_stream(id).await.expect("fresh stream id");
-        assert_eq!(rx.try_recv().unwrap(), vec![0]);
-        assert_eq!(rx.try_recv().unwrap(), vec![10]);
+        assert_eq!(rx.try_recv().unwrap().unwrap(), vec![0]);
+        assert_eq!(rx.try_recv().unwrap().unwrap(), vec![10]);
     }
 
     #[tokio::test]
@@ -744,7 +790,61 @@ mod tests {
         map.send_to_stream(&id, 0, vec![99]).await; // duplicate, dropped
         map.send_to_stream(&id, 1, vec![1]).await;
 
-        assert_eq!(rx.recv().await.unwrap(), vec![0]);
-        assert_eq!(rx.recv().await.unwrap(), vec![1]);
+        assert_eq!(rx.recv().await.unwrap().unwrap(), vec![0]);
+        assert_eq!(rx.recv().await.unwrap().unwrap(), vec![1]);
+    }
+
+    #[tokio::test]
+    async fn reorder_overflow_signals_data_loss_in_order() {
+        let map = StreamMap::new();
+        let id = StreamId::random();
+        let mut rx = map.register_stream(id).await.expect("fresh stream id");
+        let chunk = MAX_REORDER_BUFFER_BYTES / 8;
+
+        // seq 0 arrives and is delivered; seq 1 is lost in the mixnet.
+        map.send_to_stream(&id, 0, vec![0]).await;
+
+        // Frames pile up behind the gap: 2..=9 reach the cap exactly,
+        // seq 10 tips the buffer over it.
+        for seq in 2..=10 {
+            map.send_to_stream(&id, seq, vec![1; chunk]).await;
+        }
+
+        // Reader sees the intact prefix, then the loss, then the post-gap
+        // frames that the skip drained.
+        assert_eq!(rx.try_recv().unwrap().unwrap(), vec![0]);
+        assert!(matches!(
+            rx.try_recv().unwrap(),
+            Err(StreamFailure::DataLoss)
+        ));
+        for _ in 2..=10 {
+            assert!(rx.try_recv().unwrap().is_ok());
+        }
+        // Outer Err: the channel is drained, not a stream failure.
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn late_gap_filler_at_capacity_is_not_data_loss() {
+        let map = StreamMap::new();
+        let id = StreamId::random();
+        let mut rx = map.register_stream(id).await.expect("fresh stream id");
+        let chunk = MAX_REORDER_BUFFER_BYTES / 8;
+
+        // seq 0 delivered; seq 1 is late; 2..=9 fill the buffer to the cap.
+        map.send_to_stream(&id, 0, vec![0]).await;
+        for seq in 2..=9 {
+            map.send_to_stream(&id, seq, vec![1; chunk]).await;
+        }
+        // The late gap-filler tips the buffer over the cap, but nothing was
+        // lost: everything drains and no failure is reported.
+        map.send_to_stream(&id, 1, vec![1; chunk]).await;
+
+        assert_eq!(rx.try_recv().unwrap().unwrap(), vec![0]);
+        for _ in 1..=9 {
+            assert!(rx.try_recv().unwrap().is_ok());
+        }
+        // Outer Err: the channel is drained, not a stream failure.
+        assert!(rx.try_recv().is_err());
     }
 }

--- a/sdk/rust/nym-sdk/src/mixnet/stream/mod.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/stream/mod.rs
@@ -302,7 +302,11 @@ impl StreamMap {
             // Data from the peer proves it accepted the stream, so it
             // establishes the stream even when the OpenAck was lost.
             entry.last_activity = Instant::now();
-            let _ = entry.established_tx.send(true);
+            // Only the first frame needs to flip the watch; re-sending on
+            // every later Data frame would wake watchers for nothing.
+            if !*entry.established_tx.borrow() {
+                let _ = entry.established_tx.send(true);
+            }
         }
     }
 
@@ -600,9 +604,8 @@ pub(crate) async fn open_stream(
 
     // Open message with seq=0. The receiver's reorder buffer starts at
     // next_seq=0 so this could later carry an initial seq to resume a
-    // dropped stream from where it left off. The Open carries more SURBs
-    // than a Data message: it prepays the OpenAck and the peer's first
-    // replies.
+    // dropped stream from where it left off. The reply SURBs attached here
+    // also prepay the OpenAck; Data frames attach the same count.
     let wire = encode_stream_message(&stream_id, SphinxStreamMsgType::Open, 0, &[]);
     let msg = InputMessage::new_anonymous(
         recipient,

--- a/sdk/rust/nym-sdk/src/mixnet/stream/mod.rs
+++ b/sdk/rust/nym-sdk/src/mixnet/stream/mod.rs
@@ -458,6 +458,25 @@ pub(crate) async fn open_stream(
     recipient: Recipient,
     reply_surbs: u32,
 ) -> Result<MixnetStream> {
+    // Fail at dial time if the recipient's gateway is not in topology;
+    // otherwise the Open dies in the send task with only a warn log. The
+    // empty check separates "our view is gone" from "unknown gateway".
+    {
+        let permit = client
+            .client_state
+            .topology_accessor
+            .get_read_permit()
+            .await;
+        permit
+            .topology
+            .ensure_not_empty()
+            .and_then(|()| permit.egress_by_identity(recipient.gateway()).map(|_| ()))
+    }
+    .map_err(|source| Error::UnroutableRecipient {
+        recipient: Box::new(recipient),
+        source,
+    })?;
+
     let streams = ensure_init(client)?.streams.clone();
 
     // Random ids make collisions vanishingly unlikely, but regenerate on

--- a/smolmix/core/src/bridge.rs
+++ b/smolmix/core/src/bridge.rs
@@ -5,6 +5,7 @@ use futures::channel::mpsc;
 use futures::StreamExt;
 use nym_ip_packet_requests::codec::MultiIpPacketCodec;
 use nym_sdk::ipr_wrapper::IpMixStream;
+use nym_sdk::Error as SdkError;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, trace, warn};
 
@@ -94,18 +95,18 @@ impl NymIprBridge {
     ///
     /// # Cancel safety
     ///
-    /// `IpMixStream::handle_incoming()` is **not** cancel-safe. Its internal
-    /// `FramedRead` buffers partial frames, and it mutates connection state
-    /// after awaiting. Inside `tokio::select!`, the shutdown branch can cancel
-    /// a pending `handle_incoming()` call and lose buffered data. That is
-    /// acceptable during shutdown, but worth knowing about before adding new
-    /// branches to the loop.
+    /// `IpMixStream::handle_incoming()` is **not** cancel-safe: it mutates
+    /// connection state after awaiting. Inside `tokio::select!`, the
+    /// shutdown branch can cancel a pending `handle_incoming()` call and
+    /// lose buffered data. That is acceptable during shutdown, but worth
+    /// knowing about before adding new branches to the loop.
     pub(crate) async fn run(mut self) -> Result<(), SmolmixError> {
         info!("Starting bridge");
         let mut packets_sent: u64 = 0;
         let mut packets_received: u64 = 0;
+        let mut fatal: Option<SmolmixError> = None;
 
-        loop {
+        'run: loop {
             tokio::select! {
                 _ = &mut self.shutdown_rx => {
                     info!(packets_sent, packets_received, "Bridge received shutdown signal");
@@ -132,17 +133,26 @@ impl NymIprBridge {
                             for packet in packets {
                                 if self.incoming_tx.unbounded_send(packet.to_vec()).is_err() {
                                     error!("Device channel closed");
-                                    return Err(SmolmixError::ChannelClosed);
+                                    fatal = Some(SmolmixError::ChannelClosed);
+                                    break 'run;
                                 }
                                 packets_received += 1;
                             }
                             debug!(packets_received, "Packets received");
                         }
                         Ok(_) => {} // empty batch, keep polling
+                        Err(e @ (SdkError::IPRClientStreamClosed | SdkError::IprTunnelDisconnected)) => {
+                            // The stream is gone and errors return instantly;
+                            // retrying would busy-loop.
+                            error!("Mixnet receive error, stopping bridge: {e}");
+                            fatal = Some(e.into());
+                            break;
+                        }
                         Err(e) => {
-                            // handle_incoming() internally uses a 10-second timeout,
-                            // so this won't busy-loop on persistent errors.
+                            // Pace the retry: an instantly-returning error
+                            // must not spin the loop.
                             warn!("Mixnet receive error: {e}");
+                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                         }
                     }
                 }
@@ -159,6 +169,9 @@ impl NymIprBridge {
         self.stream.disconnect().await;
         info!("Disconnected");
 
-        Ok(())
+        match fatal {
+            Some(err) => Err(err),
+            None => Ok(()),
+        }
     }
 }

--- a/smolmix/core/src/bridge.rs
+++ b/smolmix/core/src/bridge.rs
@@ -9,6 +9,10 @@ use nym_sdk::Error as SdkError;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, trace, warn};
 
+/// Delay before retrying a failed mixnet receive, so a transient error
+/// cannot spin the event loop.
+const RECEIVE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Asynchronous bridge between the smoltcp device and the Nym mixnet.
 ///
 /// Runs as a background task, shuttling raw IP packets in both directions:
@@ -88,31 +92,54 @@ impl NymIprBridge {
         )
     }
 
-    /// Runs the bridge event loop.
+    /// Runs the bridge event loop, then disconnects the mixnet client.
     ///
     /// Should be spawned via `tokio::spawn`. The loop exits when a shutdown
-    /// signal is received, channels close, or an unrecoverable error occurs.
+    /// signal is received or an unrecoverable error occurs; either way the
+    /// disconnect below runs, so there is exactly one exit path.
+    pub(crate) async fn run(mut self) -> Result<(), SmolmixError> {
+        info!("Starting bridge");
+        let result = self.event_loop().await;
+
+        // disconnect() internally waits for all SDK tasks via TaskTracker.
+        info!("Disconnecting from mixnet...");
+        self.stream.disconnect().await;
+        info!("Disconnected");
+        result
+    }
+
+    /// The select loop proper, split out of [`Self::run`] so an error can
+    /// simply be returned instead of stashed in a flag for the disconnect
+    /// code after the loop.
     ///
     /// # Cancel safety
     ///
-    /// `IpMixStream::handle_incoming()` is **not** cancel-safe: it mutates
-    /// connection state after awaiting. Inside `tokio::select!`, the
-    /// shutdown branch can cancel a pending `handle_incoming()` call and
-    /// lose buffered data. That is acceptable during shutdown, but worth
-    /// knowing about before adding new branches to the loop.
-    pub(crate) async fn run(mut self) -> Result<(), SmolmixError> {
-        info!("Starting bridge");
+    /// Every future raced here is cancel-safe. In particular
+    /// `IpMixStream::handle_incoming()` has a single await point (a channel
+    /// receive) and mutates no state before it resolves, so losing the race
+    /// to another arm cannot drop a buffered packet. A cancelled pacing
+    /// sleep restarts at full length next iteration, which only ever waits
+    /// longer than intended.
+    async fn event_loop(&mut self) -> Result<(), SmolmixError> {
         let mut packets_sent: u64 = 0;
         let mut packets_received: u64 = 0;
-        let mut fatal: Option<SmolmixError> = None;
+        // Set after a transient receive error. The delay lives inside the
+        // receive arm's own future, so it paces only the receive path:
+        // outgoing packets and shutdown stay responsive in their arms
+        // while an instantly-returning error is prevented from spinning
+        // the loop.
+        let mut pace_next_receive = false;
 
-        'run: loop {
+        loop {
             tokio::select! {
                 _ = &mut self.shutdown_rx => {
                     info!(packets_sent, packets_received, "Bridge received shutdown signal");
-                    break;
+                    return Ok(());
                 }
 
+                // When the device drops its sender this arm yields `None`,
+                // stops matching, and the bridge keeps relaying inbound
+                // packets until told to shut down.
                 Some(packet) = self.outgoing_rx.next() => {
                     trace!(len = packet.len(), "Sending packet to mixnet");
 
@@ -126,15 +153,20 @@ impl NymIprBridge {
                     }
                 }
 
-                result = self.stream.handle_incoming() => {
+                result = async {
+                    if pace_next_receive {
+                        tokio::time::sleep(RECEIVE_RETRY_DELAY).await;
+                    }
+                    self.stream.handle_incoming().await
+                } => {
+                    pace_next_receive = false;
                     match result {
                         Ok(packets) if !packets.is_empty() => {
                             trace!(count = packets.len(), "Received packets from mixnet");
                             for packet in packets {
                                 if self.incoming_tx.unbounded_send(packet.to_vec()).is_err() {
                                     error!("Device channel closed");
-                                    fatal = Some(SmolmixError::ChannelClosed);
-                                    break 'run;
+                                    return Err(SmolmixError::ChannelClosed);
                                 }
                                 packets_received += 1;
                             }
@@ -145,33 +177,15 @@ impl NymIprBridge {
                             // The stream is gone and errors return instantly;
                             // retrying would busy-loop.
                             error!("Mixnet receive error, stopping bridge: {e}");
-                            fatal = Some(e.into());
-                            break;
+                            return Err(e.into());
                         }
                         Err(e) => {
-                            // Pace the retry: an instantly-returning error
-                            // must not spin the loop.
                             warn!("Mixnet receive error: {e}");
-                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                            pace_next_receive = true;
                         }
                     }
                 }
-
-                else => {
-                    info!(packets_sent, packets_received, "All channels closed, shutting down");
-                    break;
-                }
             }
-        }
-
-        // disconnect() internally waits for all SDK tasks via TaskTracker.
-        info!("Disconnecting from mixnet...");
-        self.stream.disconnect().await;
-        info!("Disconnected");
-
-        match fatal {
-            Some(err) => Err(err),
-            None => Ok(()),
         }
     }
 }

--- a/smolmix/core/src/bridge.rs
+++ b/smolmix/core/src/bridge.rs
@@ -118,18 +118,19 @@ impl NymIprBridge {
     /// Every future raced here is cancel-safe. In particular
     /// `IpMixStream::handle_incoming()` has a single await point (a channel
     /// receive) and mutates no state before it resolves, so losing the race
-    /// to another arm cannot drop a buffered packet. A cancelled pacing
-    /// sleep restarts at full length next iteration, which only ever waits
-    /// longer than intended.
+    /// to another arm cannot drop a buffered packet. The pacing delay uses an
+    /// absolute deadline, so a cancelled sleep waits to the same instant next
+    /// iteration. It does not restart.
     async fn event_loop(&mut self) -> Result<(), SmolmixError> {
         let mut packets_sent: u64 = 0;
         let mut packets_received: u64 = 0;
-        // Set after a transient receive error. The delay lives inside the
-        // receive arm's own future, so it paces only the receive path:
-        // outgoing packets and shutdown stay responsive in their arms
-        // while an instantly-returning error is prevented from spinning
-        // the loop.
-        let mut pace_next_receive = false;
+        // A deadline set after a transient receive error. The delay is inside
+        // the receive arm's own future, so it paces only the receive path:
+        // outgoing packets and shutdown stay responsive in their arms while an
+        // instantly-returning error cannot spin the loop. The deadline is
+        // absolute, so outgoing traffic that cancels the sleep cannot push the
+        // retry past RECEIVE_RETRY_DELAY.
+        let mut retry_at: Option<tokio::time::Instant> = None;
 
         loop {
             tokio::select! {
@@ -155,12 +156,12 @@ impl NymIprBridge {
                 }
 
                 result = async {
-                    if pace_next_receive {
-                        tokio::time::sleep(RECEIVE_RETRY_DELAY).await;
+                    if let Some(at) = retry_at {
+                        tokio::time::sleep_until(at).await;
                     }
                     self.stream.handle_incoming().await
                 } => {
-                    pace_next_receive = false;
+                    retry_at = None;
                     match result {
                         Ok(packets) if !packets.is_empty() => {
                             trace!(count = packets.len(), "Received packets from mixnet");
@@ -182,7 +183,7 @@ impl NymIprBridge {
                         }
                         Err(e) => {
                             warn!("Mixnet receive error: {e}");
-                            pace_next_receive = true;
+                            retry_at = Some(tokio::time::Instant::now() + RECEIVE_RETRY_DELAY);
                         }
                     }
                 }

--- a/smolmix/core/src/bridge.rs
+++ b/smolmix/core/src/bridge.rs
@@ -6,12 +6,13 @@ use futures::StreamExt;
 use nym_ip_packet_requests::codec::MultiIpPacketCodec;
 use nym_sdk::ipr_wrapper::IpMixStream;
 use nym_sdk::Error as SdkError;
+use std::time::Duration;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, trace, warn};
 
 /// Delay before retrying a failed mixnet receive, so a transient error
 /// cannot spin the event loop.
-const RECEIVE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+const RECEIVE_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 /// Asynchronous bridge between the smoltcp device and the Nym mixnet.
 ///


### PR DESCRIPTION
Implementing a few tweaks in line with conversation in https://forum.zcashcommunity.com/t/lwd-mixnet-proxy-light-wallet-grpc-over-the-nym-mixnet-and-what-three-days-of-measuring-it-found/57000/32

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7098)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stream establishment acknowledgements, optional establishment waiting, and recent peer activity tracking.
  * Added clearer errors when a recipient cannot be reached through the current network topology.

* **Bug Fixes**
  * Improved stream reliability by tolerating recoverable lost frames.
  * Stream data-loss events and persistent stream failures are now reported clearly.
  * Improved bridge retry behavior and fatal disconnection reporting.

* **Documentation**
  * Clarified stream establishment, failure handling, buffering limits, compatibility behavior, and tutorial usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->