### PR TITLE
poc: manually control sending counters

### DIFF
--- a/common/nym-lp/Cargo.toml
+++ b/common/nym-lp/Cargo.toml
@@ -29,7 +29,7 @@ nym-kkt-ciphersuite = { workspace = true }
 nym-lp-data.workspace = true
 
 # libcrux dependencies for PSQ (Post-Quantum PSK derivation)
-libcrux-psq = { workspace = true }
+libcrux-psq = { workspace = true, features = ["nonce-control"] }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 

--- a/common/nym-lp/src/codec.rs
+++ b/common/nym-lp/src/codec.rs
@@ -12,11 +12,36 @@ pub(crate) const SANE_ENC_OVERHEAD: usize = 32;
 // needs to be equal or below the actual overhead
 pub(crate) const SANE_DEC_OVERHEAD: usize = 24;
 
+// same as libcrux_psq::aead::NONCE_LEN;
+pub(crate) const NONCE_LEN: usize = 12;
+
+// same as libcrux_psq::aead::NONCE_MAX;
+pub(crate) const COUNTER_MAX: u128 = u128::MAX >> (128 - NONCE_LEN * 8);
+
+fn counter_to_nonce(ctr: u128) -> Result<[u8; NONCE_LEN], LpError> {
+    if ctr > COUNTER_MAX {
+        return Err(LpError::InvalidCounter);
+    }
+
+    let mut nonce = [0u8; NONCE_LEN];
+    let buf = ctr.to_be_bytes();
+    nonce.copy_from_slice(&buf[16 - NONCE_LEN..]);
+
+    Ok(nonce)
+}
+
 pub(crate) fn encrypt_data(
+    counter: u128,
     plaintext: &[u8],
     transport: &mut libcrux_psq::session::Transport,
 ) -> Result<Vec<u8>, LpError> {
+    // ideally we'd expire the transport but unfortunately the method is not public,
+    // so the caller will have to do it manually
+    let nonce = counter_to_nonce(counter)?;
+
     let mut ciphertext = vec![0u8; plaintext.len() + SANE_ENC_OVERHEAD];
+
+    transport.set_sender_nonce(&nonce);
     let n = transport.write_message(plaintext, &mut ciphertext)?;
 
     if plaintext.len() + SANE_ENC_OVERHEAD != n {
@@ -27,14 +52,20 @@ pub(crate) fn encrypt_data(
 }
 
 pub(crate) fn decrypt_data(
+    counter: u128,
     ciphertext: &[u8],
     transport: &mut libcrux_psq::session::Transport,
 ) -> Result<Vec<u8>, LpError> {
     if ciphertext.len() < SANE_DEC_OVERHEAD {
         return Err(LpError::InsufficientBufferSize);
     }
+    // ideally we'd expire the transport but unfortunately the method is not public,
+    // so the caller will have to do it manually
+    let nonce = counter_to_nonce(counter)?;
+
     let mut plaintext = vec![0u8; ciphertext.len() - SANE_DEC_OVERHEAD];
 
+    transport.set_receiver_nonce(&nonce);
     let (_, n) = transport.read_message(ciphertext, &mut plaintext)?;
     if n != ciphertext.len() - SANE_DEC_OVERHEAD {
         plaintext.truncate(n);
@@ -50,7 +81,8 @@ pub(crate) fn encrypt_lp_packet(
     packet.header().inner.encode(&mut plaintext);
     packet.frame().encode(&mut plaintext);
 
-    let ciphertext = encrypt_data(plaintext.as_ref(), transport)?;
+    let counter = packet.header().counter();
+    let ciphertext = encrypt_data(counter as u128, plaintext.as_ref(), transport)?;
 
     Ok(EncryptedLpPacket::new(packet.header().outer, ciphertext))
 }
@@ -65,7 +97,8 @@ pub(crate) fn decrypt_lp_packet(
         return Err(LpError::InsufficientBufferSize);
     }
 
-    let plaintext = decrypt_data(packet.ciphertext(), transport)?;
+    let counter = packet.outer_header().counter;
+    let plaintext = decrypt_data(counter as u128, packet.ciphertext(), transport)?;
 
     let inner_header = InnerHeader::parse(&plaintext)?;
     #[allow(clippy::indexing_slicing)]

--- a/common/nym-lp/src/codec.rs
+++ b/common/nym-lp/src/codec.rs
@@ -12,36 +12,32 @@ pub(crate) const SANE_ENC_OVERHEAD: usize = 32;
 // needs to be equal or below the actual overhead
 pub(crate) const SANE_DEC_OVERHEAD: usize = 24;
 
-// same as libcrux_psq::aead::NONCE_LEN;
+// same as libcrux_psq::aead::NONCE_LEN, which libcrux does not re-export
 pub(crate) const NONCE_LEN: usize = 12;
 
-// same as libcrux_psq::aead::NONCE_MAX;
-pub(crate) const COUNTER_MAX: u128 = u128::MAX >> (128 - NONCE_LEN * 8);
-
-fn counter_to_nonce(ctr: u128) -> Result<[u8; NONCE_LEN], LpError> {
-    if ctr > COUNTER_MAX {
-        return Err(LpError::InvalidCounter);
-    }
+/// Derives the AEAD nonce of the packet with the given counter.
+///
+/// libcrux increments its nonce *before* every use, so prior to `nonce-control` the packet with
+/// counter `n` was encrypted under nonce `n + 1`. The offset keeps the wire format identical.
+pub(crate) fn counter_to_nonce(counter: u64) -> [u8; NONCE_LEN] {
+    // a u64 counter plus one always fits into the 96-bit nonce
+    let buf = (counter as u128 + 1).to_be_bytes();
+    let (_, tail) = buf.split_at(16 - NONCE_LEN);
 
     let mut nonce = [0u8; NONCE_LEN];
-    let buf = ctr.to_be_bytes();
-    nonce.copy_from_slice(&buf[16 - NONCE_LEN..]);
-
-    Ok(nonce)
+    nonce.copy_from_slice(tail);
+    nonce
 }
 
 pub(crate) fn encrypt_data(
-    counter: u128,
+    counter: u64,
     plaintext: &[u8],
     transport: &mut libcrux_psq::session::Transport,
 ) -> Result<Vec<u8>, LpError> {
-    // ideally we'd expire the transport but unfortunately the method is not public,
-    // so the caller will have to do it manually
-    let nonce = counter_to_nonce(counter)?;
-
     let mut ciphertext = vec![0u8; plaintext.len() + SANE_ENC_OVERHEAD];
 
-    transport.set_sender_nonce(&nonce);
+    // with `nonce-control` libcrux uses the nonce verbatim, so counter uniqueness is on the caller
+    transport.set_sender_nonce(&counter_to_nonce(counter));
     let n = transport.write_message(plaintext, &mut ciphertext)?;
 
     if plaintext.len() + SANE_ENC_OVERHEAD != n {
@@ -52,20 +48,17 @@ pub(crate) fn encrypt_data(
 }
 
 pub(crate) fn decrypt_data(
-    counter: u128,
+    counter: u64,
     ciphertext: &[u8],
     transport: &mut libcrux_psq::session::Transport,
 ) -> Result<Vec<u8>, LpError> {
     if ciphertext.len() < SANE_DEC_OVERHEAD {
         return Err(LpError::InsufficientBufferSize);
     }
-    // ideally we'd expire the transport but unfortunately the method is not public,
-    // so the caller will have to do it manually
-    let nonce = counter_to_nonce(counter)?;
 
     let mut plaintext = vec![0u8; ciphertext.len() - SANE_DEC_OVERHEAD];
 
-    transport.set_receiver_nonce(&nonce);
+    transport.set_receiver_nonce(&counter_to_nonce(counter));
     let (_, n) = transport.read_message(ciphertext, &mut plaintext)?;
     if n != ciphertext.len() - SANE_DEC_OVERHEAD {
         plaintext.truncate(n);
@@ -81,8 +74,7 @@ pub(crate) fn encrypt_lp_packet(
     packet.header().inner.encode(&mut plaintext);
     packet.frame().encode(&mut plaintext);
 
-    let counter = packet.header().counter();
-    let ciphertext = encrypt_data(counter as u128, plaintext.as_ref(), transport)?;
+    let ciphertext = encrypt_data(packet.header().counter(), plaintext.as_ref(), transport)?;
 
     Ok(EncryptedLpPacket::new(packet.header().outer, ciphertext))
 }
@@ -97,8 +89,11 @@ pub(crate) fn decrypt_lp_packet(
         return Err(LpError::InsufficientBufferSize);
     }
 
-    let counter = packet.outer_header().counter;
-    let plaintext = decrypt_data(counter as u128, packet.ciphertext(), transport)?;
+    let plaintext = decrypt_data(
+        packet.outer_header().counter,
+        packet.ciphertext(),
+        transport,
+    )?;
 
     let inner_header = InnerHeader::parse(&plaintext)?;
     #[allow(clippy::indexing_slicing)]
@@ -117,16 +112,71 @@ pub(crate) fn decrypt_lp_packet(
 #[cfg(test)]
 mod tests {
     use crate::LpError;
-    use crate::codec::{decrypt_data, decrypt_lp_packet, encrypt_data, encrypt_lp_packet};
+    use crate::codec::{
+        NONCE_LEN, SANE_ENC_OVERHEAD, counter_to_nonce, decrypt_data, decrypt_lp_packet,
+        encrypt_data, encrypt_lp_packet,
+    };
     use crate::peer::mock_peers;
     use crate::psq::initiator::{build_psq_ciphersuite, build_psq_principal};
     use crate::psq::{PSQ_MSG2_SIZE, psq_msg1_size, responder};
+    use bytes::BytesMut;
+    use libcrux_psq::session::Transport;
     use libcrux_psq::{Channel, IntoSession};
     use nym_kkt_ciphersuite::KEM;
     use nym_lp_data::packet::{
-        EncryptedLpPacket, LpFrame, LpHeader, LpPacket, MalformedLpPacketError, version,
+        EncryptedLpPacket, InnerHeader, LpFrame, LpHeader, LpPacket, MalformedLpPacketError,
+        version,
     };
     use nym_test_utils::helpers::u64_seeded_rng_09;
+
+    /// Emulates the nonce handling of libcrux without `nonce-control`, i.e. what peers running the
+    /// previous nym-lp release do: a 12-byte big-endian counter incremented *before* every use.
+    #[derive(Default)]
+    struct LegacyNonce([u8; NONCE_LEN]);
+
+    impl LegacyNonce {
+        fn next(&mut self) -> [u8; NONCE_LEN] {
+            let mut buf = [0u8; 16];
+            buf[16 - NONCE_LEN..].copy_from_slice(&self.0);
+            let incremented = (u128::from_be_bytes(buf) + 1).to_be_bytes();
+            self.0.copy_from_slice(&incremented[16 - NONCE_LEN..]);
+            self.0
+        }
+    }
+
+    /// The previous release's `encrypt_lp_packet`: same framing, nonce driven by libcrux's counter.
+    fn legacy_encrypt_lp_packet(
+        packet: &LpPacket,
+        nonce: &mut LegacyNonce,
+        transport: &mut Transport,
+    ) -> EncryptedLpPacket {
+        let mut plaintext = BytesMut::new();
+        packet.header().inner.encode(&mut plaintext);
+        packet.frame().encode(&mut plaintext);
+
+        let mut ciphertext = vec![0u8; plaintext.len() + SANE_ENC_OVERHEAD];
+        transport.set_sender_nonce(&nonce.next());
+        let n = transport
+            .write_message(&plaintext, &mut ciphertext)
+            .unwrap();
+        ciphertext.truncate(n);
+
+        EncryptedLpPacket::new(packet.header().outer, ciphertext)
+    }
+
+    /// The previous release's `decrypt_lp_packet`: ignores the header counter entirely.
+    fn legacy_decrypt_lp_packet(
+        packet: &EncryptedLpPacket,
+        nonce: &mut LegacyNonce,
+        transport: &mut Transport,
+    ) -> LpFrame {
+        let mut plaintext = vec![0u8; packet.ciphertext().len()];
+        transport.set_receiver_nonce(&nonce.next());
+        let (_, n) = transport
+            .read_message(packet.ciphertext(), &mut plaintext)
+            .unwrap();
+        LpFrame::decode(&plaintext[InnerHeader::SIZE..n]).unwrap()
+    }
 
     fn mock_transport() -> (
         libcrux_psq::session::Transport,
@@ -274,22 +324,106 @@ mod tests {
 
         // happy path
         let msg = b"foomp".to_vec();
-        let ciphertext = encrypt_data(&msg, &mut init_transport).unwrap();
-        let plaintext = decrypt_data(&ciphertext, &mut resp_transport).unwrap();
+        let ciphertext = encrypt_data(0, &msg, &mut init_transport).unwrap();
+        let plaintext = decrypt_data(0, &ciphertext, &mut resp_transport).unwrap();
         assert_eq!(msg, plaintext);
 
         // incomplete ciphertext
         let msg2 = b"foomp".to_vec();
-        let ciphertext2 = encrypt_data(&msg2, &mut init_transport).unwrap();
+        let ciphertext2 = encrypt_data(1, &msg2, &mut init_transport).unwrap();
         let len = ciphertext2.len();
-        let dec_err = decrypt_data(&ciphertext2[..len - 1], &mut resp_transport).unwrap_err();
+        let dec_err = decrypt_data(1, &ciphertext2[..len - 1], &mut resp_transport).unwrap_err();
         assert!(matches!(dec_err, LpError::PSQSessionFailure { .. }));
 
         // too small buffer
         let msg3 = b"foomp".to_vec();
-        let ciphertext3 = encrypt_data(&msg3, &mut resp_transport).unwrap();
-        let dec_err = decrypt_data(&ciphertext3[..10], &mut init_transport).unwrap_err();
+        let ciphertext3 = encrypt_data(0, &msg3, &mut resp_transport).unwrap();
+        let dec_err = decrypt_data(0, &ciphertext3[..10], &mut init_transport).unwrap_err();
         assert!(matches!(dec_err, LpError::InsufficientBufferSize));
+    }
+
+    #[test]
+    fn counter_to_nonce_matches_legacy_increment_before_use() {
+        assert_eq!(counter_to_nonce(0), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        assert_eq!(counter_to_nonce(1), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]);
+        assert_eq!(counter_to_nonce(255), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0]);
+        // u64::MAX + 1 = 2^64 sets bit 64, i.e. byte 3 of the 12-byte big-endian nonce
+        assert_eq!(
+            counter_to_nonce(u64::MAX),
+            [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
+
+        let mut legacy = LegacyNonce::default();
+        for counter in 0..1000u64 {
+            assert_eq!(counter_to_nonce(counter), legacy.next());
+        }
+    }
+
+    #[test]
+    fn legacy_sender_to_new_receiver() {
+        let (mut legacy, mut new) = mock_transport();
+        let mut legacy_nonce = LegacyNonce::default();
+
+        for counter in 0..5u64 {
+            let packet = LpPacket::new(
+                LpHeader::new(123, counter, 1),
+                LpFrame::new_opaque(vec![counter as u8; 8]),
+            );
+            let encrypted = legacy_encrypt_lp_packet(&packet, &mut legacy_nonce, &mut legacy);
+            assert_eq!(decrypt_lp_packet(encrypted, &mut new).unwrap(), packet);
+        }
+    }
+
+    #[test]
+    fn new_sender_to_legacy_receiver() {
+        let (mut new, mut legacy) = mock_transport();
+        let mut legacy_nonce = LegacyNonce::default();
+
+        for counter in 0..5u64 {
+            let frame = LpFrame::new_opaque(vec![counter as u8; 8]);
+            let packet = LpPacket::new(LpHeader::new(123, counter, 1), frame.clone());
+            let encrypted = encrypt_lp_packet(packet, &mut new).unwrap();
+            assert_eq!(
+                legacy_decrypt_lp_packet(&encrypted, &mut legacy_nonce, &mut legacy),
+                frame
+            );
+        }
+    }
+
+    #[test]
+    fn decryption_requires_the_matching_counter() {
+        let (mut init_transport, mut resp_transport) = mock_transport();
+
+        let ciphertext = encrypt_data(5, b"foomp", &mut init_transport).unwrap();
+        let err = decrypt_data(6, &ciphertext, &mut resp_transport).unwrap_err();
+        assert!(matches!(err, LpError::PSQSessionFailure { .. }));
+
+        // a failed attempt must not affect later ones
+        let plaintext = decrypt_data(5, &ciphertext, &mut resp_transport).unwrap();
+        assert_eq!(plaintext, b"foomp".to_vec());
+    }
+
+    #[test]
+    fn out_of_order_and_lossy_decryption() {
+        let (mut init_transport, mut resp_transport) = mock_transport();
+
+        let packets: Vec<_> = (0..6u64)
+            .map(|counter| {
+                let packet = LpPacket::new(
+                    LpHeader::new(123, counter, 1),
+                    LpFrame::new_opaque(vec![counter as u8; 16]),
+                );
+                let encrypted = encrypt_lp_packet(packet.clone(), &mut init_transport).unwrap();
+                (packet, encrypted)
+            })
+            .collect();
+
+        // reordered, with packet 4 never arriving
+        for idx in [3, 0, 5, 1, 2] {
+            let (expected, encrypted) = &packets[idx];
+            let decrypted = decrypt_lp_packet(encrypted.clone(), &mut resp_transport).unwrap();
+            assert_eq!(&decrypted, expected);
+        }
     }
 
     #[test]

--- a/common/nym-lp/src/error.rs
+++ b/common/nym-lp/src/error.rs
@@ -120,6 +120,9 @@ pub enum LpError {
 
     #[error("failed to generate randomness: {0}")]
     RngFailure(#[from] getrandom04::Error),
+
+    #[error("the counter value has exceeded its maximum value")]
+    InvalidCounter,
 }
 
 impl LpError {

--- a/common/nym-lp/src/error.rs
+++ b/common/nym-lp/src/error.rs
@@ -121,8 +121,8 @@ pub enum LpError {
     #[error("failed to generate randomness: {0}")]
     RngFailure(#[from] getrandom04::Error),
 
-    #[error("the counter value has exceeded its maximum value")]
-    InvalidCounter,
+    #[error("the sending counter of the transport channel has been exhausted")]
+    SendingCounterExhausted,
 }
 
 impl LpError {

--- a/common/nym-lp/src/lib.rs
+++ b/common/nym-lp/src/lib.rs
@@ -154,3 +154,62 @@ pub fn sessions_for_tests() -> (LpTransportSession, LpTransportSession) {
 pub fn mock_session_for_test() -> LpTransportSession {
     SessionsMock::mock_initiator()
 }
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use crate::codec::{decrypt_lp_packet, encrypt_lp_packet};
+    use crate::session::{LpAction, LpInput, LpTransportSession};
+    use libcrux_psq::session::Transport;
+    use nym_lp_data::packet::{LpFrame, LpHeader, LpPacket};
+
+    /// Sends `payload` from `sender` and asserts that `receiver` delivers it unchanged.
+    pub(crate) fn assert_frame_delivered(
+        sender: &mut LpTransportSession,
+        receiver: &mut LpTransportSession,
+        payload: &[u8],
+    ) {
+        let frame = LpFrame::new_opaque(payload.to_vec());
+        let LpAction::SendPacket(packet) = sender
+            .process_input(LpInput::SendFrame(frame.clone()))
+            .unwrap()
+        else {
+            panic!("expected SendPacket")
+        };
+        let LpAction::DeliverFrame(delivered) = receiver
+            .process_input(LpInput::ReceivePacket(packet))
+            .unwrap()
+        else {
+            panic!("expected DeliverFrame")
+        };
+        assert_eq!(delivered, frame);
+    }
+
+    /// Asserts that `session` and a bare libcrux `transport` derived on the other side of the same
+    /// handshake share keys, by exchanging one packet in each direction.
+    pub(crate) fn assert_session_matches_transport(
+        session: &mut LpTransportSession,
+        transport: &mut Transport,
+    ) {
+        let to_transport = LpFrame::new_opaque(b"Derived session hey".to_vec());
+        let LpAction::SendPacket(packet) = session
+            .process_input(LpInput::SendFrame(to_transport.clone()))
+            .unwrap()
+        else {
+            panic!("expected SendPacket")
+        };
+        let decrypted = decrypt_lp_packet(packet, transport).unwrap();
+        assert_eq!(decrypted.into_frame(), to_transport);
+
+        let to_session = LpFrame::new_opaque(b"Derived session ho".to_vec());
+        let header = LpHeader::new(session.receiver_index(), 0, session.negotiated_version());
+        let packet =
+            encrypt_lp_packet(LpPacket::new(header, to_session.clone()), transport).unwrap();
+        let LpAction::DeliverFrame(delivered) = session
+            .process_input(LpInput::ReceivePacket(packet))
+            .unwrap()
+        else {
+            panic!("expected DeliverFrame")
+        };
+        assert_eq!(delivered, to_session);
+    }
+}

--- a/common/nym-lp/src/psq/initiator.rs
+++ b/common/nym-lp/src/psq/initiator.rs
@@ -272,10 +272,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::{decrypt_data, encrypt_data};
     use crate::peer::mock_peers;
     use crate::peer_config::LP_PEER_CONFIG_SIZE;
     use crate::psq::{PSQ_MSG2_SIZE, psq_msg1_size, responder};
+    use crate::test_helpers::assert_session_matches_transport;
     use nym_kkt::context::KKTMode;
     use nym_kkt::responder::KKTResponder;
     use nym_kkt_ciphersuite::{Ciphersuite, HashFunction, IntoEnumIterator, KEM, SignatureScheme};
@@ -384,24 +384,9 @@ mod tests {
 
             let mut r_transport = responder.into_session().unwrap();
 
-            // test serialization, deserialization
-            let channel_i = session_init.active_transport();
+            // both sides must have derived the same transport keys
             let mut channel_r = r_transport.transport_channel().unwrap();
-
-            assert_eq!(channel_i.identifier(), channel_r.identifier());
-
-            let app_data_i = b"Derived session hey".as_slice();
-            let app_data_r = b"Derived session ho".as_slice();
-
-            let ct_i = encrypt_data(app_data_i, channel_i)?;
-            let pt_r = decrypt_data(&ct_i, &mut channel_r)?;
-
-            assert_eq!(app_data_i, pt_r);
-
-            let ct_r = encrypt_data(app_data_r, &mut channel_r)?;
-            let pt_i = decrypt_data(&ct_r, channel_i)?;
-
-            assert_eq!(app_data_r, pt_i);
+            assert_session_matches_transport(&mut session_init, &mut channel_r);
         }
         Ok(())
     }
@@ -506,24 +491,9 @@ mod tests {
 
             let mut r_transport = responder.into_session().unwrap();
 
-            // test serialization, deserialization
-            let channel_i = session_init.active_transport();
+            // both sides must have derived the same transport keys
             let mut channel_r = r_transport.transport_channel().unwrap();
-
-            assert_eq!(channel_i.identifier(), channel_r.identifier());
-
-            let app_data_i = b"Derived session hey".as_slice();
-            let app_data_r = b"Derived session ho".as_slice();
-
-            let ct_i = encrypt_data(app_data_i, channel_i)?;
-            let pt_r = decrypt_data(&ct_i, &mut channel_r)?;
-
-            assert_eq!(app_data_i, pt_r);
-
-            let ct_r = encrypt_data(app_data_r, &mut channel_r)?;
-            let pt_i = decrypt_data(&ct_r, channel_i)?;
-
-            assert_eq!(app_data_r, pt_i);
+            assert_session_matches_transport(&mut session_init, &mut channel_r);
         }
         Ok(())
     }

--- a/common/nym-lp/src/psq/mod.rs
+++ b/common/nym-lp/src/psq/mod.rs
@@ -141,6 +141,7 @@ mod tests {
     use crate::codec::{decrypt_data, encrypt_data};
     use crate::peer::mock_peers;
     use crate::peer_config::{LP_PEER_CONFIG_SIZE, LpPeerConfig};
+    use crate::test_helpers::assert_frame_delivered;
     use libcrux_psq::handshake::types::Authenticator;
     use libcrux_psq::session::{Session, SessionBinding};
     use libcrux_psq::{Channel, IntoSession};
@@ -205,24 +206,9 @@ mod tests {
                 session_resp.session_identifier()
             );
 
-            // test serialization, deserialization
-            let channel_i = session_init.active_transport();
-            let channel_r = session_resp.active_transport();
-
-            assert_eq!(channel_i.identifier(), channel_r.identifier());
-
-            let app_data_i = b"Derived session hey".as_slice();
-            let app_data_r = b"Derived session ho".as_slice();
-
-            let ct_i = encrypt_data(app_data_i, channel_i)?;
-            let pt_r = decrypt_data(&ct_i, channel_r)?;
-
-            assert_eq!(app_data_i, pt_r);
-
-            let ct_r = encrypt_data(app_data_r, channel_r)?;
-            let pt_i = decrypt_data(&ct_r, channel_i)?;
-
-            assert_eq!(app_data_r, pt_i);
+            // both sides must have derived the same transport keys
+            assert_frame_delivered(&mut session_init, &mut session_resp, b"Derived session hey");
+            assert_frame_delivered(&mut session_resp, &mut session_init, b"Derived session ho");
         }
 
         Ok(())
@@ -281,24 +267,9 @@ mod tests {
                 session_resp.session_identifier()
             );
 
-            // test serialization, deserialization
-            let channel_i = session_init.active_transport();
-            let channel_r = session_resp.active_transport();
-
-            assert_eq!(channel_i.identifier(), channel_r.identifier());
-
-            let app_data_i = b"Derived session hey".as_slice();
-            let app_data_r = b"Derived session ho".as_slice();
-
-            let ct_i = encrypt_data(app_data_i, channel_i)?;
-            let pt_r = decrypt_data(&ct_i, channel_r)?;
-
-            assert_eq!(app_data_i, pt_r);
-
-            let ct_r = encrypt_data(app_data_r, channel_r)?;
-            let pt_i = decrypt_data(&ct_r, channel_i)?;
-
-            assert_eq!(app_data_r, pt_i);
+            // both sides must have derived the same transport keys
+            assert_frame_delivered(&mut session_init, &mut session_resp, b"Derived session hey");
+            assert_frame_delivered(&mut session_resp, &mut session_init, b"Derived session ho");
         }
 
         Ok(())
@@ -467,13 +438,13 @@ mod tests {
             let app_data_i = b"Derived session hey".as_slice();
             let app_data_r = b"Derived session ho".as_slice();
 
-            let ct_i = encrypt_data(app_data_i, &mut channel_i).unwrap();
-            let pt_r = decrypt_data(&ct_i, &mut channel_r).unwrap();
+            let ct_i = encrypt_data(0, app_data_i, &mut channel_i).unwrap();
+            let pt_r = decrypt_data(0, &ct_i, &mut channel_r).unwrap();
 
             assert_eq!(app_data_i, pt_r);
 
-            let ct_r = encrypt_data(app_data_r, &mut channel_r).unwrap();
-            let pt_i = decrypt_data(&ct_r, &mut channel_i).unwrap();
+            let ct_r = encrypt_data(0, app_data_r, &mut channel_r).unwrap();
+            let pt_i = decrypt_data(0, &ct_r, &mut channel_i).unwrap();
 
             assert_eq!(app_data_r, pt_i);
         }
@@ -651,13 +622,13 @@ mod tests {
             let app_data_i = b"Derived session hey".as_slice();
             let app_data_r = b"Derived session ho".as_slice();
 
-            let ct_i = encrypt_data(app_data_i, &mut channel_i).unwrap();
-            let pt_r = decrypt_data(&ct_i, &mut channel_r).unwrap();
+            let ct_i = encrypt_data(0, app_data_i, &mut channel_i).unwrap();
+            let pt_r = decrypt_data(0, &ct_i, &mut channel_r).unwrap();
 
             assert_eq!(app_data_i, pt_r);
 
-            let ct_r = encrypt_data(app_data_r, &mut channel_r).unwrap();
-            let pt_i = decrypt_data(&ct_r, &mut channel_i).unwrap();
+            let ct_r = encrypt_data(0, app_data_r, &mut channel_r).unwrap();
+            let pt_i = decrypt_data(0, &ct_r, &mut channel_i).unwrap();
 
             assert_eq!(app_data_r, pt_i);
         }

--- a/common/nym-lp/src/psq/responder.rs
+++ b/common/nym-lp/src/psq/responder.rs
@@ -246,10 +246,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::{decrypt_data, encrypt_data};
     use crate::peer::mock_peers;
     use crate::peer_config::LpPeerConfig;
     use crate::psq::initiator;
+    use crate::test_helpers::assert_session_matches_transport;
     use nym_kkt::initiator::KKTInitiator;
     use nym_kkt_ciphersuite::{Ciphersuite, IntoEnumIterator};
     use nym_lp_data::packet::version;
@@ -353,24 +353,9 @@ mod tests {
 
             let mut i_transport = initiator.into_session().unwrap();
 
-            // test serialization, deserialization
+            // both sides must have derived the same transport keys
             let mut channel_i = i_transport.transport_channel().unwrap();
-            let channel_r = session_resp.active_transport();
-
-            assert_eq!(channel_i.identifier(), channel_r.identifier());
-
-            let app_data_i = b"Derived session hey".as_slice();
-            let app_data_r = b"Derived session ho".as_slice();
-
-            let ct_i = encrypt_data(app_data_i, &mut channel_i)?;
-            let pt_r = decrypt_data(&ct_i, channel_r)?;
-
-            assert_eq!(app_data_i, pt_r);
-
-            let ct_r = encrypt_data(app_data_r, channel_r)?;
-            let pt_i = decrypt_data(&ct_r, &mut channel_i)?;
-
-            assert_eq!(app_data_r, pt_i);
+            assert_session_matches_transport(&mut session_resp, &mut channel_i);
         }
 
         Ok(())
@@ -473,24 +458,9 @@ mod tests {
 
             let mut i_transport = initiator.into_session().unwrap();
 
-            // test serialization, deserialization
+            // both sides must have derived the same transport keys
             let mut channel_i = i_transport.transport_channel().unwrap();
-            let channel_r = session_resp.active_transport();
-
-            assert_eq!(channel_i.identifier(), channel_r.identifier());
-
-            let app_data_i = b"Derived session hey".as_slice();
-            let app_data_r = b"Derived session ho".as_slice();
-
-            let ct_i = encrypt_data(app_data_i, &mut channel_i)?;
-            let pt_r = decrypt_data(&ct_i, channel_r)?;
-
-            assert_eq!(app_data_i, pt_r);
-
-            let ct_r = encrypt_data(app_data_r, channel_r)?;
-            let pt_i = decrypt_data(&ct_r, &mut channel_i)?;
-
-            assert_eq!(app_data_r, pt_i);
+            assert_session_matches_transport(&mut session_resp, &mut channel_i);
         }
 
         Ok(())

--- a/common/nym-lp/src/session.rs
+++ b/common/nym-lp/src/session.rs
@@ -5,7 +5,7 @@
 //!
 //! This module implements session management functionality, including replay protection
 
-use crate::codec::{decrypt_lp_packet, encrypt_lp_packet};
+use crate::codec::{NONCE_LEN, decrypt_lp_packet, encrypt_lp_packet};
 use crate::peer::{LpLocalPeer, LpRemotePeer};
 use crate::psq::initiator::HandshakeMode;
 use crate::psq::{
@@ -68,9 +68,6 @@ pub struct LpTransportSession {
     /// Negotiated protocol version from handshake.
     protocol_version: u8,
 
-    /// Counter for outgoing packets
-    sending_counter: u64,
-
     /// Validator for incoming packet counters to prevent replay attacks
     receiving_counter: ReceivingKeyCounterValidator,
 }
@@ -121,7 +118,6 @@ impl Debug for LpTransportSession {
             .field("session_binding", &self.session_binding)
             .field("active_transport_id", &self.active_transport.identifier())
             .field("protocol_version", &self.protocol_version)
-            .field("sending_counter", &self.sending_counter)
             .field("receiving_counter", &self.receiving_counter)
             .finish()
     }
@@ -146,7 +142,6 @@ impl LpTransportSession {
             active_transport: transport,
             receiver_index,
             protocol_version,
-            sending_counter: 0,
             receiving_counter: Default::default(),
         })
     }
@@ -249,17 +244,23 @@ impl LpTransportSession {
     }
 
     pub fn next_packet(&mut self, frame: LpFrame) -> Result<LpPacket, LpError> {
-        let counter = self.next_counter();
+        let counter = self.next_counter()?;
         let header = LpHeader::new(self.receiver_index(), counter, self.protocol_version);
         let packet = LpPacket::new(header, frame);
         Ok(packet)
     }
 
     /// Generates the next counter value for outgoing packets.
-    pub fn next_counter(&mut self) -> u64 {
-        let counter = self.sending_counter;
-        self.sending_counter += 1;
-        counter
+    pub fn next_counter(&mut self) -> Result<u64, LpError> {
+        // replicate the behaviour from libcrux' counter increase
+        let mut buf = [0u8; 16];
+        buf[16 - NONCE_LEN..].copy_from_slice(self.active_transport.sender_nonce());
+        let mut nonce = u128::from_be_bytes(buf);
+        nonce += 1;
+
+        let counter: u64 = nonce.try_into().map_err(|_| LpError::InvalidCounter)?;
+
+        Ok(counter)
     }
 
     /// Performs a quick validation check for an incoming packet counter.
@@ -480,11 +481,11 @@ mod tests {
             let mut session = SessionsMock::mock_post_handshake(kem).responder;
 
             // Initial counter should be zero
-            let counter = session.next_counter();
+            let counter = session.next_counter().unwrap();
             assert_eq!(counter, 0);
 
             // Counter should increment
-            let counter = session.next_counter();
+            let counter = session.next_counter().unwrap();
             assert_eq!(counter, 1);
         }
     }

--- a/common/nym-lp/src/session.rs
+++ b/common/nym-lp/src/session.rs
@@ -5,7 +5,7 @@
 //!
 //! This module implements session management functionality, including replay protection
 
-use crate::codec::{NONCE_LEN, decrypt_lp_packet, encrypt_lp_packet};
+use crate::codec::{decrypt_lp_packet, encrypt_lp_packet};
 use crate::peer::{LpLocalPeer, LpRemotePeer};
 use crate::psq::initiator::HandshakeMode;
 use crate::psq::{
@@ -60,16 +60,43 @@ pub struct LpTransportSession {
 
     /// The current active transport channel
     // In the future it might get split between UDP and TCP transports
-    active_transport: libcrux_psq::session::Transport,
+    channel: LpChannel,
 
     /// Look-up index established during the initial KKT exchange
     receiver_index: LpReceiverIndex,
 
     /// Negotiated protocol version from handshake.
     protocol_version: u8,
+}
 
-    /// Validator for incoming packet counters to prevent replay attacks
+/// A transport channel bundled with the counter state guarding its keys.
+///
+/// The sending counter selects the AEAD nonce of every outgoing packet and the replay validator
+/// tracks the counters of incoming ones, so both are created and replaced together with the keys.
+struct LpChannel {
+    transport: libcrux_psq::session::Transport,
+    sending_counter: u64,
     receiving_counter: ReceivingKeyCounterValidator,
+}
+
+impl LpChannel {
+    fn new(transport: libcrux_psq::session::Transport) -> Self {
+        LpChannel {
+            transport,
+            sending_counter: 0,
+            receiving_counter: Default::default(),
+        }
+    }
+
+    /// Reserves the counter for the next outgoing packet.
+    fn next_counter(&mut self) -> Result<u64, LpError> {
+        let counter = self.sending_counter;
+        // the counter is what keeps nonces unique under this key, so it must never wrap around
+        self.sending_counter = counter
+            .checked_add(1)
+            .ok_or(LpError::SendingCounterExhausted)?;
+        Ok(counter)
+    }
 }
 
 /// Wraps public key material that is bound to a session.
@@ -116,9 +143,10 @@ impl Debug for LpTransportSession {
         f.debug_struct("LpSession")
             .field("session_id", &self.psq_session.identifier())
             .field("session_binding", &self.session_binding)
-            .field("active_transport_id", &self.active_transport.identifier())
+            .field("active_transport_id", &self.channel.transport.identifier())
             .field("protocol_version", &self.protocol_version)
-            .field("receiving_counter", &self.receiving_counter)
+            .field("sending_counter", &self.channel.sending_counter)
+            .field("receiving_counter", &self.channel.receiving_counter)
             .finish()
     }
 }
@@ -139,10 +167,9 @@ impl LpTransportSession {
         Ok(LpTransportSession {
             psq_session,
             session_binding,
-            active_transport: transport,
+            channel: LpChannel::new(transport),
             receiver_index,
             protocol_version,
-            receiving_counter: Default::default(),
         })
     }
 
@@ -224,10 +251,6 @@ impl LpTransportSession {
         &self.session_binding
     }
 
-    pub fn active_transport(&mut self) -> &mut libcrux_psq::session::Transport {
-        &mut self.active_transport
-    }
-
     pub fn session_identifier(&self) -> &[u8; 32] {
         self.psq_session.identifier()
     }
@@ -250,17 +273,9 @@ impl LpTransportSession {
         Ok(packet)
     }
 
-    /// Generates the next counter value for outgoing packets.
+    /// Reserves the next counter value for outgoing packets.
     pub fn next_counter(&mut self) -> Result<u64, LpError> {
-        // replicate the behaviour from libcrux' counter increase
-        let mut buf = [0u8; 16];
-        buf[16 - NONCE_LEN..].copy_from_slice(self.active_transport.sender_nonce());
-        let mut nonce = u128::from_be_bytes(buf);
-        nonce += 1;
-
-        let counter: u64 = nonce.try_into().map_err(|_| LpError::InvalidCounter)?;
-
-        Ok(counter)
+        self.channel.next_counter()
     }
 
     /// Performs a quick validation check for an incoming packet counter.
@@ -279,7 +294,8 @@ impl LpTransportSession {
     pub fn receiving_counter_quick_check(&self, counter: u64) -> Result<(), LpError> {
         // Branchless implementation uses SIMD when available for constant-time
         // operations, preventing timing attacks. Check before crypto to save CPU cycles.
-        self.receiving_counter
+        self.channel
+            .receiving_counter
             .will_accept_branchless(counter)
             .map_err(LpError::Replay)
     }
@@ -298,7 +314,8 @@ impl LpTransportSession {
     /// * `Ok(())` if the counter was successfully marked
     /// * `Err(LpError::Replay)` if the counter cannot be marked (duplicate, too old, etc.)
     pub fn receiving_counter_mark(&mut self, counter: u64) -> Result<(), LpError> {
-        self.receiving_counter
+        self.channel
+            .receiving_counter
             .mark_did_receive_branchless(counter)
             .map_err(LpError::Replay)
     }
@@ -311,7 +328,7 @@ impl LpTransportSession {
     /// * The next expected counter value for incoming packets
     /// * The total number of received packets
     pub fn current_packet_cnt(&self) -> PacketCount {
-        self.receiving_counter.current_packet_cnt()
+        self.channel.receiving_counter.current_packet_cnt()
     }
 
     /// Wrap the provided `LpFrame` into an `LpPacket` and encrypt its content using the established transport session
@@ -327,7 +344,7 @@ impl LpTransportSession {
     /// * `Err(LpError)` if the session is not in transport mode or encryption fails.
     pub(crate) fn wrap_lp_frame(&mut self, frame: LpFrame) -> Result<EncryptedLpPacket, LpError> {
         let packet = self.next_packet(frame)?;
-        encrypt_lp_packet(packet, &mut self.active_transport)
+        encrypt_lp_packet(packet, &mut self.channel.transport)
     }
 
     /// Decrypts an incoming LpPacket
@@ -344,7 +361,7 @@ impl LpTransportSession {
         &mut self,
         packet: EncryptedLpPacket,
     ) -> Result<LpPacket, LpError> {
-        decrypt_lp_packet(packet, &mut self.active_transport)
+        decrypt_lp_packet(packet, &mut self.channel.transport)
     }
 
     /// Processes an input event and returns an action to perform.
@@ -554,6 +571,97 @@ mod tests {
             let packet_count = session.current_packet_cnt();
             assert_eq!(packet_count.next, 2);
             assert_eq!(packet_count.received, 2);
+        }
+    }
+
+    #[test]
+    fn out_of_order_delivery_and_replay() {
+        for kem in KEM::iter() {
+            let mock_sessions = SessionsMock::mock_post_handshake(kem);
+            let mut initiator = mock_sessions.initiator;
+            let mut responder = mock_sessions.responder;
+
+            let mut packets = Vec::new();
+            for i in 0..6u8 {
+                let frame = LpFrame::new_opaque(vec![i; 8]);
+                let LpAction::SendPacket(packet) = initiator
+                    .process_input(LpInput::SendFrame(frame.clone()))
+                    .unwrap()
+                else {
+                    panic!("expected SendPacket")
+                };
+                assert_eq!(packet.outer_header().counter, u64::from(i));
+                packets.push((frame, packet));
+            }
+
+            // reordered delivery with packet 4 delayed
+            for idx in [3, 0, 5, 1, 2] {
+                let (frame, packet) = &packets[idx];
+                let LpAction::DeliverFrame(delivered) = responder
+                    .process_input(LpInput::ReceivePacket(packet.clone()))
+                    .unwrap()
+                else {
+                    panic!("expected DeliverFrame")
+                };
+                assert_eq!(&delivered, frame);
+            }
+
+            // an already delivered packet is a replay
+            let err = responder
+                .process_input(LpInput::ReceivePacket(packets[3].1.clone()))
+                .unwrap_err();
+            assert!(matches!(
+                err,
+                LpError::Replay(ReplayError::DuplicateCounter)
+            ));
+
+            // the delayed packet still decrypts and gets delivered
+            let (frame, packet) = &packets[4];
+            let LpAction::DeliverFrame(delivered) = responder
+                .process_input(LpInput::ReceivePacket(packet.clone()))
+                .unwrap()
+            else {
+                panic!("expected DeliverFrame")
+            };
+            assert_eq!(&delivered, frame);
+            assert_eq!(responder.current_packet_cnt().received, 6);
+        }
+    }
+
+    #[test]
+    fn tampered_counter_is_rejected_without_marking_the_window() {
+        for kem in KEM::iter() {
+            let mock_sessions = SessionsMock::mock_post_handshake(kem);
+            let mut initiator = mock_sessions.initiator;
+            let mut responder = mock_sessions.responder;
+
+            let frame = LpFrame::new_opaque(b"genuine".to_vec());
+            let LpAction::SendPacket(packet) = initiator
+                .process_input(LpInput::SendFrame(frame.clone()))
+                .unwrap()
+            else {
+                panic!("expected SendPacket")
+            };
+
+            // the cleartext counter is bound to the nonce, so rewriting it must break decryption
+            let mut tampered_header = packet.outer_header();
+            tampered_header.counter = 5000;
+            let tampered = EncryptedLpPacket::new(tampered_header, packet.ciphertext().to_vec());
+
+            let err = responder
+                .process_input(LpInput::ReceivePacket(tampered))
+                .unwrap_err();
+            assert!(matches!(err, LpError::PSQSessionFailure { .. }));
+
+            // and the failure must not have advanced the replay window
+            assert_eq!(responder.current_packet_cnt().received, 0);
+            let LpAction::DeliverFrame(delivered) = responder
+                .process_input(LpInput::ReceivePacket(packet))
+                .unwrap()
+            else {
+                panic!("expected DeliverFrame")
+            };
+            assert_eq!(delivered, frame);
         }
     }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7102)
<!-- Reviewable:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Improved packet encryption for reordered, delayed, or lost packet delivery.
  * Added protection against replayed, tampered, or incorrectly versioned packets.
  * Sending counters now fail safely when exhausted instead of wrapping around.

* **Compatibility**
  * Improved interoperability with legacy transport implementations.
  * Handshakes now support all listed protocol versions and reject unsupported versions.

* **Configuration**
  * Added controls for configuring and viewing the replay protection window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->