### PR TITLE
bugfix: fix various bugs within nym-api making future re-DKG smoother [vol5]

### DIFF
--- a/common/client-libs/validator-client/src/nyxd/contract_traits/dkg_signing_client.rs
+++ b/common/client-libs/validator-client/src/nyxd/contract_traits/dkg_signing_client.rs
@@ -139,6 +139,14 @@ pub trait DkgSigningClient {
             .await
     }
 
+    /// The admin escape hatch: forces a DKG reset from any epoch state, including mid-exchange.
+    async fn trigger_dkg_forced_reset(&self, fee: Option<Fee>) -> Result<ExecuteResult, NyxdError> {
+        let req = DkgExecuteMsg::TriggerForcedReset {};
+
+        self.execute_dkg_contract(fee, req, "trigger forced DKG reset".to_string(), vec![])
+            .await
+    }
+
     async fn transfer_ownership(
         &self,
         transfer_to: String,
@@ -238,6 +246,7 @@ mod tests {
             DkgExecuteMsg::AdvanceEpochState {} => client.advance_dkg_epoch_state(None).ignore(),
             DkgExecuteMsg::TriggerReset {} => client.trigger_dkg_reset(None).ignore(),
             DkgExecuteMsg::TriggerResharing {} => client.trigger_dkg_resharing(None).ignore(),
+            DkgExecuteMsg::TriggerForcedReset {} => client.trigger_dkg_forced_reset(None).ignore(),
             ExecuteMsg::TransferOwnership { transfer_to } => {
                 client.transfer_ownership(transfer_to, None).ignore()
             }

--- a/common/cosmwasm-smart-contracts/coconut-dkg/src/event_attributes.rs
+++ b/common/cosmwasm-smart-contracts/coconut-dkg/src/event_attributes.rs
@@ -3,3 +3,9 @@
 
 pub const NODE_INDEX: &str = "node_index";
 pub const DKG_PROPOSAL_ID: &str = "proposal_id";
+
+/// Emitted (with the held epoch's id as the value) when an epoch-state advance is held
+/// because nobody has registered as a dealer - without it, the held transaction succeeds
+/// looking exactly like a real advance, and a ceremony stuck waiting for dealers can only
+/// be noticed by diffing successive epoch queries.
+pub const AWAITING_DEALERS: &str = "awaiting_dealers";

--- a/common/cosmwasm-smart-contracts/coconut-dkg/src/msg.rs
+++ b/common/cosmwasm-smart-contracts/coconut-dkg/src/msg.rs
@@ -78,6 +78,12 @@ pub enum ExecuteMsg {
 
     TriggerResharing {},
 
+    /// Admin-only escape hatch: force a reset from any epoch state, including mid-exchange.
+    /// A ceremony that keeps ending sub-threshold auto-resets straight into the next attempt
+    /// without ever passing through `InProgress`, which is the only state [`Self::TriggerReset`]
+    /// accepts - so without this, a looping ceremony can never be stopped or redirected.
+    TriggerForcedReset {},
+
     /// Transfers ownership of the epoch dealer to another address.
     /// This assumes off-chain hand-over of keys
     TransferOwnership {

--- a/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
+++ b/common/cosmwasm-smart-contracts/coconut-dkg/src/types.rs
@@ -278,10 +278,12 @@ impl Epoch {
     ///
     /// Sitting below the current epoch is not enough: a failed ceremony moves the id on and
     /// leaves an epoch behind that concluded nothing, and calling that concluded would let
-    /// callers cache its empty signer set for good. So the boundary is the epoch in service,
-    /// which no unconcluded epoch is ever ahead of. Callers working from a cached copy of the
-    /// current epoch can only get a pessimistic answer out of a stale one, never a premature
-    /// "yes".
+    /// callers cache its empty signer set for good. So the boundary is the epoch in service:
+    /// nothing at or below it can ever change again, and no epoch that can still change reads
+    /// concluded. (An epoch a failed ceremony abandoned below the boundary reads concluded
+    /// too - its records are equally frozen, merely empty.) Callers working from a cached
+    /// copy of the current epoch can only get a pessimistic answer out of a stale one, never
+    /// a premature "yes".
     pub fn is_ceremony_concluded(&self, epoch_id: EpochId) -> bool {
         match self.issuing_epoch_id() {
             Some(in_service) => epoch_id <= in_service,

--- a/common/credential-proxy/src/nym_api_helpers.rs
+++ b/common/credential-proxy/src/nym_api_helpers.rs
@@ -43,9 +43,15 @@ impl CachedEpoch {
             #[allow(clippy::unwrap_used)]
             let state_end =
                 OffsetDateTime::from_unix_timestamp(epoch_finish.seconds() as i64).unwrap();
-            let until_epoch_state_end = state_end - now;
-            // make it valid until the next epoch transition or next 5min, whichever is smaller
-            min(until_epoch_state_end, 5 * time::Duration::MINUTE)
+            if state_end <= now {
+                // a deadline nothing will ever advance (the settled epoch's lapsed
+                // self-extension) - an expiry computed against it would land in the
+                // past and disable the cache for good
+                5 * time::Duration::MINUTE
+            } else {
+                // valid until the next epoch transition or next 5min, whichever is smaller
+                min(state_end - now, 5 * time::Duration::MINUTE)
+            }
         } else {
             5 * time::Duration::MINUTE
         };
@@ -108,4 +114,40 @@ where
     }
 
     Ok(shares)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::Timestamp;
+
+    /// The settled mainnet epoch keeps the deadline of its last self-extension, and since
+    /// the extension's removal nothing will ever move it. Once that timestamp passes, an
+    /// expiry computed against it lands in the past - a permanently invalid cache, sending
+    /// every epoch read to the chain until the next ceremony stores a fresh epoch.
+    #[test]
+    fn a_lapsed_deadline_does_not_disable_the_cache() {
+        let mut epoch = Epoch::default();
+        epoch.deadline = Some(Timestamp::from_seconds(1));
+
+        let mut cached = CachedEpoch::default();
+        cached.update(epoch);
+
+        assert!(cached.is_valid());
+    }
+
+    /// The counterpart boundary: a deadline still ahead caps the expiry below the refresh
+    /// interval, so the copy dies at the state change it cannot see past and never claims
+    /// a ceremony has concluded when it has not.
+    #[test]
+    fn a_nearer_state_end_still_caps_the_cache_validity() {
+        let now = OffsetDateTime::now_utc().unix_timestamp() as u64;
+        let mut epoch = Epoch::default();
+        epoch.deadline = Some(Timestamp::from_seconds(now + 60));
+
+        let mut cached = CachedEpoch::default();
+        cached.update(epoch);
+
+        assert!(cached.valid_until <= OffsetDateTime::now_utc() + time::Duration::seconds(60));
+    }
 }

--- a/common/credential-proxy/src/nym_api_helpers.rs
+++ b/common/credential-proxy/src/nym_api_helpers.rs
@@ -127,8 +127,10 @@ mod tests {
     /// every epoch read to the chain until the next ceremony stores a fresh epoch.
     #[test]
     fn a_lapsed_deadline_does_not_disable_the_cache() {
-        let mut epoch = Epoch::default();
-        epoch.deadline = Some(Timestamp::from_seconds(1));
+        let epoch = Epoch {
+            deadline: Some(Timestamp::from_seconds(1)),
+            ..Default::default()
+        };
 
         let mut cached = CachedEpoch::default();
         cached.update(epoch);
@@ -142,8 +144,10 @@ mod tests {
     #[test]
     fn a_nearer_state_end_still_caps_the_cache_validity() {
         let now = OffsetDateTime::now_utc().unix_timestamp() as u64;
-        let mut epoch = Epoch::default();
-        epoch.deadline = Some(Timestamp::from_seconds(now + 60));
+        let epoch = Epoch {
+            deadline: Some(Timestamp::from_seconds(now + 60)),
+            ..Default::default()
+        };
 
         let mut cached = CachedEpoch::default();
         cached.update(epoch);

--- a/common/credential-proxy/src/ticketbook_manager/wallet_shares.rs
+++ b/common/credential-proxy/src/ticketbook_manager/wallet_shares.rs
@@ -24,6 +24,11 @@ use tracing::{debug, error, info, instrument};
 use uuid::Uuid;
 
 impl TicketbookManager {
+    /// `epoch` is resolved once by the caller and used for everything here: the signers asked,
+    /// the threshold required of them, the auxiliary data returned alongside, the epoch stated on
+    /// each request, and the epoch the shares are stored under. Resolving it again here would let
+    /// a ceremony concluding in between hand back shares and auxiliary data from two different
+    /// epochs, which a client cannot combine.
     #[instrument(
         skip(self, request_data, request, requested_on),
             fields(
@@ -31,11 +36,6 @@ impl TicketbookManager {
                 ticketbook_type = %request_data.ticketbook_type
         )
     )]
-    /// `epoch` is resolved once by the caller and used for everything here: the signers asked,
-    /// the threshold required of them, the auxiliary data returned alongside, the epoch stated on
-    /// each request, and the epoch the shares are stored under. Resolving it again here would let
-    /// a ceremony concluding in between hand back shares and auxiliary data from two different
-    /// epochs, which a client cannot combine.
     pub async fn try_obtain_wallet_shares(
         &self,
         request: Uuid,

--- a/contracts/coconut-dkg/schema/nym-coconut-dkg.json
+++ b/contracts/coconut-dkg/schema/nym-coconut-dkg.json
@@ -291,6 +291,20 @@
         "additionalProperties": false
       },
       {
+        "description": "Admin-only escape hatch: force a reset from any epoch state, including mid-exchange. A ceremony that keeps ending sub-threshold auto-resets straight into the next attempt without ever passing through `InProgress`, which is the only state [`Self::TriggerReset`] accepts - so without this, a looping ceremony can never be stopped or redirected.",
+        "type": "object",
+        "required": [
+          "trigger_forced_reset"
+        ],
+        "properties": {
+          "trigger_forced_reset": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Transfers ownership of the epoch dealer to another address. This assumes off-chain hand-over of keys",
         "type": "object",
         "required": [

--- a/contracts/coconut-dkg/schema/raw/execute.json
+++ b/contracts/coconut-dkg/schema/raw/execute.json
@@ -200,6 +200,20 @@
       "additionalProperties": false
     },
     {
+      "description": "Admin-only escape hatch: force a reset from any epoch state, including mid-exchange. A ceremony that keeps ending sub-threshold auto-resets straight into the next attempt without ever passing through `InProgress`, which is the only state [`Self::TriggerReset`] accepts - so without this, a looping ceremony can never be stopped or redirected.",
+      "type": "object",
+      "required": [
+        "trigger_forced_reset"
+      ],
+      "properties": {
+        "trigger_forced_reset": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Transfers ownership of the epoch dealer to another address. This assumes off-chain hand-over of keys",
       "type": "object",
       "required": [

--- a/contracts/coconut-dkg/src/contract.rs
+++ b/contracts/coconut-dkg/src/contract.rs
@@ -20,7 +20,8 @@ use crate::epoch_state::queries::{
 };
 use crate::epoch_state::storage::{load_current_epoch, save_epoch};
 use crate::epoch_state::transactions::{
-    try_advance_epoch_state, try_initiate_dkg, try_trigger_reset, try_trigger_resharing,
+    try_advance_epoch_state, try_initiate_dkg, try_trigger_forced_reset, try_trigger_reset,
+    try_trigger_resharing,
 };
 use crate::error::ContractError;
 use crate::state::queries::query_state;
@@ -130,6 +131,7 @@ pub fn execute(
         ExecuteMsg::AdvanceEpochState {} => try_advance_epoch_state(deps, env),
         ExecuteMsg::TriggerReset {} => try_trigger_reset(deps, env, info),
         ExecuteMsg::TriggerResharing {} => try_trigger_resharing(deps, env, info),
+        ExecuteMsg::TriggerForcedReset {} => try_trigger_forced_reset(deps, env, info),
         ExecuteMsg::TransferOwnership { transfer_to } => {
             try_transfer_ownership(deps, env, info, transfer_to)
         }

--- a/contracts/coconut-dkg/src/epoch_state/transactions/advance_epoch_state.rs
+++ b/contracts/coconut-dkg/src/epoch_state/transactions/advance_epoch_state.rs
@@ -70,7 +70,12 @@ pub fn try_advance_epoch_state(deps: DepsMut<'_>, env: Env) -> Result<Response, 
         let current_state = current_epoch.state;
         let extended = current_epoch.update(current_state, env.block.time);
         save_epoch(deps.storage, env.block.height, &extended)?;
-        return Ok(Response::new());
+        // the transaction succeeds either way, so the hold has to announce itself - see
+        // the attribute's doc
+        return Ok(Response::new().add_attribute(
+            nym_coconut_dkg_common::event_attributes::AWAITING_DEALERS,
+            extended.epoch_id.to_string(),
+        ));
     }
 
     // `InProgress` is the only state with nothing after it, and `ensure_can_advance_state` has
@@ -701,7 +706,15 @@ mod tests {
         // ceremony would otherwise have walked through, each longer than the longest of them
         for _ in 0..5 {
             env.block.time = env.block.time.plus_seconds(601);
-            try_advance_epoch_state(deps.as_mut(), env.clone()).unwrap();
+            let response = try_advance_epoch_state(deps.as_mut(), env.clone()).unwrap();
+
+            // the hold must say so on the transaction itself: it succeeds, and without the
+            // attribute it would be indistinguishable from a real advance without diffing
+            // successive epoch queries
+            assert!(response.attributes.iter().any(|attribute| {
+                attribute.key == nym_coconut_dkg_common::event_attributes::AWAITING_DEALERS
+                    && attribute.value == initial_epoch_id.to_string()
+            }));
 
             let epoch = load_current_epoch(&deps.storage).unwrap();
             assert_eq!(
@@ -752,13 +765,18 @@ mod tests {
         });
 
         env.block.time = env.block.time.plus_seconds(601);
-        try_advance_epoch_state(deps.as_mut(), env.clone()).unwrap();
+        let response = try_advance_epoch_state(deps.as_mut(), env.clone()).unwrap();
         check_epoch_state(
             deps.as_ref().storage,
             EpochState::DealingExchange { resharing: false },
         )
         .unwrap();
         assert_eq!(THRESHOLD.load(&deps.storage).unwrap(), 1);
+
+        // and a real advance does not claim to be waiting
+        assert!(!response.attributes.iter().any(|attribute| {
+            attribute.key == nym_coconut_dkg_common::event_attributes::AWAITING_DEALERS
+        }));
     }
 
     /// The same hold applies to resharing, and must not quietly drop the resharing flag.
@@ -776,7 +794,7 @@ mod tests {
         save_epoch(deps.as_mut().storage, env.block.height, &epoch).unwrap();
 
         env.block.time = env.block.time.plus_seconds(601);
-        try_advance_epoch_state(deps.as_mut(), env.clone()).unwrap();
+        let response = try_advance_epoch_state(deps.as_mut(), env.clone()).unwrap();
 
         let current = load_current_epoch(&deps.storage).unwrap();
         assert_eq!(
@@ -784,6 +802,10 @@ mod tests {
             EpochState::PublicKeySubmission { resharing: true }
         );
         assert_eq!(current.epoch_id, 7);
+        assert!(response.attributes.iter().any(|attribute| {
+            attribute.key == nym_coconut_dkg_common::event_attributes::AWAITING_DEALERS
+                && attribute.value == "7"
+        }));
     }
 
     #[test]

--- a/contracts/coconut-dkg/src/epoch_state/transactions/mod.rs
+++ b/contracts/coconut-dkg/src/epoch_state/transactions/mod.rs
@@ -53,7 +53,36 @@ pub(crate) fn try_trigger_reset(
 
     // only allow reset when the DKG exchange isn't in progress
     if !current_epoch.state.is_in_progress() {
-        return Err(ContractError::CantReshareDuringExchange);
+        return Err(ContractError::CantResetDuringExchange);
+    }
+
+    let next_epoch = current_epoch.next_reset(env.block.time);
+    save_epoch(deps.storage, env.block.height, &next_epoch)?;
+
+    reset_dkg_state(deps.storage)?;
+
+    Ok(Response::default())
+}
+
+/// The admin's escape hatch: a reset callable from any state past initialisation.
+///
+/// [`try_trigger_reset`] is deliberately gated on `InProgress`, but a ceremony that keeps ending
+/// sub-threshold auto-resets straight into the next attempt without ever getting there, so the
+/// ordinary lever can never stop or redirect a looping ceremony. This one can, and it can also
+/// abort an exchange already in flight. Aborting leaves the in-flight epoch abandoned, which
+/// issuance already tolerates: `keys_in_service` is carried over, not derived from the epoch id.
+pub(crate) fn try_trigger_forced_reset(
+    deps: DepsMut<'_>,
+    env: Env,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
+    // only the admin is allowed to force a DKG reset
+    DKG_ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
+    let current_epoch = load_current_epoch(deps.storage)?;
+
+    // there is nothing to reset before the DKG has been initiated
+    if matches!(current_epoch.state, EpochState::WaitingInitialisation) {
+        return Err(ContractError::WaitingInitialisation);
     }
 
     let next_epoch = current_epoch.next_reset(env.block.time);
@@ -153,5 +182,142 @@ pub(crate) mod tests {
         reset_dkg_state(deps.as_mut().storage).unwrap();
 
         assert!(THRESHOLD.may_load(&deps.storage).unwrap().is_none());
+    }
+
+    #[cfg(test)]
+    mod forced_reset {
+        use super::*;
+        use nym_coconut_dkg_common::types::{StateProgress, TimeConfiguration};
+
+        #[test]
+        fn only_the_admin_may_force_a_reset() {
+            let mut deps = init_contract();
+            let env = mock_env();
+
+            try_initiate_dkg(
+                deps.as_mut(),
+                env.clone(),
+                message_info(&Addr::unchecked(ADMIN_ADDRESS), &[]),
+            )
+            .unwrap();
+
+            let not_admin = deps.api.addr_make("not an admin");
+            let res =
+                try_trigger_forced_reset(deps.as_mut(), env.clone(), message_info(&not_admin, &[]))
+                    .unwrap_err();
+            assert_eq!(ContractError::Admin(AdminError::NotAdmin {}), res);
+
+            // and the epoch was left alone
+            assert_eq!(0, load_current_epoch(&deps.storage).unwrap().epoch_id);
+        }
+
+        #[test]
+        fn there_is_nothing_to_force_before_initialisation() {
+            let mut deps = init_contract();
+            let env = mock_env();
+
+            let res = try_trigger_forced_reset(
+                deps.as_mut(),
+                env,
+                message_info(&Addr::unchecked(ADMIN_ADDRESS), &[]),
+            )
+            .unwrap_err();
+            assert_eq!(ContractError::WaitingInitialisation, res);
+        }
+
+        /// The reason this message exists: a ceremony that keeps ending sub-threshold auto-resets
+        /// into the next attempt without ever reaching `InProgress`, which is the only state the
+        /// ordinary `TriggerReset` accepts - so a looping ceremony locks the admin out entirely.
+        #[test]
+        fn a_forced_reset_escapes_the_sub_threshold_loop() {
+            let mut deps = init_contract();
+            let mut env = mock_env();
+            let admin = message_info(&Addr::unchecked(ADMIN_ADDRESS), &[]);
+
+            // epoch 7's keys are in service and the ceremony for 11 is about to end sub-threshold
+            THRESHOLD.save(deps.as_mut().storage, &42).unwrap();
+            let failing = Epoch {
+                state_progress: StateProgress {
+                    verified_keys: 41,
+                    ..Default::default()
+                },
+                keys_in_service: Some(7),
+                ..Epoch::new(
+                    EpochState::VerificationKeyFinalization { resharing: false },
+                    11,
+                    TimeConfiguration::default(),
+                    env.block.time,
+                )
+            };
+            save_epoch(deps.as_mut().storage, env.block.height, &failing).unwrap();
+
+            env.block.time = env.block.time.plus_seconds(
+                TimeConfiguration::default().verification_key_finalization_time_secs + 1,
+            );
+            try_advance_epoch_state(deps.as_mut(), env.clone()).unwrap();
+
+            // the loop: a fresh attempt is already running, and the ordinary lever is refused
+            // (with the reset error, not the resharing one it used to misreport)
+            let looping = load_current_epoch(&deps.storage).unwrap();
+            assert_eq!(12, looping.epoch_id);
+            assert!(!looping.state.is_in_progress());
+            let res = try_trigger_reset(deps.as_mut(), env.clone(), admin.clone()).unwrap_err();
+            assert_eq!(ContractError::CantResetDuringExchange, res);
+
+            // the escape hatch is not
+            try_trigger_forced_reset(deps.as_mut(), env.clone(), admin).unwrap();
+
+            let after = load_current_epoch(&deps.storage).unwrap();
+            assert_eq!(13, after.epoch_id);
+            assert_eq!(
+                EpochState::PublicKeySubmission { resharing: false },
+                after.state
+            );
+            // the abandoned attempts retired nothing: epoch 7 keeps issuing throughout
+            assert_eq!(Some(7), after.issuing_epoch_id());
+            assert!(THRESHOLD.may_load(&deps.storage).unwrap().is_none());
+        }
+
+        #[test]
+        fn a_forced_reset_works_from_every_post_initialisation_state() {
+            let states = [
+                EpochState::PublicKeySubmission { resharing: false },
+                EpochState::PublicKeySubmission { resharing: true },
+                EpochState::DealingExchange { resharing: false },
+                EpochState::DealingExchange { resharing: true },
+                EpochState::VerificationKeySubmission { resharing: false },
+                EpochState::VerificationKeySubmission { resharing: true },
+                EpochState::VerificationKeyValidation { resharing: false },
+                EpochState::VerificationKeyValidation { resharing: true },
+                EpochState::VerificationKeyFinalization { resharing: false },
+                EpochState::VerificationKeyFinalization { resharing: true },
+                EpochState::InProgress,
+            ];
+
+            for state in states {
+                let mut deps = init_contract();
+                let env = mock_env();
+
+                let epoch = Epoch::new(state, 5, TimeConfiguration::default(), env.block.time);
+                save_epoch(deps.as_mut().storage, env.block.height, &epoch).unwrap();
+
+                try_trigger_forced_reset(
+                    deps.as_mut(),
+                    env,
+                    message_info(&Addr::unchecked(ADMIN_ADDRESS), &[]),
+                )
+                .unwrap();
+
+                let after = load_current_epoch(&deps.storage).unwrap();
+                assert_eq!(6, after.epoch_id, "from {state}");
+                // always a reset, never a resharing: aborted resharings included, since their
+                // registrants may hold nothing to reshare
+                assert_eq!(
+                    EpochState::PublicKeySubmission { resharing: false },
+                    after.state,
+                    "from {state}"
+                );
+            }
+        }
     }
 }

--- a/contracts/coconut-dkg/src/testable_dkg_contract/mod.rs
+++ b/contracts/coconut-dkg/src/testable_dkg_contract/mod.rs
@@ -333,8 +333,8 @@ pub trait DkgContractTesterExt:
             .unwrap()
     }
 
-    /// Replace a dealer's verification key share with an arbitrary string, so that it
-    /// no longer pairs with the dealings that dealer actually distributed.
+    /// Corrupt a dealer's stored verification key share with the supplied mutation, so
+    /// that it no longer pairs with the dealings that dealer actually distributed.
     fn corrupt_vk_share<F>(&mut self, epoch_id: EpochId, owner: &Addr, mutate: F)
     where
         F: FnOnce(&mut VerificationKeyShare),

--- a/contracts/coconut-dkg/src/verification_key_shares/transactions.rs
+++ b/contracts/coconut-dkg/src/verification_key_shares/transactions.rs
@@ -537,11 +537,18 @@ mod tests {
             .plus_seconds(timings.verification_key_validation_time_secs);
         try_advance_epoch_state(deps.as_mut(), env.clone()).unwrap();
 
-        // now the stale order finally gets executed
-        let replayed = crate::contract::execute(deps.as_mut(), env, multisig_info, epoch_0_order);
+        // now the stale order finally gets executed, and it is the epoch guard that
+        // refuses it, not some incidental failure
+        let replayed =
+            crate::contract::execute(deps.as_mut(), env, multisig_info, epoch_0_order).unwrap_err();
 
-        assert!(
-            replayed.is_err(),
+        assert_eq!(
+            replayed,
+            ContractError::StaleVerificationOrder {
+                owner: owner.to_string(),
+                order_epoch_id: 0,
+                current_epoch_id: 1,
+            },
             "an order minted for epoch 0 verified a share in epoch 1"
         );
         let share = vk_shares().load(&deps.storage, (&owner, 1)).unwrap();

--- a/nym-api/src/ecash/comm.rs
+++ b/nym-api/src/ecash/comm.rs
@@ -69,10 +69,16 @@ impl CachedEpoch {
             #[allow(clippy::unwrap_used)]
             let state_end =
                 OffsetDateTime::from_unix_timestamp(epoch_finish.seconds() as i64).unwrap();
-            let until_epoch_state_end = state_end - now;
-            // make it valid until the next epoch transition or the staleness ceiling, whichever
-            // is smaller
-            min(until_epoch_state_end, max_staleness)
+            if state_end <= now {
+                // a deadline nothing will ever advance (the settled epoch's lapsed
+                // self-extension) - an expiry computed against it would land in the
+                // past and disable the cache for good
+                max_staleness
+            } else {
+                // valid until the next epoch transition or the staleness ceiling,
+                // whichever is smaller
+                min(state_end - now, max_staleness)
+            }
         } else {
             max_staleness
         };
@@ -329,9 +335,10 @@ mod tests {
     /// whatever it sees under that epoch id with no expiry and no invalidation, so a
     /// single mid-ceremony query pins an empty signer set for good.
     ///
-    /// Currently RED. Note the fix for the unverified-share handling widened this:
-    /// mid-ceremony queries used to fail (and errors are not cached), whereas now they
-    /// succeed with an empty list, which is exactly what gets cached.
+    /// Note the fix for the unverified-share handling had widened this before the
+    /// mid-ceremony bypass closed it: mid-ceremony queries used to fail (and errors are
+    /// not cached), whereas they now succeed with an empty list, which is exactly what
+    /// would have been cached.
     ///
     /// The ceremony here is a precondition, not the subject, so it runs against the
     /// contract without any DKG cryptography.
@@ -380,5 +387,40 @@ mod tests {
         assert_eq!(clients.len(), validators);
 
         Ok(())
+    }
+
+    /// The settled mainnet epoch keeps the deadline of its last self-extension, and since
+    /// the extension's removal nothing will ever move it. Once that timestamp passes, an
+    /// expiry computed against it lands in the past - a permanently invalid cache, sending
+    /// every epoch read to the chain until the next ceremony stores a fresh epoch.
+    #[test]
+    fn a_lapsed_deadline_does_not_disable_the_cache() {
+        use nym_coconut_dkg_common::types::Timestamp;
+
+        let mut epoch = Epoch::default();
+        epoch.deadline = Some(Timestamp::from_seconds(1));
+
+        let mut cached = CachedEpoch::default();
+        cached.update(epoch, Duration::from_secs(300)).unwrap();
+
+        assert!(cached.is_valid());
+    }
+
+    /// The counterpart boundary: a deadline still ahead caps the expiry below the staleness
+    /// ceiling. This is the pessimism guarantee `current_epoch_details` documents - the copy
+    /// dies at the state change it cannot see past, so it can never claim a ceremony has
+    /// concluded when it has not.
+    #[test]
+    fn a_nearer_state_end_still_caps_the_cache_validity() {
+        use nym_coconut_dkg_common::types::Timestamp;
+
+        let now = OffsetDateTime::now_utc().unix_timestamp() as u64;
+        let mut epoch = Epoch::default();
+        epoch.deadline = Some(Timestamp::from_seconds(now + 60));
+
+        let mut cached = CachedEpoch::default();
+        cached.update(epoch, Duration::from_secs(300)).unwrap();
+
+        assert!(cached.valid_until <= OffsetDateTime::now_utc() + time::Duration::seconds(60));
     }
 }

--- a/nym-api/src/ecash/comm.rs
+++ b/nym-api/src/ecash/comm.rs
@@ -397,8 +397,10 @@ mod tests {
     fn a_lapsed_deadline_does_not_disable_the_cache() {
         use nym_coconut_dkg_common::types::Timestamp;
 
-        let mut epoch = Epoch::default();
-        epoch.deadline = Some(Timestamp::from_seconds(1));
+        let epoch = Epoch {
+            deadline: Some(Timestamp::from_seconds(1)),
+            ..Default::default()
+        };
 
         let mut cached = CachedEpoch::default();
         cached.update(epoch, Duration::from_secs(300)).unwrap();
@@ -415,8 +417,10 @@ mod tests {
         use nym_coconut_dkg_common::types::Timestamp;
 
         let now = OffsetDateTime::now_utc().unix_timestamp() as u64;
-        let mut epoch = Epoch::default();
-        epoch.deadline = Some(Timestamp::from_seconds(now + 60));
+        let epoch = Epoch {
+            deadline: Some(Timestamp::from_seconds(now + 60)),
+            ..Default::default()
+        };
 
         let mut cached = CachedEpoch::default();
         cached.update(epoch, Duration::from_secs(300)).unwrap();

--- a/nym-api/src/ecash/keys/mod.rs
+++ b/nym-api/src/ecash/keys/mod.rs
@@ -75,16 +75,6 @@ impl KeyPair {
         self.archived.write().await.insert(epoch_id, keypair);
     }
 
-    /// The epoch our currently held keys were derived for, regardless of whether they may
-    /// yet be used for issuance.
-    async fn current_key_epoch(&self) -> Option<EpochId> {
-        self.keys
-            .read()
-            .await
-            .as_ref()
-            .map(|keys| keys.issued_for_epoch)
-    }
-
     /// The keys derived for `epoch_id`, wherever we happen to be keeping them - the live slot
     /// if it is still the epoch we sign for, otherwise the archive.
     ///
@@ -101,17 +91,28 @@ impl KeyPair {
         &self,
         epoch_id: EpochId,
     ) -> Result<RwLockReadGuard<'_, KeyPairWithEpoch>, EcashError> {
-        let current = self.current_key_epoch().await;
+        // the epoch check happens on the guard actually returned: were "which epoch is
+        // live" a separate read, the controller could rotate the slot between it and the
+        // re-acquisition, and a keypair for a different epoch than requested would be
+        // served - with its wrong-epoch partials persisted
+        let live = match RwLockReadGuard::try_map(self.read_keys().await, |keys| {
+            keys.as_ref()
+                .filter(|keys| keys.issued_for_epoch == epoch_id)
+        }) {
+            Ok(keys) => return Ok(keys),
+            Err(live) => live,
+        };
 
-        if current == Some(epoch_id) {
-            return RwLockReadGuard::try_map(self.read_keys().await, |keys| keys.as_ref())
-                .map_err(|_| EcashError::KeyPairNotDerivedYet);
-        }
+        // the archive is consulted whenever the live slot did not match, so keys that
+        // rotated out between the two reads are found where they now live rather than
+        // erroring on where they used to
+        let available = live.as_ref().map(|keys| keys.issued_for_epoch);
+        drop(live);
 
         RwLockReadGuard::try_map(self.archived.read().await, |archived| {
             archived.get(&epoch_id)
         })
-        .map_err(|_| match current {
+        .map_err(|_| match available {
             Some(available) => EcashError::InvalidSigningKeyEpoch {
                 requested: epoch_id,
                 available,

--- a/nym-api/src/ecash/state/mod.rs
+++ b/nym-api/src/ecash/state/mod.rs
@@ -1398,8 +1398,8 @@ mod tests {
     /// thing every ticket verification does, and gateways poll continuously, so a query
     /// landing mid-ceremony is a certainty rather than a risk.
     ///
-    /// Currently RED. Note `active_signer` is a *separate* cache from the communication
-    /// channel's `epoch_clients`, so fixing that one alone would not fix this.
+    /// Note `active_signer` is a *separate* cache from the communication channel's
+    /// `epoch_clients`, so the bypass fixing that one alone would not have fixed this.
     #[tokio::test]
     async fn a_signer_still_recognises_itself_after_a_ceremony() -> anyhow::Result<()> {
         let chain = SharedContractChain::new(3);
@@ -1440,8 +1440,8 @@ mod tests {
     /// signer discovery, so a poisoned signer set leaves it permanently unavailable.
     ///
     /// It is guarded by a threshold check and `get_or_init` never caches errors, so it
-    /// is *designed* to recover on the next request. Currently RED because the layer
-    /// beneath it cannot.
+    /// is *designed* to recover on the next request - which it could not do while the
+    /// layer beneath it could not.
     #[tokio::test]
     async fn the_master_verification_key_becomes_available_after_a_ceremony() -> anyhow::Result<()>
     {

--- a/nym-api/src/ecash/tests/contract_chain.rs
+++ b/nym-api/src/ecash/tests/contract_chain.rs
@@ -848,10 +848,10 @@ mod tests {
             );
         assert_eq!(node_index.as_deref(), Some("1"));
 
-        // and a non-member is rejected by the real group check
-        let outsider: AccountId = "n19lc9u84cz0yz3fww5283nucc9yvr8gsjmgeul0".parse().unwrap();
+        // and a non-member is rejected by the real group check, not for some incidental reason
+        let outsider = chain.make_address("outsider".to_string());
         let outsider_client = ContractChainClient::new(outsider, chain.clone());
-        assert!(outsider_client
+        let refusal = outsider_client
             .register_dealer(
                 "bte-key-2".to_string(),
                 "identity-2".to_string(),
@@ -859,7 +859,11 @@ mod tests {
                 false,
             )
             .await
-            .is_err());
+            .unwrap_err();
+        assert!(
+            format!("{refusal:?}").contains("not in the coconut signer group"),
+            "rejected, but not by the group check: {refusal:?}"
+        );
 
         Ok(())
     }

--- a/nym-api/src/ecash/tests/mod.rs
+++ b/nym-api/src/ecash/tests/mod.rs
@@ -1198,10 +1198,15 @@ impl SharedCommState {
 
     /// Put the current epoch mid-ceremony, as a rotation would: its own keys do not exist yet, so
     /// the epoch before it is the one in service.
+    /// A ceremony for the current epoch id begins. This doubles as a state constructor
+    /// (pair it with `set_epoch`), so unlike the chain it synthesizes `keys_in_service`
+    /// from the id below; the other fields follow `next_ceremony` - the recorded
+    /// conclusion is cleared (starting a ceremony revokes the grace window) and
+    /// `outgoing_keys` carries over untouched.
     pub async fn start_ceremony(&self) {
         self.inner.ceremony_in_flight.store(true, Ordering::Relaxed);
         *self.inner.keys_in_service.write().await = self.current_epoch().checked_sub(1);
-        *self.inner.outgoing_keys.write().await = None;
+        *self.inner.ceremony_concluded_at.write().await = None;
     }
 
     /// A ceremony that failed: the contract resets into a fresh epoch id and the keys already in

--- a/nym-api/src/ecash/tests/mod.rs
+++ b/nym-api/src/ecash/tests/mod.rs
@@ -393,7 +393,7 @@ impl FakeChainState {
             nym_coconut_dkg_common::msg::ExecuteMsg::VerifyVerificationKeyShare {
                 owner,
                 resharing,
-                ..
+                epoch_id: order_epoch_id,
             } => {
                 if sender.sender != self.multisig_contract.address {
                     panic!("not multisig")
@@ -403,6 +403,9 @@ impl FakeChainState {
                     EpochState::VerificationKeyFinalization { resharing }
                 );
                 let epoch_id = self.dkg_contract.epoch.epoch_id;
+                // mirror the contract's StaleVerificationOrder gate: an order names the
+                // epoch it was minted for, and only that epoch's share may be verified by it
+                assert_eq!(order_epoch_id, epoch_id, "stale verification order");
                 let Some(shares) = self.dkg_contract.verification_shares.get_mut(&epoch_id) else {
                     panic!("no shares for epoch")
                 };


### PR DESCRIPTION
# Upgrade-mode claims at ticket exhaustion + admin forced DKG reset

Two changes that close out the reset-mandatory client and contract work.

## Claim with the upgrade-mode token when tickets run out

LP registration - the client default - ignored upgrade mode entirely: it raised `NoTicketsAvailable` before ever building a claim, and the mixnet websocket path did the same with `NoMoreBandwidthCredentials`. An exhausted stock is precisely the situation the upgrade-mode token exists for: during an upgrade window a gateway stops metering, so a client with nothing to spend can still connect.

Both paths now fall back to the stored token **only once the ticket stock is exhausted** - a held ticket always wins. Ticket-first is deliberate: signers now keep issuing through a ceremony (earlier on this branch), so tickets are replaceable mid-ceremony, while a refused JWT (e.g. the gateway's 30s recheck rate limit) would fail registrations a held ticket would have carried. Without a token, exhaustion errors exactly as before.

Everything gateway-side already existed; this is the missing client branch. The wire format and all function signatures are unchanged, so app-side integration is a dependency bump. `send_upgrade_mode_jwt` gains its first caller instead of being dead surface. Arm selection is unit-tested against a provider holding both a ticket and a token (mutation-checked).

## Admin forced DKG reset (`TriggerForcedReset`)

A ceremony that keeps ending sub-threshold auto-resets straight into the next attempt without ever passing through `InProgress` - the only state `TriggerReset` accepts - so a looping ceremony locks the admin out entirely.

`TriggerForcedReset` is admin-only, callable from any post-initialisation state, and always resets (never reshares - an aborted resharing's registrants may hold nothing to reshare). `keys_in_service` carries over, so aborting an exchange retires nothing and issuance continues under the epoch in service. It is a separate message rather than a widened `TriggerReset`: the state gate on the ordinary lever is a safety interlock, and the chain log stays self-describing in a post-mortem. Also fixes the reset handler misreporting its refusal as `CantReshareDuringExchange`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7107)
<!-- Reviewable:end -->
