### PR TITLE
feat: LP: claim UM token when out of tickets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8398,11 +8398,13 @@ dependencies = [
 name = "nym-registration-client"
 version = "1.21.5"
 dependencies = [
+ "async-trait",
  "bincode",
  "bytes",
  "futures",
  "getrandom 0.4.2",
  "nym-authenticator-client",
+ "nym-authenticator-requests",
  "nym-bandwidth-controller",
  "nym-credential-storage",
  "nym-credentials-interface",
@@ -8416,6 +8418,7 @@ dependencies = [
  "nym-test-utils",
  "nym-wireguard-types",
  "rand 0.10.2",
+ "rand 0.8.6",
  "thiserror 2.0.19",
  "time",
  "tokio",

--- a/common/client-libs/gateway-client/src/client/mod.rs
+++ b/common/client-libs/gateway-client/src/client/mod.rs
@@ -806,7 +806,7 @@ impl GatewayClient {
                 negotiated_protocol: Some(gateway_protocol),
             });
         }
-        let prepared_credential = self
+        let maybe_credential = self
             .bandwidth_provider
             .get_ecash_ticket(
                 MIXNET_TICKET,
@@ -814,8 +814,19 @@ impl GatewayClient {
                 TICKETS_TO_SPEND,
                 OffsetDateTime::now_utc(),
             )
-            .await?
-            .ok_or(GatewayClientError::NoMoreBandwidthCredentials)?;
+            .await?;
+
+        // out of tickets: while the network is undergoing an upgrade the gateway stops metering
+        // and takes a JWT in place of one, which is the situation that token exists for.
+        // without a token, exhaustion stays the error it has always been
+        let Some(prepared_credential) = maybe_credential else {
+            let Some(token) = self.bandwidth_provider.get_upgrade_mode_token().await? else {
+                return Err(GatewayClientError::NoMoreBandwidthCredentials);
+            };
+
+            info!("out of mixnet tickets - claiming with the stored upgrade mode token instead");
+            return self.send_upgrade_mode_jwt(token).await;
+        };
 
         match self.claim_ecash_bandwidth(prepared_credential.data).await {
             Ok(_) => {

--- a/nym-registration-client/Cargo.toml
+++ b/nym-registration-client/Cargo.toml
@@ -29,6 +29,7 @@ tracing.workspace = true
 typed-builder.workspace = true
 
 nym-authenticator-client = { workspace = true }
+nym-authenticator-requests = { workspace = true }
 nym-bandwidth-controller = { workspace = true }
 nym-credential-storage = { workspace = true }
 nym-credentials-interface = { workspace = true }
@@ -41,5 +42,8 @@ nym-sdk = { workspace = true }
 nym-wireguard-types = { workspace = true }
 
 [dev-dependencies]
+async-trait.workspace = true
 nym-kkt.workspace = true
 nym-test-utils.workspace = true
+rand.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/nym-registration-client/src/lp_client/bandwidth_claim.rs
+++ b/nym-registration-client/src/lp_client/bandwidth_claim.rs
@@ -1,0 +1,209 @@
+// Copyright 2026 - Nym Technologies SA <contact@nymtech.net>
+// SPDX-License-Identifier: Apache-2.0
+
+use super::error::{LpClientError, Result};
+use nym_authenticator_requests::models::BandwidthClaim;
+use nym_bandwidth_controller::{BandwidthTicketProvider, DEFAULT_TICKETS_TO_SPEND};
+use nym_credentials_interface::{BandwidthCredential, TicketType};
+use nym_crypto::asymmetric::ed25519;
+use time::{Duration as TimeDuration, OffsetDateTime};
+use tracing::warn;
+
+/// Builds the claim a dVPN registration is finalised with.
+///
+/// Spends a ticket whenever one is available. Only once the stock is exhausted does it fall back
+/// to an upgrade-mode JWT, which is precisely the situation that token exists for: while the
+/// network is undergoing an upgrade a gateway stops metering bandwidth, so a client holding no
+/// tickets can still register. Without a token, exhaustion stays the error it has always been.
+pub(crate) async fn produce_bandwidth_claim(
+    bandwidth_provider: &dyn BandwidthTicketProvider,
+    gateway_identity: ed25519::PublicKey,
+    spend_time_skew: Option<TimeDuration>,
+    ticket_type: TicketType,
+) -> Result<BandwidthClaim> {
+    let ticket = bandwidth_provider
+        .get_ecash_ticket(
+            ticket_type,
+            gateway_identity,
+            DEFAULT_TICKETS_TO_SPEND,
+            OffsetDateTime::now_utc() - spend_time_skew.unwrap_or_default(),
+        )
+        .await
+        .map_err(|e| {
+            LpClientError::SendRegistrationRequest(format!(
+                "Failed to acquire bandwidth credential: {e}",
+            ))
+        })?;
+
+    // note that only an exhausted stock reaches for the token; a failed lookup is a real failure
+    // and stays one
+    if let Some(ticket) = ticket {
+        return ticket
+            .data
+            .try_into()
+            .map_err(|err| LpClientError::Other(format!("malformed stored credential: {err}")));
+    }
+
+    let token = bandwidth_provider
+        .get_upgrade_mode_token()
+        .await
+        .map_err(|e| {
+            LpClientError::SendRegistrationRequest(format!(
+                "Failed to look up the upgrade mode token: {e}",
+            ))
+        })?
+        .ok_or(LpClientError::NoTicketsAvailable {
+            ticketbook_type: ticket_type,
+        })?;
+
+    warn!("out of {ticket_type} tickets - registering with the stored upgrade mode token instead");
+
+    Ok(BandwidthClaim {
+        credential: BandwidthCredential::UpgradeModeJWT { token },
+        kind: ticket_type,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use nym_bandwidth_controller::error::BandwidthControllerError;
+    use nym_bandwidth_controller::mock::MockBandwidthController;
+    use nym_bandwidth_controller::{PreparedCredential, PreparedCredentialMetadata};
+
+    /// A provider that is out of tickets, holding the given token (if any).
+    struct ExhaustedTickets {
+        upgrade_mode_token: Option<String>,
+    }
+
+    #[async_trait]
+    impl BandwidthTicketProvider for ExhaustedTickets {
+        async fn get_ecash_ticket(
+            &self,
+            _ticket_type: TicketType,
+            _gateway_id: ed25519::PublicKey,
+            _tickets_to_spend: u32,
+            _spend_time: OffsetDateTime,
+        ) -> std::result::Result<Option<PreparedCredential>, BandwidthControllerError> {
+            Ok(None)
+        }
+
+        async fn get_upgrade_mode_token(
+            &self,
+        ) -> std::result::Result<Option<String>, BandwidthControllerError> {
+            Ok(self.upgrade_mode_token.clone())
+        }
+
+        async fn attempt_revert_spending(
+            &self,
+            _metadata: PreparedCredentialMetadata,
+        ) -> std::result::Result<bool, BandwidthControllerError> {
+            Ok(true)
+        }
+
+        async fn close(&self) {}
+    }
+
+    /// A provider holding both a ticket and a token, so that which arm is taken is observable.
+    #[derive(Default)]
+    struct TicketAndToken {
+        tickets: MockBandwidthController,
+    }
+
+    #[async_trait]
+    impl BandwidthTicketProvider for TicketAndToken {
+        async fn get_ecash_ticket(
+            &self,
+            ticket_type: TicketType,
+            gateway_id: ed25519::PublicKey,
+            tickets_to_spend: u32,
+            spend_time: OffsetDateTime,
+        ) -> std::result::Result<Option<PreparedCredential>, BandwidthControllerError> {
+            self.tickets
+                .get_ecash_ticket(ticket_type, gateway_id, tickets_to_spend, spend_time)
+                .await
+        }
+
+        async fn get_upgrade_mode_token(
+            &self,
+        ) -> std::result::Result<Option<String>, BandwidthControllerError> {
+            Ok(Some("token".to_string()))
+        }
+
+        async fn attempt_revert_spending(
+            &self,
+            _metadata: PreparedCredentialMetadata,
+        ) -> std::result::Result<bool, BandwidthControllerError> {
+            Ok(true)
+        }
+
+        async fn close(&self) {}
+    }
+
+    fn gateway_identity() -> ed25519::PublicKey {
+        let mut rng = rand::rngs::OsRng;
+        *ed25519::KeyPair::new(&mut rng).public_key()
+    }
+
+    #[tokio::test]
+    async fn a_held_ticket_is_spent_rather_than_the_token() {
+        // the provider holds both, so this fails if the arms are ever reordered
+        let claim = produce_bandwidth_claim(
+            &TicketAndToken::default(),
+            gateway_identity(),
+            None,
+            TicketType::V1WireguardEntry,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(claim.credential, BandwidthCredential::ZkNym(_)));
+        assert_eq!(TicketType::V1WireguardEntry, claim.kind);
+    }
+
+    #[tokio::test]
+    async fn an_exhausted_stock_falls_back_to_the_token() {
+        let provider = ExhaustedTickets {
+            upgrade_mode_token: Some("token".to_string()),
+        };
+
+        let claim = produce_bandwidth_claim(
+            &provider,
+            gateway_identity(),
+            None,
+            TicketType::V1WireguardEntry,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            claim.credential,
+            BandwidthCredential::UpgradeModeJWT { token } if token == "token"
+        ));
+        // the claim is still tagged with the type that was asked for
+        assert_eq!(TicketType::V1WireguardEntry, claim.kind);
+    }
+
+    #[tokio::test]
+    async fn an_exhausted_stock_without_a_token_stays_the_error_it_was() {
+        let provider = ExhaustedTickets {
+            upgrade_mode_token: None,
+        };
+
+        let err = produce_bandwidth_claim(
+            &provider,
+            gateway_identity(),
+            None,
+            TicketType::V1WireguardEntry,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            LpClientError::NoTicketsAvailable { ticketbook_type }
+                if ticketbook_type == TicketType::V1WireguardEntry
+        ));
+    }
+}

--- a/nym-registration-client/src/lp_client/client.rs
+++ b/nym-registration-client/src/lp_client/client.rs
@@ -3,6 +3,7 @@
 
 //! LP (Lewes Protocol) registration client for direct gateway connections.
 
+use super::bandwidth_claim::produce_bandwidth_claim;
 use super::config::LpRegistrationConfig;
 use super::error::{LpClientError, Result};
 use crate::lp_client::helpers::{
@@ -10,7 +11,7 @@ use crate::lp_client::helpers::{
 };
 use crate::lp_client::nested_session::connection::NestedConnection;
 use crate::lp_client::session_helpers::{extract_forwarded_response, prepare_send_packet};
-use nym_bandwidth_controller::{BandwidthTicketProvider, DEFAULT_TICKETS_TO_SPEND};
+use nym_bandwidth_controller::BandwidthTicketProvider;
 use nym_credentials_interface::TicketType;
 use nym_crypto::asymmetric::{ed25519, x25519};
 use nym_lp::Ciphersuite;
@@ -30,7 +31,7 @@ use rand010::{CryptoRng, Rng};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use time::{Duration as TimeDuration, OffsetDateTime};
+use time::Duration as TimeDuration;
 use tokio::net::TcpStream;
 use tracing::{debug, warn};
 
@@ -440,31 +441,15 @@ where
         tracing::debug!("Acquiring bandwidth credential for registration");
 
         // 1. Get bandwidth credential from controller
-        let credential_spending = bandwidth_provider
-            .get_ecash_ticket(
-                ticket_type,
-                gateway_identity,
-                DEFAULT_TICKETS_TO_SPEND,
-                OffsetDateTime::now_utc() - spend_time_skew.unwrap_or_default(),
-            )
-            .await
-            .map_err(|e| {
-                LpClientError::SendRegistrationRequest(format!(
-                    "Failed to acquire bandwidth credential: {e}",
-                ))
-            })?
-            .ok_or(LpClientError::NoTicketsAvailable {
-                ticketbook_type: ticket_type,
-            })?
-            .data;
+        let credential = produce_bandwidth_claim(
+            bandwidth_provider,
+            gateway_identity,
+            spend_time_skew,
+            ticket_type,
+        )
+        .await?;
 
         // 2. Build registration request
-
-        // for now we do NOT support upgrade mode (yeah... no.)
-        let credential = credential_spending
-            .try_into()
-            .map_err(|err| LpClientError::Other(format!("malformed stored credential: {err}")))?;
-
         let request = LpRegistrationRequest::new_finalise_dvpn(credential);
 
         tracing::trace!("Built dVPN registration finalisation request");

--- a/nym-registration-client/src/lp_client/mod.rs
+++ b/nym-registration-client/src/lp_client/mod.rs
@@ -31,6 +31,7 @@
 //! let gateway_data = client.register(wg_keypair, gateway_identity, bandwidth_controller, ticket_type).await?;
 //! ```
 
+mod bandwidth_claim;
 mod client;
 mod config;
 pub(crate) mod error;

--- a/nym-registration-client/src/lp_client/nested_session/mod.rs
+++ b/nym-registration-client/src/lp_client/nested_session/mod.rs
@@ -18,13 +18,14 @@
 //! The entry gateway sees the client's IP but doesn't know the final destination.
 //! The exit gateway processes the LP handshake but only sees the entry gateway's IP.
 
+use super::bandwidth_claim::produce_bandwidth_claim;
 use super::client::LpRegistrationClient;
 use super::error::{LpClientError, Result};
 use crate::lp_client::helpers::{
     LpFrameDeliverExt, LpFrameSendExt, exponential_backoff_with_jitter,
 };
 use crate::lp_client::session_helpers::{extract_forwarded_response, prepare_send_packet};
-use nym_bandwidth_controller::{BandwidthTicketProvider, DEFAULT_TICKETS_TO_SPEND};
+use nym_bandwidth_controller::BandwidthTicketProvider;
 use nym_credentials_interface::TicketType;
 use nym_crypto::asymmetric::{ed25519, x25519};
 use nym_lp::peer::{DHKeyPair, LpLocalPeer, LpRemotePeer};
@@ -43,7 +44,7 @@ use nym_wireguard_types::PeerPublicKey;
 use rand010::{CryptoRng, Rng};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use time::{Duration as TimeDuration, OffsetDateTime};
+use time::Duration as TimeDuration;
 use tracing::{debug, warn};
 
 pub(crate) mod connection;
@@ -237,31 +238,15 @@ impl NestedLpSession {
         let mut nested_connection = outer_client.as_nested_connection(self.exit_address);
 
         // Step 1: Get bandwidth credential from controller
-        let credential_spending = bandwidth_provider
-            .get_ecash_ticket(
-                ticket_type,
-                gateway_identity,
-                DEFAULT_TICKETS_TO_SPEND,
-                OffsetDateTime::now_utc() - spend_time_skew.unwrap_or_default(),
-            )
-            .await
-            .map_err(|e| {
-                LpClientError::SendRegistrationRequest(format!(
-                    "Failed to acquire bandwidth credential: {e}",
-                ))
-            })?
-            .ok_or(LpClientError::NoTicketsAvailable {
-                ticketbook_type: ticket_type,
-            })?
-            .data;
+        let credential = produce_bandwidth_claim(
+            bandwidth_provider,
+            gateway_identity,
+            spend_time_skew,
+            ticket_type,
+        )
+        .await?;
 
         // Step 2: Build registration request
-
-        // for now we do NOT support upgrade mode (yeah... no.)
-        let credential = credential_spending
-            .try_into()
-            .map_err(|err| LpClientError::Other(format!("malformed stored credential: {err}")))?;
-
         let request = LpRegistrationRequest::new_finalise_dvpn(credential);
 
         tracing::trace!("Built dVPN registration finalisation request");


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7110)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fallback authentication path using an upgrade token when ecash bandwidth tickets are unavailable.
  * dVPN registration can now complete using either an available ecash ticket or an upgrade token.

* **Bug Fixes**
  * Registration now reports a clear error when neither bandwidth tickets nor an upgrade token is available.
  * Preserved the existing ecash ticket flow when tickets are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->