### PR TITLE
bugfix: don't panic on Socks5 Controller Sender failure

### DIFF
--- a/common/socks5-client-core/src/socks/client.rs
+++ b/common/socks5-client-core/src/socks/client.rs
@@ -197,8 +197,7 @@ impl Drop for SocksClient {
             self.controller_sender
                 .unbounded_send(ControllerCommand::Remove {
                     connection_id: self.connection_id,
-                })
-                .unwrap();
+                });
         }
     }
 }
@@ -495,8 +494,7 @@ impl SocksClient {
                     .unbounded_send(ControllerCommand::Insert {
                         connection_id: self.connection_id,
                         connection_sender: mix_sender,
-                    })
-                    .unwrap();
+                    });
 
                 info!(
                     "Starting proxy for {} (id: {})",

--- a/common/socks5-client-core/src/socks/mixnet_responses.rs
+++ b/common/socks5-client-core/src/socks/mixnet_responses.rs
@@ -82,8 +82,7 @@ impl MixnetResponseListener {
             }
             Socks5ResponseContent::NetworkData { content } => {
                 self.controller_sender
-                    .unbounded_send(ControllerCommand::new_send(content))
-                    .unwrap();
+                    .unbounded_send(ControllerCommand::new_send(content));
                 Ok(())
             }
             Socks5ResponseContent::Query(response) => {

--- a/common/socks5/proxy-helpers/src/connection_controller.rs
+++ b/common/socks5/proxy-helpers/src/connection_controller.rs
@@ -31,7 +31,21 @@ pub type ConnectionSender = mpsc::UnboundedSender<ConnectionMessage>;
 /// Receiver part of the [`ConnectionSender`]
 pub type ConnectionReceiver = mpsc::UnboundedReceiver<ConnectionMessage>;
 
-pub type ControllerSender = mpsc::UnboundedSender<ControllerCommand>;
+#[derive(Clone)]
+pub struct ControllerSender(mpsc::UnboundedSender<ControllerCommand>);
+
+impl ControllerSender {
+    pub fn new(sender: mpsc::UnboundedSender<ControllerCommand>) -> Self {
+        ControllerSender(sender)
+    }
+
+    pub fn unbounded_send(&self, command: ControllerCommand) {
+        if self.0.unbounded_send(command).is_err() {
+            debug!("could not send command to controller - is it going through shutdown?");
+        }
+    }
+}
+
 pub type ControllerReceiver = mpsc::UnboundedReceiver<ControllerCommand>;
 
 pub enum ControllerCommand {
@@ -119,7 +133,7 @@ impl Controller {
                 pending_messages: HashMap::new(),
                 shutdown,
             },
-            sender,
+            ControllerSender::new(sender),
         )
     }
 

--- a/service-providers/network-requester/src/core.rs
+++ b/service-providers/network-requester/src/core.rs
@@ -411,12 +411,10 @@ impl NRServiceProvider {
 
         // Connect implies it's a fresh connection - register it with our controller
         let (mix_sender, mix_receiver) = mpsc::unbounded();
-        controller_sender
-            .unbounded_send(ControllerCommand::Insert {
-                connection_id,
-                connection_sender: mix_sender,
-            })
-            .unwrap();
+        controller_sender.unbounded_send(ControllerCommand::Insert {
+            connection_id,
+            connection_sender: mix_sender,
+        });
 
         let old_count = ACTIVE_PROXIES.fetch_add(1, Ordering::SeqCst);
         log::info!(
@@ -436,9 +434,7 @@ impl NRServiceProvider {
         .await;
 
         // proxy is done - remove the access channel from the controller
-        controller_sender
-            .unbounded_send(ControllerCommand::Remove { connection_id })
-            .unwrap();
+        controller_sender.unbounded_send(ControllerCommand::Remove { connection_id });
 
         let old_count = ACTIVE_PROXIES.fetch_sub(1, Ordering::SeqCst);
         log::info!(
@@ -518,7 +514,6 @@ impl NRServiceProvider {
     fn handle_proxy_send(&mut self, req: SendRequest) {
         self.controller_sender
             .unbounded_send(ControllerCommand::new_send(req.data))
-            .unwrap()
     }
 
     fn handle_query(


### PR DESCRIPTION
fixes https://github.com/nymtech/nym/issues/7108

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7114)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling when controller messages cannot be delivered.
  * Prevented connection-related operations from crashing due to failed internal message sends.
  * Added debug logging to help diagnose undelivered controller commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->