### PR TITLE
chore: revert manually setting LP AEAD nonce

### DIFF
--- a/common/nym-lp/Cargo.toml
+++ b/common/nym-lp/Cargo.toml
@@ -29,7 +29,7 @@ nym-kkt-ciphersuite = { workspace = true }
 nym-lp-data.workspace = true
 
 # libcrux dependencies for PSQ (Post-Quantum PSK derivation)
-libcrux-psq = { workspace = true, features = ["nonce-control"] }
+libcrux-psq = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 

--- a/common/nym-lp/src/codec.rs
+++ b/common/nym-lp/src/codec.rs
@@ -13,12 +13,14 @@ pub(crate) const SANE_ENC_OVERHEAD: usize = 32;
 pub(crate) const SANE_DEC_OVERHEAD: usize = 24;
 
 // same as libcrux_psq::aead::NONCE_LEN, which libcrux does not re-export
+#[expect(dead_code)]
 pub(crate) const NONCE_LEN: usize = 12;
 
 /// Derives the AEAD nonce of the packet with the given counter.
 ///
 /// libcrux increments its nonce *before* every use, so prior to `nonce-control` the packet with
 /// counter `n` was encrypted under nonce `n + 1`. The offset keeps the wire format identical.
+#[expect(dead_code)]
 pub(crate) fn counter_to_nonce(counter: u64) -> [u8; NONCE_LEN] {
     // a u64 counter plus one always fits into the 96-bit nonce
     let buf = (counter as u128 + 1).to_be_bytes();
@@ -29,6 +31,7 @@ pub(crate) fn counter_to_nonce(counter: u64) -> [u8; NONCE_LEN] {
     nonce
 }
 
+#[expect(unused)]
 pub(crate) fn encrypt_data(
     counter: u64,
     plaintext: &[u8],
@@ -36,8 +39,7 @@ pub(crate) fn encrypt_data(
 ) -> Result<Vec<u8>, LpError> {
     let mut ciphertext = vec![0u8; plaintext.len() + SANE_ENC_OVERHEAD];
 
-    // with `nonce-control` libcrux uses the nonce verbatim, so counter uniqueness is on the caller
-    transport.set_sender_nonce(&counter_to_nonce(counter));
+    // transport.set_sender_nonce(&counter_to_nonce(counter));
     let n = transport.write_message(plaintext, &mut ciphertext)?;
 
     if plaintext.len() + SANE_ENC_OVERHEAD != n {
@@ -47,6 +49,7 @@ pub(crate) fn encrypt_data(
     Ok(ciphertext)
 }
 
+#[expect(unused)]
 pub(crate) fn decrypt_data(
     counter: u64,
     ciphertext: &[u8],
@@ -58,7 +61,7 @@ pub(crate) fn decrypt_data(
 
     let mut plaintext = vec![0u8; ciphertext.len() - SANE_DEC_OVERHEAD];
 
-    transport.set_receiver_nonce(&counter_to_nonce(counter));
+    // transport.set_receiver_nonce(&counter_to_nonce(counter));
     let (_, n) = transport.read_message(ciphertext, &mut plaintext)?;
     if n != ciphertext.len() - SANE_DEC_OVERHEAD {
         plaintext.truncate(n);
@@ -112,71 +115,16 @@ pub(crate) fn decrypt_lp_packet(
 #[cfg(test)]
 mod tests {
     use crate::LpError;
-    use crate::codec::{
-        NONCE_LEN, SANE_ENC_OVERHEAD, counter_to_nonce, decrypt_data, decrypt_lp_packet,
-        encrypt_data, encrypt_lp_packet,
-    };
+    use crate::codec::{decrypt_data, decrypt_lp_packet, encrypt_data, encrypt_lp_packet};
     use crate::peer::mock_peers;
     use crate::psq::initiator::{build_psq_ciphersuite, build_psq_principal};
     use crate::psq::{PSQ_MSG2_SIZE, psq_msg1_size, responder};
-    use bytes::BytesMut;
-    use libcrux_psq::session::Transport;
     use libcrux_psq::{Channel, IntoSession};
     use nym_kkt_ciphersuite::KEM;
     use nym_lp_data::packet::{
-        EncryptedLpPacket, InnerHeader, LpFrame, LpHeader, LpPacket, MalformedLpPacketError,
-        version,
+        EncryptedLpPacket, LpFrame, LpHeader, LpPacket, MalformedLpPacketError, version,
     };
     use nym_test_utils::helpers::u64_seeded_rng_09;
-
-    /// Emulates the nonce handling of libcrux without `nonce-control`, i.e. what peers running the
-    /// previous nym-lp release do: a 12-byte big-endian counter incremented *before* every use.
-    #[derive(Default)]
-    struct LegacyNonce([u8; NONCE_LEN]);
-
-    impl LegacyNonce {
-        fn next(&mut self) -> [u8; NONCE_LEN] {
-            let mut buf = [0u8; 16];
-            buf[16 - NONCE_LEN..].copy_from_slice(&self.0);
-            let incremented = (u128::from_be_bytes(buf) + 1).to_be_bytes();
-            self.0.copy_from_slice(&incremented[16 - NONCE_LEN..]);
-            self.0
-        }
-    }
-
-    /// The previous release's `encrypt_lp_packet`: same framing, nonce driven by libcrux's counter.
-    fn legacy_encrypt_lp_packet(
-        packet: &LpPacket,
-        nonce: &mut LegacyNonce,
-        transport: &mut Transport,
-    ) -> EncryptedLpPacket {
-        let mut plaintext = BytesMut::new();
-        packet.header().inner.encode(&mut plaintext);
-        packet.frame().encode(&mut plaintext);
-
-        let mut ciphertext = vec![0u8; plaintext.len() + SANE_ENC_OVERHEAD];
-        transport.set_sender_nonce(&nonce.next());
-        let n = transport
-            .write_message(&plaintext, &mut ciphertext)
-            .unwrap();
-        ciphertext.truncate(n);
-
-        EncryptedLpPacket::new(packet.header().outer, ciphertext)
-    }
-
-    /// The previous release's `decrypt_lp_packet`: ignores the header counter entirely.
-    fn legacy_decrypt_lp_packet(
-        packet: &EncryptedLpPacket,
-        nonce: &mut LegacyNonce,
-        transport: &mut Transport,
-    ) -> LpFrame {
-        let mut plaintext = vec![0u8; packet.ciphertext().len()];
-        transport.set_receiver_nonce(&nonce.next());
-        let (_, n) = transport
-            .read_message(packet.ciphertext(), &mut plaintext)
-            .unwrap();
-        LpFrame::decode(&plaintext[InnerHeader::SIZE..n]).unwrap()
-    }
 
     fn mock_transport() -> (
         libcrux_psq::session::Transport,
@@ -342,89 +290,41 @@ mod tests {
         assert!(matches!(dec_err, LpError::InsufficientBufferSize));
     }
 
-    #[test]
-    fn counter_to_nonce_matches_legacy_increment_before_use() {
-        assert_eq!(counter_to_nonce(0), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
-        assert_eq!(counter_to_nonce(1), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]);
-        assert_eq!(counter_to_nonce(255), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0]);
-        // u64::MAX + 1 = 2^64 sets bit 64, i.e. byte 3 of the 12-byte big-endian nonce
-        assert_eq!(
-            counter_to_nonce(u64::MAX),
-            [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
-        );
-
-        let mut legacy = LegacyNonce::default();
-        for counter in 0..1000u64 {
-            assert_eq!(counter_to_nonce(counter), legacy.next());
-        }
-    }
-
-    #[test]
-    fn legacy_sender_to_new_receiver() {
-        let (mut legacy, mut new) = mock_transport();
-        let mut legacy_nonce = LegacyNonce::default();
-
-        for counter in 0..5u64 {
-            let packet = LpPacket::new(
-                LpHeader::new(123, counter, 1),
-                LpFrame::new_opaque(vec![counter as u8; 8]),
-            );
-            let encrypted = legacy_encrypt_lp_packet(&packet, &mut legacy_nonce, &mut legacy);
-            assert_eq!(decrypt_lp_packet(encrypted, &mut new).unwrap(), packet);
-        }
-    }
-
-    #[test]
-    fn new_sender_to_legacy_receiver() {
-        let (mut new, mut legacy) = mock_transport();
-        let mut legacy_nonce = LegacyNonce::default();
-
-        for counter in 0..5u64 {
-            let frame = LpFrame::new_opaque(vec![counter as u8; 8]);
-            let packet = LpPacket::new(LpHeader::new(123, counter, 1), frame.clone());
-            let encrypted = encrypt_lp_packet(packet, &mut new).unwrap();
-            assert_eq!(
-                legacy_decrypt_lp_packet(&encrypted, &mut legacy_nonce, &mut legacy),
-                frame
-            );
-        }
-    }
-
-    #[test]
-    fn decryption_requires_the_matching_counter() {
-        let (mut init_transport, mut resp_transport) = mock_transport();
-
-        let ciphertext = encrypt_data(5, b"foomp", &mut init_transport).unwrap();
-        let err = decrypt_data(6, &ciphertext, &mut resp_transport).unwrap_err();
-        assert!(matches!(err, LpError::PSQSessionFailure { .. }));
-
-        // a failed attempt must not affect later ones
-        let plaintext = decrypt_data(5, &ciphertext, &mut resp_transport).unwrap();
-        assert_eq!(plaintext, b"foomp".to_vec());
-    }
-
-    #[test]
-    fn out_of_order_and_lossy_decryption() {
-        let (mut init_transport, mut resp_transport) = mock_transport();
-
-        let packets: Vec<_> = (0..6u64)
-            .map(|counter| {
-                let packet = LpPacket::new(
-                    LpHeader::new(123, counter, 1),
-                    LpFrame::new_opaque(vec![counter as u8; 16]),
-                );
-                let encrypted = encrypt_lp_packet(packet.clone(), &mut init_transport).unwrap();
-                (packet, encrypted)
-            })
-            .collect();
-
-        // reordered, with packet 4 never arriving
-        for idx in [3, 0, 5, 1, 2] {
-            let (expected, encrypted) = &packets[idx];
-            let decrypted = decrypt_lp_packet(encrypted.clone(), &mut resp_transport).unwrap();
-            assert_eq!(&decrypted, expected);
-        }
-    }
+    // #[test]
+    // fn decryption_requires_the_matching_counter() {
+    //     let (mut init_transport, mut resp_transport) = mock_transport();
+    //
+    //     let ciphertext = encrypt_data(5, b"foomp", &mut init_transport).unwrap();
+    //     let err = decrypt_data(6, &ciphertext, &mut resp_transport).unwrap_err();
+    //     assert!(matches!(err, LpError::PSQSessionFailure { .. }));
+    //
+    //     // a failed attempt must not affect later ones
+    //     let plaintext = decrypt_data(5, &ciphertext, &mut resp_transport).unwrap();
+    //     assert_eq!(plaintext, b"foomp".to_vec());
+    // }
+    //
+    // #[test]
+    // fn out_of_order_and_lossy_decryption() {
+    //     let (mut init_transport, mut resp_transport) = mock_transport();
+    //
+    //     let packets: Vec<_> = (0..6u64)
+    //         .map(|counter| {
+    //             let packet = LpPacket::new(
+    //                 LpHeader::new(123, counter, 1),
+    //                 LpFrame::new_opaque(vec![counter as u8; 16]),
+    //             );
+    //             let encrypted = encrypt_lp_packet(packet.clone(), &mut init_transport).unwrap();
+    //             (packet, encrypted)
+    //         })
+    //         .collect();
+    //
+    //     // reordered, with packet 4 never arriving
+    //     for idx in [3, 0, 5, 1, 2] {
+    //         let (expected, encrypted) = &packets[idx];
+    //         let decrypted = decrypt_lp_packet(encrypted.clone(), &mut resp_transport).unwrap();
+    //         assert_eq!(&decrypted, expected);
+    //     }
+    // }
 
     #[test]
     fn basic_packet_encryption() {
@@ -484,5 +384,105 @@ mod tests {
             LpError::MalformedPacket(MalformedLpPacketError::UnsupportedPacketVersion { got })
                 if got == future
         ));
+    }
+
+    #[cfg(test)]
+    mod legacy_nonce {
+        // /// Emulates the nonce handling of libcrux without `nonce-control`, i.e. what peers running the
+        // /// previous nym-lp release do: a 12-byte big-endian counter incremented *before* every use.
+        // #[derive(Default)]
+        // struct LegacyNonce([u8; NONCE_LEN]);
+        //
+        // impl LegacyNonce {
+        //     fn next(&mut self) -> [u8; NONCE_LEN] {
+        //         let mut buf = [0u8; 16];
+        //         buf[16 - NONCE_LEN..].copy_from_slice(&self.0);
+        //         let incremented = (u128::from_be_bytes(buf) + 1).to_be_bytes();
+        //         self.0.copy_from_slice(&incremented[16 - NONCE_LEN..]);
+        //         self.0
+        //     }
+        // }
+        //
+        // /// The previous release's `encrypt_lp_packet`: same framing, nonce driven by libcrux's counter.
+        // fn legacy_encrypt_lp_packet(
+        //     packet: &LpPacket,
+        //     nonce: &mut LegacyNonce,
+        //     transport: &mut Transport,
+        // ) -> EncryptedLpPacket {
+        //     let mut plaintext = BytesMut::new();
+        //     packet.header().inner.encode(&mut plaintext);
+        //     packet.frame().encode(&mut plaintext);
+        //
+        //     let mut ciphertext = vec![0u8; plaintext.len() + SANE_ENC_OVERHEAD];
+        //     transport.set_sender_nonce(&nonce.next());
+        //     let n = transport
+        //         .write_message(&plaintext, &mut ciphertext)
+        //         .unwrap();
+        //     ciphertext.truncate(n);
+        //
+        //     EncryptedLpPacket::new(packet.header().outer, ciphertext)
+        // }
+        //
+        // /// The previous release's `decrypt_lp_packet`: ignores the header counter entirely.
+        // fn legacy_decrypt_lp_packet(
+        //     packet: &EncryptedLpPacket,
+        //     nonce: &mut LegacyNonce,
+        //     transport: &mut Transport,
+        // ) -> LpFrame {
+        //     let mut plaintext = vec![0u8; packet.ciphertext().len()];
+        //     transport.set_receiver_nonce(&nonce.next());
+        //     let (_, n) = transport
+        //         .read_message(packet.ciphertext(), &mut plaintext)
+        //         .unwrap();
+        //     LpFrame::decode(&plaintext[InnerHeader::SIZE..n]).unwrap()
+        // }
+        //
+        // #[test]
+        // fn counter_to_nonce_matches_legacy_increment_before_use() {
+        //     assert_eq!(counter_to_nonce(0), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        //     assert_eq!(counter_to_nonce(1), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]);
+        //     assert_eq!(counter_to_nonce(255), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0]);
+        //     // u64::MAX + 1 = 2^64 sets bit 64, i.e. byte 3 of the 12-byte big-endian nonce
+        //     assert_eq!(
+        //         counter_to_nonce(u64::MAX),
+        //         [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+        //     );
+        //
+        //     let mut legacy = LegacyNonce::default();
+        //     for counter in 0..1000u64 {
+        //         assert_eq!(counter_to_nonce(counter), legacy.next());
+        //     }
+        // }
+        //
+        // #[test]
+        // fn legacy_sender_to_new_receiver() {
+        //     let (mut legacy, mut new) = mock_transport();
+        //     let mut legacy_nonce = LegacyNonce::default();
+        //
+        //     for counter in 0..5u64 {
+        //         let packet = LpPacket::new(
+        //             LpHeader::new(123, counter, 1),
+        //             LpFrame::new_opaque(vec![counter as u8; 8]),
+        //         );
+        //         let encrypted = legacy_encrypt_lp_packet(&packet, &mut legacy_nonce, &mut legacy);
+        //         assert_eq!(decrypt_lp_packet(encrypted, &mut new).unwrap(), packet);
+        //     }
+        // }
+        //
+        // #[test]
+        // fn new_sender_to_legacy_receiver() {
+        //     let (mut new, mut legacy) = mock_transport();
+        //     let mut legacy_nonce = LegacyNonce::default();
+        //
+        //     for counter in 0..5u64 {
+        //         let frame = LpFrame::new_opaque(vec![counter as u8; 8]);
+        //         let packet = LpPacket::new(LpHeader::new(123, counter, 1), frame.clone());
+        //         let encrypted = encrypt_lp_packet(packet, &mut new).unwrap();
+        //         assert_eq!(
+        //             legacy_decrypt_lp_packet(&encrypted, &mut legacy_nonce, &mut legacy),
+        //             frame
+        //         );
+        //     }
+        // }
     }
 }

--- a/common/nym-lp/src/session.rs
+++ b/common/nym-lp/src/session.rs
@@ -574,96 +574,96 @@ mod tests {
         }
     }
 
-    #[test]
-    fn out_of_order_delivery_and_replay() {
-        for kem in KEM::iter() {
-            let mock_sessions = SessionsMock::mock_post_handshake(kem);
-            let mut initiator = mock_sessions.initiator;
-            let mut responder = mock_sessions.responder;
-
-            let mut packets = Vec::new();
-            for i in 0..6u8 {
-                let frame = LpFrame::new_opaque(vec![i; 8]);
-                let LpAction::SendPacket(packet) = initiator
-                    .process_input(LpInput::SendFrame(frame.clone()))
-                    .unwrap()
-                else {
-                    panic!("expected SendPacket")
-                };
-                assert_eq!(packet.outer_header().counter, u64::from(i));
-                packets.push((frame, packet));
-            }
-
-            // reordered delivery with packet 4 delayed
-            for idx in [3, 0, 5, 1, 2] {
-                let (frame, packet) = &packets[idx];
-                let LpAction::DeliverFrame(delivered) = responder
-                    .process_input(LpInput::ReceivePacket(packet.clone()))
-                    .unwrap()
-                else {
-                    panic!("expected DeliverFrame")
-                };
-                assert_eq!(&delivered, frame);
-            }
-
-            // an already delivered packet is a replay
-            let err = responder
-                .process_input(LpInput::ReceivePacket(packets[3].1.clone()))
-                .unwrap_err();
-            assert!(matches!(
-                err,
-                LpError::Replay(ReplayError::DuplicateCounter)
-            ));
-
-            // the delayed packet still decrypts and gets delivered
-            let (frame, packet) = &packets[4];
-            let LpAction::DeliverFrame(delivered) = responder
-                .process_input(LpInput::ReceivePacket(packet.clone()))
-                .unwrap()
-            else {
-                panic!("expected DeliverFrame")
-            };
-            assert_eq!(&delivered, frame);
-            assert_eq!(responder.current_packet_cnt().received, 6);
-        }
-    }
-
-    #[test]
-    fn tampered_counter_is_rejected_without_marking_the_window() {
-        for kem in KEM::iter() {
-            let mock_sessions = SessionsMock::mock_post_handshake(kem);
-            let mut initiator = mock_sessions.initiator;
-            let mut responder = mock_sessions.responder;
-
-            let frame = LpFrame::new_opaque(b"genuine".to_vec());
-            let LpAction::SendPacket(packet) = initiator
-                .process_input(LpInput::SendFrame(frame.clone()))
-                .unwrap()
-            else {
-                panic!("expected SendPacket")
-            };
-
-            // the cleartext counter is bound to the nonce, so rewriting it must break decryption
-            let mut tampered_header = packet.outer_header();
-            tampered_header.counter = 5000;
-            let tampered = EncryptedLpPacket::new(tampered_header, packet.ciphertext().to_vec());
-
-            let err = responder
-                .process_input(LpInput::ReceivePacket(tampered))
-                .unwrap_err();
-            assert!(matches!(err, LpError::PSQSessionFailure { .. }));
-
-            // and the failure must not have advanced the replay window
-            assert_eq!(responder.current_packet_cnt().received, 0);
-            let LpAction::DeliverFrame(delivered) = responder
-                .process_input(LpInput::ReceivePacket(packet))
-                .unwrap()
-            else {
-                panic!("expected DeliverFrame")
-            };
-            assert_eq!(delivered, frame);
-        }
-    }
+    // #[test]
+    // fn out_of_order_delivery_and_replay() {
+    //     for kem in KEM::iter() {
+    //         let mock_sessions = SessionsMock::mock_post_handshake(kem);
+    //         let mut initiator = mock_sessions.initiator;
+    //         let mut responder = mock_sessions.responder;
+    //
+    //         let mut packets = Vec::new();
+    //         for i in 0..6u8 {
+    //             let frame = LpFrame::new_opaque(vec![i; 8]);
+    //             let LpAction::SendPacket(packet) = initiator
+    //                 .process_input(LpInput::SendFrame(frame.clone()))
+    //                 .unwrap()
+    //             else {
+    //                 panic!("expected SendPacket")
+    //             };
+    //             assert_eq!(packet.outer_header().counter, u64::from(i));
+    //             packets.push((frame, packet));
+    //         }
+    //
+    //         // reordered delivery with packet 4 delayed
+    //         for idx in [3, 0, 5, 1, 2] {
+    //             let (frame, packet) = &packets[idx];
+    //             let LpAction::DeliverFrame(delivered) = responder
+    //                 .process_input(LpInput::ReceivePacket(packet.clone()))
+    //                 .unwrap()
+    //             else {
+    //                 panic!("expected DeliverFrame")
+    //             };
+    //             assert_eq!(&delivered, frame);
+    //         }
+    //
+    //         // an already delivered packet is a replay
+    //         let err = responder
+    //             .process_input(LpInput::ReceivePacket(packets[3].1.clone()))
+    //             .unwrap_err();
+    //         assert!(matches!(
+    //             err,
+    //             LpError::Replay(ReplayError::DuplicateCounter)
+    //         ));
+    //
+    //         // the delayed packet still decrypts and gets delivered
+    //         let (frame, packet) = &packets[4];
+    //         let LpAction::DeliverFrame(delivered) = responder
+    //             .process_input(LpInput::ReceivePacket(packet.clone()))
+    //             .unwrap()
+    //         else {
+    //             panic!("expected DeliverFrame")
+    //         };
+    //         assert_eq!(&delivered, frame);
+    //         assert_eq!(responder.current_packet_cnt().received, 6);
+    //     }
+    // }
+    //
+    // #[test]
+    // fn tampered_counter_is_rejected_without_marking_the_window() {
+    //     for kem in KEM::iter() {
+    //         let mock_sessions = SessionsMock::mock_post_handshake(kem);
+    //         let mut initiator = mock_sessions.initiator;
+    //         let mut responder = mock_sessions.responder;
+    //
+    //         let frame = LpFrame::new_opaque(b"genuine".to_vec());
+    //         let LpAction::SendPacket(packet) = initiator
+    //             .process_input(LpInput::SendFrame(frame.clone()))
+    //             .unwrap()
+    //         else {
+    //             panic!("expected SendPacket")
+    //         };
+    //
+    //         // the cleartext counter is bound to the nonce, so rewriting it must break decryption
+    //         let mut tampered_header = packet.outer_header();
+    //         tampered_header.counter = 5000;
+    //         let tampered = EncryptedLpPacket::new(tampered_header, packet.ciphertext().to_vec());
+    //
+    //         let err = responder
+    //             .process_input(LpInput::ReceivePacket(tampered))
+    //             .unwrap_err();
+    //         assert!(matches!(err, LpError::PSQSessionFailure { .. }));
+    //
+    //         // and the failure must not have advanced the replay window
+    //         assert_eq!(responder.current_packet_cnt().received, 0);
+    //         let LpAction::DeliverFrame(delivered) = responder
+    //             .process_input(LpInput::ReceivePacket(packet))
+    //             .unwrap()
+    //         else {
+    //             panic!("expected DeliverFrame")
+    //         };
+    //         assert_eq!(delivered, frame);
+    //     }
+    // }
 
     #[test]
     fn test_state_machine_simplified_flow() {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7130)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated encrypted transport handling to rely on the underlying library for nonce sequencing.
  * Removed legacy nonce compatibility behavior and related interoperability checks.
* **Tests**
  * Disabled tests covering legacy nonce handling, packet reordering, replay, and tampered counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->