### PR TITLE
fix: update mainnet swap links and remove deprecated bridges

### DIFF
--- a/documentation/docs/pages/developers/swizzle.mdx
+++ b/documentation/docs/pages/developers/swizzle.mdx
@@ -55,7 +55,7 @@ Add `nym-swizzle` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-nym-swizzle = "1.21.5"
+nym-swizzle = "1.21.6"
 ```
 
 **Minimum Rust version:** {RUST_MSRV}+

--- a/documentation/docs/pages/developers/swizzle/zcash.mdx
+++ b/documentation/docs/pages/developers/swizzle/zcash.mdx
@@ -136,7 +136,7 @@ Add `nym-swizzle-zcash` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-nym-swizzle-zcash = "1.21.5"
+nym-swizzle-zcash = "1.21.6"
 ```
 
 No network stack and no build script. It compiles for

--- a/documentation/docs/pages/operators/nodes/preliminary-steps/wallet-preparation.mdx
+++ b/documentation/docs/pages/operators/nodes/preliminary-steps/wallet-preparation.mdx
@@ -13,9 +13,11 @@ If you don't already have one, please create a Nym address using the wallet, and
 
 `NYM` can be swapped in these places:
 
-- [SpectreDAO Swap](https://explorer.nym.spectredao.net/swap) (1000+ tokens supported) 
-- [Binance bridge](https://bridge.nym.com/)
-- [ERC20 bridge](https://swapper.nym.com/swap) - follow [this guide](https://nym.com/blog/nym-for-nym-swapper-app-bridges-native-and-erc20-token)
+- [Nym Swapper](https://swapper.nym.com/swap) - swap native and ERC20 NYM tokens
+- [SpectreDAO Swap](https://explorer.nym.spectredao.net/swap) (1000+ tokens supported)
+- [Zcash Swapper](https://zcash-swapper.nym.com/swap) - swap ZEC for native or ERC20 NYM. Detailed guide can be found [here](https://nym.com/blog/zec-nym-swapper).
+- [PancakeSwap](https://pancakeswap.finance/swap?inputCurrency=0x31d0E332ccEf98b583E40e0cEFBb7502c9a6b3f8) - swap on BSC, then [bridge](https://bridge.nym.com) to native NYM. Detailed guide can be found [here](https://nym.com/blog/nym-binance-bridge).
+- [Uniswap](https://app.uniswap.org/explore/tokens/ethereum/0x525a8f6f3ba4752868cde25164382bfbae3990e1) - swap ERC20 NYM tokens
 
 `NYM` can be also bought on several [exchanges](https://www.coingecko.com/en/coins/nym#markets).
 

--- a/documentation/docs/pages/operators/nodes/preliminary-steps/wallet-preparation.mdx
+++ b/documentation/docs/pages/operators/nodes/preliminary-steps/wallet-preparation.mdx
@@ -13,7 +13,7 @@ If you don't already have one, please create a Nym address using the wallet, and
 
 `NYM` can be swapped in these places:
 
-- [Nym Swapper](https://swapper.nym.com/swap) - swap native and ERC20 NYM tokens
+- [Nym Swapper](https://swapper.nym.com/swap) - swap native and ERC20 NYM tokens (also supports BTC, ETH, USDC, and USDT)
 - [SpectreDAO Swap](https://explorer.nym.spectredao.net/swap) (1000+ tokens supported)
 - [Zcash Swapper](https://zcash-swapper.nym.com/swap) - swap ZEC for native or ERC20 NYM. Detailed guide can be found [here](https://nym.com/blog/zec-nym-swapper).
 - [PancakeSwap](https://pancakeswap.finance/swap?inputCurrency=0x31d0E332ccEf98b583E40e0cEFBb7502c9a6b3f8) - swap on BSC, then [bridge](https://bridge.nym.com) to native NYM. Detailed guide can be found [here](https://nym.com/blog/nym-binance-bridge).


### PR DESCRIPTION
- Remove Gravity Bridge (still down)
- Remove Binance Bridge (no liquidity, not for swapping NYM)
- Update ERC20 bridge to Nym Swapper
- Add Zcash Swapper with guide link
- Add PancakeSwap with BSC bridge guide
- Add Uniswap for ERC-20 NYM
- Fix typos (ERC20 -> ERC-20, can be also -> can also)
- Remove confusing blog post link

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7140)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated wallet preparation guidance with current NYM swapping and bridging options.
  * Documented Nym Swapper, SpectreDAO Swap, Zcash Swapper, PancakeSwap, and Uniswap, including supported assets and usage instructions.
  * Updated the recommended `nym-swizzle` and `nym-swizzle-zcash` versions to 1.21.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->