### PR TITLE
Hotfix: Update nodes top up program name

### DIFF
--- a/documentation/docs/pages/operators/nodes/nym-node/bonding.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/bonding.mdx
@@ -293,9 +293,9 @@ account address from the node's HTTP endpoint and the balance from the chain. `n
 
 - Usage:
 ```sh
-python3 topup_nodes.py nodes.csv [options]
+python3 nodes_account_topup.py nodes.csv [options]
 # or
-MNEMONIC="word1 word2 ..." python3 topup_nodes.py nodes.csv [options]
+MNEMONIC="word1 word2 ..." python3 nodes_account_topup.py nodes.csv [options]
 ```
 
 | Flag | Purpose |


### PR DESCRIPTION
There was a trace of an old script name in documentation, this PR corrects that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7142)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated automated funding examples to use the renamed `nodes_account_topup.py` script.
  * Updated both standard and `MNEMONIC` environment variable invocation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->