### PR TITLE
Fix: Non-interactive mode on client auto-topup

### DIFF
--- a/documentation/docs/pages/operators/nodes/nym-node/bonding.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/bonding.mdx
@@ -295,7 +295,7 @@ account address from the node's HTTP endpoint and the balance from the chain. `n
 ```sh
 python3 nodes_account_topup.py nodes.csv [options]
 # or
-MNEMONIC="word1 word2 ..." python3 nodes_account_topup.py nodes.csv [options]
+MNEMONIC="<MNEMONIC>" python3 nodes_account_topup.py nodes.csv [options]
 ```
 
 | Flag | Purpose |
@@ -304,7 +304,7 @@ MNEMONIC="word1 word2 ..." python3 nodes_account_topup.py nodes.csv [options]
 | `--mnemonic` | Master funding account mnemonic. Or set MNEMONIC env var. Only needed for the actual top-up, not for --check-only |
 | `--node-account-amount <NYM>` | Target balance in NYM for every node; overrides each row's node_account_amount |
 | `--cli-dir <PATH>` | Directory containing the nym-cli binary. Only needed for the send step |
-| `-y`, `--assume-yes` | Auto-confirm the nym-cli transfer prompt (non-interactive/batch). Without it, you're shown the transfer table and asked to confirm |
+| `-y`, `--assume-yes` | <abbr title="The non-interactive mode only works on Unix based systems, on Windows you must run the program without this flag.)">Auto-confirm the nym-cli transfer prompt (non-interactive/batch)</abbr>. Without it, you're shown the transfer table and asked to confirm |
 | `--check-only` | Read addresses + balances and write them back; send nothing (no nym-cli needed) |
 | `--dry-run` | Print what would happen; no network writes |
 
@@ -322,3 +322,5 @@ overwritten on save.
 Now your `nym-node` client can use inbuilt Nyx account to create a multisig proposal on chain, update config on chain and redeem user tickets.
 
 > Note: The `nym-api` endpoint updates every 24h, so don't expect to see your updated balance immediately.
+
+

--- a/documentation/docs/pages/operators/nodes/nym-node/bonding.mdx
+++ b/documentation/docs/pages/operators/nodes/nym-node/bonding.mdx
@@ -304,7 +304,7 @@ MNEMONIC="<MNEMONIC>" python3 nodes_account_topup.py nodes.csv [options]
 | `--mnemonic` | Master funding account mnemonic. Or set MNEMONIC env var. Only needed for the actual top-up, not for --check-only |
 | `--node-account-amount <NYM>` | Target balance in NYM for every node; overrides each row's node_account_amount |
 | `--cli-dir <PATH>` | Directory containing the nym-cli binary. Only needed for the send step |
-| `-y`, `--assume-yes` | <abbr title="The non-interactive mode only works on Unix based systems, on Windows you must run the program without this flag.)">Auto-confirm the nym-cli transfer prompt (non-interactive/batch)</abbr>. Without it, you're shown the transfer table and asked to confirm |
+| `-y`, `--assume-yes` | <abbr title="The non-interactive mode only works on Unix-based systems, on Windows you must run the program without this flag.">Auto-confirm the `nym-cli` transfer prompt (non-interactive/batch)</abbr>. Without it, you're shown the transfer table and asked to confirm |
 | `--check-only` | Read addresses + balances and write them back; send nothing (no nym-cli needed) |
 | `--dry-run` | Print what would happen; no network writes |
 

--- a/scripts/nym-node-setup/auto-bond/nodes_account_topup.py
+++ b/scripts/nym-node-setup/auto-bond/nodes_account_topup.py
@@ -38,6 +38,7 @@ import csv
 import json
 import os
 import time
+import signal
 import subprocess
 import sys
 import tempfile
@@ -415,15 +416,32 @@ def main():
                         os.write(master_fd, b"y\r")
                         answered = True
             except KeyboardInterrupt:
-                pass
-            finally:
+                # The child runs in its own session (pty.fork), so Ctrl-C reaches
+                # only this parent — nym-cli would otherwise keep running and, if
+                # already confirmed, complete the transfer. Forward the signal so
+                # the child actually stops, then report it as an interruption
+                # rather than silently swallowing it.
                 try:
-                    os.close(master_fd)
-                except OSError:
+                    os.kill(pid, signal.SIGINT)
+                except ProcessLookupError:
                     pass
+                err("interrupted — sent SIGINT to nym-cli; the transfer may or may "
+                    "not have been broadcast. Verify balances before re-running.")
+
+            try:
+                os.close(master_fd)
+            except OSError:
+                pass
 
             _, status = os.waitpid(pid, 0)
-            returncode = os.waitstatus_to_exitcode(status)
+            # os.waitstatus_to_exitcode exists only on Python 3.9+; decode the
+            # raw wait status manually so the script also works on 3.8 and below.
+            if os.WIFEXITED(status):
+                returncode = os.WEXITSTATUS(status)
+            elif os.WIFSIGNALED(status):
+                returncode = -os.WTERMSIG(status)
+            else:
+                returncode = 1
             result = subprocess.CompletedProcess(cmd, returncode)
             combined = "".join(captured_chunks)
 

--- a/scripts/nym-node-setup/auto-bond/nodes_account_topup.py
+++ b/scripts/nym-node-setup/auto-bond/nodes_account_topup.py
@@ -37,6 +37,7 @@ import argparse
 import csv
 import json
 import os
+import time
 import subprocess
 import sys
 import tempfile
@@ -161,7 +162,7 @@ def fetch_node_address(ip: str, dry_run: bool) -> str:
     url = f"http://{ip}:{NODE_HTTP_PORT}{AUX_DETAILS_PATH}"
     if dry_run:
         return "DRY_RUN_ADDRESS"
-    req = urllib.request.Request(url, headers={"User-Agent": "nodes_account_topup/1.0"})
+    req = urllib.request.Request(url, headers={"User-Agent": "nym-topup/1.0"})
     with urllib.request.urlopen(req, timeout=15) as resp:
         data = json.loads(resp.read().decode("utf-8"))
     addr = data.get("address")
@@ -180,7 +181,7 @@ def fetch_balance_nym(address: str, dry_run: bool) -> Decimal:
     for base in LCD_ENDPOINTS:
         url = base.rstrip("/") + LCD_BALANCE_PATH.format(address=address)
         try:
-            req = urllib.request.Request(url, headers={"User-Agent": "nodes_account_topup/1.0"})
+            req = urllib.request.Request(url, headers={"User-Agent": "nym-topup/1.0"})
             with urllib.request.urlopen(req, timeout=15) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
             unym = 0
@@ -342,31 +343,89 @@ def main():
         info("dry run — not sending")
     else:
         if not args.assume_yes:
-            # nym-cli will show the transfer table and prompt for confirmation;
-            # answer it interactively (output is NOT captured so the prompt shows).
+            # nym-cli shows the transfer table and an interactive confirmation
+            # (via the `inquire` crate, which reads the TTY). Run it attached to
+            # the real terminal so the table renders correctly and the operator
+            # answers the prompt themselves.
             result = subprocess.run(cmd, text=True)
-            combined = ""  # we didn't capture; rely on exit code + log below
+            combined = ""  # not captured; rely on exit code + log below
         else:
-            # non-interactive: auto-confirm by feeding "y" to the prompt.
-            # Stream output live AND collect it so we can scan for error markers
-            # (nym-cli has logged fatal errors while still exiting 0).
-            proc = subprocess.Popen(
-                cmd, text=True, stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            )
-            captured = []
+            # Non-interactive auto-confirm.
+            #
+            # nym-cli's confirmation uses `inquire::Confirm`, which reads from the
+            # TTY, NOT stdin — so feeding stdin does nothing and it still blocks.
+            # Piping stdout also strips the TTY, making inquire emit cursor-control
+            # escapes that render as a garbled "staircase". The only reliable fix
+            # is to attach nym-cli to a pseudo-terminal (pty): inquire then sees a
+            # real terminal, the table renders cleanly, and we can answer "y" on
+            # the pty. We tee everything to our stdout and capture it for the
+            # error-marker scan.
             try:
-                proc.stdin.write("y\n")
-                proc.stdin.flush()
-                proc.stdin.close()
-            except (BrokenPipeError, OSError):
+                import pty
+                import select
+            except ImportError:
+                err("--assume-yes (-y) needs a Unix pseudo-terminal (pty), which "
+                    "is not available on this platform. Re-run without -y and "
+                    "confirm the transfer prompt interactively.")
+                try:
+                    input_csv.unlink()
+                except OSError:
+                    pass
+                sys.exit(1)
+
+            captured_chunks = []
+
+            def _emit(text):
+                sys.stdout.write(text)
+                sys.stdout.flush()
+                captured_chunks.append(text)
+
+            pid, master_fd = pty.fork()
+            if pid == 0:
+                # child: exec nym-cli with the pty as its controlling terminal
+                try:
+                    os.execvp(cmd[0], cmd)
+                except Exception:
+                    os._exit(127)
+
+            # parent: stream pty output, answer the confirmation once, until EOF
+            answered = False
+            try:
+                while True:
+                    try:
+                        rlist, _, _ = select.select([master_fd], [], [], 1.0)
+                    except (OSError, ValueError):
+                        break
+                    if master_fd not in rlist:
+                        continue
+                    try:
+                        data = os.read(master_fd, 1024)
+                    except OSError:
+                        break  # pty closed (child exited)
+                    if not data:
+                        break
+                    _emit(data.decode(errors="replace"))
+                    if not answered and "continue with the transfers" in "".join(captured_chunks):
+                        # Give inquire a moment to enter its raw-mode line reader,
+                        # then submit. inquire's Confirm reads from the TTY and
+                        # needs a carriage return (\r) to submit — a bare \n is not
+                        # treated as "enter" in the pty's raw mode and shows up as
+                        # a stray "^J"/"j" while the prompt keeps waiting.
+                        time.sleep(0.3)
+                        os.write(master_fd, b"y\r")
+                        answered = True
+            except KeyboardInterrupt:
                 pass
-            for line in proc.stdout:
-                print(line, end="")
-                captured.append(line)
-            proc.wait()
-            result = subprocess.CompletedProcess(cmd, proc.returncode)
-            combined = "".join(captured)
+            finally:
+                try:
+                    os.close(master_fd)
+                except OSError:
+                    pass
+
+            _, status = os.waitpid(pid, 0)
+            returncode = os.waitstatus_to_exitcode(status)
+            result = subprocess.CompletedProcess(cmd, returncode)
+            combined = "".join(captured_chunks)
 
         failed_markers = ("Failed to read input file", "ERROR", "error trying to",
                           "does not have enough columns", "insufficient funds")


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7143)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automated node account top-ups support batched gas funding to reach a target balance.

- **Bug Fixes**
  - Improved handling of interruptions during non-interactive top-ups.
  - Improved compatibility with older Python versions.
  - Interactive top-ups now preserve terminal behavior and command output.
  - Improved communication with node APIs when retrieving addresses and balances.

- **Documentation**
  - Updated the top-up example to use a placeholder mnemonic.
  - Clarified that non-interactive mode is supported on Unix-based systems only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->