### PR TITLE
Apply clock skew to LP registration timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 ## [Unreleased]
 
+- bugfix: apply VPN API clock skew to LP registration timestamps so a device clock more than 30s ahead is not rejected as invalid
+
 ## [2026.14-amsterdam] (2026-07-21)
 
 - bugfix: don't use hickory DNS for resolving gateway hostname within the NM ([#6955])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8035,6 +8035,7 @@ dependencies = [
  "nym-test-utils",
  "nym-wireguard-types",
  "serde",
+ "time",
  "tracing",
 ]
 

--- a/common/registration/Cargo.toml
+++ b/common/registration/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies]
 bincode = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+time = { workspace = true }
 tracing = { workspace = true }
 
 nym-authenticator-requests = { workspace = true }

--- a/common/registration/src/lp_messages.rs
+++ b/common/registration/src/lp_messages.rs
@@ -113,26 +113,18 @@ impl RegistrationStatus {
     }
 }
 
-fn current_timestamp() -> u64 {
+fn current_timestamp() -> std::time::Duration {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .inspect_err(|_| error!("the current timestamp predates unix epoch!"))
         .unwrap_or_default()
-        .as_secs()
 }
 
 impl LpRegistrationRequest {
-    /// `spend_time_skew_secs` is local-ahead-of-api-call seconds; gateways allow 30s.
-    fn new(
-        registration_data: LpRegistrationRequestData,
-        spend_time_skew_secs: i64,
-    ) -> LpRegistrationRequest {
-        let timestamp = (current_timestamp() as i64)
-            .saturating_sub(spend_time_skew_secs)
-            .max(0) as u64;
+    fn new(registration_data: LpRegistrationRequestData) -> LpRegistrationRequest {
         Self {
             registration_data,
-            timestamp,
+            timestamp: current_timestamp().as_secs(),
         }
     }
 
@@ -140,36 +132,41 @@ impl LpRegistrationRequest {
     pub fn new_initial_dvpn(
         wg_public_key: nym_wireguard_types::PeerPublicKey,
         psk: [u8; 32],
-        spend_time_skew_secs: i64,
     ) -> Self {
-        Self::new(
-            LpRegistrationRequestData::Dvpn {
-                data: Box::new(LpDvpnRegistrationRequestMessage {
-                    content: LpDvpnRegistrationRequestMessageContent::InitialRequest(
-                        LpDvpnRegistrationInitialRequest { wg_public_key, psk },
-                    ),
-                }),
-            },
-            spend_time_skew_secs,
-        )
+        Self::new(LpRegistrationRequestData::Dvpn {
+            data: Box::new(LpDvpnRegistrationRequestMessage {
+                content: LpDvpnRegistrationRequestMessageContent::InitialRequest(
+                    LpDvpnRegistrationInitialRequest { wg_public_key, psk },
+                ),
+            }),
+        })
     }
 
-    pub fn new_finalise_dvpn(credential: BandwidthClaim, spend_time_skew_secs: i64) -> Self {
-        Self::new(
-            LpRegistrationRequestData::Dvpn {
-                data: Box::new(LpDvpnRegistrationRequestMessage {
-                    content: LpDvpnRegistrationRequestMessageContent::Finalisation(
-                        LpDvpnRegistrationFinalisation { credential },
-                    ),
-                }),
-            },
-            spend_time_skew_secs,
-        )
+    pub fn new_finalise_dvpn(credential: BandwidthClaim) -> Self {
+        Self::new(LpRegistrationRequestData::Dvpn {
+            data: Box::new(LpDvpnRegistrationRequestMessage {
+                content: LpDvpnRegistrationRequestMessageContent::Finalisation(
+                    LpDvpnRegistrationFinalisation { credential },
+                ),
+            }),
+        })
+    }
+
+    pub fn with_spend_time_skew(mut self, skew: time::Duration) -> Self {
+        let stamped = std::time::Duration::from_secs(self.timestamp);
+        let abs = skew.unsigned_abs();
+        self.timestamp = if skew.is_negative() {
+            stamped.saturating_add(abs)
+        } else {
+            stamped.saturating_sub(abs)
+        }
+        .as_secs();
+        self
     }
 
     /// Validate the request timestamp is within acceptable bounds
     pub fn validate_timestamp(&self, max_skew_secs: u64) -> bool {
-        let now = current_timestamp();
+        let now = current_timestamp().as_secs();
 
         (now as i64 - self.timestamp as i64).abs() <= max_skew_secs as i64
     }
@@ -463,24 +460,28 @@ mod tests {
     }
 
     #[test]
-    fn lp_registration_request_spend_time_skew_zero_keeps_local_now() {
-        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32], 0);
-        let delta = current_timestamp() as i64 - req.timestamp as i64;
-        assert!((-1..=1).contains(&delta), "delta={delta}");
+    fn lp_registration_request_new_initial_dvpn_stamps_local_now() {
+        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32]);
+        let delta = current_timestamp().as_secs().abs_diff(req.timestamp);
+        assert!(delta <= 1, "delta={delta}");
     }
 
     #[test]
     fn lp_registration_request_spend_time_skew_subtracts_ahead_clock() {
-        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32], 38);
-        let delta = current_timestamp() as i64 - req.timestamp as i64;
-        assert!((37..=39).contains(&delta), "delta={delta}");
+        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32])
+            .with_spend_time_skew(time::Duration::seconds(38));
+        let expected = current_timestamp().saturating_sub(std::time::Duration::from_secs(38));
+        let delta = expected.as_secs().abs_diff(req.timestamp);
+        assert!(delta <= 1, "delta={delta}");
     }
 
     #[test]
     fn lp_registration_request_spend_time_skew_adds_behind_clock() {
-        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32], -38);
-        let delta = req.timestamp as i64 - current_timestamp() as i64;
-        assert!((37..=39).contains(&delta), "delta={delta}");
+        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32])
+            .with_spend_time_skew(time::Duration::seconds(-38));
+        let expected = current_timestamp().saturating_add(std::time::Duration::from_secs(38));
+        let delta = expected.as_secs().abs_diff(req.timestamp);
+        assert!(delta <= 1, "delta={delta}");
     }
 
     // ==================== LpRegistrationResponse Tests ====================

--- a/common/registration/src/lp_messages.rs
+++ b/common/registration/src/lp_messages.rs
@@ -152,6 +152,7 @@ impl LpRegistrationRequest {
         })
     }
 
+    /// Positive `skew` is how far the device is ahead of the VPN API; the stamp is moved back (negative moves it forward).
     pub fn with_spend_time_skew(mut self, skew: time::Duration) -> Self {
         let stamped = std::time::Duration::from_secs(self.timestamp);
         let abs = skew.unsigned_abs();

--- a/common/registration/src/lp_messages.rs
+++ b/common/registration/src/lp_messages.rs
@@ -122,11 +122,17 @@ fn current_timestamp() -> u64 {
 }
 
 impl LpRegistrationRequest {
-    /// Helper wrapping timestamp extraction
-    fn new(registration_data: LpRegistrationRequestData) -> LpRegistrationRequest {
+    /// `spend_time_skew_secs` is local-ahead-of-api-call seconds; gateways allow 30s.
+    fn new(
+        registration_data: LpRegistrationRequestData,
+        spend_time_skew_secs: i64,
+    ) -> LpRegistrationRequest {
+        let timestamp = (current_timestamp() as i64)
+            .saturating_sub(spend_time_skew_secs)
+            .max(0) as u64;
         Self {
             registration_data,
-            timestamp: current_timestamp(),
+            timestamp,
         }
     }
 
@@ -134,24 +140,31 @@ impl LpRegistrationRequest {
     pub fn new_initial_dvpn(
         wg_public_key: nym_wireguard_types::PeerPublicKey,
         psk: [u8; 32],
+        spend_time_skew_secs: i64,
     ) -> Self {
-        Self::new(LpRegistrationRequestData::Dvpn {
-            data: Box::new(LpDvpnRegistrationRequestMessage {
-                content: LpDvpnRegistrationRequestMessageContent::InitialRequest(
-                    LpDvpnRegistrationInitialRequest { wg_public_key, psk },
-                ),
-            }),
-        })
+        Self::new(
+            LpRegistrationRequestData::Dvpn {
+                data: Box::new(LpDvpnRegistrationRequestMessage {
+                    content: LpDvpnRegistrationRequestMessageContent::InitialRequest(
+                        LpDvpnRegistrationInitialRequest { wg_public_key, psk },
+                    ),
+                }),
+            },
+            spend_time_skew_secs,
+        )
     }
 
-    pub fn new_finalise_dvpn(credential: BandwidthClaim) -> Self {
-        Self::new(LpRegistrationRequestData::Dvpn {
-            data: Box::new(LpDvpnRegistrationRequestMessage {
-                content: LpDvpnRegistrationRequestMessageContent::Finalisation(
-                    LpDvpnRegistrationFinalisation { credential },
-                ),
-            }),
-        })
+    pub fn new_finalise_dvpn(credential: BandwidthClaim, spend_time_skew_secs: i64) -> Self {
+        Self::new(
+            LpRegistrationRequestData::Dvpn {
+                data: Box::new(LpDvpnRegistrationRequestMessage {
+                    content: LpDvpnRegistrationRequestMessageContent::Finalisation(
+                        LpDvpnRegistrationFinalisation { credential },
+                    ),
+                }),
+            },
+            spend_time_skew_secs,
+        )
     }
 
     /// Validate the request timestamp is within acceptable bounds
@@ -443,6 +456,32 @@ mod tests {
     }
 
     // ==================== LpRegistrationRequest Tests ====================
+
+    fn test_wg_peer_key() -> nym_wireguard_types::PeerPublicKey {
+        nym_crypto::asymmetric::x25519::PublicKey::from(nym_sphinx::PublicKey::from([1u8; 32]))
+            .into()
+    }
+
+    #[test]
+    fn lp_registration_request_spend_time_skew_zero_keeps_local_now() {
+        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32], 0);
+        let delta = current_timestamp() as i64 - req.timestamp as i64;
+        assert!((-1..=1).contains(&delta), "delta={delta}");
+    }
+
+    #[test]
+    fn lp_registration_request_spend_time_skew_subtracts_ahead_clock() {
+        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32], 38);
+        let delta = current_timestamp() as i64 - req.timestamp as i64;
+        assert!((37..=39).contains(&delta), "delta={delta}");
+    }
+
+    #[test]
+    fn lp_registration_request_spend_time_skew_adds_behind_clock() {
+        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32], -38);
+        let delta = req.timestamp as i64 - current_timestamp() as i64;
+        assert!((37..=39).contains(&delta), "delta={delta}");
+    }
 
     // ==================== LpRegistrationResponse Tests ====================
 

--- a/nym-registration-client/src/lp_client/client.rs
+++ b/nym-registration-client/src/lp_client/client.rs
@@ -465,7 +465,10 @@ where
             .try_into()
             .map_err(|err| LpClientError::Other(format!("malformed stored credential: {err}")))?;
 
-        let request = LpRegistrationRequest::new_finalise_dvpn(credential);
+        let request = LpRegistrationRequest::new_finalise_dvpn(
+            credential,
+            spend_time_skew.unwrap_or_default().whole_seconds(),
+        );
 
         tracing::trace!("Built dVPN registration finalisation request");
 
@@ -553,7 +556,11 @@ where
         let wg_public_key = PeerPublicKey::from(*wg_keypair.public_key());
         let mut psk = [0u8; 32];
         rng.fill_bytes(&mut psk);
-        let request = LpRegistrationRequest::new_initial_dvpn(wg_public_key, psk);
+        let request = LpRegistrationRequest::new_initial_dvpn(
+            wg_public_key,
+            psk,
+            spend_time_skew.unwrap_or_default().whole_seconds(),
+        );
 
         tracing::trace!("Built dVPN registration request: {request:?}");
 

--- a/nym-registration-client/src/lp_client/client.rs
+++ b/nym-registration-client/src/lp_client/client.rs
@@ -465,10 +465,10 @@ where
             .try_into()
             .map_err(|err| LpClientError::Other(format!("malformed stored credential: {err}")))?;
 
-        let request = LpRegistrationRequest::new_finalise_dvpn(
-            credential,
-            spend_time_skew.unwrap_or_default().whole_seconds(),
-        );
+        let mut request = LpRegistrationRequest::new_finalise_dvpn(credential);
+        if let Some(skew) = spend_time_skew {
+            request = request.with_spend_time_skew(skew);
+        }
 
         tracing::trace!("Built dVPN registration finalisation request");
 
@@ -556,11 +556,10 @@ where
         let wg_public_key = PeerPublicKey::from(*wg_keypair.public_key());
         let mut psk = [0u8; 32];
         rng.fill_bytes(&mut psk);
-        let request = LpRegistrationRequest::new_initial_dvpn(
-            wg_public_key,
-            psk,
-            spend_time_skew.unwrap_or_default().whole_seconds(),
-        );
+        let mut request = LpRegistrationRequest::new_initial_dvpn(wg_public_key, psk);
+        if let Some(skew) = spend_time_skew {
+            request = request.with_spend_time_skew(skew);
+        }
 
         tracing::trace!("Built dVPN registration request: {request:?}");
 

--- a/nym-registration-client/src/lp_client/nested_session/mod.rs
+++ b/nym-registration-client/src/lp_client/nested_session/mod.rs
@@ -262,7 +262,10 @@ impl NestedLpSession {
             .try_into()
             .map_err(|err| LpClientError::Other(format!("malformed stored credential: {err}")))?;
 
-        let request = LpRegistrationRequest::new_finalise_dvpn(credential);
+        let request = LpRegistrationRequest::new_finalise_dvpn(
+            credential,
+            spend_time_skew.unwrap_or_default().whole_seconds(),
+        );
 
         tracing::trace!("Built dVPN registration finalisation request");
 
@@ -360,7 +363,11 @@ impl NestedLpSession {
         let mut psk = [0u8; 32];
         rng.fill_bytes(&mut psk);
 
-        let request = LpRegistrationRequest::new_initial_dvpn(wg_public_key, psk);
+        let request = LpRegistrationRequest::new_initial_dvpn(
+            wg_public_key,
+            psk,
+            spend_time_skew.unwrap_or_default().whole_seconds(),
+        );
 
         // Step 3: Serialize the request
         let send_data = request.to_lp_frame()?;

--- a/nym-registration-client/src/lp_client/nested_session/mod.rs
+++ b/nym-registration-client/src/lp_client/nested_session/mod.rs
@@ -262,10 +262,10 @@ impl NestedLpSession {
             .try_into()
             .map_err(|err| LpClientError::Other(format!("malformed stored credential: {err}")))?;
 
-        let request = LpRegistrationRequest::new_finalise_dvpn(
-            credential,
-            spend_time_skew.unwrap_or_default().whole_seconds(),
-        );
+        let mut request = LpRegistrationRequest::new_finalise_dvpn(credential);
+        if let Some(skew) = spend_time_skew {
+            request = request.with_spend_time_skew(skew);
+        }
 
         tracing::trace!("Built dVPN registration finalisation request");
 
@@ -363,11 +363,10 @@ impl NestedLpSession {
         let mut psk = [0u8; 32];
         rng.fill_bytes(&mut psk);
 
-        let request = LpRegistrationRequest::new_initial_dvpn(
-            wg_public_key,
-            psk,
-            spend_time_skew.unwrap_or_default().whole_seconds(),
-        );
+        let mut request = LpRegistrationRequest::new_initial_dvpn(wg_public_key, psk);
+        if let Some(skew) = spend_time_skew {
+            request = request.with_spend_time_skew(skew);
+        }
 
         // Step 3: Serialize the request
         let send_data = request.to_lp_frame()?;


### PR DESCRIPTION
Bandwidth claims already subtract cached VPN API skew. LP request stamps still used raw local now, so a device more than 30s fast was rejected as invalid timestamp. Same subtract-ahead convention - nodes and the wire format are unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7150)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - VPN registration now accounts for clock differences between the device and the VPN API when validating registration timestamps.
  - Devices with clocks more than 30 seconds ahead are no longer incorrectly rejected as having invalid timestamps.
  - Clock-skew adjustments are applied consistently during both initial registration and registration finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->