### PR TITLE
Apply VPN API clock skew to LP registration timestamps (#7150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 ## [Unreleased]
 
-- bugfix: apply VPN API clock skew to LP registration timestamps so a device clock more than 30s ahead is not rejected as invalid ([#7150])
-
-[#7150]: https://github.com/nymtech/nym/pull/7150
-
 ## [2026.17-djibouti] (2026-09-01)
 
 - fixed nym-node config migration ([#7106])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Post 1.0.0 release, the changelog format is based on [Keep a Changelog](https://
 
 ## [Unreleased]
 
+- bugfix: apply VPN API clock skew to LP registration timestamps so a device clock more than 30s ahead is not rejected as invalid ([#7150])
+
+[#7150]: https://github.com/nymtech/nym/pull/7150
+
 ## [2026.17-djibouti] (2026-09-01)
 
 - fixed nym-node config migration ([#7106])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8915,6 +8915,7 @@ dependencies = [
  "nym-test-utils",
  "nym-wireguard-types",
  "serde",
+ "time",
  "tracing",
 ]
 

--- a/common/registration/Cargo.toml
+++ b/common/registration/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies]
 bincode = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+time = { workspace = true }
 tracing = { workspace = true }
 
 nym-authenticator-requests = { workspace = true }

--- a/common/registration/src/lp_messages.rs
+++ b/common/registration/src/lp_messages.rs
@@ -113,20 +113,18 @@ impl RegistrationStatus {
     }
 }
 
-fn current_timestamp() -> u64 {
+fn current_timestamp() -> std::time::Duration {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .inspect_err(|_| error!("the current timestamp predates unix epoch!"))
         .unwrap_or_default()
-        .as_secs()
 }
 
 impl LpRegistrationRequest {
-    /// Helper wrapping timestamp extraction
     fn new(registration_data: LpRegistrationRequestData) -> LpRegistrationRequest {
         Self {
             registration_data,
-            timestamp: current_timestamp(),
+            timestamp: current_timestamp().as_secs(),
         }
     }
 
@@ -154,9 +152,22 @@ impl LpRegistrationRequest {
         })
     }
 
+    /// Positive `skew` is how far the device is ahead of the VPN API; the stamp is moved back (negative moves it forward).
+    pub fn with_spend_time_skew(mut self, skew: time::Duration) -> Self {
+        let stamped = std::time::Duration::from_secs(self.timestamp);
+        let abs = skew.unsigned_abs();
+        self.timestamp = if skew.is_negative() {
+            stamped.saturating_add(abs)
+        } else {
+            stamped.saturating_sub(abs)
+        }
+        .as_secs();
+        self
+    }
+
     /// Validate the request timestamp is within acceptable bounds
     pub fn validate_timestamp(&self, max_skew_secs: u64) -> bool {
-        let now = current_timestamp();
+        let now = current_timestamp().as_secs();
 
         (now as i64 - self.timestamp as i64).abs() <= max_skew_secs as i64
     }
@@ -443,6 +454,36 @@ mod tests {
     }
 
     // ==================== LpRegistrationRequest Tests ====================
+
+    fn test_wg_peer_key() -> nym_wireguard_types::PeerPublicKey {
+        nym_crypto::asymmetric::x25519::PublicKey::from(nym_sphinx::PublicKey::from([1u8; 32]))
+            .into()
+    }
+
+    #[test]
+    fn lp_registration_request_new_initial_dvpn_stamps_local_now() {
+        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32]);
+        let delta = current_timestamp().as_secs().abs_diff(req.timestamp);
+        assert!(delta <= 1, "delta={delta}");
+    }
+
+    #[test]
+    fn lp_registration_request_spend_time_skew_subtracts_ahead_clock() {
+        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32])
+            .with_spend_time_skew(time::Duration::seconds(38));
+        let expected = current_timestamp().saturating_sub(std::time::Duration::from_secs(38));
+        let delta = expected.as_secs().abs_diff(req.timestamp);
+        assert!(delta <= 1, "delta={delta}");
+    }
+
+    #[test]
+    fn lp_registration_request_spend_time_skew_adds_behind_clock() {
+        let req = LpRegistrationRequest::new_initial_dvpn(test_wg_peer_key(), [0u8; 32])
+            .with_spend_time_skew(time::Duration::seconds(-38));
+        let expected = current_timestamp().saturating_add(std::time::Duration::from_secs(38));
+        let delta = expected.as_secs().abs_diff(req.timestamp);
+        assert!(delta <= 1, "delta={delta}");
+    }
 
     // ==================== LpRegistrationResponse Tests ====================
 

--- a/nym-registration-client/src/clients/lp/dvpn.rs
+++ b/nym-registration-client/src/clients/lp/dvpn.rs
@@ -52,13 +52,18 @@ async fn build_finalisation_request(
 
     tracing::trace!("Built dVPN registration finalisation request");
 
-    Ok(LpRegistrationRequest::new_finalise_dvpn(credential))
+    let mut request = LpRegistrationRequest::new_finalise_dvpn(credential);
+    if let Some(skew) = spend_time_skew {
+        request = request.with_spend_time_skew(skew);
+    }
+    Ok(request)
 }
 
 /// Build an initial dVPN request, returning it alongside the PSK it carries.
 fn build_initial_request<R>(
     rng: &mut R,
     wg_keypair: &x25519::KeyPair,
+    spend_time_skew: Option<TimeDuration>,
 ) -> (LpRegistrationRequest, [u8; 32])
 where
     R: Rng + CryptoRng,
@@ -67,7 +72,10 @@ where
     let mut psk = [0u8; 32];
     rng.fill_bytes(&mut psk);
 
-    let request = LpRegistrationRequest::new_initial_dvpn(wg_public_key, psk);
+    let mut request = LpRegistrationRequest::new_initial_dvpn(wg_public_key, psk);
+    if let Some(skew) = spend_time_skew {
+        request = request.with_spend_time_skew(skew);
+    }
     tracing::trace!("Built dVPN registration request: {request:?}");
 
     (request, psk)
@@ -152,7 +160,7 @@ where
     where
         R: Rng + CryptoRng,
     {
-        let (request, psk) = build_initial_request(rng, wg_keypair);
+        let (request, psk) = build_initial_request(rng, wg_keypair, spend_time_skew);
 
         let final_response = match self.exchange(request).await? {
             DvpnAnswer::Completed(config) => *config,
@@ -298,7 +306,7 @@ where
         R: Rng + CryptoRng,
     {
         tracing::debug!("Building registration request for exit gateway");
-        let (request, psk) = build_initial_request(rng, wg_keypair);
+        let (request, psk) = build_initial_request(rng, wg_keypair, spend_time_skew);
 
         let final_response = match self.exchange(request).await? {
             DvpnAnswer::Completed(config) => *config,


### PR DESCRIPTION
Port of the amsterdam merge onto develop after #7112 moved the LP client.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7152)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dVPN registration for devices whose clocks are more than 30 seconds ahead or behind the VPN API.
  * Registration timestamps now account for detected clock differences during both initial registration and finalization.
  * Prevents valid devices from being rejected due to timestamp discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->