### PR TITLE
[DOCs:operators]: Residential IP research docs

### DIFF
--- a/documentation/docs/pages/operators/community-counsel/_meta.json
+++ b/documentation/docs/pages/operators/community-counsel/_meta.json
@@ -1,5 +1,5 @@
 {
-  "residential-ip": "Residentianl IP",
+  "residential-ip": "Residential IP",
   "exit-gateway": "Exit Gateway",
   "legal": "Legal Counsel",
   "templates": "Templates",

--- a/documentation/docs/pages/operators/community-counsel/_meta.json
+++ b/documentation/docs/pages/operators/community-counsel/_meta.json
@@ -1,4 +1,5 @@
 {
+  "residential-ip": "Residentianl IP",
   "exit-gateway": "Exit Gateway",
   "legal": "Legal Counsel",
   "templates": "Templates",

--- a/documentation/docs/pages/operators/community-counsel/residential-ip.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip.mdx
@@ -1,0 +1,162 @@
+import { Callout } from 'nextra/components';
+import { Tabs } from 'nextra/components';
+import { MyTab } from 'components/generic-tabs.tsx';
+import { VarInfo } from 'components/variable-info.tsx';
+import { Steps } from 'nextra/components';
+import { AccordionTemplate } from 'components/accordion-template.tsx';
+
+# Residential IPs
+
+**Research on scaling residential and ISP-classified IPs for Nym exit gateways.**
+
+<Callout>
+To see the list of current residential IPs, go to [load.nymte.ch](https://load.nymte.ch/) and scroll down.
+</Callout>
+
+## Problem
+
+NymVPN users want to reach services that block or refuse signup from VPN traffic. Among other criteria, those services check public IP-intelligence databases for a `hosting` tag, which is assigned to IP ranges owned by VPS providers.
+
+Operators run nodes on servers in data centers owned by VPS providers. Those ranges carry the `hosting` tag, so VPN users get censored.
+
+Operators mostly cannot run nodes at home either:
+
+- The public and static IP that the Nym network requires is usually not provided
+- The legal exposure to risk-reward ratio is net negative
+- A shared uplink with other users on the same fiber (house, block, street) gives a poor connection experience
+
+## The core mechanic
+
+IP-intelligence databases ([ipinfo.io](https://ipinfo.io), [ipapi.is](https://ipapi.is), MaxMind, IP2Location) do **not** look at where the box physically sits. They derive `as_type` from the **WHOIS/RIR registration of the IP block and the ASN that announces it**, then confirm the org type by inspecting the org name and website.
+
+For the [NymVPN APIs](https://mainnet-node-status-api.nymtech.cc/dvpn/v1/directory/gateways) we scrape this from [ipinfo.io](https://ipinfo.io) and expose it as `location.asn.kind`:
+
+| Registrant org | `as_type` on ipinfo | `location.asn.kind` in NymVPN API |
+| --- | --- | --- |
+| Consumer ISP org | `isp` | `residential` |
+| Cloud / hosting org | `hosting` | `other` |
+
+A server in a rack in a data center can legitimately show as `residential` **if the IP it exits from is registered to, and announced under, a real ISP**.
+
+<Callout type="warning" emoji="⚠️">
+Nothing you change on the node itself moves the needle. Not reverse DNS, not config, not the kernel. The only lever is **who owns and announces the IP space**.
+</Callout>
+
+So the whole problem reduces to: acquire IP space whose registration lineage is a consumer or fixed-line ISP, and run an Exit Gateway on it. Each route below is a different way to do that.
+
+## Solution
+
+| Route | Scales? | Summary |
+| --- | --- | --- |
+| [Mislabeled VPS ranges](/operators/community-counsel/residential-ip/vps) | Yes, but fragile | Cheap and immediate but it can dissapear as `residential` without notice |
+| [ISP-tier IP blocks and BYOIP](/operators/community-counsel/residential-ip/byoip) | Yes | Lease ISP-registered space, announce it on bare metal or colo |
+| [Partnership with a small ISP](/operators/community-counsel/residential-ip/small-isp) | Yes, slowly | Cleanest lineage, compounds over time, relationship work building social networks |
+| [Mobile 4G/5G gateways](/operators/community-counsel/residential-ip/mobile) | Poorly | Highest trust score of any IP class, hard to scale |
+| [Home-hosted nodes](/operators/community-counsel/residential-ip/ip-home) | No | Sub-optimal in general, but works in the [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) |
+
+## How to verify classification
+
+This applies to every route. Cross-check each candidate IP against [**ipinfo**](https://ipinfo.io), [**ipapi.is**](https://ipapi.is), **MaxMind** and a proxy/fraud score (**IPQualityScore** or **Spur**) — never just one source.
+
+ASN → org → org-type is the chain that matters. The pass condition is a low fraud score **and** an `isp` type (mapping to `residential`). One without the other is not enough.
+
+## What to avoid, and why
+
+Prevent burning resources on things that already failed for others.
+
+<AccordionTemplate name="Residential-proxy pools (Bright Data-style rotating residential, and anything cheaper)">
+Wrong architecture *and* wrong ethics.
+
+Architecturally, they route traffic through third-party consumer devices. You don't get to *host a node* on that IP, which is what an Exit Gateway needs.
+
+Ethically, a large share of this industry sources IPs from malware and SDK-bundled installs without real consent. 911 S5 (19M hijacked IPs, FBI takedown May 2024) and NetNut (disrupted July 2026) are the headline cases. For a privacy project, buying botnet-adjacent residential access is reputational and legal poison.
+</AccordionTemplate>
+
+<AccordionTemplate name="'Residential VPS' resellers with opaque sourcing">
+A wave of cheap "residential IP VPS" shops exists. Many are just proxy fronts, or brokered residential IPs of unknown origin.
+
+OVHcloud publicly *refuses* to sell residential IPs precisely because the sourcing and ownership are murky and legally risky.
+
+If a vendor can't tell us the ASN and the registration lineage, we can assume it won't survive verification. See the [vendor research](/operators/community-counsel/residential-ip/vps) for which ones cleared this bar and which did not.
+</AccordionTemplate>
+
+<AccordionTemplate name="Getting Nym's own ASN and PI space and expecting as_type: isp">
+Worth having an ASN for routing control, but it won't classify as `isp`. The org resolves to a tech/VPN/hosting entity, so we'd land on `hosting` or `business`.
+
+Owning the ASN doesn't buy the residential tag. The *ISP lineage of the block* does.
+</AccordionTemplate>
+
+<AccordionTemplate name="Reconfiguring existing hosting-ASN VPS">
+No rDNS trick, tunnel, or config makes a Hetzner, OVH or DigitalOcean IP read as `isp` (mapping to `residential`).
+</AccordionTemplate>
+
+## Possible Experiments
+
+As shared above, there are multiple routes to try, if you are interested to test the options, you can test some possibilities with a fairly low budget:
+
+- Lease one small ISP-classified block from IPXO or InterLIR, announce it via HOSTKEY or NovoServe BYOIP on a bare-metal box, stand up a test exit, and check `as_type` across ipinfo, ipapi.is and MaxMind. Confirms the route end to end for a low cost
+
+- Re-check the same IP after two to four weeks of live exit traffic to see whether classification or reputation drifts. This is the durability question in the [BYOIP route](/operators/community-counsel/residential-ip/byoip)
+
+- Buy one mobile-gateway setup in a target country and compare real-world unblock rates against the ISP-tier box, on the actual services users complain about
+
+- Look for a [small-ISP partnership](/operators/community-counsel/residential-ip/small-isp) pitch in parallel. 
+
+## Additional Concerns
+
+<Callout type="warning" emoji="⚠️">
+**Nym Exit Gateways IPs are publicly enumerable from the network's own mainnet API.** Anyone can pull the current exit set and feed it straight into a blocklist.
+</Callout>
+
+Residential classification is **necessary but not sufficient**. It gets past Cloudflare and DataDome-style ASN gating and most geo-locked services. It will *not* keep Nym off dedicated exit-node feeds like Spur, IPQualityScore and ipgeolocation.io, who continuously connect *through* anonymity networks and record the exit IPs.
+
+Treat these as two separate problems. Residential IPs are the high-leverage fix for the "obviously a datacenter VPN" majority of blocks. The enumeration problem is a different project — churn and rotation of exit space, not publishing more than necessary — and shouldn't be conflated with this one when setting expectations for operators and users.
+
+## References
+
+<AccordionTemplate name="Classification mechanics">
+- ipinfo — how ASN types are classified: [https://community.ipinfo.io/t/how-do-we-classify-asn-types/2236](https://community.ipinfo.io/t/how-do-we-classify-asn-types/2236)
+- ipinfo — hosting vs ISP decisioning: [https://community.ipinfo.io/t/hosting-vs-isp-how-we-decide-the-ip-connection-types/5521](https://community.ipinfo.io/t/hosting-vs-isp-how-we-decide-the-ip-connection-types/5521)
+- ipinfo — VPN/hosting signal framework: [https://ipinfo.io/blog/interpret-ipinfos-vpn-hosting-signals-classification-framework](https://ipinfo.io/blog/interpret-ipinfos-vpn-hosting-signals-classification-framework)
+- ipapi.is — classification methodology, WHOIS-driven: [https://ipapi.is/blog/ipinfo-io-is-worse-than-ipapi-is.html](https://ipapi.is/blog/ipinfo-io-is-worse-than-ipapi-is.html)
+- Shifter — IP reputation vs classification, why clean ISP IPs still get flagged: [https://shifter.io/blog/what-is-ip-reputation](https://shifter.io/blog/what-is-ip-reputation)
+</AccordionTemplate>
+
+<AccordionTemplate name="ISP-tier / static residential model">
+- Evomi — ISP proxies vs residential, architecture and sourcing ethics: [https://evomi.com/blog/isp-proxies-vs.-residential-proxies-the-performance-deep-dive](https://evomi.com/blog/isp-proxies-vs.-residential-proxies-the-performance-deep-dive)
+- The Web Scraping Club — engineer's guide to residential/ISP exit sourcing: [https://substack.thewebscraping.club/p/the-engineers-guide-residential-proxies](https://substack.thewebscraping.club/p/the-engineers-guide-residential-proxies)
+- Coronium — ISP vs residential vs mobile trust scores and pricing: [https://www.coronium.io/blog/static-residential-ip-proxy-vs-residential-proxy](https://www.coronium.io/blog/static-residential-ip-proxy-vs-residential-proxy)
+- OVHcloud — why they refuse to sell residential IPs: [https://www.ovhcloud.com/en/vps/residential-ip-vps/](https://www.ovhcloud.com/en/vps/residential-ip-vps/)
+</AccordionTemplate>
+
+<AccordionTemplate name="BYOIP hosts and IPv4 brokers">
+- InterLIR — BYOIP and IPv4 leasing economics: [https://interlir.com/bring-your-own-ip/](https://interlir.com/bring-your-own-ip/)
+- InterLIR — renting IPv4 addresses: [https://interlir.com/how-to-rent-ipv4-addresses/](https://interlir.com/how-to-rent-ipv4-addresses/)
+- IPXO — lease IPs: [https://www.ipxo.com/lease-ips/](https://www.ipxo.com/lease-ips/)
+- IPbnb IPv4 leasing: [https://ipbnb.com/](https://ipbnb.com/)
+- HOSTKEY BYOIP: [https://hostkey.com/services/byoip/](https://hostkey.com/services/byoip/)
+- NovoServe BYOIP: [https://novoserve.com/blog/bring-your-own-ip-byoip](https://novoserve.com/blog/bring-your-own-ip-byoip)
+- Dedicated.com BYOIP terms: [https://my.dedicated.com/index.php?rp=/knowledgebase/16/Bringing-Your-Own-IP-Addresses-or-BYOIP.html](https://my.dedicated.com/index.php?rp=/knowledgebase/16/Bringing-Your-Own-IP-Addresses-or-BYOIP.html)
+- ServerSP BYOIP: [https://serversp.com/byoip-bring-your-own-ip/](https://serversp.com/byoip-bring-your-own-ip/)
+</AccordionTemplate>
+
+<AccordionTemplate name="Exit-node enumeration and reputation">
+- Spur — continuous exit-node enumeration: [https://spur.us/](https://spur.us/)
+- ipgeolocation.io — active VPN/proxy exit enumeration: [https://ipgeolocation.io/ip-security-api.html](https://ipgeolocation.io/ip-security-api.html)
+</AccordionTemplate>
+
+<AccordionTemplate name="Why we avoid residential-proxy pools">
+- FBI/DOJ — 911 S5 takedown, malware-sourced residential proxies: [https://www.ic3.gov/PSA/2024/PSA240529](https://www.ic3.gov/PSA/2024/PSA240529)
+- Krebs on Security — 911 S5 sourcing via bundled installers: [https://krebsonsecurity.com/2024/05/treasury-sanctions-creators-of-911-s5-proxy-botnet/](https://krebsonsecurity.com/2024/05/treasury-sanctions-creators-of-911-s5-proxy-botnet/)
+</AccordionTemplate>
+
+<AccordionTemplate name="ASN and network lookups used in this research">
+- PeeringDB — Init7 AS13030: [https://www.peeringdb.com/asn/13030](https://www.peeringdb.com/asn/13030)
+- bgp.he.net — Init7 AS13030: [https://bgp.he.net/AS13030](https://bgp.he.net/AS13030)
+- PeeringDB — Free SAS AS12322: [https://www.peeringdb.com/asn/12322](https://www.peeringdb.com/asn/12322)
+- ipregistry — NeocomISP AS9902, reports `AS Type: ISP`: [https://ipregistry.co/AS9902](https://ipregistry.co/AS9902)
+- bgp.he.net — Internet Multifeed AS7521: [https://bgp.he.net/AS7521](https://bgp.he.net/AS7521)
+- ipinfo — Cogent AS174: [https://ipinfo.io/AS174](https://ipinfo.io/AS174)
+- ipinfo — Trooli AS48101: [https://ipinfo.io/AS48101](https://ipinfo.io/AS48101)
+- Init7 datacenter internet access: [https://www.init7.net/en/offer/datacenter-access/](https://www.init7.net/en/offer/datacenter-access/)
+</AccordionTemplate>

--- a/documentation/docs/pages/operators/community-counsel/residential-ip.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip.mdx
@@ -25,9 +25,11 @@ Operators mostly cannot run nodes at home either:
 - The legal exposure to risk-reward ratio is net negative
 - A shared uplink with other users on the same fiber (house, block, street) gives a poor connection experience
 
-## The core mechanic
+## The Core Mechanic
 
 IP-intelligence databases ([ipinfo.io](https://ipinfo.io), [ipapi.is](https://ipapi.is), MaxMind, IP2Location) do **not** look at where the box physically sits. They derive `as_type` from the **WHOIS/RIR registration of the IP block and the ASN that announces it**, then confirm the org type by inspecting the org name and website.
+
+### NymVPN API Logic
 
 For the [NymVPN APIs](https://mainnet-node-status-api.nymtech.cc/dvpn/v1/directory/gateways) we scrape this from [ipinfo.io](https://ipinfo.io) and expose it as `location.asn.kind`:
 
@@ -60,7 +62,7 @@ This applies to every route. Cross-check each candidate IP against [**ipinfo**](
 
 ASN → org → org-type is the chain that matters. The pass condition is a low fraud score **and** an `isp` type (mapping to `residential`). One without the other is not enough.
 
-## What to avoid, and why
+## What to Avoid
 
 Prevent burning resources on things that already failed for others.
 

--- a/documentation/docs/pages/operators/community-counsel/residential-ip.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip.mdx
@@ -27,7 +27,7 @@ Operators mostly cannot run nodes at home either:
 
 ## The Core Mechanic
 
-IP-intelligence databases ([ipinfo.io](https://ipinfo.io), [ipapi.is](https://ipapi.is), MaxMind, IP2Location) do **not** look at where the box physically sits. They derive `as_type` from the **WHOIS/RIR registration of the IP block and the ASN that announces it**, then confirm the org type by inspecting the org name and website.
+IP-intelligence databases ([ipinfo.io](https://ipinfo.io), [ipapi.is](https://ipapi.is), MaxMind, IP2Location) do **not** look at where the box physically sits. They derive `as_type` largely from the **WHOIS/RIR registration of the IP block and the ASN that announces it**, confirm the org type by inspecting the org name and website, and weigh observed network behaviour on top of that.
 
 ### NymVPN API Logic
 
@@ -41,8 +41,10 @@ For the [NymVPN APIs](https://mainnet-node-status-api.nymtech.cc/dvpn/v1/directo
 A server in a rack in a data center can legitimately show as `residential` **if the IP it exits from is registered to, and announced under, a real ISP**.
 
 <Callout type="warning" emoji="⚠️">
-Nothing you change on the node itself moves the needle. Not reverse DNS, not config, not the kernel. The only lever is **who owns and announces the IP space**.
+Nothing you change on the node itself moves the needle. Not reverse DNS, not config, not the kernel. The only lever is **who owns and announces the IP space** — and because classification is assigned per range and partly from observed behaviour, the right registrant makes a good result likely, never certain. Always [verify the actual prefix](#how-to-verify-classification).
 </Callout>
+
+
 
 So the whole problem reduces to: acquire IP space whose registration lineage is a consumer or fixed-line ISP, and run an Exit Gateway on it. Each route below is a different way to do that.
 

--- a/documentation/docs/pages/operators/community-counsel/residential-ip.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip.mdx
@@ -52,9 +52,9 @@ So the whole problem reduces to: acquire IP space whose registration lineage is 
 | --- | --- | --- |
 | [Mislabeled VPS ranges](/operators/community-counsel/residential-ip/vps) | Yes, but fragile | Cheap and immediate but it can dissapear as `residential` without notice |
 | [ISP-tier IP blocks and BYOIP](/operators/community-counsel/residential-ip/byoip) | Yes | Lease ISP-registered space, announce it on bare metal or colo |
-| [Partnership with a small ISP](/operators/community-counsel/residential-ip/small-isp) | Yes, slowly | Cleanest lineage, compounds over time, relationship work building social networks |
+| [Partnership with a small ISP](/operators/community-counsel/residential-ip/isp) | Yes, slowly | Cleanest lineage, compounds over time, relationship work building social networks |
 | [Mobile 4G/5G gateways](/operators/community-counsel/residential-ip/mobile) | Poorly | Highest trust score of any IP class, hard to scale |
-| [Home-hosted nodes](/operators/community-counsel/residential-ip/ip-home) | No | Sub-optimal in general, but works in the [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) |
+| [Home-hosted nodes](/operators/community-counsel/residential-ip/home) | No | Sub-optimal in general, but works in the [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) |
 
 ## How to verify classification
 
@@ -102,7 +102,7 @@ As shared above, there are multiple routes to try, if you are interested to test
 
 - Buy one mobile-gateway setup in a target country and compare real-world unblock rates against the ISP-tier box, on the actual services users complain about
 
-- Look for a [small-ISP partnership](/operators/community-counsel/residential-ip/small-isp) pitch in parallel. 
+- Look for a [small-ISP partnership](/operators/community-counsel/residential-ip/isp) pitch in parallel. 
 
 ## Additional Concerns
 

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/_meta.json
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/_meta.json
@@ -1,0 +1,7 @@
+{
+  "vps": "Mislabeled VPS",
+  "byoip": "BYOIP on Bare-metal",
+  "isp": "ISP Partnership",
+  "mobile": "Mobile IP",
+  "home": "Home IP"
+}

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/byoip.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/byoip.mdx
@@ -63,7 +63,7 @@ Brokers sell *clean* space (blocklist-free, correct geo). That is **not** the sa
 
 `as_type` follows the block's registrant org, and marketplace inventory skews hosting and enterprise, so the default result is `hosting` or `business`, not `isp` (`residential`). None of the brokers filter by ISP registrant.
 
-So request ranges whose holder is an ISP org, and [verify `as_type`](/operators/community-counsel/residential-ip#how-to-verify-classification) on a sample across [ipinfo](https://ipinfo.io), [ipapi.is](https://ipapi.is) and [MaxMind](https://www.maxmind.com/en/geoip-demo) before signing anything.
+So request ranges whose holder is an ISP org, then [verify](/operators/community-counsel/residential-ip#how-to-verify-classification) the **exact prefix** on a sample across [ipinfo](https://ipinfo.io), [ipapi.is](https://ipapi.is) and [MaxMind](https://www.maxmind.com/en/geoip-demo) before signing anything. Registrant identity is a signal, not a result — one org can hold ranges that classify differently, so a good answer on one prefix does not carry to the next.
 
 And if you announce under your own ASN, the ROA names your ASN as origin, which is the reclassification-drift risk described above. [InterLIR's RIPE ASN-sponsorship path](https://interlir.com/bring-your-own-ip/) is the cleanest fit here.
 

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/byoip.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/byoip.mdx
@@ -1,0 +1,90 @@
+import { Callout } from 'nextra/components';
+import { Tabs } from 'nextra/components';
+import { MyTab } from 'components/generic-tabs.tsx';
+import { VarInfo } from 'components/variable-info.tsx';
+import { Steps } from 'nextra/components';
+import { AccordionTemplate } from 'components/accordion-template.tsx';
+
+# ISP-tier IP Blocks and BYOIP
+
+This is the industry's "static residential" or "ISP proxy" model, repurposed. Lease IP space that is **registered under a real ISP's ASN**, then announce it via BGP on a bare-metal or colo provider that supports **BYOIP**. The box sits in a data center, and the exit IP classifies as `isp`.
+
+Operators control the hardware and bandwidth, which fits Exit Gateway, WG-exit and IPR needs. It scales by leasing more space rather than by recruiting more households.
+
+## Two variants, and the difference matters
+
+The durability of this route depends entirely on which one you build.
+
+<Tabs items={['Fragile', 'More resilient']}>
+  <MyTab>
+
+Lease a clean `/24` and announce it under *your own* (that is, hosting) ASN.
+
+The block may still WHOIS to the leasing org for a while, but self-announcing VPN-exit traffic under a hosting ASN is exactly what re-classification heuristics catch. This decays.
+
+  </MyTab>
+  <MyTab>
+
+The block stays **registered to and originated from the ISP's ASN**. You are effectively a downstream customer using PA space, or the ISP announces on your behalf.
+
+This is what commercial ISP-proxy vendors actually do — they procure static IPs directly from ISPs and host them on their own servers, keeping the ISP registration intact.
+
+Prioritise providers and brokers who can keep the block under a genuine ISP origin, not just "clean" data center space.
+
+  </MyTab>
+</Tabs>
+
+## BYOIP Hosts
+
+Providers seen offering BYOIP on dedicated or colo.
+
+| Provider | BYOIP cost | Server types | Key terms / notes |
+| --- | --- | --- | --- |
+| [HOSTKEY](https://hostkey.com/services/byoip/) | Free | Dedicated + colo | ARIN/RIPE, next-business-day setup. **Drops your announcement if the block hits Spamhaus**, which matters for GWx |
+| [NovoServe](https://novoserve.com/blog/bring-your-own-ip-byoip) | Free | Bare metal | IPv4 + IPv6, announce under your own ASN, explicitly VPN-operator friendly |
+| [Dedicated.com](https://my.dedicated.com/index.php?rp=/knowledgebase/16/Bringing-Your-Own-IP-Addresses-or-BYOIP.html) | ~$250 setup + $100/mo per location | Dedicated / colo, **not VPS** | You run the BGP session yourself |
+| [ServerSP](https://serversp.com/byoip-bring-your-own-ip/) | TBD | Bare metal / VPS / VDC | Announce under their ASN (AS214456) or yours. Integrates with IPXO-leased space |
+
+## IPv4 Leasing Brokers
+
+For the block itself.
+
+| Broker | Price (/24, per IP/mo) | Block sizes | RIRs | Setup | Included | Notes relevant to us |
+| --- | --- | --- | --- | --- | --- | --- |
+| [IPXO](https://www.ipxo.com/lease-ips/) | ~$0.35/IP (2026 avg), 5% txn fee | /24+ | Any RIR | ~1–3 days, often under 24h | Automated LOA/ROA, WHOIS + rDNS sync, geolocation correction, continuous blocklist and reputation monitoring | Largest, most self-service inventory. Filter by size, RIR and **geolocation** — but **no** `as_type=isp` filter, and org type still tracks the block's registrant. Their reputation tooling is about *clean*, not *residential* |
+| [InterLIR](https://interlir.com/how-to-rent-ipv4-addresses/) (InterLIR GmbH, Berlin) | ~$0.50–0.60 clean, $0.30–0.40 reputation-flagged; from €99–110/mo per /24 | /24–/16 | RIPE primary, plus ARIN, APNIC, LACNIC, AFRINIC | 24–48h | LOA/RPKI/ROA, 50+ blacklist screen at onboarding, 24/7 abuse management, **free replacement if a leased IP gets blacklisted** | Managed hybrid model. Can **sponsor ASN registration in RIPE** if you don't have an LIR, which is useful here. Watch hidden fees: setup $50–200, BGP config $100–300, early-termination penalty |
+| [IPbnb](https://ipbnb.com/) | Per-listing, transparent, 5% flat txn fee | /24+ | RIPE primary, ARIN | ~24h | RPKI/ROA, LOA, ASN registration, reputation checks at onboarding | Two-sided marketplace, so you **see the subnet's source and terms before committing**. Less opaque than a managed pool, good for vetting registrant lineage |
+
+## Possible Downside
+
+<Callout type="warning" emoji="⚠️">
+Brokers sell *clean* space (blocklist-free, correct geo). That is **not** the same as *residential*.
+</Callout>
+
+`as_type` follows the block's registrant org, and marketplace inventory skews hosting and enterprise, so the default result is `hosting` or `business`, not `isp`. None of the brokers filter by ISP registrant.
+
+So request ranges whose holder is an ISP org, and [verify `as_type`](/operators/community-counsel/residential-ip#how-to-verify-classification) on a sample across [ipinfo](https://ipinfo.io), [ipapi.is](https://ipapi.is) and [MaxMind](https://www.maxmind.com/en/geoip-demo) before signing anything.
+
+And if you announce under your own ASN, the ROA names your ASN as origin, which is the reclassification-drift risk described above. [InterLIR's RIPE ASN-sponsorship path](https://interlir.com/bring-your-own-ip/) is the cleanest fit here.
+
+## Suggested first experiment
+
+Lease one small ISP-classified block from [IPXO](https://www.ipxo.com/lease-ips/) or [InterLIR](https://interlir.com/how-to-rent-ipv4-addresses/), announce it via [HOSTKEY](https://hostkey.com/services/byoip/) or [NovoServe](https://novoserve.com/blog/bring-your-own-ip-byoip) BYOIP on a bare-metal box, stand up a test exit, and check `as_type` across [ipinfo](https://ipinfo.io), [ipapi.is](https://ipapi.is) and [MaxMind](https://www.maxmind.com/en/geoip-demo). That confirms the route end to end for a low cost.
+
+Then re-check the same IP after two to four weeks of live exit traffic, to see whether classification or reputation drifts.
+
+## References
+
+<AccordionTemplate name="Sources for this page">
+- InterLIR — BYOIP and IPv4 leasing economics: [https://interlir.com/bring-your-own-ip/](https://interlir.com/bring-your-own-ip/)
+- InterLIR — renting IPv4 addresses: [https://interlir.com/how-to-rent-ipv4-addresses/](https://interlir.com/how-to-rent-ipv4-addresses/)
+- IPXO — lease IPs: [https://www.ipxo.com/lease-ips/](https://www.ipxo.com/lease-ips/)
+- IPbnb IPv4 leasing: [https://ipbnb.com/](https://ipbnb.com/)
+- HOSTKEY BYOIP: [https://hostkey.com/services/byoip/](https://hostkey.com/services/byoip/)
+- NovoServe BYOIP: [https://novoserve.com/blog/bring-your-own-ip-byoip](https://novoserve.com/blog/bring-your-own-ip-byoip)
+- Dedicated.com BYOIP terms: [https://my.dedicated.com/index.php?rp=/knowledgebase/16/Bringing-Your-Own-IP-Addresses-or-BYOIP.html](https://my.dedicated.com/index.php?rp=/knowledgebase/16/Bringing-Your-Own-IP-Addresses-or-BYOIP.html)
+- ServerSP BYOIP: [https://serversp.com/byoip-bring-your-own-ip/](https://serversp.com/byoip-bring-your-own-ip/)
+- Evomi — ISP proxies vs residential, architecture and sourcing: [https://evomi.com/blog/isp-proxies-vs.-residential-proxies-the-performance-deep-dive](https://evomi.com/blog/isp-proxies-vs.-residential-proxies-the-performance-deep-dive)
+- The Web Scraping Club — engineer's guide to residential/ISP exit sourcing: [https://substack.thewebscraping.club/p/the-engineers-guide-residential-proxies](https://substack.thewebscraping.club/p/the-engineers-guide-residential-proxies)
+- Shifter — IP reputation vs classification: [https://shifter.io/blog/what-is-ip-reputation](https://shifter.io/blog/what-is-ip-reputation)
+</AccordionTemplate>

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/byoip.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/byoip.mdx
@@ -7,7 +7,7 @@ import { AccordionTemplate } from 'components/accordion-template.tsx';
 
 # ISP-tier IP Blocks and BYOIP
 
-This is the industry's "static residential" or "ISP proxy" model, repurposed. Lease IP space that is **registered under a real ISP's ASN**, then announce it via BGP on a bare-metal or colo provider that supports **BYOIP**. The box sits in a data center, and the exit IP classifies as `isp`.
+This is the industry's "static residential" or "ISP proxy" model, repurposed. Lease IP space that is **registered under a real ISP's ASN**, then announce it via BGP on a bare-metal or colo provider that supports **BYOIP**. The box sits in a data center, and the exit IP classifies as `isp` (mapping to `residential`).
 
 Operators control the hardware and bandwidth, which fits Exit Gateway, WG-exit and IPR needs. It scales by leasing more space rather than by recruiting more households.
 
@@ -61,7 +61,7 @@ For the block itself.
 Brokers sell *clean* space (blocklist-free, correct geo). That is **not** the same as *residential*.
 </Callout>
 
-`as_type` follows the block's registrant org, and marketplace inventory skews hosting and enterprise, so the default result is `hosting` or `business`, not `isp`. None of the brokers filter by ISP registrant.
+`as_type` follows the block's registrant org, and marketplace inventory skews hosting and enterprise, so the default result is `hosting` or `business`, not `isp` (`residential`). None of the brokers filter by ISP registrant.
 
 So request ranges whose holder is an ISP org, and [verify `as_type`](/operators/community-counsel/residential-ip#how-to-verify-classification) on a sample across [ipinfo](https://ipinfo.io), [ipapi.is](https://ipapi.is) and [MaxMind](https://www.maxmind.com/en/geoip-demo) before signing anything.
 

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/home.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/home.mdx
@@ -31,7 +31,7 @@ The constraints above are ISP-dependent, not universal. Where an ISP routes a st
 That combination is what makes the [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) viable, and it is the model to look for if we want to repeat this elsewhere.
 
 
-A better way may be to treat any ISP willing to support residential IP based Nym nodes as a candidate for a [formal partnership](/operators/community-counsel/residential-ip/small-isp) — which is the version of this route that actually scales.
+A better way may be to treat any ISP willing to support residential IP based Nym nodes as a candidate for a [formal partnership](/operators/community-counsel/residential-ip/isp) — which is the version of this route that actually scales.
 
 ## References
 

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/home.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/home.mdx
@@ -1,0 +1,43 @@
+import { Callout } from 'nextra/components';
+import { Tabs } from 'nextra/components';
+import { MyTab } from 'components/generic-tabs.tsx';
+import { VarInfo } from 'components/variable-info.tsx';
+import { Steps } from 'nextra/components';
+import { AccordionTemplate } from 'components/accordion-template.tsx';
+
+# Home-hosted Nym Nodes
+
+Running `nym-node` on a residential line gives the strongest possible `isp` (mapping as `residential`) classification, because the lineage is not merely ISP-registered — it *is* a consumer subscription.
+
+It is also the route that scales worst, and in most cases we do *not recommend* it.
+
+<Callout type="warning" emoji="⚠️">
+This option is sub-optimal in general. It works today in Switzerland with a specific hardware and ISP setup, documented in [Swiss setup](/operators/community-counsel/residential-ip/home/swiss).
+</Callout>
+
+## Why it is Sub-optimal
+
+- The public and static IP that the Nym network requires is usually not provided
+- The legal exposure to risk-reward ratio is net negative. Running a `nym-node` is not illegal, but some jurisdictions, would go after people running exit nodes from home
+- A shared uplink with other users on the same fiber (house, block, street) results in a poor connection quality experience
+- One line means one operator in one location. Adding capacity means recruiting another household, not buying another server.
+
+## Usecase 
+
+The constraints above are ISP-dependent, not universal. Where an ISP routes a static block to the premises, permits servers, and does not block ports, the objections largely fall away — what remains is the legal-exposure question, which is the operator's own call.
+
+[Init7](https://www.init7.net/de) in Switzerland is the clearest example we have found. AS13030, own backbone, no reseller layer, explicitly net-neutral, no port blocking, servers permitted on residential Fiber7, and static IPv4 plus IPv6. Their ASN is already tagged with tor and bittorrent traffic in ipinfo, which tells you what they tolerate.
+
+That combination is what makes the [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) viable, and it is the model to look for if we want to repeat this elsewhere.
+
+
+A better way may be to treat any ISP willing to support residential IP based Nym nodes as a candidate for a [formal partnership](/operators/community-counsel/residential-ip/small-isp) — which is the version of this route that actually scales.
+
+## References
+
+<AccordionTemplate name="Sources for this page">
+- PeeringDB — Init7 AS13030: [https://www.peeringdb.com/asn/13030](https://www.peeringdb.com/asn/13030)
+- bgp.he.net — Init7 AS13030: [https://bgp.he.net/AS13030](https://bgp.he.net/AS13030)
+- Init7 datacenter internet access: [https://www.init7.net/en/offer/datacenter-access/](https://www.init7.net/en/offer/datacenter-access/)
+- ipinfo — how ASN types are classified: [https://community.ipinfo.io/t/how-do-we-classify-asn-types/2236](https://community.ipinfo.io/t/how-do-we-classify-asn-types/2236)
+</AccordionTemplate>

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/home/swiss.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/home/swiss.mdx
@@ -1,0 +1,11 @@
+import { Callout } from 'nextra/components';
+import { Tabs } from 'nextra/components';
+import { MyTab } from 'components/generic-tabs.tsx';
+import { VarInfo } from 'components/variable-info.tsx';
+import { Steps } from 'nextra/components';
+import { AccordionTemplate } from 'components/accordion-template.tsx';
+
+# Swiss Setup
+
+A specific nym-nodes-hosted-at-home design, built by Oceanus in Switzerland, that can be expanded to more Swiss operators. This page will soon share the components and, more usefully, the three things that actually cost time.
+

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/isp.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/isp.mdx
@@ -7,36 +7,30 @@ import { AccordionTemplate } from 'components/accordion-template.tsx';
 
 # Partnership with a Small ISP
 
-No broker in the middle. Become a downstream of a friendly regional or fixed-line ISP and have them **reassign** (SWIP in ARIN, or a RIPE assignment) a sub-block to Nym operators, while keeping it under the ISP's own ASN.
+Nym node operators can reach out to a friendly regional or fixed-line ISP and ask them to **reassign** (SWIP in ARIN, or a RIPE assignment) a sub-block to them, while keeping it under the ISP's own ASN.
 
-This is the cleanest possible `isp` result because the lineage is real, and it is the version least likely to get reclassified later.
+This is the cleanest possible `isp` (mapping to `residential`) result because the lineage is real, and it is the version least likely to get reclassified later.
 
-<Callout type="info" emoji="📌">
-**Status:** I will again reach out to a few orgs who could be helpful here and ask about their requirements and cost.
-</Callout>
-
-## Why this compounds
+## Why & How This Works
 
 Small ISPs, community networks and co-op ISPs are natural allies for a privacy network, so this doubles as a mission fit rather than just a procurement exercise.
 
-A few anchor partnerships, ideally one per region, could supply space to many operators at once. That is a different shape from every other route on this page: instead of buying N servers to get N residential IPs, one relationship unlocks a block that many operators can draw from.
+A few anchor partnerships, ideally one per region, could supply space to many operators at once. That is a different shape from every other route on this page: instead of buying *N* servers to get *N* residential IPs, one relationship unlocks a block that many operators can draw from.
 
-## Who to approach
+## Who to Approach
 
-The pattern to look for is an ISP or LIR that already sells transit or colocation on its own `isp`-classified space. Two of the networks already carrying our nodes fit exactly this description:
+The pattern to look for is an ISP or LIR that already sells transit or colocation on its own `isp`-classified space (`residential`). Two of the networks already carrying Nym nodes fit exactly this description:
 
 | Network | Why it fits |
 | --- | --- |
 | [NeocomISP](https://neocomisp.com.kh/en) (KH) | AS9902, and [ipregistry reports `AS Type: ISP` explicitly](https://ipregistry.co/AS9902). Self-describes as an IPTX Transit and Network Service Provider. An LIR with 74 IPv4 prefixes marked ALLOCATED PORTABLE |
 | [Init7](https://www.init7.net/de) (CH) | AS13030, own backbone, no reseller layer, militantly net-neutral, and already tolerant of Tor traffic on their ASN. Best partnership target in Europe. See the [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) for what we already run there |
 
-See the [full provider research](/operators/community-counsel/residential-ip/vps#provider-research) for the rest of the networks we are already on, several of which are worth approaching for a formal arrangement rather than the current ad-hoc one.
+See the [full provider research](/operators/community-counsel/residential-ip/vps#provider-research) for the rest of the networks Nym is already on, several of which are worth approaching for a formal arrangement rather than the current ad-hoc one.
 
 ## Downside
 
 It is relationship and legal work, not a set-and-forget business. Expect a sales cycle, contracts, and in some regions paperwork in the local language.
-
-That is the cost of the thing that compounds. Worth a dedicated outreach track rather than being folded into general operator support.
 
 ## References
 

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/isp.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/isp.mdx
@@ -29,7 +29,7 @@ The pattern to look for is an ISP or LIR that already sells transit or colocatio
 
 | Network | Why it fits |
 | --- | --- |
-| [NeocomISP](https://neocomisp.com.kh/en) (KH) | AS9902, and [ipregistry reports `AS Type: ISP`](https://ipregistry.co/AS9902). Self-describes as an IPTX Transit and Network Service Provider. An LIR with 74 IPv4 prefixes marked ALLOCATED PORTABLE |
+| [NeocomISP](https://neocomisp.com.kh/en) (KH) | AS9902, and [ipregistry reports `AS Type: ISP`](https://ipregistry.co/AS9902). Self-describes as an IPTX Transit and Network Service Provider. An LIR with 67 IPv4 prefixes marked ALLOCATED PORTABLE |
 | [Init7](https://www.init7.net/de) (CH) | AS13030, own backbone, no reseller layer, net-neutral by policy, and tolerant of Tor traffic on their ASN. See the [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) for a working deployment on their network |
 
 See the [full provider research](/operators/community-counsel/residential-ip/vps#provider-research) for the rest of the networks Nym nodes currently run on, several of which are candidates for a formal arrangement.

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/isp.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/isp.mdx
@@ -7,26 +7,32 @@ import { AccordionTemplate } from 'components/accordion-template.tsx';
 
 # Partnership with a Small ISP
 
-Nym node operators can reach out to a friendly regional or fixed-line ISP and ask them to **reassign** (SWIP in ARIN, or a RIPE assignment) a sub-block to them, while keeping it under the ISP's own ASN.
+Nym node operators can reach out to a regional or fixed-line ISP and ask for a sub-block from the ISP's own PA space, kept under the ISP's allocation and announced from the ISP's ASN.
 
-This is the cleanest possible `isp` (mapping to `residential`) result because the lineage is real, and it is the version least likely to get reclassified later.
+This is the cleanest available `isp` (mapping to `residential`) lineage, and the version least likely to be reclassified later.
+
+<Callout type="warning" emoji="⚠️">
+Ask for **provider-controlled PA space, not a customer reassignment.** An ARIN SWIP or RIPE assignment publishes a customer record naming the recipient in public whois. The block may then resolve to the operator rather than to the ISP, which is the opposite of the intended lineage, and it places an Exit Gateway operator's name and address in a public database.
+</Callout>
+
+Registrant identity is a signal, not a guarantee. Validate the exact prefix with [ipinfo](https://ipinfo.io), [ipapi.is](https://ipapi.is), [MaxMind](https://www.maxmind.com/en/geoip-demo) and a fraud or proxy classifier before deploying on it.
 
 ## Why & How This Works
 
 Small ISPs, community networks and co-op ISPs are natural allies for a privacy network, so this doubles as a mission fit rather than just a procurement exercise.
 
-A few anchor partnerships, ideally one per region, could supply space to many operators at once. That is a different shape from every other route on this page: instead of buying *N* servers to get *N* residential IPs, one relationship unlocks a block that many operators can draw from.
+A few anchor partnerships, ideally one per region, could supply space to many operators at once. Instead of buying *N* servers to get *N* residential IPs, one relationship unlocks a block that many operators can draw from.
 
 ## Who to Approach
 
-The pattern to look for is an ISP or LIR that already sells transit or colocation on its own `isp`-classified space (`residential`). Two of the networks already carrying Nym nodes fit exactly this description:
+The pattern to look for is an ISP or LIR that already sells transit or colocation on its own `isp`-classified space (`residential`). Two of the networks already carrying Nym nodes fit this description:
 
 | Network | Why it fits |
 | --- | --- |
-| [NeocomISP](https://neocomisp.com.kh/en) (KH) | AS9902, and [ipregistry reports `AS Type: ISP` explicitly](https://ipregistry.co/AS9902). Self-describes as an IPTX Transit and Network Service Provider. An LIR with 74 IPv4 prefixes marked ALLOCATED PORTABLE |
-| [Init7](https://www.init7.net/de) (CH) | AS13030, own backbone, no reseller layer, militantly net-neutral, and already tolerant of Tor traffic on their ASN. Best partnership target in Europe. See the [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) for what we already run there |
+| [NeocomISP](https://neocomisp.com.kh/en) (KH) | AS9902, and [ipregistry reports `AS Type: ISP`](https://ipregistry.co/AS9902). Self-describes as an IPTX Transit and Network Service Provider. An LIR with 74 IPv4 prefixes marked ALLOCATED PORTABLE |
+| [Init7](https://www.init7.net/de) (CH) | AS13030, own backbone, no reseller layer, net-neutral by policy, and tolerant of Tor traffic on their ASN. See the [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) for a working deployment on their network |
 
-See the [full provider research](/operators/community-counsel/residential-ip/vps#provider-research) for the rest of the networks Nym is already on, several of which are worth approaching for a formal arrangement rather than the current ad-hoc one.
+See the [full provider research](/operators/community-counsel/residential-ip/vps#provider-research) for the rest of the networks Nym nodes currently run on, several of which are candidates for a formal arrangement.
 
 ## Downside
 

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/isp.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/isp.mdx
@@ -1,0 +1,50 @@
+import { Callout } from 'nextra/components';
+import { Tabs } from 'nextra/components';
+import { MyTab } from 'components/generic-tabs.tsx';
+import { VarInfo } from 'components/variable-info.tsx';
+import { Steps } from 'nextra/components';
+import { AccordionTemplate } from 'components/accordion-template.tsx';
+
+# Partnership with a Small ISP
+
+No broker in the middle. Become a downstream of a friendly regional or fixed-line ISP and have them **reassign** (SWIP in ARIN, or a RIPE assignment) a sub-block to Nym operators, while keeping it under the ISP's own ASN.
+
+This is the cleanest possible `isp` result because the lineage is real, and it is the version least likely to get reclassified later.
+
+<Callout type="info" emoji="📌">
+**Status:** I will again reach out to a few orgs who could be helpful here and ask about their requirements and cost.
+</Callout>
+
+## Why this compounds
+
+Small ISPs, community networks and co-op ISPs are natural allies for a privacy network, so this doubles as a mission fit rather than just a procurement exercise.
+
+A few anchor partnerships, ideally one per region, could supply space to many operators at once. That is a different shape from every other route on this page: instead of buying N servers to get N residential IPs, one relationship unlocks a block that many operators can draw from.
+
+## Who to approach
+
+The pattern to look for is an ISP or LIR that already sells transit or colocation on its own `isp`-classified space. Two of the networks already carrying our nodes fit exactly this description:
+
+| Network | Why it fits |
+| --- | --- |
+| [NeocomISP](https://neocomisp.com.kh/en) (KH) | AS9902, and [ipregistry reports `AS Type: ISP` explicitly](https://ipregistry.co/AS9902). Self-describes as an IPTX Transit and Network Service Provider. An LIR with 74 IPv4 prefixes marked ALLOCATED PORTABLE |
+| [Init7](https://www.init7.net/de) (CH) | AS13030, own backbone, no reseller layer, militantly net-neutral, and already tolerant of Tor traffic on their ASN. Best partnership target in Europe. See the [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) for what we already run there |
+
+See the [full provider research](/operators/community-counsel/residential-ip/vps#provider-research) for the rest of the networks we are already on, several of which are worth approaching for a formal arrangement rather than the current ad-hoc one.
+
+## Downside
+
+It is relationship and legal work, not a set-and-forget business. Expect a sales cycle, contracts, and in some regions paperwork in the local language.
+
+That is the cost of the thing that compounds. Worth a dedicated outreach track rather than being folded into general operator support.
+
+## References
+
+<AccordionTemplate name="Sources for this page">
+- ipinfo — how ASN types are classified: [https://community.ipinfo.io/t/how-do-we-classify-asn-types/2236](https://community.ipinfo.io/t/how-do-we-classify-asn-types/2236)
+- ipregistry — NeocomISP AS9902, reports `AS Type: ISP`: [https://ipregistry.co/AS9902](https://ipregistry.co/AS9902)
+- PeeringDB — Init7 AS13030: [https://www.peeringdb.com/asn/13030](https://www.peeringdb.com/asn/13030)
+- bgp.he.net — Init7 AS13030: [https://bgp.he.net/AS13030](https://bgp.he.net/AS13030)
+- Init7 datacenter internet access: [https://www.init7.net/en/offer/datacenter-access/](https://www.init7.net/en/offer/datacenter-access/)
+- InterLIR — can sponsor ASN registration in RIPE: [https://interlir.com/bring-your-own-ip/](https://interlir.com/bring-your-own-ip/)
+</AccordionTemplate>

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/mobile.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/mobile.mdx
@@ -1,0 +1,33 @@
+import { Callout } from 'nextra/components';
+import { Tabs } from 'nextra/components';
+import { MyTab } from 'components/generic-tabs.tsx';
+import { VarInfo } from 'components/variable-info.tsx';
+import { Steps } from 'nextra/components';
+import { AccordionTemplate } from 'components/accordion-template.tsx';
+
+# Mobile 4G/5G Gateways
+
+Carrier and mobile IPs get the **highest trust scores** in every reputation database, and they are effectively un-blockable per-IP because CGNAT shares one address across many real subscribers. An Exit Gateway behind a SIM and modem exits as mobile.
+
+## Limitation & Usecase
+
+**Cost is per-device.** A modem or router plus a data plan for every node. For comparison, the proxy market prices dedicated mobile IPs at roughly $27/mo and up.
+
+**CGNAT means no inbound reachability.** That is fine for an *outbound* exit path, but Nym network requires to handle NAT for the gateway's own reachability. The [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) documents in detail what goes wrong when a Nym node sits behind translation, and much of that experience transfers here.
+
+**Per-SIM data caps and throttling hurt a high-throughput exit.** Mobile plans are not built for sustained gateway traffic.
+
+This design does not scale to hundreds of nodes. It can be used for a handful of **high-value un-blockable exits** in specific countries, where nothing else gets through and the per-node cost is justified by the access it buys.
+
+
+## Possible Test
+
+Buy one mobile-gateway setup in a target country and compare real-world unblock rates against an ISP-tier box, tested on the actual services users complain about. That gives you a like-for-like number rather than a trust-score abstraction.
+
+## References
+
+<AccordionTemplate name="Sources for this page">
+- Coronium — ISP vs residential vs mobile trust scores and pricing: [https://www.coronium.io/blog/static-residential-ip-proxy-vs-residential-proxy](https://www.coronium.io/blog/static-residential-ip-proxy-vs-residential-proxy)
+- ipinfo — VPN/hosting signal framework: [https://ipinfo.io/blog/interpret-ipinfos-vpn-hosting-signals-classification-framework](https://ipinfo.io/blog/interpret-ipinfos-vpn-hosting-signals-classification-framework)
+- Shifter — IP reputation vs classification: [https://shifter.io/blog/what-is-ip-reputation](https://shifter.io/blog/what-is-ip-reputation)
+</AccordionTemplate>

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/mobile.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/mobile.mdx
@@ -5,11 +5,17 @@ import { VarInfo } from 'components/variable-info.tsx';
 import { Steps } from 'nextra/components';
 import { AccordionTemplate } from 'components/accordion-template.tsx';
 
+
+
+
+
 # Mobile 4G/5G Gateways
 
-Carrier and mobile IPs get the **highest trust scores** in every reputation database, and they are effectively un-blockable per-IP because CGNAT shares one address across many real subscribers. An Exit Gateway behind a SIM and modem exits as mobile.
+Carrier and mobile IPs generally score well in reputation databases, and CGNAT makes per-IP blocking costly for the blocker because one address is shared with many real subscribers. An Exit Gateway behind a SIM and modem exits as mobile.
 
 ## Limitation & Usecase
+
+This is a strong position, not an immune one. Mobile ASNs are identifiable, CGNAT ranges do get blocked, and acceptance varies by target service — so treat the unblock-rate test below as a deployment condition rather than a nice-to-have.
 
 **Cost is per-device.** A modem or router plus a data plan for every node. For comparison, the proxy market prices dedicated mobile IPs at roughly $27/mo and up.
 

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/vps.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/vps.mdx
@@ -9,7 +9,7 @@ import { AccordionTemplate } from 'components/accordion-template.tsx';
 
 The trick is cheap and quick to set up. The core mechanic is a [mislabeled IP range](/operators/community-counsel/residential-ip#the-core-mechanic) owned by a VPS provider, plus us asking operators to set up nodes there or starting our own.
 
- The downside is that nodes can flip from `isp` back to `hosting` without notice, and that often the origin of the IP is unknown to say the least. 
+ The downside is that nodes can flip from `isp` (mapping to `residential`) back to `hosting` without notice, and that often the origin of the IP is unknown to say the least. 
  
 Make sure to check [*What to avoid* section](/operators/community-counsel/residential-ip#what-to-avoid) and treat every IP acquired this way as temporary
 
@@ -51,7 +51,7 @@ Sorted by status: networks already carrying our nodes first, then untested candi
 **Method key** 
 
 * `Consumer ISP` — a genuine residential broadband subscription
-* `Carrier ASN` — a transit or ISP carrier that also sells colo/transit; its ASN is registered as a telecom, so its space classifies `isp`
+* `Carrier ASN` — a transit or ISP carrier that also sells colo/transit; its ASN is registered as a telecom, so its space classifies `isp` (mapping to `residential`)
 * `Real last-mile` — an actual home broadband line, backhauled to the box
 * `Mislabeled / ISP-tier` — datacenter hardware, IP registered to a consumer-ISP org
 
@@ -109,7 +109,7 @@ Windows/RDP-only, so they cannot run `nym-node`. Kept because their ISP-range co
 
 ## Research Findings
 
-The existing IPs already contain the most useful finding. They split into three methods, and the one that scales is the **carrier ASN**: Cogent, mfeed and NeocomISP sell colo and IP transit like any host, but their ASN is registered as a telecom, so the space they assign classifies `isp` rather than `hosting`. Datacenter reliability, static addressing, real bandwidth and a normal commercial relationship, with residential-class classification as a side effect of who the registrant is.
+The existing IPs already contain the most useful finding. They split into three methods, and the one that scales is the **carrier ASN**: Cogent, mfeed and NeocomISP sell colo and IP transit like any host, but their ASN is registered as a telecom, so the space they assign classifies `isp` (mapping to `residential`) rather than `hosting`. Datacenter reliability, static addressing, real bandwidth and a normal commercial relationship, with residential-class classification as a side effect of who the registrant is.
 
 The **consumer ISP lines** (Free, Trooli, Init7 Fiber7) give perfect classification and zero scalability. One line, one operator, one location. Keep them, don't build on them.
 

--- a/documentation/docs/pages/operators/community-counsel/residential-ip/vps.mdx
+++ b/documentation/docs/pages/operators/community-counsel/residential-ip/vps.mdx
@@ -1,0 +1,136 @@
+import { Callout } from 'nextra/components';
+import { Tabs } from 'nextra/components';
+import { MyTab } from 'components/generic-tabs.tsx';
+import { VarInfo } from 'components/variable-info.tsx';
+import { Steps } from 'nextra/components';
+import { AccordionTemplate } from 'components/accordion-template.tsx';
+
+# Mislabeled VPS Ranges
+
+The trick is cheap and quick to set up. The core mechanic is a [mislabeled IP range](/operators/community-counsel/residential-ip#the-core-mechanic) owned by a VPS provider, plus us asking operators to set up nodes there or starting our own.
+
+ The downside is that nodes can flip from `isp` back to `hosting` without notice, and that often the origin of the IP is unknown to say the least. 
+ 
+Make sure to check [*What to avoid* section](/operators/community-counsel/residential-ip#what-to-avoid) and treat every IP acquired this way as temporary
+
+## The flow
+
+<Steps>
+
+###### 1. Find a candidate provider
+
+Look for VPS providers whose IP ranges are labeled `isp` rather than `hosting`. See the [provider research](#provider-research) below for the current shortlist.
+
+###### 2. Confirm they will host Nym Exit Gateway
+
+Check with them whether they are fine hosting `nym-nodes` by sending the [introduction template](/operators/community-counsel/templates#introduction-to-server-provider).
+
+###### 3. Buy and deploy
+
+Buy a server, start with one.
+
+###### 4. Verify before trusting
+
+Cross-check the assigned IP against [ipinfo](https://ipinfo.io), [ipapi.is](https://ipapi.is), [MaxMind](https://www.maxmind.com/en/geoip-demo) and a fraud score ([IPQualityScore](https://www.ipqualityscore.com/) or [Spur](https://spur.us/)) before counting it as residential. See [how to verify classification](/operators/community-counsel/residential-ip#how-to-verify-classification).
+
+###### 5. Setup nodes
+
+If all checks, start a `nym-node` and check the [API status](/operators/community-counsel/residential-ip#nymvpn-api-logic).
+
+###### 6. Move if needed
+
+When the provider corrects the `as_type`, ask them for another range, or kill the nodes and move to another provider.
+
+</Steps>
+
+## Provider research
+
+Sorted by status: networks already carrying our nodes first, then untested candidates, then rejected. Windows-only vendors are archived at the bottom. Last update on every row: **2026-09-10**.
+
+
+**Method key** 
+
+* `Consumer ISP` — a genuine residential broadband subscription
+* `Carrier ASN` — a transit or ISP carrier that also sells colo/transit; its ASN is registered as a telecom, so its space classifies `isp`
+* `Real last-mile` — an actual home broadband line, backhauled to the box
+* `Mislabeled / ISP-tier` — datacenter hardware, IP registered to a consumer-ISP org
+
+<Tabs items={['In use', 'Candidates', 'Rejected', 'Archive']}>
+  <MyTab>
+
+These carry part of our current 32 residential IPs.
+
+| Provider | Method | Pricing | Crypto | Locations | Danger / Limit | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| [Free (Iliad)](https://www.free.fr) | Consumer ISP, real FTTH | Consumer Freebox sub, ~€30–50/mo | No | France | **Limit, not danger:** consumer subscription in the operator's own name at their own address. No legal buffer, shared upstream, one line per operator | AS12322. ipinfo profiles it as a classic eyeball network with a pronounced day/night rhythm. 2nd largest French ISP. Static IPv4 available |
+| [Init7](https://www.init7.net/de) | Consumer ISP + carrier | Fiber7 ~CHF 64–84/mo (1–25 Gbit/s symmetric); colo full-rack+ only | No | Switzerland | **Limit, not danger:** no 1U colo, full racks and up. The cheap path is a Fiber7 line, which puts it back in one-line-per-operator unless we take a rack | AS13030, own backbone, ~8000 peering sessions, no reseller layer. Net-neutral: no port blocking, servers explicitly permitted on residential Fiber7, static v4+v6. ipinfo already tags the ASN with tor/bittorrent. Basis of the [Swiss setup](/operators/community-counsel/residential-ip/home/swiss) |
+| [Trooli](https://www.trooli.com) | Consumer ISP, UK FTTP | Consumer/business FTTP sub | No | UK, rural South East England | **Limit, not danger:** same as Free. One operator per line, coverage restricted to Trooli's own footprint | AS48101. Independent altnet building its own FTTP, also wholesales to Zen and Freeola. Business plans carry static IPs |
+| [Cogent](https://cogentco.com/en/) | **Carrier ASN**, tier-1 selling colo + transit | Colo and IP transit quoted; the transit market's aggressive discounter | No | **Global, 200+ metros** | **Danger:** heavily-scanned tier-1 whose space is well known to IP-intelligence vendors, so `isp` won't by itself buy a clean reputation. Also known for aggressive peering disputes and de-peering events, meaning possible reachability gaps to specific destinations. Verify per-prefix before scaling | AS174. Registered as a telecom carrier, not a hosting company, so PA space from Cogent inherits `isp`-class treatment. **Most scalable option on the sheet** |
+| [Internet Multifeed (mfeed)](https://www.mfeed.ad.jp) | **Carrier ASN** | Contact sales | Unknown | Japan | **Limit, not danger:** wholesale sales motion, not self-serve. Contract, sales cycle and Japanese-language paperwork rather than a checkout button | AS7521, plus AS55391/55392 transix East/West. Operates JPNAP and the transix IPv4-over-IPv6 service. Carrier-class org, not a hosting brand |
+| [NeocomISP](https://neocomisp.com.kh/en) | **Carrier ASN**, ISP selling transit | Contact sales | Unknown | Cambodia, Phnom Penh | **Limit, not danger:** single-country and small. A thin market for exit capacity, and a small LIR. Proof of the model rather than a scaling lever itself | AS9902. [ipregistry reports `AS Type: ISP` explicitly](https://ipregistry.co/AS9902). Self-describes as an IPTX Transit and Network Service Provider. LIR with 74 IPv4 prefixes, ALLOCATED PORTABLE |
+| [Blythe](https://blythe.org/lander) | Unknown, needs verification | Unknown | Unknown | US | **Danger: undocumented.** Landing page is empty/JS-only and no ASN resolves cleanly from public sources. We are running production exit capacity on a network we cannot identify from outside | Ask the operator running this node directly which entity and ASN it is |
+| [BeHostings](https://www.behostings.com/fr/) | Unknown, brand says hosting | Unknown | Unknown | Belgium | **Danger: undocumented, and the brand name says hosting.** If it is in fact classifying `isp` that is fragile — a hosting-branded org is exactly what IP-intelligence vendors reclassify on their next ASN review. Treat any `isp` result as temporary | No ASN or product data retrievable publicly. If it does classify `isp` despite the hosting brand, worth documenting properly as a mislabeled-ASN find |
+
+  </MyTab>
+  <MyTab>
+
+Researched, not yet trialled.
+
+| Provider | Method | Pricing | Crypto | Locations | Danger / Limit | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| [AaITR](https://www.aaitr.com/store/pr) | **Real last-mile**, genuine AT&T / Verizon home lines | CNY 149/mo (~$21) for 2 vCPU / 2 GB / 25 GB / 100 Mbit/s / 2000 GB, upgradable. 20% off annual | Likely, verify USDT at checkout | US California only, multi-city and multi-segment | **Danger:** vendor explicitly does **not** guarantee IP cleanliness, only that the line is genuine home broadband. Previous tenants may have burned the address, so a clean `as_type` does not imply a clean reputation. Pre-order queue with **no refunds during the wait**, and California-only concentrates capacity in one metro and one jurisdiction | Best of the commercial set and unusually honest. Dedicated static AT&T (AS7018) or Verizon (AS5650). No real-name/KYC on static IP products. AT&T sold out, Verizon available. Linux KVM. **Recommended trial** |
+| [LisaHost](https://www.lisahost.com/) | Mislabeled / ISP-tier, own cabinets | From CNY 47.6–61/mo (~$7–9); JP IIJ ~CNY 899/yr; DE ~CNY 152/mo; premium US static home-broadband VDS CNY 399–5999/mo | Yes, USDT + Alipay | US (LA, NY), HK, SG, TW, JP, KR, VN, UK, DE | **Danger: IP sourcing is undocumented.** Marketed for TikTok and streaming unblocking, so the ranges are actively used for exactly the behaviour anti-bot vendors enumerate. Expect reputation wear even where `as_type` is correct. Verify each range independently rather than trusting the dual-ISP label | Widest country spread of any vendor found, and the only one with real EU + Asia coverage. Founded 2017, HQ Hong Kong, own racks and dedicated bandwidth. KVM, Linux or Windows. 48h no-questions refund reported. Chinese-language site. **Recommended trial** |
+| [TmhHost](https://www.tmhhost.com/) | Mislabeled / ISP-tier | US LA dual-ISP residential from CNY 388–470/yr; quarterly CNY 120; monthly ~CNY 33–50 (~$5–7) | Alipay confirmed, USDT unconfirmed | US (Los Angeles), HK, JP, KR, CN | **Danger: Chinese legal domicile** (Shenyang Ouxun Network Technology, holds PRC ISP/ICP licences). For an exit gateway that is a real jurisdictional consideration — the operating company is subject to PRC data and lawful-access requirements regardless of where the US metal sits | Founded 2019. Routes AS4837 / AS9929 / CN2-GIA. No real-name verification, 24h refund. Cheapest per-month of the credible set. Windows and Linux |
+| [Akile](https://akile.ai/shop/server) | Mixed, some real residential and some ISP-tier | HK HKBN residential CNY 1000/mo; VN VNPT dual-ISP from CNY 158.88/yr; general VPS from CNY 9.99/mo | Yes, USDT + Alipay + FPS + intl cards | HK, JP, KR, VN, SG, US, TW, DE, ~16 nodes | **Danger: the HK HKBN product is dynamic**, a disqualifying rotation problem at CNY 1000/mo. Most of the catalogue is ordinary hosting that classifies as `hosting`; only specific SKUs are residential and the shop is JS-rendered, so it is easy to buy the wrong thing. Confirm the exact SKU and test `as_type` first | Owns its own ASN. The Vietnam VNPT dual-ISP SKU is cheap and static-ish, and the only one worth our attention. KVM Linux |
+
+  </MyTab>
+  <MyTab>
+
+Researched and ruled out. Kept so nobody re-researches them.
+
+| Provider | Method | Pricing | Crypto | Locations | Danger / Limit | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| [Mondoze](https://www.mondoze.com/isp-ip-vps) | Real last-mile, Malaysian telco | Not published, contact sales | Yes, **crypto only** for the residential product | Malaysia | **Danger: IP is dynamic**, auto-refreshes every 12–24h with no static option. Breaks node identity, bonding and gateway reachability, which is disqualifying regardless of classification quality. Pricing unpublished and crypto-only, so no chargeback path if supply is not as described | Test IP available on request. Real Malaysian telco last-mile, but the rotation makes it unusable for us |
+| [ISPVPS](https://ispvps.me/) | Unknown | Not retrievable | Unknown | Unknown | **Danger: total opacity.** Site blocks automated access and publishes no company, ASN, location or pricing data. A residential-IP vendor that will not say where its IPs come from is the exact profile of a resold or unclean pool. Do not spend before a manual visit and a written answer on sourcing | Zero public information available. Needs manual evaluation or should be dropped |
+
+  </MyTab>
+  <MyTab>
+
+Windows/RDP-only, so they cannot run `nym-node`. Kept because their ISP-range coverage is useful reference for which consumer ranges are in commercial circulation.
+
+| Provider | Method | Pricing | Crypto | Locations | Blocker | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| [IPBurger](https://www.ipburger.com/residential-vps) | Mislabeled / ISP-tier | Residential VPS on request; static ISP proxy $14.41/IP/mo annual | Yes, BTC + cards + PayPal | VPS: US only. ISP proxy: US, UK, CA, DE, FR, AU | Windows 10 + RDP only, no Linux and no root SSH | Proxy vendor first, VPS second. Retained only as a reference for which ISP ranges are in commercial circulation |
+| [ResidentialVPS.com](https://www.residentialvps.com/) | Mislabeled / ISP-tier | $34.95 / $39.95 / $49.95 per mo, −25% quarterly | No | US only, 20+ cities | Windows 10 only. Also no crypto option at all | Claims AT&T, Spectrum, Verizon, Comcast, CenturyLink and Optimum ranges. Has an explicit "Residential IP Disclaimer" legal page |
+| [TryRDP](https://tryrdp.com/residential-rdp) | Mislabeled / ISP-tier | $24.99/mo flat, all locations | Yes, BTC + ETH + USDT + cards + PayPal | US, UK, CA, SG, DE | Windows Server only on residential plans. Separately, their DE "ISPs" are Orange, NTT America and zyNox IT Group, and CA is Cronomagic — none are consumer ISPs, so supply quality is mixed even setting the OS aside | Operating since 2018. **Best public documentation of the WHOIS/ASN mechanic of any vendor found** — explicitly tells buyers to verify on ipinfo/Scamalytics and offers a 72h refund if the IP tests as datacenter. Worth reading as reference material |
+
+  </MyTab>
+</Tabs>
+
+## Research Findings
+
+The existing IPs already contain the most useful finding. They split into three methods, and the one that scales is the **carrier ASN**: Cogent, mfeed and NeocomISP sell colo and IP transit like any host, but their ASN is registered as a telecom, so the space they assign classifies `isp` rather than `hosting`. Datacenter reliability, static addressing, real bandwidth and a normal commercial relationship, with residential-class classification as a side effect of who the registrant is.
+
+The **consumer ISP lines** (Free, Trooli, Init7 Fiber7) give perfect classification and zero scalability. One line, one operator, one location. Keep them, don't build on them.
+
+<Callout type="warning" emoji="⚠️">
+**Dynamic IPs disqualify a vendor for Nym** even when the classification is perfect. A rotating exit IP breaks bonding and gateway reachability. That ruled out Mondoze and Akile's HKBN SKU on the spot.
+
+The honest vendors converge on the same finding we reached independently. AaITR states upfront that it will not guarantee cleanliness, and TryRDP tells buyers to verify for themselves. **Any vendor claiming both perfect residential classification and a clean IP is overselling** — those are two separate properties, and only one of them is about the ASN.
+</Callout>
+
+## References
+
+<AccordionTemplate name="Sources for this page">
+- ipinfo — how ASN types are classified: [https://community.ipinfo.io/t/how-do-we-classify-asn-types/2236](https://community.ipinfo.io/t/how-do-we-classify-asn-types/2236)
+- ipinfo — hosting vs ISP decisioning: [https://community.ipinfo.io/t/hosting-vs-isp-how-we-decide-the-ip-connection-types/5521](https://community.ipinfo.io/t/hosting-vs-isp-how-we-decide-the-ip-connection-types/5521)
+- ipapi.is — classification methodology: [https://ipapi.is/blog/ipinfo-io-is-worse-than-ipapi-is.html](https://ipapi.is/blog/ipinfo-io-is-worse-than-ipapi-is.html)
+- OVHcloud — why they refuse to sell residential IPs: [https://www.ovhcloud.com/en/vps/residential-ip-vps/](https://www.ovhcloud.com/en/vps/residential-ip-vps/)
+- Shifter — IP reputation vs classification: [https://shifter.io/blog/what-is-ip-reputation](https://shifter.io/blog/what-is-ip-reputation)
+- ipregistry — NeocomISP AS9902, reports `AS Type: ISP`: [https://ipregistry.co/AS9902](https://ipregistry.co/AS9902)
+- ipinfo — Cogent AS174: [https://ipinfo.io/AS174](https://ipinfo.io/AS174)
+- ipinfo — Trooli AS48101: [https://ipinfo.io/AS48101](https://ipinfo.io/AS48101)
+- PeeringDB — Free SAS AS12322: [https://www.peeringdb.com/asn/12322](https://www.peeringdb.com/asn/12322)
+- PeeringDB — Init7 AS13030: [https://www.peeringdb.com/asn/13030](https://www.peeringdb.com/asn/13030)
+- bgp.he.net — Internet Multifeed AS7521: [https://bgp.he.net/AS7521](https://bgp.he.net/AS7521)
+</AccordionTemplate>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nymtech/nym/7153)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for operating Nym exit gateways with residential or ISP-classified IPs.
  * Added dedicated guidance for BYOIP, ISP partnerships, home-hosted nodes, mobile 4G/5G gateways, and VPS options.
  * Expanded coverage of IP classification, exact-prefix verification, deployment considerations, scalability, risks, and reputation.
  * Added Swiss residential-IP setup guidance and supporting references.
  * Clarified that registrant details are indicators rather than guarantees and that results require verification.
  * Corrected the “Residential IP” navigation label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->